### PR TITLE
Use wto-related images from quay.io/wto

### DIFF
--- a/deploy/k8s/controller.yaml
+++ b/deploy/k8s/controller.yaml
@@ -39,17 +39,17 @@ spec:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-              value: "quay.io/eclipse/che-machine-exec:nightly"
+              value: "quay.io/wto/web-terminal-exec:1.0"
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
-              value: "quay.io/eclipse/che-machine-exec:nightly"
+              value: "quay.io/wto/web-terminal-exec:1.0"
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_web_terminal_tooling
-              value: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1"
+              value: "quay.io/wto/web-terminal-tooling:latest"
             - name: RELATED_IMAGE_openshift_oauth_proxy
               value: "openshift/oauth-proxy:latest"
             - name: RELATED_IMAGE_devworkspace_webhook_server

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -38,17 +38,17 @@ spec:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-              value: "quay.io/eclipse/che-machine-exec:nightly"
+              value: "quay.io/wto/web-terminal-exec:1.0"
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
-              value: "quay.io/eclipse/che-machine-exec:nightly"
+              value: "quay.io/wto/web-terminal-exec:1.0"
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_web_terminal_tooling
-              value: "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1"
+              value: "quay.io/wto/web-terminal-tooling:latest"
             - name: RELATED_IMAGE_openshift_oauth_proxy
               value: "openshift/oauth-proxy:latest"
             - name: RELATED_IMAGE_devworkspace_webhook_server


### PR DESCRIPTION
### What does this PR do?
Use wto-related images from quay.io/wto, now:
- `redhat-developer/web-terminal:4.5.0` plugin uses moving tag `quay.io/wto/web-terminal-exec:1.0`
- `redhat-developer/web-terminal-dev:4.5.0` plugin also uses moving tag `quay.io/wto/web-terminal-exec:1.0`
- default `web-terminal-tooling` is `quay.io/wto/web-terminal-tooling:latest`

^ let me know if you have another opinion about tags which should be used there

Note that `redhat-developer/web-terminal:nightly` still depends on `quay.io/eclipse/che-machine-exec:nightly` which should be OK at this point I think.

It's draft because PR in web-terminal-operator is not created yet.

### What issues does this PR fix or reference?
Related to https://issues.redhat.com/browse/WTO-21

### Is it tested? How?
Is not tested yet but I plan to test that Web Terminal is working with that changes on OpenShift 4.5
