### PR TITLE
Use che-machine-exec target port selector

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1277,6 +1277,7 @@ k8s.io/kube-state-metrics v1.7.2/go.mod h1:U2Y6DRi07sS85rmVPmBFlmv+2peBcL8IWGjM+
 k8s.io/kubectl v0.17.2/go.mod h1:y4rfLV0n6aPmvbRCqZQjvOp3ezxsFgpqL+zF5jH/lxk=
 k8s.io/kubectl v0.17.3/go.mod h1:NUn4IBY7f7yCMwSop2HCXlw/MVYP4HJBiUmOR3n9w28=
 k8s.io/kubectl v0.17.4/go.mod h1:im5QWmh6fvtmJkkNm4HToLe8z9aM3jihYK5X/wOybcY=
+k8s.io/kubernetes v1.13.0 h1:qTfB+u5M92k2fCCCVP2iuhgwwSOv1EkAkvQY1tQODD8=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.17.2/go.mod h1:3TkNHET4ROd+NfzNxkjoVfQ0Ob4iZnaHmSEA4vYpwLw=
 k8s.io/metrics v0.17.3/go.mod h1:HEJGy1fhHOjHggW9rMDBJBD3YuGroH3Y1pnIRw9FFaI=

--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -12,18 +12,21 @@ firstPublicationDate: "2020-01-29"
 category: Other
 spec:
   endpoints:
-   -  name: cloud-shell
-      public: true
-      targetPort: 4444
-      attributes:
-        protocol: http
-        type: ide
-        path: /static/
-        discoverable: false
-        secure: true
-        cookiesAuthEnabled: true
+  - name: cloud-shell
+    public: true
+    targetPort: 4444
+    attributes:
+      protocol: http
+      type: ide
+      path: /static/
+      discoverable: false
+      secure: true
+      cookiesAuthEnabled: true
   containers:
-   - name: che-machine-exec
-     image: "quay.io/eclipse/che-machine-exec:nightly"
-     ports:
-       - exposedPort: 4444
+  - name: che-machine-exec
+    image: "quay.io/eclipse/che-machine-exec:nightly"
+    ports:
+    - exposedPort: 4444
+    env:
+    - name: "POD_LABEL_SELECTOR"
+      value: "org.eclipse.che.workspace/id"

--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -29,4 +29,4 @@ spec:
     - exposedPort: 4444
     env:
     - name: "POD_SELECTOR"
-      value: "controller.devfile.io/workspace_id"
+      value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"

--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -28,5 +28,5 @@ spec:
     ports:
     - exposedPort: 4444
     env:
-    - name: "POD_LABEL_SELECTOR"
-      value: "org.eclipse.che.workspace/id"
+    - name: "POD_SELECTOR"
+      value: "controller.devfile.io/workspace_id"

--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -27,6 +27,8 @@ spec:
     image: "quay.io/eclipse/che-machine-exec:nightly"
     ports:
     - exposedPort: 4444
-    env:
-    - name: "POD_SELECTOR"
-      value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"
+    command: ["/go/bin/che-machine-exec",
+              "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
+              "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+              "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
+              "--static", "/cloud-shell"]

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -28,7 +28,8 @@ spec:
       image: "quay.io/eclipse/che-machine-exec:nightly"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
+                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+                "--pod-selector", "org.eclipse.che.workspace/id"]
       ports:
         - exposedPort: 4444
       env:

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -28,11 +28,10 @@ spec:
       image: "quay.io/eclipse/che-machine-exec:nightly"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
+                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
       ports:
         - exposedPort: 4444
       env:
         - name: USE_BEARER_TOKEN
           value: true
-        - name: "POD_SELECTOR"
-          value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -29,7 +29,7 @@ spec:
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                 "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-                "--pod-selector", "org.eclipse.che.workspace/id"]
+                "--pod-selector", "controller.devfile.io/workspace_id"]
       ports:
         - exposedPort: 4444
       env:

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -29,7 +29,7 @@ spec:
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                 "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-                "--pod-selector", "controller.devfile.io/workspace_id"]
+                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
       ports:
         - exposedPort: 4444
       env:

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -28,10 +28,11 @@ spec:
       image: "quay.io/eclipse/che-machine-exec:nightly"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
