### PR TITLE
Rename config properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,11 @@ endif
 
 # -i.bak is needed for compatibility between OS X and Linux versions of sed
 _update_yamls: _set_registry_url
-	sed -i.bak -e "s|plugin.registry.url: .*|plugin.registry.url: http://$(PLUGIN_REGISTRY_HOST)|g" ./deploy/controller_config.yaml
-	sed -i.bak -e 's|che.webhooks.enabled: .*|che.webhooks.enabled: "$(WEBHOOK_ENABLED)"|g' ./deploy/controller_config.yaml
-	sed -i.bak -e 's|che.workspace.default_routing_class: .*|che.workspace.default_routing_class: "$(DEFAULT_ROUTING)"|g' ./deploy/controller_config.yaml
-	sed -i.bak -e 's|cluster.routing_suffix: .*|cluster.routing_suffix: $(ROUTING_SUFFIX)|g' ./deploy/controller_config.yaml
-	sed -i.bak -e 's|che.workspace.sidecar.image_pull_policy: .*|che.workspace.sidecar.image_pull_policy: $(PULL_POLICY)|g' ./deploy/controller_config.yaml
+	sed -i.bak -e "s|controller.plugin_registry.url: .*|controller.plugin_registry.url: http://$(PLUGIN_REGISTRY_HOST)|g" ./deploy/controller_config.yaml
+	sed -i.bak -e 's|controller.webhooks.enabled: .*|controller.webhooks.enabled: "$(WEBHOOK_ENABLED)"|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|devworkspace.default_routing_class: .*|devworkspace.default_routing_class: "$(DEFAULT_ROUTING)"|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|devworkspace.routing.cluster_host_suffix: .*|devworkspace.routing.cluster_host_suffix: $(ROUTING_SUFFIX)|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|devworkspace.sidecar.image_pull_policy: .*|devworkspace.sidecar.image_pull_policy: $(PULL_POLICY)|g' ./deploy/controller_config.yaml
 	rm ./deploy/controller_config.yaml.bak
 ifeq ($(TOOL),oc)
 	sed -i.bak -e "s|image: .*|image: $(IMG)|g" ./deploy/os/controller.yaml
@@ -88,10 +88,10 @@ endif
 
 _reset_yamls: _set_registry_url
 	sed -i.bak -e "s|http://$(PLUGIN_REGISTRY_HOST)|http://che-plugin-registry.192.168.99.100.nip.io/v3|g" ./deploy/controller_config.yaml
-	sed -i.bak -e 's|che.webhooks.enabled: .*|che.webhooks.enabled: "true"|g' ./deploy/controller_config.yaml
-	sed -i.bak -e 's|che.workspace.default_routing_class: .*|che.workspace.default_routing_class: "basic"|g' ./deploy/controller_config.yaml
-	sed -i.bak -e 's|cluster.routing_suffix: .*|cluster.routing_suffix: 192.168.99.100.nip.io|g' ./deploy/controller_config.yaml
-	sed -i.bak -e 's|che.workspace.sidecar.image_pull_policy: .*|che.workspace.sidecar.image_pull_policy: Always|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|controller.webhooks.enabled: .*|controller.webhooks.enabled: "true"|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|devworkspace.default_routing_class: .*|devworkspace.default_routing_class: "basic"|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|devworkspace.routing.cluster_host_suffix: .*|devworkspace.routing.cluster_host_suffix: 192.168.99.100.nip.io|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|devworkspace.sidecar.image_pull_policy: .*|devworkspace.sidecar.image_pull_policy: Always|g' ./deploy/controller_config.yaml
 	rm ./deploy/controller_config.yaml.bak
 ifeq ($(TOOL),oc)
 	sed -i.bak -e "s|image: $(IMG)|image: quay.io/che-incubator/che-workspace-controller:nightly|g" ./deploy/os/controller.yaml

--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -4,11 +4,11 @@ kind: ConfigMap
 metadata:
   name: che-workspace-controller
 data:
-  cluster.routing_suffix: 192.168.99.100.nip.io
-  plugin.registry.url: http://che-plugin-registry.192.168.99.100.nip.io/v3
-  che.webhooks.enabled: "true"
-  che.workspace.default_routing_class: "basic"
-  che.workspace.che_api_sidecar.image: amisevsk/che-rest-apis:v0.0.2
-  che.workspace.plugin_broker.artifacts.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0
+  devworkspace.routing.cluster_host_suffix: 192.168.99.100.nip.io
+  controller.plugin_registry.url: http://che-plugin-registry.192.168.99.100.nip.io/v3
+  controller.plugin_artifacts_broker.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0
+  controller.webhooks.enabled: "true"
+  devworkspace.api_sidecar.image: amisevsk/che-rest-apis:v0.0.2
+  devworkspace.default_routing_class: "basic"
   # image pull policy that is applied to all workspace's containers
-  che.workspace.sidecar.image_pull_policy: Always
+  devworkspace.sidecar.image_pull_policy: Always

