### PR TITLE
Introduce blocker webhook to delay workspace creation until real webhooks are created

### DIFF
--- a/cert-generation/config/constants.go
+++ b/cert-generation/config/constants.go
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package config
+
+// Constants for cert generation
+const (
+	SecureServiceName = "devworkspace-controller"
+	CertConfigMapName = "devworkspace-controller-secure-service"
+	CertSecretName    = "devworkspace-controller"
+	WebhookServerName = "webhook-server"
+)

--- a/cert-generation/main.go
+++ b/cert-generation/main.go
@@ -16,6 +16,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/devfile/devworkspace-operator/cert-generation/config"
 	"github.com/devfile/devworkspace-operator/cert-generation/webhooks"
@@ -119,7 +121,8 @@ func main() {
 		log.Fatal("Failed when attempting to setup the webhook: ", err)
 	}
 
-	log.Println("Certs have been successfully created.")
-	for {
-	}
+	log.Println("Certificates and webhooks are up to date. Idling until interrupted")
+	var shutdownChan = make(chan os.Signal, 1)
+	signal.Notify(shutdownChan, syscall.SIGTERM)
+	<-shutdownChan
 }

--- a/cert-generation/main.go
+++ b/cert-generation/main.go
@@ -66,11 +66,13 @@ func main() {
 		if err != nil {
 			log.Fatal("Failed when attempting to create configmap: ", err)
 		}
+		log.Printf("Created config map %s where certs are going to be injected", config.CertConfigMapName)
 	} else {
 		_, err = clientset.CoreV1().ConfigMaps(namespace).Update(configMap)
 		if err != nil {
 			log.Fatal("Failed when attempting to update configmap: ", err)
 		}
+		log.Printf("Updated config map %s where certs are going to be injected", config.CertConfigMapName)
 	}
 
 	label := map[string]string{"app": "che-workspace-controller"}
@@ -103,6 +105,7 @@ func main() {
 		if err != nil {
 			log.Fatal("Failed when attempting to create service: ", err)
 		}
+		log.Printf("Created service %s for webhook server", config.SecureServiceName)
 	} else {
 		// Cannot naively copy spec, as clusterIP is unmodifiable
 		clusterIP := clusterService.Spec.ClusterIP
@@ -114,6 +117,7 @@ func main() {
 		if err != nil {
 			log.Fatal("Failed when attempting to update service: ", err)
 		}
+		log.Printf("Updated service %s for webhook server", config.SecureServiceName)
 	}
 
 	err = webhooks.WebhookInit(clientset, namespace)

--- a/cert-generation/webhooks/webhook.go
+++ b/cert-generation/webhooks/webhook.go
@@ -13,6 +13,8 @@
 package webhooks
 
 import (
+	"log"
+
 	"github.com/devfile/devworkspace-operator/pkg/webhook/workspace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
@@ -24,8 +26,14 @@ func WebhookInit(clientset *kubernetes.Clientset, namespace string) error {
 
 	// Create mutating webhook
 	_, err := clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(configuration)
-	if !apierrors.IsNotFound(err) {
-		return err
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			log.Printf("Mutating webhooks configuration %s already exists", configuration.Name)
+			return nil
+		} else {
+			return err
+		}
 	}
+	log.Printf("Created Mutating webhooks configuration %s", configuration.Name)
 	return nil
 }

--- a/cert-generation/webhooks/webhook.go
+++ b/cert-generation/webhooks/webhook.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package webhooks
+
+import (
+	"github.com/devfile/devworkspace-operator/pkg/webhook/workspace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+)
+
+// WebhookInit Initialize the webhook that denies everything until controller is started succesfully
+func WebhookInit(clientset *kubernetes.Clientset, namespace string) error {
+	configuration := workspace.BuildMutateWebhookCfg(namespace)
+
+	// Create mutating webhook
+	_, err := clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(configuration)
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -44,9 +44,9 @@ spec:
           projected:
             sources:
               - configMap:
-                  name: che-workspace-controller-secure-service
+                  name: devworkspace-controller-secure-service
                   items:
                     - key: service-ca.crt
                       path: ./ca.crt
               - secret:
-                  name: workspace-controller
+                  name: devworkspace-controller

--- a/pkg/webhook/workspace/config.go
+++ b/pkg/webhook/workspace/config.go
@@ -45,7 +45,7 @@ func Configure(ctx context.Context) error {
 		return err
 	}
 
-	mutateWebhookCfg := buildMutateWebhookCfg(namespace)
+	mutateWebhookCfg := BuildMutateWebhookCfg(namespace)
 	validateWebhookCfg := buildValidatingWebhookCfg(namespace)
 
 	if !server.IsSetUp() {

--- a/pkg/webhook/workspace/mutating_cfg.go
+++ b/pkg/webhook/workspace/mutating_cfg.go
@@ -24,14 +24,15 @@ const (
 	mutateWebhookFailurePolicy = v1beta1.Fail
 )
 
-func buildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfiguration {
+// BuildMutateWebhookCfg creates the mutating webhook configuration for the controller
+func BuildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfiguration {
 	mutateWebhookFailurePolicy := mutateWebhookFailurePolicy
 	mutateWebhookPath := mutateWebhookPath
 	labelExistsOp := metav1.LabelSelectorOpExists
 	equivalentMatchPolicy := v1beta1.Equivalent
 	webhookClientConfig := v1beta1.WebhookClientConfig{
 		Service: &v1beta1.ServiceReference{
-			Name:      "workspace-controller",
+			Name:      "devworkspace-controller",
 			Namespace: namespace,
 			Path:      &mutateWebhookPath,
 		},

--- a/pkg/webhook/workspace/validating_cfg.go
+++ b/pkg/webhook/workspace/validating_cfg.go
@@ -36,7 +36,7 @@ func buildValidatingWebhookCfg(namespace string) *v1beta1.ValidatingWebhookConfi
 				FailurePolicy: &validateWebhookFailurePolicy,
 				ClientConfig: v1beta1.WebhookClientConfig{
 					Service: &v1beta1.ServiceReference{
-						Name:      "workspace-controller",
+						Name:      "devworkspace-controller",
 						Namespace: namespace,
 						Path:      &validateWebhookPath,
 					},


### PR DESCRIPTION
### What does this PR do?
This PR introduces a blocker webhook that delays workspace creation until real webhooks are created. Basically what will happen is if you try and do `oc apply -f samples/cloud-shell.yaml` you'll get a response of:

```Error from server (InternalError): error when creating "samples/cloud-shell.yaml": Internal error occurred: failed calling webhook "mutate.che-workspace-controller.svc": Post https://workspace-controller.che-workspace-controller.svc:443/mutate?timeout=30s: dial tcp 10.128.0.55:8443: connect: connection refused```.

until the actual webhook server is connected. Once the webhook server is started then you'll be able to create a dev workspace successfully.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17200

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Webhooks enabled, then create the cert gen image `make docker_cert` then the regular controller image `make docker` then `make deploy`. Right after you run `make deploy` start doing `oc apply -f samples/cloud-shell.yaml`
