### PR TITLE
fix(yaml): avoid validation error

### DIFF
--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: devworkspace-controller
-labels:
-  app.kubernetes.io/name: devworkspace-controller
-  app.kubernetes.io/part-of: devworkspace-operator
+  labels:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator


### PR DESCRIPTION
### What does this PR do?
I get error:
error: error validating "deploy/service_account.yaml": error validating data: ValidationError(ServiceAccount): unknown field "labels" in io.k8s.api.core.v1.ServiceAccount; if you choose to ignore these errors, turn validation off with --validate=false

labels are in metadata, not in root element
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#serviceaccount-v1-core

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
launching `make deploy`