### PR TITLE
Update README to remove references to Che

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ make local
 operator-sdk up local --namespace ${NAMESPACE}
 ```
 
-When running locally, only a single namespace is wat
-d; as a result, all workspaces have to be deployed to `${NAMESPACE}`
+When running locally, only a single namespace is watched; as a result, all workspaces have to be deployed to `${NAMESPACE}`
 
 ### Run controller locally and debug
 Debugging the controller depends on `delve` being installed (`go get -u github.com/go-delve/delve/cmd/dlv`). Note that at the time of writing, executing `go get` in this repo's directory will update go.mod; these changes should be dropped before committing.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Che Workspace Operator
+# Dev Workspace Operator
 
-Che workspace operator repository that contains K8s API for Che workspace and controller for them.
+Dev Workspace operator repository that contains the controller for the DevWorkspace Custom Resource. The Kubernetes API of the DevWorkspace is defined in the https://github.com/devfile/kubernetes-api repository.
 
 ## Running the controller in a cluster
 
@@ -79,7 +79,8 @@ make local
 operator-sdk up local --namespace ${NAMESPACE}
 ```
 
-When running locally, only a single namespace is watched; as a result, all workspaces have to be deployed to `${NAMESPACE}`
+When running locally, only a single namespace is wat
+d; as a result, all workspaces have to be deployed to `${NAMESPACE}`
 
 ### Run controller locally and debug
 Debugging the controller depends on `delve` being installed (`go get -u github.com/go-delve/delve/cmd/dlv`). Note that at the time of writing, executing `go get` in this repo's directory will update go.mod; these changes should be dropped before committing.


### PR DESCRIPTION
### What does this PR do?

Update the README now that the operator is supposed to be a dependency not only of Che but of the Web Terminal too.
