### PR TITLE
Variable images

### DIFF
--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -8,7 +8,6 @@ data:
   controller.plugin_registry.url: http://che-plugin-registry.192.168.99.100.nip.io/v3
   controller.plugin_artifacts_broker.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0
   controller.webhooks.enabled: "true"
-  devworkspace.api_sidecar.image: amisevsk/che-rest-apis:v0.0.2
   devworkspace.default_routing_class: "basic"
   # image pull policy that is applied to all workspace's containers
   devworkspace.sidecar.image_pull_policy: Always

--- a/deploy/k8s/controller.yaml
+++ b/deploy/k8s/controller.yaml
@@ -33,6 +33,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
+            - name: IMAGE_plugin_redhat_developer_web_terminal_4_5_0
+              value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: IMAGE_plugin_redhat_developer_web_terminal_nightly
+              value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
+              value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
+              value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: IMAGE_plugin_eclipse_cloud_shell_nightly
+              value: "quay.io/eclipse/che-machine-exec:nightly"
           ports:
             - name: webhook-server
               containerPort: 8443

--- a/deploy/k8s/controller.yaml
+++ b/deploy/k8s/controller.yaml
@@ -33,19 +33,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-            - name: IMAGE_plugin_redhat_developer_web_terminal_4_5_0
+            - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: IMAGE_plugin_redhat_developer_web_terminal_nightly
+            - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
+            - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
+            - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: IMAGE_plugin_eclipse_cloud_shell_nightly
+            - name: RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: "IMAGE_web_terminal_tooling"
+            - name: RELATED_IMAGE_web_terminal_tooling
               value: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1"
-            - name: "IMAGE_openshift_oauth_proxy"
+            - name: RELATED_IMAGE_openshift_oauth_proxy
               value: "openshift/oauth-proxy:latest"
           ports:
             - name: webhook-server

--- a/deploy/k8s/controller.yaml
+++ b/deploy/k8s/controller.yaml
@@ -43,6 +43,10 @@ spec:
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: IMAGE_plugin_eclipse_cloud_shell_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: "IMAGE_web_terminal_tooling"
+              value: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1"
+            - name: "IMAGE_openshift_oauth_proxy"
+              value: "openshift/oauth-proxy:latest"
           ports:
             - name: webhook-server
               containerPort: 8443

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -42,6 +42,10 @@ spec:
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: IMAGE_plugin_eclipse_cloud_shell_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: "IMAGE_web_terminal_tooling"
+              value: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1"
+            - name: "IMAGE_openshift_oauth_proxy"
+              value: "openshift/oauth-proxy:latest"
           ports:
             - name: webhook-server
               containerPort: 8443

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -32,6 +32,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
+            - name: IMAGE_plugin_redhat_developer_web_terminal_4_5_0
+              value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: IMAGE_plugin_redhat_developer_web_terminal_nightly
+              value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
+              value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
+              value: "quay.io/eclipse/che-machine-exec:nightly"
+            - name: IMAGE_plugin_eclipse_cloud_shell_nightly
+              value: "quay.io/eclipse/che-machine-exec:nightly"
           ports:
             - name: webhook-server
               containerPort: 8443

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -32,19 +32,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-            - name: IMAGE_plugin_redhat_developer_web_terminal_4_5_0
+            - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: IMAGE_plugin_redhat_developer_web_terminal_nightly
+            - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
+            - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
+            - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: IMAGE_plugin_eclipse_cloud_shell_nightly
+            - name: RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: "IMAGE_web_terminal_tooling"
+            - name: RELATED_IMAGE_web_terminal_tooling
               value: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1"
-            - name: "IMAGE_openshift_oauth_proxy"
+            - name: RELATED_IMAGE_openshift_oauth_proxy
               value: "openshift/oauth-proxy:latest"
           ports:
             - name: webhook-server

--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -24,7 +24,7 @@ spec:
       cookiesAuthEnabled: true
   containers:
   - name: che-machine-exec
