### PR TITLE
Build next dockerimage with GitHub Workflow

### DIFF
--- a/.github/workflows/dockerimage-next.yml
+++ b/.github/workflows/dockerimage-next.yml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Next Dockerimage
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout devworkspace-operator source code
+      uses: actions/checkout@v2
+    - name: Docker Build & Push
+      uses: docker/build-push-action@v1.1.0
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+        repository: devfile/devworkspace-controller
+        dockerfile: ./build/Dockerfile
+        tags: next

--- a/.github/workflows/dockerimage-next.yml
+++ b/.github/workflows/dockerimage-next.yml
@@ -28,3 +28,4 @@ jobs:
         repository: devfile/devworkspace-controller
         dockerfile: ./build/Dockerfile
         tags: next
+        tag_with_sha: true

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := bash
 
 OPERATOR_SDK_VERSION = v0.17.0
 NAMESPACE ?= devworkspace-controller
-IMG ?= quay.io/che-incubator/che-workspace-controller:nightly
+IMG ?= quay.io/devfile/devworkspace-controller:next
 TOOL ?= oc
 ROUTING_SUFFIX ?= 192.168.99.100.nip.io
 PULL_POLICY ?= Always
@@ -98,7 +98,7 @@ _reset_yamls: _set_registry_url
 	sed -i.bak -e 's|devworkspace.sidecar.image_pull_policy: .*|devworkspace.sidecar.image_pull_policy: Always|g' ./deploy/controller_config.yaml
 	rm ./deploy/controller_config.yaml.bak
 ifeq ($(TOOL),oc)
-	sed -i.bak -e "s|image: $(IMG)|image: quay.io/che-incubator/che-workspace-controller:nightly|g" ./deploy/os/controller.yaml
+	sed -i.bak -e "s|image: $(IMG)|image: quay.io/devfile/devworkspace-controller:next|g" ./deploy/os/controller.yaml
 	sed -i.bak -e "s|imagePullPolicy: $(PULL_POLICY)|imagePullPolicy: Always|g" ./deploy/os/controller.yaml
 	sed -i.bak -e 's|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: ""|g' ./deploy/os/controller.yaml
 
@@ -108,7 +108,7 @@ ifeq ($(TOOL),oc)
 	rm ./deploy/os/controller.yaml.bak
 	rm ./deploy/os/devworkspace-controller-cert-gen-deployment.yaml.bak
 else
-	sed -i.bak -e "s|image: $(IMG)|image: quay.io/che-incubator/che-workspace-controller:nightly|g" ./deploy/k8s/controller.yaml
+	sed -i.bak -e "s|image: $(IMG)|image: quay.io/devfile/devworkspace-controller:next|g" ./deploy/k8s/controller.yaml
 	sed -i.bak -e "s|imagePullPolicy: $(PULL_POLICY)|imagePullPolicy: Always|g" ./deploy/k8s/controller.yaml
 	sed -i.bak -e 's|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: ""|g' ./deploy/k8s/controller.yaml
 	rm ./deploy/k8s/controller.yaml.bak

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Che workspace operator repository that contains K8s API for Che workspace and co
 The controller can be deployed to a cluster provided you are logged in with cluster-admin credentials:
 
 ```bash
-export IMG=quay.io/che-incubator/che-workspace-controller:nightly
+export IMG=quay.io/devfile/devworkspace-controller:next
 export TOOL=oc # Use 'export TOOL=kubectl' for kubernetes
 make deploy
 ```
@@ -41,7 +41,7 @@ The repository contains a Makefile; building and deploying can be configured via
 
 |variable|purpose|default value|
 |---|---|---|
-| `IMG` | Image used for controller | `quay.io/che-incubator/che-workspace-controller:nightly` |
+| `IMG` | Image used for controller | `quay.io/devfile/devworkspace-controller:next` |
 | `TOOL` | CLI tool for interfacing with the cluster: `kubectl` or `oc`; if `oc` is used, deployment is tailored to OpenShift, otherwise Kubernetes | `oc` |
 | `ROUTING_SUFFIX` | Cluster routing suffix (e.g. `$(minikube ip).nip.io`, `apps-crc.testing`). Required for Kubernetes | `192.168.99.100.nip.io` |
 | `PULL_POLICY` | Image pull policy for controller | `Always` |
@@ -108,7 +108,13 @@ make uninstall
 ```
 This will delete all custom resource definitions created for the controller, as well as the `devworkspace-controller` namespace.
 
-### CentOS CI
+### CI
+
+#### GitHub actions
+
+- [Next Dockerimage](https://github.com/devfile/devworkspace-operator/blob/master/.github/workflows/dockerimage-next.yml) action build master and push it to [quay.io/devfile/devworkspace-controller:next](https://quay.io/repository/devfile/devworkspace-controller?tag=latest&tab=tags)
+
+#### CentOS CI
 The following [CentOS CI jobs](https://ci.centos.org/) are associated with the repository:
 
 - [`master`](https://ci.centos.org/job/devtools-che-workspace-operator-build-master/) - builds CentOS images on each commit to the [`master`](https://github.com/devfile/devworkspace-operator/tree/master) branch and pushes them to [quay.io/che-incubator/che-workspace-controller](https://quay.io/repository/che-incubator/che-workspace-controller).

--- a/deploy/k8s/controller.yaml
+++ b/deploy/k8s/controller.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: devworkspace-controller
       containers:
         - name: devworkspace-controller
-          image: quay.io/che-incubator/che-workspace-controller:nightly
+          image: quay.io/devfile/devworkspace-controller:next
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: devworkspace-controller
       containers:
         - name: devworkspace-controller
-          image: quay.io/che-incubator/che-workspace-controller:nightly
+          image: quay.io/devfile/devworkspace-controller:next
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
### What does this PR do?
This PR adds build next dockerimage with GitHub Workflow.

Next step is deprecating CentOS CI job for nightly

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17179

### Is it tested? How?
It tested in https://github.com/devfile/devworkspace-operator/pull/130/checks?check_run_id=858350749

> Building image [quay.io/devfile/devworkspace-controller:next quay.io/devfile/devworkspace-controller:sha-4acf58c]

https://quay.io/repository/devfile/devworkspace-controller?tag=latest&tab=tags