### PR TITLE
Remove Che references from code

### DIFF
--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -28,7 +28,7 @@ spec:
     ports:
     - exposedPort: 4444
     command: ["/go/bin/che-machine-exec",
-              "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-              "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+              "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+              "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
               "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
               "--static", "/cloud-shell"]

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -8,7 +8,7 @@ title: Web Terminal
 description: Web provides the ability to start a terminal inside
   the OpenShift Console. The development version does not run with TLS enabled and
   is intended for development purposes only.
-icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+icon: null
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2020-06-01"
 category: Other

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -27,8 +27,8 @@ spec:
     - name: web-terminal
       image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0}"
       command: ["/go/bin/che-machine-exec",
-                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+                "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+                "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
                 "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
       ports:
         - exposedPort: 4444

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -27,8 +27,8 @@ spec:
     - name: web-terminal
       image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly}"
       command: ["/go/bin/che-machine-exec",
-                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+                "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+                "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
                 "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
       ports:
         - exposedPort: 4444

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -8,7 +8,7 @@ title: Web Terminal
 description: Web provides the ability to start a terminal inside
   the OpenShift Console. The development version does not run with TLS enabled and
   is intended for development purposes only.
-icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+icon: null
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2020-06-01"
 category: Other

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -25,8 +25,8 @@ spec:
    - name: web-terminal
      image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0}"
      command: ["/go/bin/che-machine-exec",
-               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+               "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+               "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
                "--use-tls"]
      ports:

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -6,7 +6,7 @@ type: Che Editor
 displayName: Web Terminal
 title: Web Terminal
 description: Web Terminal provides the ability to start a terminal inside the OpenShift Console.
-icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+icon: null
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2020-05-13"
 category: Other

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -6,7 +6,7 @@ type: Che Editor
 displayName: Web Terminal
 title: Web Terminal
 description: Web Terminal provides the ability to start a terminal inside the OpenShift Console.
-icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+icon: null
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2020-05-13"
 category: Other

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -25,8 +25,8 @@ spec:
   - name: web-terminal
     image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly}"
     command: ["/go/bin/che-machine-exec",
-              "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-              "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+              "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+              "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
               "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
               "--use-tls"]
     ports:

--- a/pkg/config/cmd_terminal.go
+++ b/pkg/config/cmd_terminal.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// property name for value with yaml for default dockerimage component
-	// that should be provisioned if devfile DOES have redhat-developer/web-terminal cheEditor
+	// that should be provisioned if devfile DOES have redhat-developer/web-terminal plugin
 	// and DOES NOT have any dockerimage component
 	defaultTerminalDockerimageProperty = "devworkspace.default_dockerimage.redhat-developer.web-terminal"
 )

--- a/pkg/controller/workspace/env/common_env_vars.go
+++ b/pkg/controller/workspace/env/common_env_vars.go
@@ -59,11 +59,11 @@ func CommonEnvironmentVariables(workspaceName, workspaceId, namespace, creator s
 			Value: config.ControllerCfg.GetWebhooksEnabled(),
 		},
 		{
-			Name:  "CHE_WORKSPACE_CREATOR",
+			Name:  "DEVWORKSPACE_CREATOR",
 			Value: creator,
 		},
 		{
-			Name:  "CHE_WORKSPACE_IDLE_TIMEOUT",
+			Name:  "DEVWORKSPACE_IDLE_TIMEOUT",
 			Value: config.ControllerCfg.GetWorkspaceIdleTimeout(),
 		},
 	}

--- a/test/e2e/pkg/deploy/controller.go
+++ b/test/e2e/pkg/deploy/controller.go
@@ -45,7 +45,7 @@ func (w *Deployment) DeployWorkspacesController() error {
 	deploy, err := w.kubeClient.WaitForPodRunningByLabel(label)
 	fmt.Println("Waiting controller pod to be ready")
 	if !deploy || err != nil {
-		fmt.Println("Che Workspaces Controller not deployed")
+		fmt.Println("DevWorkspace Controller not deployed")
 		return err
 	}
 
@@ -60,7 +60,7 @@ func (w *Deployment) DeployWorkspacesController() error {
 }
 
 func (w *Deployment) CreateAdditionalControllerResources() error {
-	//sed "s/\${NAMESPACE}/che/g" <<< cat *.yaml | oc apply -f -
+	//sed "s/\${NAMESPACE}/config.Namespace/g" <<< cat *.yaml | oc apply -f -
 	cmd := exec.Command(
 		"bash", "-c",
 		"sed 's/\\${NAMESPACE}/"+config.Namespace+"/g' <<< "+


### PR DESCRIPTION
### What does this PR do?
One does not simply get rid of Che references =) It's why this PR appeared.
It contains three commits with self-describing messages.
The only thing that makes sense to mention, we still have che references in:
- che REST API sidecar;
- che plugin broker;
- che plugin registry;
- Che Related env vars, like CHE_WORKSPACE_ID, CHE_WORKSPACE_NAMESPACE, ... I assume they are used by Theia and it's better to migrate them later.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17179

### Is it tested? How?
I've tested that CloudShell workspace with OpenShift OAuth still work.