### PR TITLE
Add sample of web-terminal workspace to deploy/crds

### DIFF
--- a/deploy/crds/samples/web-terminal.yaml
+++ b/deploy/crds/samples/web-terminal.yaml
@@ -1,0 +1,16 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha1
+metadata:
+  name: web-terminal
+  annotations:
+    controller.devfile.io/restricted-access: "true"
+  labels:
+    console.openshift.io/terminal: "true"
+spec:
+  started: true
+  routingClass: 'web-terminal'
+  template:
+    components:
+      - plugin:
+          name: web-terminal
+          id: redhat-developer/web-terminal/4.5.0


### PR DESCRIPTION
### What does this PR do?
This PR adds sample of web-terminal workspace to deploy/crds to avoid manual action on WebTerminal manifests generation.
This commit is extracted from https://github.com/devfile/devworkspace-operator/pull/121

### What issues does this PR fix or reference?
N/A

### Is it tested? How?

