### PR TITLE
Fail workspace startup if workspace is older than webhooks

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -134,6 +134,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
   - create
   - patch
   - update

--- a/pkg/controller/workspace/validation.go
+++ b/pkg/controller/workspace/validation.go
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/devfile/devworkspace-operator/pkg/config"
+	"github.com/devfile/devworkspace-operator/pkg/webhook"
+	devworkspace "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+)
+
+func (r *ReconcileWorkspace) validateCreatorTimestamp(workspace *devworkspace.DevWorkspace) error {
+	if config.ControllerCfg.GetWebhooksEnabled() != "true" {
+		return nil
+	}
+	if _, present := workspace.Labels[config.WorkspaceCreatorLabel]; !present {
+		return fmt.Errorf("devworkspace does not have creator label -- it must be recreated to resolve the issue")
+	}
+
+	webhooksTimestamp, err := webhook.GetWebhooksCreationTimestamp(r.client)
+	if err != nil {
+		return fmt.Errorf("webhooks not set up yet: %w", err)
+	}
+	if workspace.CreationTimestamp.Before(&webhooksTimestamp) {
+		return fmt.Errorf("devworkspace created before webhooks -- it must be recreated to resolve the issue")
+	}
+
+	return nil
+}

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -210,6 +210,13 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 		return r.updateWorkspaceStatus(workspace, reqLogger, &reconcileStatus, reconcileResult, err)
 	}()
 
+	if config.ControllerCfg.GetWebhooksEnabled() == "true" {
+		if _, present := workspace.Labels[config.WorkspaceCreatorLabel]; !present {
+			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
+			return reconcile.Result{}, fmt.Errorf("workspace does not have creator label -- it must be recreated to resolve the issue")
+		}
+	}
+
 	immutable := workspace.Annotations[config.WorkspaceImmutableAnnotation]
 	if immutable == "true" && config.ControllerCfg.GetWebhooksEnabled() != "true" {
 		reqLogger.Info("Workspace is configured as immutable but webhooks are not enabled.")

--- a/pkg/webhook/cluster_roles.go
+++ b/pkg/webhook/cluster_roles.go
@@ -70,6 +70,7 @@ func getSpecClusterRole() (*v1.ClusterRole, error) {
 				Verbs: []string{
 					"create",
 					"list",
+					"watch",
 					"get",
 					"patch",
 					"update",

--- a/pkg/webhook/info.go
+++ b/pkg/webhook/info.go
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	webhookCfg "github.com/devfile/devworkspace-operator/webhook/workspace"
+	"k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var webhooksCreationTimestamp = metav1.Time{}
+
+func GetWebhooksCreationTimestamp(client client.Client) (metav1.Time, error) {
+	if webhooksCreationTimestamp.IsZero() {
+		webhook := &v1beta1.MutatingWebhookConfiguration{}
+		err := client.Get(context.TODO(), types.NamespacedName{Name: webhookCfg.MutateWebhookCfgName}, webhook)
+		if err != nil {
+			return metav1.Time{}, fmt.Errorf("failed to get webhook: %w", err)
+		}
+		webhooksCreationTimestamp = webhook.CreationTimestamp
+	}
+	return webhooksCreationTimestamp, nil
+}


### PR DESCRIPTION
### What does this PR do?
- Fail startup at start of reconcile loop if creator id isn't present, instead of during deployment provisioning
- Fail workspace startup if creationTimestamp is older than mutating webhook's creationTimestamp
- Fix a minor issue in clusterrole (watch permissions seem to be required by controller-runtime)

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/16914

Web Terminal Operator manifests are updated in https://github.com/redhat-developer/web-terminal-operator/pull/11

### Is it tested? How?
Tested on `crc`:

```bash
# set env vars as usual
make uninstall
kubectl apply -f devworkspace-crds/deploy/crds/ \
  && kubectl apply -f deploy/crds/ \
  && oc new-project ${NAMESPACE} \
  && kubectl apply -f samples/cloud-shell.yaml
kubectl patch devworkspace cloud-shell --type='merge' \
  -p '{"metadata": {"labels": {"controller.devfile.io/creator": "test"}}}'
make docker deploy
# Check that workspace start fails and message is logged
```
