### PR TITLE
feat(tls): Allow to skip insecure TLS config

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -14,12 +14,15 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"runtime"
 
+	operatorConfig "github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/webhook"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -128,6 +131,11 @@ func main() {
 	if err := controller.AddToManager(mgr); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
+	}
+
+	if operatorConfig.ControllerCfg.GetTlsInsecureSkipVerify() == "true" {
+		log.Info("Warning: TLS InsecureSkipVerify is enabled")
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
 	// Setup certs for webhook and create seperate webhook server deployment

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,6 +106,10 @@ func (wc *ControllerConfig) GetWebhooksEnabled() string {
 	return wc.GetPropertyOrDefault(webhooksEnabled, defaultWebhooksEnabled)
 }
 
+func (wc *ControllerConfig) GetTlsInsecureSkipVerify() string {
+	return wc.GetPropertyOrDefault(tlsInsecureSkipVerify, defaultTlsInsecureSkipVerify)
+}
+
 func (wc *ControllerConfig) GetProperty(name string) *string {
 	val, exists := wc.configMap.Data[name]
 	if exists {

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -49,4 +49,9 @@ const (
 
 	workspaceIdleTimeout        = "devworkspace.idle_timeout"
 	defaultWorkspaceIdleTimeout = "15m"
+
+	// Skip Verify for TLS connections
+	// It's insecure and should be used only for testing
+	tlsInsecureSkipVerify        = "tls.insecure_skip_verify"
+	defaultTlsInsecureSkipVerify = "false"
 )


### PR DESCRIPTION
### What does this PR do?
Add a flag named `tls.skip_verify_insecure` to skip TLS verification
default is false

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17898

it could avoid errors such as `x509: certificate signed by unknown authority`:
```
{"level":"error","ts":1600356104.0124047,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"component-controller","request":"florent/components-workspacea88cc17cf4ca4a53-plugins","error":"failed to fetch plugin meta.yaml from URL 'https://plugin-registry-che.192.168.64.19.nip.io/plugins/eclipse/che-machine-exec-plugin/latest/meta.yaml': failed to get data from https://plugin-registry-che.192.168.64.19.nip.io/plugins/eclipse/che-machine-exec-plugin/latest/meta.yaml: Get https://plugin-registry-che.192.168.64.19.nip.io/plugins/eclipse/che-machine-exec-plugin/latest/meta.yaml: x509: certificate signed by unknown authority","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:258\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.17.4/pkg/util/wait/wait.go:88"}
```

### Is it tested? How?

Using che registry fails without the configuration


It's a WIP so we can discuss it :-)