+                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
       ports:
         - exposedPort: 4444
       env:
         - name: USE_BEARER_TOKEN
           value: true
+        - name: "POD_SELECTOR"
+          value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -28,7 +28,8 @@ spec:
       image: "quay.io/eclipse/che-machine-exec:nightly"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
+                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+                "--pod-selector", "org.eclipse.che.workspace/id"]
       ports:
         - exposedPort: 4444
       env:

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -28,11 +28,10 @@ spec:
       image: "quay.io/eclipse/che-machine-exec:nightly"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
+                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
       ports:
         - exposedPort: 4444
       env:
         - name: USE_BEARER_TOKEN
           value: true
-        - name: "POD_SELECTOR"
-          value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -29,7 +29,7 @@ spec:
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                 "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-                "--pod-selector", "org.eclipse.che.workspace/id"]
+                "--pod-selector", "controller.devfile.io/workspace_id"]
       ports:
         - exposedPort: 4444
       env:

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -29,7 +29,7 @@ spec:
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                 "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-                "--pod-selector", "controller.devfile.io/workspace_id"]
+                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
       ports:
         - exposedPort: 4444
       env:

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -28,10 +28,11 @@ spec:
       image: "quay.io/eclipse/che-machine-exec:nightly"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
+                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
       ports:
         - exposedPort: 4444
       env:
         - name: USE_BEARER_TOKEN
           value: true
+        - name: "POD_SELECTOR"
+          value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -29,7 +29,7 @@ spec:
      command: ["/go/bin/che-machine-exec",
                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-               "--pod-selector", "controller.devfile.io/workspace_id",
+               "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
                "--use-tls"]
      ports:
        - exposedPort: 4444

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -29,11 +29,10 @@ spec:
      command: ["/go/bin/che-machine-exec",
                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+               "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
                "--use-tls"]
      ports:
        - exposedPort: 4444
      env:
        - name: USE_BEARER_TOKEN
          value: true
-       - name: "POD_SELECTOR"
-         value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -29,10 +29,11 @@ spec:
      command: ["/go/bin/che-machine-exec",
                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-               "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
                "--use-tls"]
      ports:
        - exposedPort: 4444
      env:
        - name: USE_BEARER_TOKEN
          value: true
+       - name: "POD_SELECTOR"
+         value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -29,6 +29,7 @@ spec:
      command: ["/go/bin/che-machine-exec",
                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+               "--pod-selector", "org.eclipse.che.workspace/id",
                "--use-tls"]
      ports:
        - exposedPort: 4444

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -29,7 +29,7 @@ spec:
      command: ["/go/bin/che-machine-exec",
                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-               "--pod-selector", "org.eclipse.che.workspace/id",
+               "--pod-selector", "controller.devfile.io/workspace_id",
                "--use-tls"]
      ports:
        - exposedPort: 4444

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -29,6 +29,7 @@ spec:
     command: ["/go/bin/che-machine-exec",
               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+              "--pod-selector", "org.eclipse.che.workspace/id",
               "--use-tls"]
     ports:
       - exposedPort: 4444

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -29,11 +29,10 @@ spec:
     command: ["/go/bin/che-machine-exec",
               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+              "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
               "--use-tls"]
     ports:
       - exposedPort: 4444
     env:
       - name: USE_BEARER_TOKEN
         value: true
-      - name: "POD_SELECTOR"
-        value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -29,7 +29,7 @@ spec:
     command: ["/go/bin/che-machine-exec",
               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-              "--pod-selector", "org.eclipse.che.workspace/id",
+              "--pod-selector", "controller.devfile.io/workspace_id",
               "--use-tls"]
     ports:
       - exposedPort: 4444

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -29,10 +29,11 @@ spec:
     command: ["/go/bin/che-machine-exec",
               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-              "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
               "--use-tls"]
     ports:
       - exposedPort: 4444
     env:
       - name: USE_BEARER_TOKEN
         value: true
