### PR TITLE
Don't set ownerrefs for webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,8 @@ endif
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io devworkspacetemplates.workspace.devfile.io
+	$(TOOL) delete mutatingwebhookconfigurations controller.devfile.io
+	$(TOOL) delete validatingwebhookconfigurations controller.devfile.io
 
 ### docker: build and push docker image
 docker: _print_vars

--- a/pkg/webhook/workspace/config.go
+++ b/pkg/webhook/workspace/config.go
@@ -75,17 +75,6 @@ func Configure(ctx context.Context) error {
 		return err
 	}
 
-	ownRef, err := controller.FindControllerOwner(ctx, c)
-	if err != nil {
-		return err
-	}
-
-	//TODO we need to watch owned webhook configuration and clean up old ones
-
-	//TODO For some reasons it's still possible to update reference by user
-	//TODO Investigate if we can block it. The same issue is valid for Deployment owner
-	mutateWebhookCfg.SetOwnerReferences([]metav1.OwnerReference{*ownRef})
-
 	if err := c.Create(ctx, mutateWebhookCfg); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return err
@@ -108,8 +97,6 @@ func Configure(ctx context.Context) error {
 	}
 
 	server.GetWebhookServer().Register(mutateWebhookPath, &webhook.Admission{Handler: NewResourcesMutator(saUID, saName)})
-
-	validateWebhookCfg.SetOwnerReferences([]metav1.OwnerReference{*ownRef})
 
 	if err := c.Create(ctx, validateWebhookCfg); err != nil {
 		if !apierrors.IsAlreadyExists(err) {

--- a/test/e2e/cmd/workspaces_test.go
+++ b/test/e2e/cmd/workspaces_test.go
@@ -81,6 +81,14 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 	if err = k8sClient.Kube().CoreV1().Namespaces().Delete(config.Namespace, &metav1.DeleteOptions{}); err != nil {
 		_ = fmt.Errorf("Failed to uninstall workspace controller %s", err)
 	}
+
+	if err = k8sClient.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(config.WebhookName); err != nil {
+		_ = fmt.Errorf("Failed to delete mutating webhook configuration %s", err)
+	}
+
+	if err = k8sClient.Kube().AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(config.WebhookName); err != nil {
+		_ = fmt.Errorf("Failed to delete validating webhook configuration %s", err)
+	}
 }, func() {})
 
 func TestWorkspaceController(t *testing.T) {

--- a/test/e2e/cmd/workspaces_test.go
+++ b/test/e2e/cmd/workspaces_test.go
@@ -82,11 +82,11 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 		_ = fmt.Errorf("Failed to uninstall workspace controller %s", err)
 	}
 
-	if err = k8sClient.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(config.WebhookName); err != nil {
+	if err = k8sClient.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(config.WebhookName, &metav1.DeleteOptions{}); err != nil {
 		_ = fmt.Errorf("Failed to delete mutating webhook configuration %s", err)
 	}
 
-	if err = k8sClient.Kube().AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(config.WebhookName); err != nil {
+	if err = k8sClient.Kube().AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(config.WebhookName, &metav1.DeleteOptions{}); err != nil {
 		_ = fmt.Errorf("Failed to delete validating webhook configuration %s", err)
 	}
 }, func() {})

--- a/test/e2e/pkg/config/config.go
+++ b/test/e2e/pkg/config/config.go
@@ -13,3 +13,6 @@
 package config
 
 var Namespace string
+
+// WebhookName the name of the webhooks created by the devworkspace operator
+const WebhookName = "controller.devfile.io"


### PR DESCRIPTION
### What does this PR do?
This PR makes it so that ownerrefs aren't set for the mutating and validating webhooks -- meaning they won't be cleaned up when the operator is uninstalled.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/16980

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
In order to build it all together, I cherry-picked the two commits ontop of the `olm-os` branch and then build the olm stuff from there to test. You can also test using:
```
cat <<EOF | oc apply -f -
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: che-workspace-crd-registry
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/jpinkney/che-workspace-operator-index:latest
  publisher: Red Hat
  displayName: Che Workspace Operator Catalog
EOF
```

Just install the web terminal operator, check that validating and mutating webhooks are available then uninstall the web terminal operator and see that they are still on the cluster