### PR TITLE
feat(ubi8): Upgrade ubi8 version to a grade A image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
   -asmflags all=-trimpath=/ \
   webhook/main.go
 
-FROM registry.access.redhat.com/ubi8-minimal:8.1-279
+FROM registry.access.redhat.com/ubi8-minimal:8.2-349
 COPY --from=builder /devworkspace-operator/_output/bin/devworkspace-controller /usr/local/bin/devworkspace-controller
 COPY --from=builder /devworkspace-operator/_output/bin/webhook-server /usr/local/bin/webhook-server
 COPY --from=builder /devworkspace-operator/internal-registry  internal-registry

--- a/build/rhel.Dockerfile
+++ b/build/rhel.Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
   cmd/manager/main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.2-339
+FROM registry.access.redhat.com/ubi8-minimal:8.2-349
 COPY --from=builder /devworkspace-operator/_output/bin/devworkspace-controller /usr/local/bin/devworkspace-controller
 COPY --from=builder /devworkspace-operator/internal-registry  internal-registry
 


### PR DESCRIPTION
### What does this PR do?
very old image is used
wonder why alpine based image is then using ubi8 and not scratch or alpine ?


### What issues does this PR fix or reference?
https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?tag=8.1-279

### Is it tested? How?
Launch make deploy