+      - name: "POD_SELECTOR"
+        value: "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -29,7 +29,7 @@ spec:
     command: ["/go/bin/che-machine-exec",
               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-              "--pod-selector", "controller.devfile.io/workspace_id",
+              "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
               "--use-tls"]
     ports:
       - exposedPort: 4444

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -30,7 +30,7 @@ const (
 	PVCStorageSize            = "1Gi"
 
 	// WorkspaceIDLabel is label key to store workspace identifier
-	WorkspaceIDLabel = "che.workspace_id"
+	WorkspaceIDLabel = "org.eclipse.che.workspace/id"
 
 	// WorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
 	WorkspaceEndpointNameAnnotation = "controller.devfile.io/endpoint_name"

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -30,7 +30,7 @@ const (
 	PVCStorageSize            = "1Gi"
 
 	// WorkspaceIDLabel is label key to store workspace identifier
-	WorkspaceIDLabel = "org.eclipse.che.workspace/id"
+	WorkspaceIDLabel = "controller.devfile.io/workspace_id"
 
 	// WorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
 	WorkspaceEndpointNameAnnotation = "controller.devfile.io/endpoint_name"

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -140,11 +140,11 @@ func getSpecDeployment(
 	creator := workspace.Labels[config.WorkspaceCreatorLabel]
 	commonEnv := env.CommonEnvironmentVariables(workspace.Name, workspace.Status.WorkspaceId, workspace.Namespace, creator)
 	for idx := range podAdditions.Containers {
-		podAdditions.Containers[idx].Env = append(podAdditions.Containers[idx].Env, commonEnv...)
+		podAdditions.Containers[idx].Env = append(commonEnv, podAdditions.Containers[idx].Env...)
 		podAdditions.Containers[idx].VolumeMounts = append(podAdditions.Containers[idx].VolumeMounts, podAdditions.VolumeMounts...)
 	}
 	for idx := range podAdditions.InitContainers {
-		podAdditions.InitContainers[idx].Env = append(podAdditions.InitContainers[idx].Env, commonEnv...)
+		podAdditions.InitContainers[idx].Env = append(commonEnv, podAdditions.InitContainers[idx].Env...)
 		podAdditions.InitContainers[idx].VolumeMounts = append(podAdditions.InitContainers[idx].VolumeMounts, podAdditions.VolumeMounts...)
 	}
 

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -140,11 +140,11 @@ func getSpecDeployment(
 	creator := workspace.Labels[config.WorkspaceCreatorLabel]
 	commonEnv := env.CommonEnvironmentVariables(workspace.Name, workspace.Status.WorkspaceId, workspace.Namespace, creator)
 	for idx := range podAdditions.Containers {
-		podAdditions.Containers[idx].Env = append(commonEnv, podAdditions.Containers[idx].Env...)
+		podAdditions.Containers[idx].Env = append(podAdditions.Containers[idx].Env, commonEnv...)
 		podAdditions.Containers[idx].VolumeMounts = append(podAdditions.Containers[idx].VolumeMounts, podAdditions.VolumeMounts...)
 	}
 	for idx := range podAdditions.InitContainers {
-		podAdditions.InitContainers[idx].Env = append(commonEnv, podAdditions.InitContainers[idx].Env...)
+		podAdditions.InitContainers[idx].Env = append(podAdditions.InitContainers[idx].Env, commonEnv...)
 		podAdditions.InitContainers[idx].VolumeMounts = append(podAdditions.InitContainers[idx].VolumeMounts, podAdditions.VolumeMounts...)
 	}
 


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR uses these changes from che-machine-exec: https://github.com/eclipse/che-machine-exec/pull/110 to set the target pod selector. This PR will then set TARGET_POD_SELECTOR to be `io.devfile.workspace/workspace_id=$(WORKSPACE_ID)` for the workspace operator, allowing us to change the workspaceID label so that the workspace operator and che operator can live on the same cluster.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16924

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Use the changes from https://github.com/eclipse/che-machine-exec/pull/110 for che-machine-exec. Deploy the workspace operator (webhooks enabled) and che operator.  Try to start workspace in che itself, then try to start cloud shell workspace. Both should start successfully

