### PR TITLE
Make controller deployable to any namespace via Makefile

### DIFF
--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: che-workspace-controller
-  namespace: che-workspace-controller
 data:
   cluster.routing_suffix: 192.168.99.100.nip.io
   plugin.registry.url: http://che-plugin-registry.192.168.99.100.nip.io/v3

--- a/deploy/k8s/controller-tls.yaml
+++ b/deploy/k8s/controller-tls.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: che-workspace-controller
-  namespace: che-workspace-controller
 spec:
   template:
     spec:

--- a/deploy/k8s/controller.yaml
+++ b/deploy/k8s/controller.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: che-workspace-controller
-  namespace: che-workspace-controller
 spec:
   replicas: 1
   selector:
@@ -44,7 +43,6 @@ metadata:
   labels:
     app: che-workspace-controller
   name: workspace-controller
-  namespace: che-workspace-controller
 spec:
   ports:
     - targetPort: webhook-server

--- a/deploy/os/che-workspace-controller-cert-gen-deployment.yaml
+++ b/deploy/os/che-workspace-controller-cert-gen-deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: che-workspace-controller-cert-gen
-  namespace: che-workspace-controller
 spec:
   replicas: 1
   selector:

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: che-workspace-controller
-  namespace: che-workspace-controller
 spec:
   replicas: 1
   selector:

--- a/deploy/registry/local/deployment.yaml
+++ b/deploy/registry/local/deployment.yaml
@@ -13,7 +13,6 @@ metadata:
   labels:
     app: che-plugin-registry
   name: che-plugin-registry
-  namespace: che-workspace-controller
 spec:
   replicas: 1
   revisionHistoryLimit: 2

--- a/deploy/registry/local/k8s/ingress.yaml
+++ b/deploy/registry/local/k8s/ingress.yaml
@@ -11,7 +11,6 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: che-plugin-registry
-  namespace: che-workspace-controller
   annotations:
     kubernetes.io/ingress.class: nginx
 spec:

--- a/deploy/registry/local/os/route.yaml
+++ b/deploy/registry/local/os/route.yaml
@@ -10,7 +10,6 @@ apiVersion: v1
 kind: Route
 metadata:
   name: che-plugin-registry
-  namespace: che-workspace-controller
 spec:
   to:
     kind: Service

--- a/deploy/registry/local/service.yaml
+++ b/deploy/registry/local/service.yaml
@@ -13,7 +13,6 @@ metadata:
   labels:
     app: che-plugin-registry
   name: che-plugin-registry
-  namespace: che-workspace-controller
 spec:
   ports:
     - protocol: TCP

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -5,7 +5,8 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: che-workspace-controller
-  namespace: che-workspace-controller
+  # Namespace must be replaced with controller's namespace
+  namespace: ${NAMESPACE}
 roleRef:
   kind: ClusterRole
   name: che-workspace-controller

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -3,4 +3,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: che-workspace-controller
-  namespace: che-workspace-controller

--- a/test/e2e/cmd/workspaces_test.go
+++ b/test/e2e/cmd/workspaces_test.go
@@ -53,13 +53,8 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		panic(err)
 	}
 
-	if err := controller.CreateAllOperatorRoles(); err != nil {
-		fmt.Println("Failed to create roles in clusters")
-		panic(err)
-	}
-
-	if err := controller.CreateOperatorClusterRole(); err != nil {
-		fmt.Println("Failed to create cluster roles in clusters")
+	if err := controller.CreateAdditionalControllerResources(); err != nil {
+		fmt.Println("Failed to create additional controller resources in clusters")
 		panic(err)
 	}
 

--- a/test/e2e/pkg/deploy/controller.go
+++ b/test/e2e/pkg/deploy/controller.go
@@ -50,11 +50,16 @@ func (w *Deployment) DeployWorkspacesController() error {
 	return nil
 }
 
-func (w *Deployment) CreateAllOperatorRoles() error {
-	cmd := exec.Command("oc", "apply", "--namespace", config.Namespace, "-f", "deploy")
+func (w *Deployment) CreateAdditionalControllerResources() error {
+	//sed "s/\${NAMESPACE}/che/g" <<< cat *.yaml | oc apply -f -
+	cmd := exec.Command(
+		"bash", "-c",
+		"sed 's/\\${NAMESPACE}/"+config.Namespace+"/g' <<< "+
+			"cat deploy/*.yaml | "+
+			"oc apply --namespace "+config.Namespace+" -f -")
 	output, err := cmd.CombinedOutput()
 	fmt.Println(string(output))
-	if err != nil && !strings.Contains(string(output), "AlreadyExists") {
+	if err != nil {
 		fmt.Println(err)
 		return err
 	}
@@ -76,15 +81,5 @@ func (w *Deployment) CustomResourceDefinitions() error {
 		return err
 	}
 
-	return nil
-}
-
-func (w *Deployment) CreateOperatorClusterRole() error {
-	cmd := exec.Command("oc", "apply", "--namespace", config.Namespace, "-f", "deploy/role.yaml")
-	output, err := cmd.CombinedOutput()
-	if err != nil && !strings.Contains(string(output), "AlreadyExists") {
-		fmt.Println(err)
-		return err
-	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
Make it possible to manually deploy the controller to any namespace by setting the `$NAMESPACE` env var.

The only ugly workaround is that the clusterrolebinding's subject requires a namespace; this is updated via `sed` and means that manually applying files will not work.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17098

### Is it tested? How?
```
git checkout master
make uninstall
git checkout amisevsk/customize-namespace
export NAMESPACE=web-terminal-operator
make deploy
```
