### PR TITLE
Fix 'make start_local' rule and schema of theia sample

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,8 +279,8 @@ endif
 
 ### start_local: start local instance of controller using operator-sdk
 start_local: _bump_kubeconfig _generate_related_images_env _login_with_devworkspace_sa
-ifeq ($(WEBHOOK_ENABLED),true)
 	@source $(RELATED_IMAGES_FILE)
+ifeq ($(WEBHOOK_ENABLED),true)
 	#in cluster mode it comes from Deployment env var
 	export RELATED_IMAGE_devworkspace_webhook_server=$(IMG)
 	#in cluster mode it comes from configured SA propogated via env var

--- a/samples/theia-nodejs.yaml
+++ b/samples/theia-nodejs.yaml
@@ -7,9 +7,10 @@ spec:
   routingClass: 'openshift-oauth'
   template:
     projects:
-      - name: project   
+      - name: project
         git:
-          location: "https://github.com/che-samples/web-nodejs-sample.git"
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
     components:
       - plugin:
           id: eclipse/che-theia/latest
@@ -52,7 +53,7 @@ spec:
           component: nodejs
           commandLine: >-
               node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
-              echo "Stopping node server with PIDs: ${node_server_pids}" && 
+              echo "Stopping node server with PIDs: ${node_server_pids}" &&
               kill -15 ${node_server_pids} &>/dev/null && echo 'Done.'
       - vscodeLaunch:
           id: Attach remote debugger


### PR DESCRIPTION
### What does this PR do?
* Fix Makefile start_local rule to properly set environment variables when webhooks are disabled
* Fix structure of theia-nodejs to pick up changes in v1alpha1 API (git project source uses remotes instead of location to specify URL to repo)

### Is it tested? How?
Tested on `crc`