-    image: "quay.io/eclipse/che-machine-exec:nightly"
+    image: "${IMAGE_plugin_eclipse_cloud_shell_nightly}"
     ports:
     - exposedPort: 4444
     command: ["/go/bin/che-machine-exec",

--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -24,7 +24,7 @@ spec:
       cookiesAuthEnabled: true
   containers:
   - name: che-machine-exec
-    image: "${IMAGE_plugin_eclipse_cloud_shell_nightly}"
+    image: "${RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly}"
     ports:
     - exposedPort: 4444
     command: ["/go/bin/che-machine-exec",

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -25,7 +25,7 @@ spec:
         cookiesAuthEnabled: true
   containers:
     - name: web-terminal
-      image: "${IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0}"
+      image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0}"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                 "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -25,7 +25,7 @@ spec:
         cookiesAuthEnabled: true
   containers:
     - name: web-terminal
-      image: "quay.io/eclipse/che-machine-exec:nightly"
+      image: "${IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0}"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                 "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -25,7 +25,7 @@ spec:
         cookiesAuthEnabled: true
   containers:
     - name: web-terminal
-      image: "quay.io/eclipse/che-machine-exec:nightly"
+      image: "${IMAGE_plugin_redhat_developer_web_terminal_dev_nightly}"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                 "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -25,7 +25,7 @@ spec:
         cookiesAuthEnabled: true
   containers:
     - name: web-terminal
-      image: "${IMAGE_plugin_redhat_developer_web_terminal_dev_nightly}"
+      image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly}"
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                 "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -23,9 +23,7 @@ spec:
         cookiesAuthEnabled: true
   containers:
    - name: web-terminal
