### PR TITLE
Build controller image before run e2e tests in Openshift CI

### DIFF
--- a/.cico/cico_openshift_e2e.sh
+++ b/.cico/cico_openshift_e2e.sh
@@ -13,6 +13,11 @@ set -ex
 export CI="openshift"
 export ARTIFACTS_DIR="/tmp/artifacts"
 
+# Component is defined in Openshift CI job configuration. See: https://github.com/openshift/release/blob/master/ci-operator/config/devfile/devworkspace-operator/devfile-devworkspace-operator-master__v4.yaml#L8
+export CI_COMPONENT="devworkspace-operator"
+# OPENSHIFT_BUILD_NAMESPACE env var exposed by Openshift CI. More info about how images are builded in Openshift CI: https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
+export CI_CONTROLLER_IMAGE=registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:${CI_COMPONENT}
+
 # Pod created by openshift ci don't have user. Using this envs should avoid errors with git user.
 export GIT_COMMITTER_NAME="CI BOT"
 export GIT_COMMITTER_EMAIL="ci_bot@notused.com"

--- a/.cico/cico_openshift_e2e.sh
+++ b/.cico/cico_openshift_e2e.sh
@@ -41,3 +41,6 @@ go mod tidy
 go mod vendor
 
 make test_e2e
+
+# grab devworkspace-controller namespace events after running e2e
+oc get events -n devworkspace-controller | tee ${ARTIFACTS_DIR}/devworkspace-controller-events.log

--- a/.cico/cico_openshift_e2e.sh
+++ b/.cico/cico_openshift_e2e.sh
@@ -16,7 +16,7 @@ export ARTIFACTS_DIR="/tmp/artifacts"
 # Component is defined in Openshift CI job configuration. See: https://github.com/openshift/release/blob/master/ci-operator/config/devfile/devworkspace-operator/devfile-devworkspace-operator-master__v4.yaml#L8
 export CI_COMPONENT="devworkspace-operator"
 # OPENSHIFT_BUILD_NAMESPACE env var exposed by Openshift CI. More info about how images are builded in Openshift CI: https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
-export CI_CONTROLLER_IMAGE=registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:${CI_COMPONENT}
+export IMG=registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:${CI_COMPONENT}
 
 # Pod created by openshift ci don't have user. Using this envs should avoid errors with git user.
 export GIT_COMMITTER_NAME="CI BOT"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL := bash
 OPERATOR_SDK_VERSION = v0.17.0
 NAMESPACE ?= devworkspace-controller
 IMG ?= quay.io/devfile/devworkspace-controller:next
+CI_CONTROLLER_IMAGE ?= quay.io/devfile/devworkspace-controller:next
 TOOL ?= oc
 ROUTING_SUFFIX ?= 192.168.99.100.nip.io
 PULL_POLICY ?= Always
@@ -19,6 +20,7 @@ _print_vars:
 	@echo "Current env vars:"
 	@echo "    NAMESPACE=$(NAMESPACE)"
 	@echo "    IMG=$(IMG)"
+	@echo "    CI_CONTROLLER_IMAGE=$(CI_CONTROLLER_IMAGE)"
 	@echo "    PULL_POLICY=$(PULL_POLICY)"
 	@echo "    ROUTING_SUFFIX=$(ROUTING_SUFFIX)"
 	@echo "    WEBHOOK_ENABLED=$(WEBHOOK_ENABLED)"
@@ -170,6 +172,7 @@ endif
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io devworkspacetemplates.workspace.devfile.io --ignore-not-found=true
 
 _do_e2e_test:
+	sed -i.bak -e "s|image: .*|image: $(CI_CONTROLLER_IMAGE)|g" ./deploy/os/controller.yaml
 	CGO_ENABLED=0 go test -v -c -o bin/devworkspace-controller-e2e ./test/e2e/cmd/workspaces_test.go
 	./bin/devworkspace-controller-e2e
 
@@ -289,6 +292,7 @@ help: Makefile
 	@echo ''
 	@echo 'Supported environment variables:'
 	@echo '    IMG                        - Image used for controller'
+	@echo '    CI_CONTROLLER_IMAGE        - Image builded in Openshift CI and used to run e2e tests'
 	@echo '    NAMESPACE                  - Namespace to use for deploying controller'
 	@echo '    TOOL                       - CLI tool for interfacing with the cluster: kubectl or oc; if oc is used, deployment is tailored to OpenShift, otherwise Kubernetes'
 	@echo '    ROUTING_SUFFIX             - Cluster routing suffix (e.g. $$(minikube ip).nip.io, apps-crc.testing)'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ SHELL := bash
 OPERATOR_SDK_VERSION = v0.17.0
 NAMESPACE ?= devworkspace-controller
 IMG ?= quay.io/devfile/devworkspace-controller:next
