### PR TITLE
Align controller name to be devworkspace-controller

### DIFF
--- a/.cico/cico_openshift_e2e.sh
+++ b/.cico/cico_openshift_e2e.sh
@@ -38,10 +38,10 @@ go mod tidy
 go mod vendor
 
 # Output of e2e binary
-export OUT_FILE=bin/workspace-controller-e2e
+export OUT_FILE=bin/devworkspace-controller-e2e
 
 # Compile e2e binary tests
 CGO_ENABLED=0 go test -v -c -o ${OUT_FILE} ./test/e2e/cmd/workspaces_test.go
 
 # Launch tests
-./bin/workspace-controller-e2e
+./bin/devworkspace-controller-e2e

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,10 @@
       "type": "go",
       "request": "launch",
       "mode": "exec",
-      "program": "${workspaceFolder}/build/_output/bin/che-workspace-operator-local",
+      "program": "${workspaceFolder}/build/_output/bin/devworkspace-local",
       "env": {
-        "WATCH_NAMESPACE": "che-workspace-controller",
-        "CONTROLLER_CONFIG_MAP_NAMESPACE": "che-workspace-controller"
+        "WATCH_NAMESPACE": "devworkspace-controller",
+        "CONTROLLER_CONFIG_MAP_NAMESPACE": "devworkspace-controller"
       }
     },
     {
@@ -19,8 +19,8 @@
       "mode": "auto",
       "program": "${workspaceFolder}/cmd/manager/",
       "env": {
-        "WATCH_NAMESPACE": "che-workspace-controller",
-        "CONTROLLER_CONFIG_MAP_NAMESPACE": "che-workspace-controller"
+        "WATCH_NAMESPACE": "devworkspace-controller",
+        "CONTROLLER_CONFIG_MAP_NAMESPACE": "devworkspace-controller"
       },
       "args": []
     },

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 OPERATOR_SDK_VERSION = v0.17.0
-NAMESPACE ?= che-workspace-controller
+NAMESPACE ?= devworkspace-controller
 IMG ?= quay.io/che-incubator/che-workspace-controller:nightly
 TOOL ?= oc
 ROUTING_SUFFIX ?= 192.168.99.100.nip.io
 PULL_POLICY ?= Always
-WEBHOOK_ENABLED ?= false
+WEBHOOK_ENABLED ?= true
 DEFAULT_ROUTING ?= basic
 ADMIN_CTX ?= ""
 REGISTRY_ENABLED ?= true
@@ -74,11 +74,11 @@ ifeq ($(TOOL),oc)
 	sed -i.bak -e "s|imagePullPolicy: Always|imagePullPolicy: $(PULL_POLICY)|g" ./deploy/os/controller.yaml
 	sed -i.bak -e "s|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: '$$(date +%Y-%m-%dT%H:%M:%S%z)'|g" ./deploy/os/controller.yaml
 
-	sed -i.bak -e "s|image: .*|image: $(CERT_IMG)|g" ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml
-	sed -i.bak -e "s|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: '$$(date +%Y-%m-%dT%H:%M:%S%z)'|g" ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml
+	sed -i.bak -e "s|image: .*|image: $(CERT_IMG)|g" ./deploy/os/devworkspace-controller-cert-gen-deployment.yaml
+	sed -i.bak -e "s|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: '$$(date +%Y-%m-%dT%H:%M:%S%z)'|g" ./deploy/os/devworkspace-controller-cert-gen-deployment.yaml
 
 	rm ./deploy/os/controller.yaml.bak
-	rm ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml.bak
+	rm ./deploy/os/devworkspace-controller-cert-gen-deployment.yaml.bak
 else
 	sed -i.bak -e "s|image: .*|image: $(IMG)|g" ./deploy/k8s/controller.yaml
 	sed -i.bak -e "s|imagePullPolicy: Always|imagePullPolicy: $(PULL_POLICY)|g" ./deploy/k8s/controller.yaml
@@ -98,11 +98,11 @@ ifeq ($(TOOL),oc)
 	sed -i.bak -e "s|imagePullPolicy: $(PULL_POLICY)|imagePullPolicy: Always|g" ./deploy/os/controller.yaml
 	sed -i.bak -e 's|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: ""|g' ./deploy/os/controller.yaml
 
