### PR TITLE
Fix view workspaces cluster role

### DIFF
--- a/deploy/view-workspaces-cluster-role.yaml
+++ b/deploy/view-workspaces-cluster-role.yaml
@@ -16,7 +16,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - workspace.devfile.io
+      - workspace.che.eclipse.org
     resources:
       - workspaceroutings
       - components


### PR DESCRIPTION
### What does this PR do?
View workspaces cluster role uses wrong APIGroup for subresources
