### PR TITLE
Add WebTerminal Custom tooling sample

### DIFF
--- a/samples/web-terminal-custom-tooling.yaml
+++ b/samples/web-terminal-custom-tooling.yaml
@@ -1,0 +1,27 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha1
+metadata:
+  name: web-terminal
+  annotations:
+    # it's important to make workspace immutable to make sure nobody with right access
+    # won't set custom editor to steal creator's token
+    controller.devfile.io/restricted-access: "true"
+  labels:
+    # it's a label OpenShift console uses a flag to mark terminal's workspaces
+    console.openshift.io/terminal: "true"
+spec:
+  started: true
+  routingClass: 'web-terminal'
+  template:
+    components:
+      - plugin:
+          name: web-terminal
+          id: redhat-developer/web-terminal/4.5.0
+      - container:
+          memoryLimit: "256Mi"
+          name: tooling
+          image: quay.io/wto/web-terminal-tooling:latest
+          args: ["tail", "-f", "/dev/null"]
+          env:
+            - name: PS1
+              value: \[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]


### PR DESCRIPTION
### What does this PR do?
This PR adds WebTerminal Custom tooling sample. 
It could be convenient to use if custom tooling image needs to be tested.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
```bash
make deploy
kubectl apply -f ./samples/web-terminal-custom-tooling.yaml 
# make sure workspace is starting forever because of 
# workspace5858ea2c2fb446a7-7f6fd89466-45x5g    1/2     CrashLoopBackOff   2          46s
# ^ expected until fix for tooling container is not merged.
# but now you're able to customize tooling with your own
```