-     image: "quay.io/eclipse/che-machine-exec:nightly"
-#    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
-     #    image: "quay.io/redhat-developer/web-terminal:4.5.0"
+     image: "${IMAGE_plugin_redhat_developer_web_terminal_4_5_0}"
      command: ["/go/bin/che-machine-exec",
                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -23,7 +23,7 @@ spec:
         cookiesAuthEnabled: true
   containers:
    - name: web-terminal
-     image: "${IMAGE_plugin_redhat_developer_web_terminal_4_5_0}"
+     image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0}"
      command: ["/go/bin/che-machine-exec",
                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -23,9 +23,7 @@ spec:
       cookiesAuthEnabled: true
   containers:
   - name: web-terminal
-    image: "quay.io/eclipse/che-machine-exec:nightly"
-    #    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
-    #    image: "quay.io/redhat-developer/web-terminal:nightly"
+    image: "${IMAGE_plugin_redhat_developer_web_terminal_nightly}"
     command: ["/go/bin/che-machine-exec",
               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -23,7 +23,7 @@ spec:
       cookiesAuthEnabled: true
   containers:
   - name: web-terminal
-    image: "${IMAGE_plugin_redhat_developer_web_terminal_nightly}"
+    image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly}"
     command: ["/go/bin/che-machine-exec",
               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",

--- a/internal/images/image.go
+++ b/internal/images/image.go
@@ -14,15 +14,39 @@ package images
 
 import (
 	"fmt"
-	"github.com/eclipse/che-plugin-broker/model"
 	"os"
 	"regexp"
+
+	"github.com/eclipse/che-plugin-broker/model"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var log = logf.Log.WithName("container-images")
 
 var envRegexp = regexp.MustCompile(`\${(.*)}`)
+
+const (
+	webTerminalToolingImageEnvVar  = "IMAGE_web_terminal_tooling"
+	openshiftOAuthProxyImageEnvVar = "IMAGE_openshift_oauth_proxy"
+)
+
+func GetWebTerminalToolingImage() string {
+	val, ok := os.LookupEnv(webTerminalToolingImageEnvVar)
+	if !ok {
+		log.Error(fmt.Errorf("environment variable %s is not set", webTerminalToolingImageEnvVar), "Could not get web terminal tooling image")
+		return ""
+	}
+	return val
+}
+
+func GetOpenShiftOAuthProxyImage() string {
+	val, ok := os.LookupEnv(openshiftOAuthProxyImageEnvVar)
+	if !ok {
+		log.Error(fmt.Errorf("environment variable %s is not set", openshiftOAuthProxyImageEnvVar), "Could not get OpenShift OAuth proxy image")
+		return ""
+	}
+	return val
+}
 
 func FillPluginMetaEnvVars(pluginMeta model.PluginMeta) (model.PluginMeta, error) {
 	for idx, container := range pluginMeta.Spec.Containers {

--- a/internal/images/image.go
+++ b/internal/images/image.go
@@ -23,7 +23,7 @@ import (
 
 var log = logf.Log.WithName("container-images")
 
-var envRegexp = regexp.MustCompile(`\${(.*)}`)
+var envRegexp = regexp.MustCompile(`\${(IMAGE_.*)}`)
 
 const (
 	webTerminalToolingImageEnvVar  = "IMAGE_web_terminal_tooling"

--- a/internal/images/image.go
+++ b/internal/images/image.go
@@ -23,11 +23,11 @@ import (
 
 var log = logf.Log.WithName("container-images")
 
-var envRegexp = regexp.MustCompile(`\${(IMAGE_.*)}`)
+var envRegexp = regexp.MustCompile(`\${(RELATED_IMAGE_.*)}`)
 
 const (
-	webTerminalToolingImageEnvVar  = "IMAGE_web_terminal_tooling"
-	openshiftOAuthProxyImageEnvVar = "IMAGE_openshift_oauth_proxy"
+	webTerminalToolingImageEnvVar  = "RELATED_IMAGE_web_terminal_tooling"
+	openshiftOAuthProxyImageEnvVar = "RELATED_IMAGE_openshift_oauth_proxy"
 )
 
 func GetWebTerminalToolingImage() string {

--- a/internal/images/image.go
+++ b/internal/images/image.go
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package images
+
+import (
+	"fmt"
+	"github.com/eclipse/che-plugin-broker/model"
+	"os"
+	"regexp"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("container-images")
+
+var envRegexp = regexp.MustCompile(`\${(.*)}`)
+
+func FillPluginMetaEnvVars(pluginMeta model.PluginMeta) (model.PluginMeta, error) {
+	for idx, container := range pluginMeta.Spec.Containers {
+		img, err := getImageForEnvVar(container.Image)
+		if err != nil {
+			return model.PluginMeta{}, err
+		}
+		pluginMeta.Spec.Containers[idx].Image = img
+	}
+	for idx, initContainer := range pluginMeta.Spec.InitContainers {
+		img, err := getImageForEnvVar(initContainer.Image)
+		if err != nil {
+			return model.PluginMeta{}, err
+		}
+		pluginMeta.Spec.InitContainers[idx].Image = img
+	}
+	return pluginMeta, nil
+}
+
+func isImageEnvVar(query string) bool {
+	return envRegexp.MatchString(query)
+}
+
+func getImageForEnvVar(envStr string) (string, error) {
+	if !isImageEnvVar(envStr) {
+		// Value passed in is not env var, return unmodified
+		return envStr, nil
+	}
+	matches := envRegexp.FindStringSubmatch(envStr)
+	env := matches[1]
+	val, ok := os.LookupEnv(env)
+	if !ok {
+		log.Info(fmt.Sprintf("Environment variable '%s' is unset. Cannot determine image to use", env))
+		return "", fmt.Errorf("environment variable %s is unset", env)
+	}
+	return val, nil
+}

--- a/pkg/config/cmd_terminal.go
+++ b/pkg/config/cmd_terminal.go
@@ -29,27 +29,28 @@ const (
 	defaultTerminalDockerimageProperty = "devworkspace.default_dockerimage.redhat-developer.web-terminal"
 )
 
-var (
-	defaultTerminalDockerimage = &devworkspace.ContainerComponent{
-		MemoryLimit: "256Mi",
-		Container: devworkspace.Container{
-			Name:  "dev",
-			Image: images.GetWebTerminalToolingImage(),
-			Args:  []string{"tail", "-f", "/dev/null"},
-			Env: []devworkspace.EnvVar{
-				{
-					Name:  "PS1",
-					Value: `\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]`,
-				},
-			},
-		},
-	}
-)
-
 func (wc *ControllerConfig) GetDefaultTerminalDockerimage() (*devworkspace.ContainerComponent, error) {
 	defaultDockerimageYaml := wc.GetProperty(defaultTerminalDockerimageProperty)
 	if defaultDockerimageYaml == nil {
-		return defaultTerminalDockerimage.DeepCopy(), nil
+		webTerminalImage := images.GetWebTerminalToolingImage()
+		if webTerminalImage == "" {
+			return nil, fmt.Errorf("cannot determine default image for web terminal: environment variable is unset")
+		}
+		defaultTerminalDockerimage := &devworkspace.ContainerComponent{
+			MemoryLimit: "256Mi",
+			Container: devworkspace.Container{
+				Name:  "dev",
+				Image: webTerminalImage,
+				Args:  []string{"tail", "-f", "/dev/null"},
+				Env: []devworkspace.EnvVar{
+					{
+						Name:  "PS1",
+						Value: `\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]`,
+					},
+				},
+			},
+		}
+		return defaultTerminalDockerimage, nil
 	}
 
 	var dockerimage devworkspace.ContainerComponent

--- a/pkg/config/cmd_terminal.go
+++ b/pkg/config/cmd_terminal.go
@@ -15,6 +15,8 @@ package config
 import (
 	"fmt"
 
+	"github.com/devfile/devworkspace-operator/internal/images"
+
 	devworkspace "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
 
 	"gopkg.in/yaml.v2"
@@ -32,12 +34,12 @@ var (
 		MemoryLimit: "256Mi",
 		Container: devworkspace.Container{
 			Name:  "dev",
-			Image: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1",
+			Image: images.GetWebTerminalToolingImage(),
 			Args:  []string{"tail", "-f", "/dev/null"},
 			Env: []devworkspace.EnvVar{
 				{
 					Name:  "PS1",
-					Value: "\\[\\e[34m\\]>\\[\\e[m\\]\\[\\e[33m\\]>\\[\\e[m\\]",
+					Value: `\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]`,
 				},
 			},
 		},

--- a/pkg/controller/workspace/provision/components.go
+++ b/pkg/controller/workspace/provision/components.go
@@ -49,7 +49,7 @@ func SyncComponentsToCluster(
 	specComponents, err := getSpecComponents(workspace, clusterAPI.Scheme)
 	if err != nil {
 		return ComponentProvisioningStatus{
-			ProvisioningStatus: ProvisioningStatus{Err: err},
+			ProvisioningStatus: ProvisioningStatus{Err: err, FailStartup: true},
 		}
 	}
 
@@ -136,7 +136,7 @@ func getSpecComponents(workspace *devworkspace.DevWorkspace, scheme *runtime.Sch
 		if cmd_terminal.ContainsCmdTerminalComponent(pluginComponents) {
 			defaultContainer, err := config.ControllerCfg.GetDefaultTerminalDockerimage()
 			if err != nil {
-				log.Error(err, fmt.Sprintf("Failed to provision default dockerimage component for '%s'. Cause: %s", cmd_terminal.CommandLineTerminalPublisherName, err.Error()))
+				log.Error(err, fmt.Sprintf("Failed to provision default dockerimage component for '%s'", cmd_terminal.CommandLineTerminalPublisherName))
 				return nil, errors.New("configure dockerimage component or ask administrator to fix default one for " + cmd_terminal.CommandLineTerminalPublisherName)
 			}
 			dockerComponents = []devworkspace.Component{

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -220,7 +220,12 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 	// Step one: Create components, and wait for their states to be ready.
 	componentsStatus := provision.SyncComponentsToCluster(workspace, clusterAPI)
 	if !componentsStatus.Continue {
-		reqLogger.Info("Waiting on components to be ready")
+		if componentsStatus.FailStartup {
+			reqLogger.Info("Workspace start failed")
+			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
+		} else {
+			reqLogger.Info("Waiting on components to be ready")
+		}
 		return reconcile.Result{Requeue: componentsStatus.Requeue}, componentsStatus.Err
 	}
 	componentDescriptions := componentsStatus.ComponentDescriptions

--- a/pkg/controller/workspacerouting/solvers/oauth_proxy_container.go
+++ b/pkg/controller/workspacerouting/solvers/oauth_proxy_container.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/devfile/devworkspace-operator/internal/images"
+
 	"github.com/devfile/devworkspace-operator/pkg/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"
@@ -67,7 +69,7 @@ func getProxyContainerForEndpoint(proxyEndpoint proxyEndpoint, tlsProxyVolume co
 			},
 		},
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-		Image:                    "openshift/oauth-proxy:latest",
+		Image:                    images.GetOpenShiftOAuthProxyImage(),
 		Args: []string{
 			"--https-address=:" + strconv.FormatInt(int64(proxyEndpoint.publicEndpoint.TargetPort), 10),
 			"--http-address=127.0.0.1:" + strconv.FormatInt(int64(proxyEndpoint.publicEndpointHttpPort), 10),

--- a/pkg/internal_registry/registry.go
+++ b/pkg/internal_registry/registry.go
@@ -14,9 +14,10 @@ package registry
 
 import (
 	"fmt"
-	"github.com/devfile/devworkspace-operator/internal/images"
 	"io/ioutil"
 	"os"
+
+	"github.com/devfile/devworkspace-operator/internal/images"
 
 	"github.com/eclipse/che-plugin-broker/model"
 	brokerModel "github.com/eclipse/che-plugin-broker/model"

--- a/pkg/internal_registry/registry.go
+++ b/pkg/internal_registry/registry.go
@@ -14,6 +14,7 @@ package registry
 
 import (
 	"fmt"
+	"github.com/devfile/devworkspace-operator/internal/images"
 	"io/ioutil"
 	"os"
 
@@ -52,6 +53,11 @@ func InternalRegistryPluginToMetaYAML(pluginID string) (*brokerModel.PluginMeta,
 	if err := yaml.Unmarshal(yamlFile, &pluginMeta); err != nil {
 		return nil, fmt.Errorf(
 			"failed to unmarshal downloaded meta.yaml for plugin '%s': %s", pluginID, err)
+	}
+
+	pluginMeta, err = images.FillPluginMetaEnvVars(pluginMeta)
+	if err != nil {
+		return nil, fmt.Errorf("could not process plugin %s from internal registry: %s", pluginID, err)
 	}
 
 	// Ensure ID field is set since it is used all over the place in broker


### PR DESCRIPTION
### What does this PR do?
Extracts some hard-coded images to be determined by environment variables, to support restricted networks and OLM.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17224

### Is it tested? How?
Tested on `crc`

### Open questions
Do we need to do similar for e.g. the plugin artifacts broker (which is currently defined in the configmap?)