### PR TITLE
Propagate failure message when devworkspaces fail to start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.12
 require github.com/eclipse/che-plugin-broker v3.1.1-0.20200207223144-b20597f15e4c+incompatible
 
 // use-devfile-2.0-in-devworkspace-controller
-require github.com/devfile/kubernetes-api v0.0.0-20200610142627-e6a761a9ecb3
+require github.com/devfile/kubernetes-api v0.0.0-20200721203247-1ae49a1fac4c
 
 // Operator Framework 0.17.x
 require (

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1
 github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC4G4As=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
-github.com/devfile/kubernetes-api v0.0.0-20200610142627-e6a761a9ecb3 h1:+kPWDE0HQ2vrXdimAHDrUebO7xz2OD07a0ggWA2Qt2A=
-github.com/devfile/kubernetes-api v0.0.0-20200610142627-e6a761a9ecb3/go.mod h1:yqOXWQYZvwWrGU+M2bbMPkYobKw67ejseWTNdaKEPGA=
+github.com/devfile/kubernetes-api v0.0.0-20200721203247-1ae49a1fac4c h1:dW6x8CA7Qzmk9BRXzqv34U9pi9u+7zd5rWxT352FgCI=
+github.com/devfile/kubernetes-api v0.0.0-20200721203247-1ae49a1fac4c/go.mod h1:yqOXWQYZvwWrGU+M2bbMPkYobKw67ejseWTNdaKEPGA=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/pkg/controller/workspace/restapis/configmap.go
+++ b/pkg/controller/workspace/restapis/configmap.go
@@ -55,7 +55,7 @@ func SyncRestAPIsConfigMap(workspace *devworkspace.DevWorkspace, components []v1
 	}
 
 	if !cmp.Equal(specCM, clusterCM, configmapDiffOpts) {
-		clusterAPI.Logger.Info("Updateing che-rest-apis configmap")
+		clusterAPI.Logger.Info("Updating che-rest-apis configmap")
 		clusterCM.Data = specCM.Data
 		err := clusterAPI.Client.Update(context.TODO(), clusterCM)
 		if err != nil && !errors.IsConflict(err) {

--- a/pkg/controller/workspace/restapis/devfilev1.go
+++ b/pkg/controller/workspace/restapis/devfilev1.go
@@ -100,8 +100,10 @@ func toDevfileEndpoints(eps []devworkspace.Endpoint) []workspaceApi.Endpoint {
 	devfileEndpoints := []workspaceApi.Endpoint{}
 	for _, e := range eps {
 		attributes := map[workspaceApi.EndpointAttribute]string{}
-		if e.Configuration != nil {
-			attributes[workspaceApi.PROTOCOL_ENDPOINT_ATTRIBUTE] = e.Configuration.Scheme
+		if e.Protocol != "" {
+			attributes[workspaceApi.PROTOCOL_ENDPOINT_ATTRIBUTE] = e.Protocol
+		} else {
+			attributes[workspaceApi.PROTOCOL_ENDPOINT_ATTRIBUTE] = "http"
 		}
 
 		devfileEndpoints = append(devfileEndpoints, workspaceApi.Endpoint{

--- a/pkg/controller/workspace/validation.go
+++ b/pkg/controller/workspace/validation.go
@@ -30,17 +30,18 @@ func (r *ReconcileWorkspace) validateCreatorTimestamp(workspace *devworkspace.De
 		return "", nil
 	}
 	if _, present := workspace.Labels[config.WorkspaceCreatorLabel]; !present {
-		return "Devworkspace was created without creator ID label. It must be recreated to resolve the issue",
+		return "DevWorkspace was created without creator ID label. It must be recreated to resolve the issue",
 			fmt.Errorf("devworkspace does not have creator label applied")
 	}
 
 	webhooksTimestamp, err := webhook.GetWebhooksCreationTimestamp(r.client)
 	if err != nil {
-		return "Could not read devworkspace webhooks on cluster. Devworkspace must be recreated.",
+		return "Could not read devworkspace webhooks on cluster. Contact an administrator " +
+				"to check logs and fix Operator installation.",
 			fmt.Errorf("failed getting webhooks creation timestamp: %w", err)
 	}
 	if workspace.CreationTimestamp.Before(&webhooksTimestamp) {
-		return "Devworkspace was created before current webhooks were installed and must be recreated to successfully start",
+		return "DevWorkspace was created before current webhooks were installed and must be recreated to successfully start",
 			fmt.Errorf("devworkspace created before webhooks")
 	}
 

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -46,9 +46,6 @@ import (
 
 var log = logf.Log.WithName("controller_workspace")
 
-// TODO temporary condition name; remove once included in devworkspace-api
-const WorkspaceFailedStart devworkspace.WorkspaceConditionType = "FailedStart"
-
 type currentStatus struct {
 	// Map of condition types that are true for the current workspace. Key is valid condition, value is optional
 	// message to be filled into condition's 'Message' field.
@@ -217,7 +214,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 	msg, err := r.validateCreatorTimestamp(workspace)
 	if err != nil {
 		reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
-		reconcileStatus.Conditions[WorkspaceFailedStart] = msg
+		reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = msg
 		return reconcile.Result{}, err
 	}
 
@@ -225,7 +222,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 	if immutable == "true" && config.ControllerCfg.GetWebhooksEnabled() != "true" {
 		reqLogger.Info("Workspace is configured as immutable but webhooks are not enabled.")
 		reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
-		reconcileStatus.Conditions[WorkspaceFailedStart] = "Workspace has restricted-access annotation " +
+		reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = "Workspace has restricted-access annotation " +
 			"applied but operator does not have webhooks enabled. " +
 			"Remove restricted-access annotation or ask an administrator " +
 			"to reconfigure Operator."
@@ -239,7 +236,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 			reqLogger.Info("DevWorkspace start failed")
 			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
 			// TODO: Propagate more information from sync step to show a more useful message -- which plugin couldn't be installed?
-			reconcileStatus.Conditions[WorkspaceFailedStart] = "Could not find plugins for devworkspace"
+			reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = "Could not find plugins for devworkspace"
 		} else {
 			reqLogger.Info("Waiting on components to be ready")
 		}
@@ -252,7 +249,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 	if restapis.IsCheRestApisRequired(workspace.Spec.Template.Components) {
 		if !restapis.IsCheRestApisConfigured() {
 			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
-			reconcileStatus.Conditions[WorkspaceFailedStart] = "Che REST API sidecar is not configured but required for the Theia plugin"
+			reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = "Che REST API sidecar is not configured but required for the Theia plugin"
 			return reconcile.Result{Requeue: false}, errors.New("Che REST API sidecar is not configured but required for used Theia plugin")
 		}
 		// TODO: first half of provisioning rest-apis
@@ -277,7 +274,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 			reqLogger.Info("DevWorkspace start failed")
 			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
 			// TODO: Propagate failure reason from workspaceRouting
-			reconcileStatus.Conditions[WorkspaceFailedStart] = "Failed to install network objects required for devworkspace"
+			reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = "Failed to install network objects required for devworkspace"
 			return reconcile.Result{}, routingStatus.Err
 		}
 		reqLogger.Info("Waiting on routing to be ready")
@@ -334,7 +331,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 		if deploymentStatus.FailStartup {
 			reqLogger.Info("Workspace start failed")
 			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
-			reconcileStatus.Conditions[WorkspaceFailedStart] = fmt.Sprintf("Devworkspace spec is invalid: %s", deploymentStatus.Err)
+			reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = fmt.Sprintf("Devworkspace spec is invalid: %s", deploymentStatus.Err)
 			return reconcile.Result{}, deploymentStatus.Err
 		}
 		reqLogger.Info("Waiting on deployment to be ready")

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -296,13 +296,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 	if restapis.IsCheRestApisRequired(workspace.Spec.Template.Components) {
 		configMapStatus := restapis.SyncRestAPIsConfigMap(workspace, componentDescriptions, routingStatus.ExposedEndpoints, clusterAPI)
 		if !configMapStatus.Continue {
-			if configMapStatus.FailStartup {
-				reqLogger.Info("Workspace start failed")
-				reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
-				// Note: Currently this is impossible; syncRestAPIsConfigMap does not return FailStartup
-				reconcileStatus.Conditions[WorkspaceFailedStart] = "Failed to install configmap required for devworkspace"
-				return reconcile.Result{}, configMapStatus.Err
-			}
+			// FailStartup is not possible for generating the configmap
 			reqLogger.Info("Waiting on che-rest-apis configmap to be ready")
 			return reconcile.Result{Requeue: configMapStatus.Requeue}, configMapStatus.Err
 		}
@@ -325,12 +319,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 	}
 	serviceAcctStatus := provision.SyncServiceAccount(workspace, saAnnotations, clusterAPI)
 	if !serviceAcctStatus.Continue {
-		if serviceAcctStatus.FailStartup {
-			reqLogger.Info("Workspace start failed")
-			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
-			reconcileStatus.Conditions[WorkspaceFailedStart] = "Failed to install service account required for devworkspace"
-			return reconcile.Result{}, serviceAcctStatus.Err
-		}
+		// FailStartup is not possible for generating the serviceaccount
 		reqLogger.Info("Waiting for workspace ServiceAccount")
 		return reconcile.Result{Requeue: serviceAcctStatus.Requeue}, serviceAcctStatus.Err
 	}

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -226,7 +226,9 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 		reqLogger.Info("Workspace is configured as immutable but webhooks are not enabled.")
 		reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
 		reconcileStatus.Conditions[WorkspaceFailedStart] = "Workspace has restricted-access annotation " +
-			"applied but operator does not have webhooks enabled"
+			"applied but operator does not have webhooks enabled. " +
+			"Remove restricted-access annotation or ask an administrator " +
+			"to reconfigure Operator."
 		return reconcile.Result{}, nil
 	}
 
@@ -234,7 +236,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 	componentsStatus := provision.SyncComponentsToCluster(workspace, clusterAPI)
 	if !componentsStatus.Continue {
 		if componentsStatus.FailStartup {
-			reqLogger.Info("Workspace start failed")
+			reqLogger.Info("DevWorkspace start failed")
 			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
 			// TODO: Propagate more information from sync step to show a more useful message -- which plugin couldn't be installed?
 			reconcileStatus.Conditions[WorkspaceFailedStart] = "Could not find plugins for devworkspace"
@@ -272,7 +274,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 	routingStatus := provision.SyncRoutingToCluster(workspace, componentDescriptions, clusterAPI)
 	if !routingStatus.Continue {
 		if routingStatus.FailStartup {
-			reqLogger.Info("Workspace start failed")
+			reqLogger.Info("DevWorkspace start failed")
 			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
 			// TODO: Propagate failure reason from workspaceRouting
 			reconcileStatus.Conditions[WorkspaceFailedStart] = "Failed to install network objects required for devworkspace"

--- a/samples/theia-nodejs.yaml
+++ b/samples/theia-nodejs.yaml
@@ -28,9 +28,7 @@ spec:
           memoryLimit: 512Mi
           endpoints:
             - name: nodejs
-              configuration:
-                  protocol: tcp
-                  scheme: http
+              protocol: http
               targetPort: 3000
           mountSources: true
     commands:


### PR DESCRIPTION
### What does this PR do?
Propagates a user-readable error into devworkspace status via a condition when a devworkspace fails to start.

This PR depends on https://github.com/devfile/kubernetes-api/pull/99 to add the condition; for now (and to ease testing) the value is hard-coded in `workspace_controller.go` and needs to be removed before merging.

There are two `TODO`s added to the repo with this PR: some refactoring is needed in order to propagate a few other failure reasons, so it currently gives a generic message when WorkspaceRouting enters a failed state or when syncing Components to the cluster fails. I may look into adding this to this PR as well. Neither of these cases should be possible for the web-terminal use case.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17326

### Is it tested? How?
Tested on `crc` using the flow from https://github.com/devfile/devworkspace-operator/pull/136#issue-449900133 to generate a failed workspace:

```
❯ kc get devworkspace cloud-shell -o yaml | yq -Y '.status'
conditions:
  - lastTransitionTime: "2020-07-18T01:02:10Z"
    message: Devworkspace was created without creator ID label. It must be recreated
      to resolve the issue
    status: "True"
    type: FailedStart
phase: Failed
workspaceId: workspace818ff97fbf7741fb
```
