### PR TITLE
Make it possible to run controller locally with enabled webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ _do_e2e_test:
 
 # it's easier to bump whole kubeconfig instead of grabbing cluster URL from the current context
 _bump_kubeconfig:
-	mkdir -p $(BUMPED_KUBECONFIG_FLD)
+	@mkdir -p $(BUMPED_KUBECONFIG_FLD)
 ifndef KUBECONFIG
 	$(eval CONFIG_FILE = ${HOME}/.kube/config)
 else
@@ -192,9 +192,9 @@ endif
 	cp $(CONFIG_FILE) $(BUMPED_KUBECONFIG)
 
 _login_with_devworkspace_sa:
-	$(eval SA_TOKEN := $(shell $(TOOL) get secrets -o=json -n $(NAMESPACE) | jq -r '[.items[] | select (.type == "kubernetes.io/service-account-token" and .metadata.annotations."kubernetes.io/service-account.name" == "devworkspace-controller")][0].data.token' | base64 --decode ))
-	@echo "Logging as devworkspace controller SA"
-	@oc login --token=$(SA_TOKEN) --kubeconfig=$(BUMPED_KUBECONFIG)
+	@$(eval SA_TOKEN := $(shell $(TOOL) get secrets -o=json -n $(NAMESPACE) | jq -r '[.items[] | select (.type == "kubernetes.io/service-account-token" and .metadata.annotations."kubernetes.io/service-account.name" == "devworkspace-controller")][0].data.token' | base64 --decode ))
+	echo "Logging as devworkspace controller SA"
+	oc login --token=$(SA_TOKEN) --kubeconfig=$(BUMPED_KUBECONFIG)
 
 ### docker: build and push docker image
 docker: _print_vars

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,6 @@ endif
 else
 	@echo "Webhooks disabled, skipping certificate generation"
 endif
-
 ### deploy: deploy controller to cluster
 deploy: _print_vars _set_ctx _create_namespace _deploy_registry _update_yamls _update_crds _apply_controller_cfg webhook _reset_yamls _reset_ctx
 
@@ -253,10 +252,22 @@ endif
 
 ### start_local: start local instance of controller using operator-sdk
 start_local:
+ifeq ($(WEBHOOK_ENABLED),true)
+	#in cluster mode it comes from Deployment env var
+	export RELATED_IMAGE_devworkspace_webhook_server=$(IMG)
+	#in cluster mode it comes from configured SA propogated via env var
+	export CONTROLLER_SERVICE_ACCOUNT_NAME=$(shell oc whoami)
+endif
 	operator-sdk run --local --watch-namespace $(NAMESPACE) 2>&1 | grep --color=always -E '"msg":"[^"]*"|$$'
 
 ### start_local_debug: start local instance of controller with debugging enabled
 start_local_debug:
+ifeq ($(WEBHOOK_ENABLED),true)
+	#in cluster mode it comes from Deployment env var
+	export RELATED_IMAGE_devworkspace_webhook_server=$(IMG)
+	#in cluster mode it comes from configured SA propogated via env var
+	export CONTROLLER_SERVICE_ACCOUNT_NAME=$(shell oc whoami)
+endif
 	operator-sdk run --local --watch-namespace $(NAMESPACE) --enable-delve 2>&1 | grep --color=always -E '"msg":"[^"]*"|$$'
 
 .PHONY: test

--- a/pkg/webhook/create.go
+++ b/pkg/webhook/create.go
@@ -14,7 +14,9 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/devfile/devworkspace-operator/pkg/config"
 
@@ -34,7 +36,12 @@ func SetupWebhooks(ctx context.Context, cfg *rest.Config) error {
 
 	namespace, err := k8sutil.GetOperatorNamespace()
 	if err != nil {
-		return err
+		if errors.Is(err, k8sutil.ErrRunLocal) {
+			// local mode. Just read watch namespace env var set by operator sdk
+			namespace = os.Getenv("WATCH_NAMESPACE")
+		} else {
+			return err
+		}
 	}
 
 	client, err := crclient.New(cfg, crclient.Options{})


### PR DESCRIPTION
### What does this PR do?
Making webhooks server dedicated deployment unblocks us in running controller locally with enabled webhooks.
Just a few minor changes and we're able to debug controller when webhooks are enabled.
Unfortunately, I did not manage to separate common logic in internal make rule, seems parent rule can propagate env vars value but not vice verse. If someone knows how to fix it - let me know.

### What issues does this PR fix or reference?
N/A
Just tried to debug controller with enabled webhooks to test one PR and came up with those changes.

### Is it tested? How?
```
make local

export RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0="quay.io/wto/web-terminal-exec:1.0"
export RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly="quay.io/eclipse/che-machine-exec:nightly"
export RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0="quay.io/wto/web-terminal-exec:1.0"
export RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly="quay.io/eclipse/che-machine-exec:nightly"
export RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly="quay.io/eclipse/che-machine-exec:nightly"
export RELATED_IMAGE_web_terminal_tooling="quay.io/wto/web-terminal-tooling:latest"
export RELATED_IMAGE_openshift_oauth_proxy="openshift/oauth-proxy:latest"
export RELATED_IMAGE_devworkspace_webhook_server="quay.io/devfile/devworkspace-controller:next"
# ^ it's an issue but not critical... I'm not sure we should move it to makefile

make local_start
# or
# make local_start_debug
# and make sure that it's run without errors
```