-	sed -i.bak -e "s|image: $(CERT_IMG)|image: quay.io/che-incubator/che-workspace-controller-cert-gen:nightly|g" ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml
-	sed -i.bak -e 's|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: ""|g' ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml
+	sed -i.bak -e "s|image: $(CERT_IMG)|image: quay.io/che-incubator/che-workspace-controller-cert-gen:nightly|g" ./deploy/os/devworkspace-controller-cert-gen-deployment.yaml
+	sed -i.bak -e 's|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: ""|g' ./deploy/os/devworkspace-controller-cert-gen-deployment.yaml
 
 	rm ./deploy/os/controller.yaml.bak
-	rm ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml.bak
+	rm ./deploy/os/devworkspace-controller-cert-gen-deployment.yaml.bak
 else
 	sed -i.bak -e "s|image: $(IMG)|image: quay.io/che-incubator/che-workspace-controller:nightly|g" ./deploy/k8s/controller.yaml
 	sed -i.bak -e "s|imagePullPolicy: $(PULL_POLICY)|imagePullPolicy: Always|g" ./deploy/k8s/controller.yaml
@@ -123,7 +123,7 @@ _apply_controller_cfg:
 	mv ./deploy/role_binding.yaml.bak ./deploy/role_binding.yaml
 ifeq ($(TOOL),oc)
 ifeq ($(WEBHOOK_ENABLED),true)
-	$(TOOL) apply -f ./deploy/os/che-workspace-controller-cert-gen-deployment.yaml -n $(NAMESPACE)
+	$(TOOL) apply -f ./deploy/os/devworkspace-controller-cert-gen-deployment.yaml -n $(NAMESPACE)
 endif
 	$(TOOL) apply -f ./deploy/os/controller.yaml -n $(NAMESPACE)
 else
@@ -132,11 +132,11 @@ endif
 
 _do_restart:
 ifeq ($(TOOL),oc)
-	oc patch deployment/che-workspace-controller \
+	oc patch deployment/devworkspace-controller \
 		-n $(NAMESPACE) \
 		--patch "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"$$(date --iso-8601=seconds)\"}}}}}"
 else
-	kubectl rollout restart -n $(NAMESPACE) deployment/che-workspace-controller
+	kubectl rollout restart -n $(NAMESPACE) deployment/devworkspace-controller
 endif
 
 _do_uninstall:
@@ -175,7 +175,7 @@ webhook:
 ifeq ($(WEBHOOK_ENABLED),true)
 ifeq ($(TOOL),kubectl)
 	./deploy/webhook-server-certs/deploy-webhook-server-certs.sh kubectl
-	kubectl patch deployment -n $(NAMESPACE) che-workspace-controller -p "$$(cat ./deploy/k8s/controller-tls.yaml)"
+	kubectl patch deployment -n $(NAMESPACE) devworkspace-controller -p "$$(cat ./deploy/k8s/controller-tls.yaml)"
 endif
 else
 	@echo "Webhooks disabled, skipping certificate generation"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Some of the rules supported by the makefile:
 | rollout | rebuild and push docker image and restart cluster deployment |
 | update_cfg | configures already deployed controller according to set env variables |
 | update_crds | update custom resource definitions on cluster |
-| uninstall | delete controller namespace `che-workspace-controller` and remove custom resource definitions from cluster |
+| uninstall | delete controller namespace `devworkspace-controller` and remove custom resource definitions from cluster |
 | help | print all rules and variables |
 
 To see all rules supported by the makefile, run `make help`
@@ -75,7 +75,7 @@ To see all rules supported by the makefile, run `make help`
 It's possible to run an instance of the controller locally while communicating with a cluster. However, this requires webhooks to be disabled, as the webhooks need to be able to access the service created by an in-cluster deployment
 
 ```bash
-export NAMESPACE=che-workspace-controller
+export NAMESPACE=devworkspace-controller
 export TOOL=oc # Use 'export TOOL=kubectl' for kubernetes
 export WEBHOOK_ENABLED=false
 make local
@@ -88,7 +88,7 @@ When running locally, only a single namespace is watched; as a result, all works
 Debugging the controller depends on `delve` being installed (`go get -u github.com/go-delve/delve/cmd/dlv`). Note that at the time of writing, executing `go get` in this repo's directory will update go.mod; these changes should be dropped before committing.
 
 ```bash
