### PR TITLE
Fix makefile update_devworkspace_crds rule 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
 SHELL := bash
 .SHELLFLAGS = -ec
 .ONESHELL:
@@ -251,27 +261,7 @@ update_devworkspace_api:
 
 ### update_devworkspace_crds: pull latest devworkspace CRDs to ./devworkspace-crds. Note: pulls master branch
 update_devworkspace_crds:
-	@mkdir -p devworkspace-crds
-	cd devworkspace-crds
-	if [ ! -d ./.git ]; then
-		git init
-		git remote add origin -f https://github.com/devfile/api.git
-		git config core.sparsecheckout true
-		echo "deploy/crds/*" > .git/info/sparse-checkout
-	else
-		git remote set-url origin https://github.com/devfile/api.git
-	fi
-	git fetch --tags -p origin
-	if git show-ref --verify refs/tags/$(DEVWORKSPACE_API_VERSION) --quiet; then
-		echo 'DevWorkspace API is specified from tag'
-		git checkout tags/$(DEVWORKSPACE_API_VERSION)
-	elif git rev-parse --verify $(DEVWORKSPACE_API_VERSION); then
-		echo 'DevWorkspace API is specified from branch'
-		git checkout $(DEVWORKSPACE_API_VERSION) && git reset --hard origin/$(DEVWORKSPACE_API_VERSION)
-	else
-		echo 'DevWorkspace API is specified from revision'
-		git checkout $(DEVWORKSPACE_API_VERSION)
-	fi
+	./update_devworkspace_crds.sh $(DEVWORKSPACE_API_VERSION)
 
 
 ### local: set up cluster for local development

--- a/update_devworkspace_crds.sh
+++ b/update_devworkspace_crds.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+set -e
+
+DEVWORKSPACE_API_VERSION=${1:-v1alpha1}
+
+mkdir -p devworkspace-crds
+cd devworkspace-crds
+if [ ! -d ./.git ]; then
+	git init
+	git remote add origin -f https://github.com/devfile/api.git
+	git config core.sparsecheckout true
+	echo "deploy/crds/*" > .git/info/sparse-checkout
+else
+	git remote set-url origin https://github.com/devfile/api.git
+fi
+git fetch --tags -p origin
+if git show-ref --verify refs/tags/"${DEVWORKSPACE_API_VERSION}" --quiet; then
+	echo 'DevWorkspace API is specified from tag'
+	git checkout tags/"${DEVWORKSPACE_API_VERSION}"
+elif git rev-parse --verify "${DEVWORKSPACE_API_VERSION}"; then
+	echo 'DevWorkspace API is specified from branch'
+	git checkout "${DEVWORKSPACE_API_VERSION}" && git reset --hard origin/"${DEVWORKSPACE_API_VERSION}"
+else
+	echo 'DevWorkspace API is specified from revision'
+	git checkout "${DEVWORKSPACE_API_VERSION}"
+fi
+


### PR DESCRIPTION
### What does this PR do?

I have followed the instructions in the README and the command `make deploy` failed (see error below).

I have looked at the error and it was due to the fact that the rule `update_devworkspace_crds` had some multi line bash commands that do not work in a makefile.

### What issues does this PR fix or reference?

The command `make deploy` is currently not working for me (macOS, go1.14.4, GNU Make 3.81).

```bash
$ make deploy
Current env vars:
    NAMESPACE=devworkspace-controller
    IMG=quay.io/devfile/devworkspace-controller:next
    PULL_POLICY=Always
    ROUTING_SUFFIX=192.168.99.100.nip.io
    WEBHOOK_ENABLED=true
    DEFAULT_ROUTING=basic
    REGISTRY_ENABLED=true
    DEVWORKSPACE_API_VERSION=v1alpha1
oc create namespace devworkspace-controller || true
(...)
rm ./deploy/os/controller.yaml.bak
cd devworkspace-crds
if [ ! -d ./.git ]; then
bash: -c: line 1: syntax error: unexpected end of file
make: *** [update_devworkspace_crds] Error 1
```

### Is it tested? How?

On both linux and macOS the command `make deploy` completes successfully.

```bash
$ make deploy
(...)
rm ./deploy/os/controller.yaml.bak
$ echo $?
0
...