### PR TITLE
Fix issues with foreground deletion

### DIFF
--- a/pkg/controller/component/component_controller.go
+++ b/pkg/controller/component/component_controller.go
@@ -106,6 +106,11 @@ func (r *ReconcileComponent) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, err
 	}
 
+	if instance.DeletionTimestamp != nil {
+		reqLogger.V(5).Info("Skipping reconcile of deleted resource")
+		return reconcile.Result{}, nil
+	}
+
 	var components []controllerv1alpha1.ComponentDescription
 	dockerimageDevfileComponents, pluginDevfileComponents, err := adaptor.SortComponentsByType(instance.Spec.Components)
 	if err != nil {

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -176,6 +176,11 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 		return reconcile.Result{}, err
 	}
 
+	if workspace.DeletionTimestamp != nil {
+		reqLogger.V(5).Info("Skipping reconcile of deleted resource")
+		return reconcile.Result{}, nil
+	}
+
 	// Ensure workspaceID is set.
 	if workspace.Status.WorkspaceId == "" {
 		workspaceId, err := getWorkspaceId(workspace)

--- a/pkg/webhook/workspace/handler/immutable.go
+++ b/pkg/webhook/workspace/handler/immutable.go
@@ -17,11 +17,10 @@ import (
 	"reflect"
 
 	"github.com/devfile/devworkspace-operator/pkg/config"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	devworkspace "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -104,12 +103,12 @@ func changePermitted(oldObj, newObj runtime.Object) bool {
 	newCopy := newObj.DeepCopyObject()
 	oldMeta, ok := oldCopy.(metav1.Object)
 	if !ok {
-		log.Error(fmt.Errorf("Object is not a valid k8s object: does not have metadata"), "Failed to compare objects")
+		log.Error(fmt.Errorf("Object %s is not a valid k8s object: does not have metadata", oldObj.GetObjectKind()), "Failed to compare objects")
 		return false
 	}
 	newMeta, ok := newCopy.(metav1.Object)
 	if !ok {
-		log.Error(fmt.Errorf("Object is not a valid k8s object: does not have metadata"), "Failed to compare objects")
+		log.Error(fmt.Errorf("Object %s is not a valid k8s object: does not have metadata", newObj.GetObjectKind()), "Failed to compare objects")
 		return false
 	}
 	newMeta.SetFinalizers(oldMeta.GetFinalizers())

--- a/pkg/webhook/workspace/handler/workspace.go
+++ b/pkg/webhook/workspace/handler/workspace.go
@@ -17,18 +17,8 @@ import (
 
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	devworkspace "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
-
-// StopStartDiffOption is comparing options that should be used to check if there is no other changes except changing started
-var StopStartDiffOption = []cmp.Option{
-	// field managed by cluster and should be ignored while comparing
-	cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ManagedFields"),
-	cmpopts.IgnoreFields(devworkspace.DevWorkspaceSpec{}, "Started"),
-}
 
 func (h *WebhookHandler) MutateWorkspaceOnCreate(_ context.Context, req admission.Request) admission.Response {
 	wksp := &devworkspace.DevWorkspace{}


### PR DESCRIPTION
### What does this PR do?
If a deletion timestamp is set, stop the reconcile to avoid creating resources.

It's possible for the controller to race the API server, by e.g. recreating a Component after it is deleted but before the devworkspace is cleaned up. For foreground deletes, this can result in a component being re-created (without the deletion timestamp) and blocking removal of the devworkspace.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17146

### Is it tested? How?
Tested on `crc` via the process in https://github.com/eclipse/che/issues/17146. Components are correctly removed in a foreground delete. Devworkspace is removed, but takes slightly longer, since it waits for deployment and workspaceRouting to be cleaned up before it is removed.