--- a/pkg/config/cmd_terminal.go
+++ b/pkg/config/cmd_terminal.go
@@ -24,7 +24,7 @@ const (
 	// property name for value with yaml for default dockerimage component
 	// that should be provisioned if devfile DOES have redhat-developer/web-terminal cheEditor
 	// and DOES NOT have any dockerimage component
-	defaultTerminalDockerimageProperty = "che.workspace.default_dockerimage.redhat-developer.web-terminal"
+	defaultTerminalDockerimageProperty = "devworkspace.default_dockerimage.redhat-developer.web-terminal"
 )
 
 var (
@@ -53,7 +53,7 @@ func (wc *ControllerConfig) GetDefaultTerminalDockerimage() (*devworkspace.Conta
 	var dockerimage devworkspace.ContainerComponent
 	if err := yaml.Unmarshal([]byte(*defaultDockerimageYaml), &dockerimage); err != nil {
 		return nil, fmt.Errorf(
-			"%s is configure with invalid dockerimage component. Error: %s", defaultTerminalDockerimageProperty, err)
+			"%s is configured with invalid container component. Error: %s", defaultTerminalDockerimageProperty, err)
 	}
 
 	return &dockerimage, nil

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -10,7 +10,7 @@
 //   Red Hat, Inc. - initial API and implementation
 //
 
-// The package that is used by components to get configuration.
+// Package config is used by components to get configuration.
 //
 // Typically each configuration property has the default value.
 // Default value is supposed to be overridden via config map.
@@ -20,12 +20,4 @@
 // - . is used to separate subcomponents
 // - _ is used to separate words in the component name
 //
-// Examples:
-// che.workspace.plugin_broker.artifacts.image
-// che.workspace.plugin_broker.artifacts.memory_limit
-// Where:
-// che.workspace - indicates that this is going to land to workspace runtime
-// plugin_broker - is a part of workspace
-// artifacts - is a type of plugin broker component
-// memory_limit, image - are just different configuration properties for the same component
 package config

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -13,34 +13,40 @@
 package config
 
 const (
-	pluginRegistryURL = "plugin.registry.url"
+	// URL of external plugin registry; will be used when devworkspace uses plugin
+	// not included in internal registry or when devfile does not include explicit
+	// registry URL.
+	pluginRegistryURL = "controller.plugin_registry.url"
 
-	routingSuffix        = "cluster.routing_suffix"
-	defaultRoutingSuffix = ""
-
-	webhooksEnabled        = "che.webhooks.enabled"
+	webhooksEnabled        = "controller.webhooks.enabled"
 	defaultWebhooksEnabled = "true"
 
-	cheAPISidecarImage = "che.workspace.che_api_sidecar.image"
+	cheAPISidecarImage = "devworkspace.api_sidecar.image"
 	// by default that functionality is not available since it's not fully supported
 	defaultCheAPISidecarImage = ""
 
-	sidecarPullPolicy        = "che.workspace.sidecar.image_pull_policy"
+	// image pull policy that is applied to every container within workspace
+	sidecarPullPolicy        = "devworkspace.sidecar.image_pull_policy"
 	defaultSidecarPullPolicy = "Always"
 
 	// workspacePVCName config property handles the PVC name that should be created and used for all workspaces within one kubernetes namespace
-	workspacePVCName        = "che.workspace.pvc.name"
+	workspacePVCName        = "devworkspace.pvc.name"
 	defaultWorkspacePVCName = "claim-che-workspace"
 
-	workspacePVCStorageClassName = "che.workspace_pvc.storage_class.name"
+	workspacePVCStorageClassName = "devworkspace.pvc.storage_class.name"
 
-	pluginArtifactsBrokerImage        = "che.workspace.plugin_broker.artifacts.image"
+	pluginArtifactsBrokerImage        = "controller.plugin_artifacts_broker.image"
 	defaultPluginArtifactsBrokerImage = "quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0"
 
 	// routingClass defines the default routing class that should be used if user does not specify it explicitly
-	routingClass        = "che.workspace.default_routing_class"
+	routingClass        = "devworkspace.default_routing_class"
 	defaultRoutingClass = "basic"
 
-	workspaceIdleTimeout        = "che.workspace.idle_timeout"
+	// routingSuffix is the default domain for routes/ingresses created on the cluster. All
+	// routes/ingresses will be created with URL http(s)://<unique-to-workspace-part>.<routingSuffix>
+	routingSuffix        = "devworkspace.routing.cluster_host_suffix"
+	defaultRoutingSuffix = ""
+
+	workspaceIdleTimeout        = "devworkspace.idle_timeout"
 	defaultWorkspaceIdleTimeout = "15m"
 )


### PR DESCRIPTION
### What does this PR do?
Reworks config property names to be more consistent:
- config properties that reference cluster properties are prefixed by `cluster`
- config properties that impact the controller are prefixed with `controller`
- config properties that impact workspaces are prefiex with `devworkspace`

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17092

### Is it tested? How?
Deployed on `crc` and found no issues.