-export NAMESPACE=che-workspace-controller
+export NAMESPACE=devworkspace-controller
 export TOOL=oc # Use 'export TOOL=kubectl' for kubernetes
 export WEBHOOK_ENABLED=false
 make local
@@ -97,7 +97,7 @@ operator-sdk up local --namespace ${NAMESPACE} --enable-delve
 
 ### Controller configuration
 
-Controller behavior can be configured with data from the `che-workspace-controller` config map in the same namespace where controller lives.
+Controller behavior can be configured with data from the `devworkspace-controller` config map in the same namespace where controller lives.
 
 For all available configuration properties and their default values, see [pkg/config](https://github.com/devfile/devworkspace-operator/tree/master/pkg/config)
 
@@ -106,7 +106,7 @@ To uninstall the controller and associated CRDs, use the Makefile uninstall rule
 ```bash
 make uninstall
 ```
-This will delete all custom resource definitions created for the controller, as well as the `che-workspace-controller` namespace.
+This will delete all custom resource definitions created for the controller, as well as the `devworkspace-controller` namespace.
 
 ### CentOS CI
 The following [CentOS CI jobs](https://ci.centos.org/) are associated with the repository:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.13.7-alpine3.11 as builder
 
-WORKDIR /che-workspace-operator
+WORKDIR /devworkspace-operator
 
 # Populate the module cache based on the go.{mod,sum} files.
 COPY go.mod .
@@ -11,17 +11,17 @@ RUN go mod download
 COPY . .
 # compile workspace controller binaries
 RUN CGO_ENABLED=0 GOOS=linux go build \
-  -o _output/bin/che-workspace-controller \
+  -o _output/bin/devworkspace-controller \
   -gcflags all=-trimpath=/ \
   -asmflags all=-trimpath=/ \
   cmd/manager/main.go
 
 FROM registry.access.redhat.com/ubi8-minimal:8.1-279
-COPY --from=builder /che-workspace-operator/_output/bin/che-workspace-controller /usr/local/bin/che-workspace-controller
-COPY --from=builder /che-workspace-operator/internal-registry  internal-registry
+COPY --from=builder /devworkspace-operator/_output/bin/devworkspace-controller /usr/local/bin/devworkspace-controller
+COPY --from=builder /devworkspace-operator/internal-registry  internal-registry
 
 ENV USER_UID=1001 \
-    USER_NAME=che-workspace-controller
+    USER_NAME=devworkspace-controller
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
@@ -29,4 +29,4 @@ RUN  /usr/local/bin/user_setup
 USER ${USER_UID}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
-CMD /usr/local/bin/che-workspace-controller
+CMD /usr/local/bin/devworkspace-controller

--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -5,7 +5,7 @@
 
 if ! whoami &>/dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "${USER_NAME}:-che-workspace-controller:x:$(id -u):$(id -g):${USER_NAME}:-che-workspace-controller user:${HOME}:/sbin/nologin" >> /etc/passwd
+    echo "${USER_NAME}:-devworkspace-controller:x:$(id -u):$(id -g):${USER_NAME}:-devworkspace-controller user:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
 fi
 

--- a/build/rhel.Dockerfile
+++ b/build/rhel.Dockerfile
@@ -5,7 +5,7 @@ ENV GOPATH=/go/
 
 USER root
 
-WORKDIR /che-workspace-operator
+WORKDIR /devworkspace-operator
 
 # Populate the module cache based on the go.{mod,sum} files.
 COPY go.mod .
@@ -16,18 +16,18 @@ RUN go mod download
 COPY . .
 # compile workspace controller binaries
 RUN CGO_ENABLED=0 GOOS=linux go build \
-  -o _output/bin/che-workspace-controller \
+  -o _output/bin/devworkspace-controller \
   -gcflags all=-trimpath=/ \
   -asmflags all=-trimpath=/ \
   cmd/manager/main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM registry.access.redhat.com/ubi8-minimal:8.2
-COPY --from=builder /che-workspace-operator/_output/bin/che-workspace-controller /usr/local/bin/che-workspace-controller
-COPY --from=builder /che-workspace-operator/internal-registry  internal-registry
+COPY --from=builder /devworkspace-operator/_output/bin/devworkspace-controller /usr/local/bin/devworkspace-controller
+COPY --from=builder /devworkspace-operator/internal-registry  internal-registry
 
 ENV USER_UID=1001 \
-    USER_NAME=che-workspace-controller
+    USER_NAME=devworkspace-controller
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
@@ -35,4 +35,4 @@ RUN  /usr/local/bin/user_setup
 USER ${USER_UID}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
-CMD /usr/local/bin/che-workspace-controller
+CMD /usr/local/bin/devworkspace-controller

--- a/cert-generation/Dockerfile
+++ b/cert-generation/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.13.7-alpine3.11 as builder
 
-WORKDIR /che-workspace-operator
+WORKDIR /devworkspace-operator
 
 # Populate the module cache based on the go.{mod,sum} files.
 COPY go.mod .
@@ -11,16 +11,16 @@ RUN go mod download
 COPY . .
 # compile workspace controller binaries
 RUN CGO_ENABLED=0 GOOS=linux go build \
-  -o _output/bin/che-workspace-controller-cert-gen \
+  -o _output/bin/devworkspace-controller-cert-gen \
   -gcflags all=-trimpath=/ \
   -asmflags all=-trimpath=/ \
   cert-generation/main.go
 
 FROM registry.access.redhat.com/ubi8-minimal:8.1-279
-COPY --from=builder /che-workspace-operator/_output/bin/che-workspace-controller-cert-gen /usr/local/bin/che-workspace-controller-cert-gen
+COPY --from=builder /devworkspace-operator/_output/bin/devworkspace-controller-cert-gen /usr/local/bin/devworkspace-controller-cert-gen
 
 ENV USER_UID=1001 \
-    USER_NAME=che-workspace-controller-cert-gen
+    USER_NAME=devworkspace-controller-cert-gen
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
@@ -28,4 +28,4 @@ RUN  /usr/local/bin/user_setup
 USER ${USER_UID}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
-CMD /usr/local/bin/che-workspace-controller-cert-gen
+CMD /usr/local/bin/devworkspace-controller-cert-gen

--- a/cert-generation/main.go
+++ b/cert-generation/main.go
@@ -76,7 +76,7 @@ func main() {
 	}
 
 	label := map[string]string{
-		"app.kubernetes.io/name": "devworkspace-controller",
+		"app.kubernetes.io/name":    "devworkspace-controller",
 		"app.kubernetes.io/part-of": "devworkspace-operator",
 	}
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -97,7 +97,7 @@ func main() {
 
 	ctx := context.TODO()
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "che-workspace-operator-lock")
+	err = leader.Become(ctx, "devworkspace-operator-lock")
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: che-workspace-controller
+  name: devworkspace-controller
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator

--- a/deploy/k8s/controller-tls.yaml
+++ b/deploy/k8s/controller-tls.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: che-workspace-controller
+  name: devworkspace-controller
 spec:
   template:
     spec:
       containers:
-        - name: che-workspace-controller
+        - name: devworkspace-controller
           volumeMounts:
             - name: webhook-tls-certs
               mountPath: /tmp/k8s-webhook-server/serving-certs

--- a/deploy/k8s/controller.yaml
+++ b/deploy/k8s/controller.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: che-workspace-controller
+  name: devworkspace-controller
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
@@ -20,9 +20,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/restartedAt: ""
     spec:
-      serviceAccountName: che-workspace-controller
+      serviceAccountName: devworkspace-controller
       containers:
-        - name: che-workspace-controller
+        - name: devworkspace-controller
           image: quay.io/che-incubator/che-workspace-controller:nightly
           imagePullPolicy: Always
           env:
@@ -33,7 +33,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "che-workspace-operator"
+              value: "devworkspace-operator"
             - name: SERVICE_ACCOUNT_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: che-workspace-controller
+  name: devworkspace-controller
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
@@ -19,9 +19,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/restartedAt: ""
     spec:
-      serviceAccountName: che-workspace-controller
+      serviceAccountName: devworkspace-controller
       containers:
-        - name: che-workspace-controller
+        - name: devworkspace-controller
           image: quay.io/che-incubator/che-workspace-controller:nightly
           imagePullPolicy: Always
           env:
@@ -32,7 +32,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "che-workspace-operator"
+              value: "devworkspace-operator"
             - name: SERVICE_ACCOUNT_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/os/devworkspace-controller-cert-gen-deployment.yaml
+++ b/deploy/os/devworkspace-controller-cert-gen-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: che-workspace-controller-cert-gen
+  name: devworkspace-controller-cert-gen
   labels:
     app.kubernetes.io/name: cert-generator
     app.kubernetes.io/part-of: devworkspace-operator
@@ -19,9 +19,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/restartedAt: ""
     spec:
-      serviceAccountName: che-workspace-controller
+      serviceAccountName: devworkspace-controller
       containers:
-        - name: che-workspace-controller-cert-gen
+        - name: devworkspace-controller-cert-gen
           image: quay.io/che-incubator/che-workspace-controller-cert-gen:nightly
           imagePullPolicy: Always
           resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: che-workspace-controller
+  name: devworkspace-controller
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
@@ -109,7 +109,7 @@ rules:
 - apiGroups:
   - apps
   resourceNames:
-  - che-workspace-controller
+  - devworkspace-controller
   resources:
   - deployments/finalizers
   verbs:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -2,16 +2,16 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: che-workspace-controller
+  name: devworkspace-controller
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
 subjects:
 - kind: ServiceAccount
-  name: che-workspace-controller
+  name: devworkspace-controller
   # Namespace must be replaced with controller's namespace
   namespace: ${NAMESPACE}
 roleRef:
   kind: ClusterRole
-  name: che-workspace-controller
+  name: devworkspace-controller
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: che-workspace-controller
+  name: devworkspace-controller
 labels:
   app.kubernetes.io/name: devworkspace-controller
   app.kubernetes.io/part-of: devworkspace-operator

--- a/deploy/webhook-server-certs/deploy-webhook-server-certs.sh
+++ b/deploy/webhook-server-certs/deploy-webhook-server-certs.sh
@@ -11,8 +11,8 @@
 #
 
 # Generate a (self-signed) CA certificate and a certificate and private key to be used by the webhook server.
-# The certificate will be issued for the Common Name (CN) of `workspace-controller.che-workspace-controller.svc`,
-# which is the cluster-internal DNS name for the service.
+# The certificate will be issued for the Common Name (CN) of `devworkspace-controller.devworkspace-controller.svc`,
+# which is the cluster-internal DNS name for the service `devworkspace-controller` in namespace `devworkspace-controller`.
 #
 # NOTE: THIS SCRIPT EXISTS FOR TEST PURPOSES ONLY. DO NOT USE IT FOR YOUR PRODUCTION WORKLOADS.
 
@@ -32,12 +32,12 @@ docker run --name 'webhook-certs' generate-webhook-server-certs:latest exit 0
 docker cp webhook-certs:ca/. ${TARGET_FOLDER}/
 docker rm 'webhook-certs'
 
-$CLI delete secret -n che-workspace-controller webhook-server-tls --ignore-not-found=true
-$CLI -n che-workspace-controller create secret tls webhook-server-tls \
+$CLI delete secret -n devworkspace-controller webhook-server-tls --ignore-not-found=true
+$CLI -n devworkspace-controller create secret tls webhook-server-tls \
     --cert "$TARGET_FOLDER/webhook-server-tls.crt" \
     --key "$TARGET_FOLDER/webhook-server-tls.key"
 CA_BASE_64_CONTENT="$(openssl base64 -A <"${TARGET_FOLDER}/ca.crt")"
-$CLI patch -n che-workspace-controller secret webhook-server-tls -p="{\"data\":{\"ca.crt\": \"${CA_BASE_64_CONTENT}\"}}"
-echo "TLS certificates are stored in 'che-workspace-controller' namespace in 'webhook-server-tls' secret"
+$CLI patch -n devworkspace-controller secret webhook-server-tls -p="{\"data\":{\"ca.crt\": \"${CA_BASE_64_CONTENT}\"}}"
+echo "TLS certificates are stored in 'devworkspace-controller' namespace in 'webhook-server-tls' secret"
 
 rm -r ${TARGET_FOLDER}

--- a/deploy/webhook-server-certs/generate-cert.sh
+++ b/deploy/webhook-server-certs/generate-cert.sh
@@ -11,8 +11,8 @@
 #
 
 # Generate a (self-signed) CA certificate and a certificate and private key to be used by the webhook server.
-# The certificate will be issued for the Common Name (CN) of `workspace-controller.che-workspace-controller.svc`,
-# which is the cluster-internal DNS name for the service.
+# The certificate will be issued for the Common Name (CN) of `devworkspace-controller.devworkspace-controller.svc`,
+# which is the cluster-internal DNS name for the service `devworkspace-controller` in namespace `devworkspace-controller`.
 #
 # NOTE: THIS SCRIPT EXISTS FOR TEST PURPOSES ONLY. DO NOT USE IT FOR YOUR PRODUCTION WORKLOADS.
 set -e
@@ -25,9 +25,9 @@ chmod 0700 "$key_dir"
 cd "$key_dir"
 
 # Generate the CA cert and private key
-openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -days 1024 -subj "/CN=Admission Workspace Controller Webhook"
+openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -days 1024 -subj "/CN=Admission DevWorkspace Controller Webhook"
 # Generate the private key for the webhook server
 openssl genrsa -out webhook-server-tls.key 2048
 # Generate a Certificate Signing Request (CSR) for the private key, and sign it with the private key of the CA.
-openssl req -new -key webhook-server-tls.key -subj "/CN=workspace-controller.che-workspace-controller.svc" \
+openssl req -new -key webhook-server-tls.key -subj "/CN=devworkspace-controller.devworkspace-controller.svc" \
     | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -days 365 -out webhook-server-tls.crt

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/devfile/devworkspace-operator
 
 go 1.12
 
-// Che Plugin Broker branch devworkspace-controller
+// Che Plugin Broker v3.1.1
 require github.com/eclipse/che-plugin-broker v3.1.1-0.20200207223144-b20597f15e4c+incompatible
 
-// use-devfile-2.0-in-workspace-controller
+// use-devfile-2.0-in-devworkspace-controller
 require github.com/devfile/kubernetes-api v0.0.0-20200610142627-e6a761a9ecb3
 
 // Operator Framework 0.17.x

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,7 +49,7 @@ const (
 
 var ConfigMapReference = client.ObjectKey{
 	Namespace: "",
-	Name:      "che-workspace-controller",
+	Name:      "devworkspace-controller",
 }
 
 type ControllerConfig struct {
@@ -253,12 +253,12 @@ func fillOpenShiftRouteSuffixIfNecessary(nonCachedClient client.Client, configMa
 	testRoute := &routeV1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: configMap.Namespace,
-			Name:      "che-workspace-controller-test-route",
+			Name:      "devworkspace-controller-test-route",
 		},
 		Spec: routeV1.RouteSpec{
 			To: routeV1.RouteTargetReference{
 				Kind: "Service",
-				Name: "che-workspace-controller-test-route",
+				Name: "devworkspace-controller-test-route",
 			},
 		},
 	}
@@ -270,7 +270,7 @@ func fillOpenShiftRouteSuffixIfNecessary(nonCachedClient client.Client, configMa
 	defer nonCachedClient.Delete(context.TODO(), testRoute)
 	host := testRoute.Spec.Host
 	if host != "" {
-		prefixToRemove := "che-workspace-controller-test-route-" + configMap.Namespace + "."
+		prefixToRemove := "devworkspace-controller-test-route-" + configMap.Namespace + "."
 		configMap.Data[routingSuffix] = strings.TrimPrefix(host, prefixToRemove)
 	}
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -24,7 +24,7 @@ const (
 
 	AuthEnabled = "false"
 
-	ServiceAccount = "che-workspace"
+	ServiceAccount = "devworkspace"
 
 	SidecarDefaultMemoryLimit = "128M"
 	PVCStorageSize            = "1Gi"

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -31,7 +31,7 @@ const (
 
 	// workspacePVCName config property handles the PVC name that should be created and used for all workspaces within one kubernetes namespace
 	workspacePVCName        = "devworkspace.pvc.name"
-	defaultWorkspacePVCName = "claim-che-workspace"
+	defaultWorkspacePVCName = "claim-devworkspace"
 
 	workspacePVCStorageClassName = "devworkspace.pvc.storage_class.name"
 

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -319,12 +319,12 @@ func precreateSubpathsInitContainer(workspaceId string) corev1.Container {
 			"-v",
 			"-m",
 			"777",
-			"/tmp/che-workspaces/" + workspaceId,
+			"/tmp/devworkspaces/" + workspaceId,
 		},
 		ImagePullPolicy: corev1.PullPolicy(config.ControllerCfg.GetSidecarPullPolicy()),
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				MountPath: "/tmp/che-workspaces",
+				MountPath: "/tmp/devworkspaces",
 				Name:      config.ControllerCfg.GetWorkspacePVCName(),
 				ReadOnly:  false,
 			},

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -68,7 +68,7 @@ func newReconciler(mgr manager.Manager) *ReconcileWorkspace {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r *ReconcileWorkspace) error {
 	// Create a new controller
-	c, err := controller.New("workspace-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("devworkspace-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/workspace/mutating_cfg.go
+++ b/pkg/webhook/workspace/mutating_cfg.go
@@ -40,7 +40,7 @@ func BuildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfigurati
 	}
 
 	workspaceMutateWebhook := v1beta1.MutatingWebhook{
-		Name:          "mutate.che-workspace-controller.svc",
+		Name:          "mutate.devworkspace-controller.svc",
 		FailurePolicy: &mutateWebhookFailurePolicy,
 		ClientConfig:  webhookClientConfig,
 		Rules: []v1beta1.RuleWithOperations{
@@ -64,7 +64,7 @@ func BuildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfigurati
 	}
 
 	workspaceObjMutateWebhook := v1beta1.MutatingWebhook{
-		Name:          "mutate-ws-resources.che-workspace-controller.svc",
+		Name:          "mutate-ws-resources.devworkspace-controller.svc",
 		FailurePolicy: &mutateWebhookFailurePolicy,
 		ClientConfig:  webhookClientConfig,
 		ObjectSelector: &metav1.LabelSelector{

--- a/pkg/webhook/workspace/validating_cfg.go
+++ b/pkg/webhook/workspace/validating_cfg.go
@@ -36,7 +36,7 @@ func buildValidatingWebhookCfg(namespace string) *v1beta1.ValidatingWebhookConfi
 		},
 		Webhooks: []v1beta1.ValidatingWebhook{
 			{
-				Name:          "validate-exec.che-workspace-controller.svc",
+				Name:          "validate-exec.devworkspace-controller.svc",
 				FailurePolicy: &validateWebhookFailurePolicy,
 				ClientConfig: v1beta1.WebhookClientConfig{
 					Service: &v1beta1.ServiceReference{

--- a/test/e2e/cmd/workspaces_test.go
+++ b/test/e2e/cmd/workspaces_test.go
@@ -38,7 +38,7 @@ const (
 //SynchronizedBeforeSuite blocks is executed before run all test suites
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	fmt.Println("Starting to setup objects before run ginkgo suite")
-	config.Namespace = "che-workspace-controller"
+	config.Namespace = "devworkspace-controller"
 
 	k8sClient, err := client.NewK8sClient()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?
Align controller name to be devworkspace-controller. It's mainly find/replace:
- workspace-controller
- che-workspace
-> devworkspace

### What issues does this PR fix or reference?
it fixes one item from https://github.com/eclipse/che/issues/17179
CI part is going to be fixed separately.

### Is it tested? How?
```
export IMG=YOU_IMAGE_HERE
export WEBHOOK_ENABLED=true
export DEFAULT_ROUTING=openshift-oauth
export CERT_IMG=YOU_IMAGE_HERE

make docker
make docker_cert
make deploy
# wait until controller is set up
oc apply -f ./samples/cloud-shell.yaml
# make sure that  devworkspace is successfully started
make uninstall

# OR use new e2e_test makefile target
export IMG=YOU_IMAGE_HERE
export WEBHOOK_ENABLED=true
export DEFAULT_ROUTING=openshift-oauth
export CERT_IMG=YOU_IMAGE_HERE

make docker
make docker_cert
make e2e_test
# Make sure that ran tests passed
# Ran 1 of 1 Specs in 102.559 seconds
# SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```