-CI_CONTROLLER_IMAGE ?= quay.io/devfile/devworkspace-controller:next
 TOOL ?= oc
 ROUTING_SUFFIX ?= 192.168.99.100.nip.io
 PULL_POLICY ?= Always
@@ -172,7 +171,6 @@ endif
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io devworkspacetemplates.workspace.devfile.io --ignore-not-found=true
 
 _do_e2e_test:
-	sed -i.bak -e "s|image: .*|image: $(CI_CONTROLLER_IMAGE)|g" ./deploy/os/controller.yaml
 	CGO_ENABLED=0 go test -v -c -o bin/devworkspace-controller-e2e ./test/e2e/cmd/workspaces_test.go
 	./bin/devworkspace-controller-e2e
 
@@ -292,7 +290,6 @@ help: Makefile
 	@echo ''
 	@echo 'Supported environment variables:'
 	@echo '    IMG                        - Image used for controller'
-	@echo '    CI_CONTROLLER_IMAGE        - Image builded in Openshift CI and used to run e2e tests'
 	@echo '    NAMESPACE                  - Namespace to use for deploying controller'
 	@echo '    TOOL                       - CLI tool for interfacing with the cluster: kubectl or oc; if oc is used, deployment is tailored to OpenShift, otherwise Kubernetes'
 	@echo '    ROUTING_SUFFIX             - Cluster routing suffix (e.g. $$(minikube ip).nip.io, apps-crc.testing)'

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ _print_vars:
 	@echo "Current env vars:"
 	@echo "    NAMESPACE=$(NAMESPACE)"
 	@echo "    IMG=$(IMG)"
-	@echo "    CI_CONTROLLER_IMAGE=$(CI_CONTROLLER_IMAGE)"
 	@echo "    PULL_POLICY=$(PULL_POLICY)"
 	@echo "    ROUTING_SUFFIX=$(ROUTING_SUFFIX)"
 	@echo "    WEBHOOK_ENABLED=$(WEBHOOK_ENABLED)"

--- a/test/e2e/cmd/workspaces_test.go
+++ b/test/e2e/cmd/workspaces_test.go
@@ -80,10 +80,6 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 		_ = fmt.Errorf("Failed to uninstall workspace controller %s", err)
 	}
 
-	if err = k8sClient.Kube().CoreV1().Namespaces().Delete(config.Namespace, &metav1.DeleteOptions{}); err != nil {
-		_ = fmt.Errorf("Failed to uninstall workspace controller %s", err)
-	}
-
 	if err = k8sClient.Kube().AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(workspaceWebhook.MutateWebhookCfgName, &metav1.DeleteOptions{}); err != nil {
 		_ = fmt.Errorf("Failed to delete mutating webhook configuration %s", err)
 	}

--- a/test/e2e/pkg/tests/cloud_shell_tests.go
+++ b/test/e2e/pkg/tests/cloud_shell_tests.go
@@ -20,24 +20,25 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = ginkgo.Describe("[Create Cloud Shell Workspace]", func() {
-	ginkgo.It("Add cloud shell to cluster", func() {
-		label := "controller.devfile.io/workspace_name=cloud-shell"
+var _ = ginkgo.Describe("[Create Openshift Web Terminal Workspace]", func() {
+	ginkgo.It("Add openshift web terminal to cluster", func() {
+		label := "controller.devfile.io/workspace_name=web-terminal"
 		k8sClient, err := client.NewK8sClient()
 		if err != nil {
 			ginkgo.Fail("Failed to create k8s client: " + err.Error())
 			return
 		}
-		err = k8sClient.OcApplyWorkspace("samples/cloud-shell.yaml")
+		err = k8sClient.OcApplyWorkspace("samples/web-terminal.yaml")
 		if err != nil {
-			ginkgo.Fail("Failed to create cloud-shell devworkspace: " + err.Error())
+			ginkgo.Fail("Failed to create openshift web terminal workspace: " + err.Error())
 			return
 		}
 		deploy, err := k8sClient.WaitForPodRunningByLabel(label)
 
 		if !deploy {
-			fmt.Println("Cloud Shell not deployed")
+			fmt.Println("Openshift Web terminal workspace didn't start properly")
 		}
+
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })


### PR DESCRIPTION
Signed-off-by: flacatus <flacatus@redhat.com>

### What does this PR do?
After merging this PR https://github.com/openshift/release/pull/10255 in Openshift CI now we are able to build controller image in Openshift CI and use the image in e2e tests. 
Also I delete the implementation of remove namespace after tests finishing because if tests will fail we can check the pod logs in PROW after finish the job.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/17264

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
