### PR TITLE
Make e2e tests more stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 
 _reset_yamls: _set_registry_url
 	sed -i.bak -e "s|http://$(PLUGIN_REGISTRY_HOST)|http://che-plugin-registry.192.168.99.100.nip.io/v3|g" ./deploy/controller_config.yaml
-	sed -i.bak -e 's|che.webhooks.enabled: .*|che.webhooks.enabled: "false"|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|che.webhooks.enabled: .*|che.webhooks.enabled: "true"|g' ./deploy/controller_config.yaml
 	sed -i.bak -e 's|che.workspace.default_routing_class: .*|che.workspace.default_routing_class: "basic"|g' ./deploy/controller_config.yaml
 	sed -i.bak -e 's|cluster.routing_suffix: .*|cluster.routing_suffix: 192.168.99.100.nip.io|g' ./deploy/controller_config.yaml
 	sed -i.bak -e 's|che.workspace.sidecar.image_pull_policy: .*|che.workspace.sidecar.image_pull_policy: Always|g' ./deploy/controller_config.yaml

--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   cluster.routing_suffix: 192.168.99.100.nip.io
   plugin.registry.url: http://che-plugin-registry.192.168.99.100.nip.io/v3
-  che.webhooks.enabled: "false"
+  che.webhooks.enabled: "true"
   che.workspace.default_routing_class: "basic"
   che.workspace.che_api_sidecar.image: amisevsk/che-rest-apis:v0.0.2
   che.workspace.plugin_broker.artifacts.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0

--- a/test/e2e/pkg/client/webhooks.go
+++ b/test/e2e/pkg/client/webhooks.go
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package client
+
+import (
+	"errors"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (w *K8sClient) WaitForMutatingWebhooksConfigurations(name string) (deployed bool, err error) {
+	timeout := time.After(15 * time.Minute)
+	tick := time.Tick(2 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			return false, errors.New("timed out")
+		case <-tick:
+			_, err := w.kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(name, metav1.GetOptions{})
+			if err == nil {
+				return true, nil
+			}
+		}
+	}
+}

--- a/test/e2e/pkg/deploy/controller.go
+++ b/test/e2e/pkg/deploy/controller.go
@@ -43,10 +43,19 @@ func (w *Deployment) DeployWorkspacesController() error {
 	}
 
 	deploy, err := w.kubeClient.WaitForPodRunningByLabel(label)
+	fmt.Println("Waiting controller pod to be ready")
 	if !deploy || err != nil {
 		fmt.Println("Che Workspaces Controller not deployed")
 		return err
 	}
+
+	deploy, err = w.kubeClient.WaitForMutatingWebhooksConfigurations("controller.devfile.io")
+	fmt.Println("Waiting mutating webhooks to be created")
+	if !deploy || err != nil {
+		fmt.Println("WebHooks configurations are not created in time")
+		return err
+	}
+
 	return nil
 }
 

--- a/test/e2e/pkg/tests/cloud_shell_tests.go
+++ b/test/e2e/pkg/tests/cloud_shell_tests.go
@@ -28,7 +28,11 @@ var _ = ginkgo.Describe("[Create Cloud Shell Workspace]", func() {
 			ginkgo.Fail("Failed to create k8s client: " + err.Error())
 			return
 		}
-		_ = k8sClient.OcApply("samples/cloud-shell.yaml")
+		err = k8sClient.OcApplyWorkspace("samples/cloud-shell.yaml")
+		if err != nil {
+			ginkgo.Fail("Failed to create cloud-shell devworkspace: " + err.Error())
+			return
+		}
 		deploy, err := k8sClient.WaitForPodRunningByLabel(label)
 
 		if !deploy {


### PR DESCRIPTION
### What does this PR do?
Make e2e tests more stable:
1. Wait until webhooks are created to make sure that no workspace with empty creator annotation is created. Otherwise workspace won't be started.
2. Fail if there is error on oc apply resource BUT retry if webhook server is not ready yet.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
I don't know why but tests on https://github.com/devfile/devworkspace-operator/pull/112/files do not work for me locally. But tests there work fine with that fix which in general I believe makes start-up process more clear.
