### PR TITLE
feat(minikube) : better support out of the box with minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ INTERNAL_TMP_DIR=/tmp/devworkspace-controller
 BUMPED_KUBECONFIG=$(INTERNAL_TMP_DIR)/kubeconfig
 RELATED_IMAGES_FILE=$(INTERNAL_TMP_DIR)/environment
 
+# minikube handling
+ifeq ($(shell $(TOOL) config current-context),minikube)
+	ROUTING_SUFFIX := $(shell minikube ip).nip.io
+	TOOL := kubectl
+endif
+
 all: help
 
 _print_vars:

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ _print_vars:
 	@echo "    DEFAULT_ROUTING=$(DEFAULT_ROUTING)"
 	@echo "    REGISTRY_ENABLED=$(REGISTRY_ENABLED)"
 	@echo "    DEVWORKSPACE_API_VERSION=$(DEVWORKSPACE_API_VERSION)"
+	@echo "    TOOL=$(TOOL)"
 
 _set_ctx:
 ifneq ($(ADMIN_CTX),"")
@@ -238,6 +239,10 @@ endif
 else
 	@echo "Webhooks disabled, skipping certificate generation"
 endif
+
+### info: display info
+info: _print_vars
+
 ### deploy: deploy controller to cluster
 deploy: _print_vars _set_ctx _create_namespace _deploy_registry _update_yamls _update_crds _apply_controller_cfg webhook _reset_yamls _reset_ctx
 


### PR DESCRIPTION
### What does this PR do?
When minikube is used as current kube context, grab the minikube ip for ingress domain and set tool to `kubectl` automatically

Also add `make info` to display these variables.

### What issues does this PR fix or reference?
N/A
When using minikube, the default IP is not correct.

### Is it tested? How?
make deploy with minikube
