### PR TITLE
Add workspaceID label to workspaceRouting obj

### DIFF
--- a/pkg/controller/workspace/provision/routing.go
+++ b/pkg/controller/workspace/provision/routing.go
@@ -126,6 +126,9 @@ func getSpecRouting(
 		ObjectMeta: v1.ObjectMeta{
 			Name:      fmt.Sprintf("routing-%s", workspace.Status.WorkspaceId),
 			Namespace: workspace.Namespace,
+			Labels: map[string]string{
+				config.WorkspaceIDLabel: workspace.Status.WorkspaceId,
+			},
 		},
 		Spec: v1alpha1.WorkspaceRoutingSpec{
 			WorkspaceId:   workspace.Status.WorkspaceId,


### PR DESCRIPTION
### What does this PR do?
Make sure workspace ID label is added to workspace routing, to make cleanup easier in some cases.