### PR TITLE
Use nightly cert-gen tag by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DEFAULT_ROUTING ?= basic
 ADMIN_CTX ?= ""
 REGISTRY_ENABLED ?= true
 DEVWORKSPACE_API_VERSION ?= master
-CERT_IMG ?= quay.io/che-incubator/che-workspace-controller-cert-gen:latest
+CERT_IMG ?= quay.io/che-incubator/che-workspace-controller-cert-gen:nightly
 
 all: help
 
@@ -98,7 +98,7 @@ ifeq ($(TOOL),oc)
 	sed -i.bak -e "s|imagePullPolicy: $(PULL_POLICY)|imagePullPolicy: Always|g" ./deploy/os/controller.yaml
 	sed -i.bak -e 's|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: ""|g' ./deploy/os/controller.yaml
 
-	sed -i.bak -e "s|image: $(CERT_IMG)|image: quay.io/che-incubator/che-workspace-controller-cert-gen:latest|g" ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml
+	sed -i.bak -e "s|image: $(CERT_IMG)|image: quay.io/che-incubator/che-workspace-controller-cert-gen:nightly|g" ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml
 	sed -i.bak -e 's|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: ""|g' ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml
 
 	rm ./deploy/os/controller.yaml.bak

--- a/deploy/os/che-workspace-controller-cert-gen-deployment.yaml
+++ b/deploy/os/che-workspace-controller-cert-gen-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: che-workspace-controller
       containers:
         - name: che-workspace-controller-cert-gen
-          image: quay.io/che-incubator/che-workspace-controller-cert-gen:latest
+          image: quay.io/che-incubator/che-workspace-controller-cert-gen:nightly
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
### What does this PR do?
Use nightly cert-gen tag by default it's needed since we built nightly on regular base but not the latest.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
```
export IMG=quay.io/che-incubator/che-workspace-controller:nightly
export PULL_POLICY=Always
export WEBHOOK_ENABLED=true
export DEFAULT_ROUTING=openshift-oauth
export ADMIN_CTX=
export REGISTRY_ENABLED=
export CERT_IMG=
make deploy
```
make sure that controller is run