### PR TITLE
Add test_e2e Makefile target

### DIFF
--- a/.cico/cico_openshift_e2e.sh
+++ b/.cico/cico_openshift_e2e.sh
@@ -10,7 +10,7 @@
 set -ex
 
 # ENV used by PROW ci
-export CI="openshift" 
+export CI="openshift"
 export ARTIFACTS_DIR="/tmp/artifacts"
 
 # Pod created by openshift ci don't have user. Using this envs should avoid errors with git user.
@@ -30,18 +30,9 @@ if ! hash operator-sdk 2>/dev/null; then
         rm operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
 fi
 
-# Add kubernetes-api CRDS
-make update_devworkspace_crds
-
-# Install go modules
+# For some reason go on PROW force usage vendor folder
+# This workaround is here until we don't figure out cause
 go mod tidy
 go mod vendor
 
-# Output of e2e binary
-export OUT_FILE=bin/devworkspace-controller-e2e
-
-# Compile e2e binary tests
-CGO_ENABLED=0 go test -v -c -o ${OUT_FILE} ./test/e2e/cmd/workspaces_test.go
-
-# Launch tests
-./bin/devworkspace-controller-e2e
+make test_e2e

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ endif
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io devworkspacetemplates.workspace.devfile.io
 
+_do_e2e_test:
+	CGO_ENABLED=0 go test -v -c -o bin/devworkspace-controller-e2e ./test/e2e/cmd/workspaces_test.go
+	./bin/devworkspace-controller-e2e
+
 ### docker: build and push docker image
 docker: _print_vars
 	docker build -t $(IMG) -f ./build/Dockerfile .
@@ -251,10 +255,6 @@ start_local_debug:
 
 ### test_e2e: runs e2e test on the cluster set in context. Includes deploying devworkspace-controller, run test workspace, uninstall devworkspace-controller
 test_e2e: _print_vars _set_ctx _update_yamls update_devworkspace_crds _do_e2e_test _reset_yamls _reset_ctx
-
-_do_e2e_test:
-	CGO_ENABLED=0 go test -v -c -o bin/devworkspace-controller-e2e ./test/e2e/cmd/workspaces_test.go
-	./bin/devworkspace-controller-e2e
 
 ### fmt: format all go files in repository
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,13 @@ start_local:
 start_local_debug:
 	operator-sdk run --local --watch-namespace $(NAMESPACE) --enable-delve 2>&1 | grep --color=always -E '"msg":"[^"]*"|$$'
 
+### test_e2e: runs e2e test on the cluster set in context. Includes deploying devworkspace-controller, run test workspace, uninstall devworkspace-controller
+test_e2e: _print_vars _set_ctx _update_yamls update_devworkspace_crds _do_e2e_test _reset_yamls _reset_ctx
+
+_do_e2e_test:
+	CGO_ENABLED=0 go test -v -c -o bin/devworkspace-controller-e2e ./test/e2e/cmd/workspaces_test.go
+	./bin/devworkspace-controller-e2e
+
 ### fmt: format all go files in repository
 fmt:
 ifneq ($(shell command -v goimports 2> /dev/null),)


### PR DESCRIPTION
### What does this PR do?
This PR adds `test_e2e` Makefile target that allows easily run e2e tests on the cluster set in the current context.

It's 🚧 since I'm playing with PROW and try to get rid of workaround with `go mod vendor`
### What issues does this PR fix or reference?
N/A

### Is it tested? How?
```
make test_e2e
# make sure tests are run and finished with no failure, like:
# Ran 1 of 1 Specs in 71.625 seconds
# SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
#PASS
```
