### PR TITLE
Check license headers in GitHub PR actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,6 +53,12 @@ jobs:
           exit 1
         fi
     -
+      name: Check license headers
+      run: |
+        pushd $(mktemp -d); go get -u github.com/google/addlicense; popd
+        addlicense --check -v -f license_header.txt $(find . -name '*.go' -not -path '*/vendor/*') \
+          || { echo 'Go sources are missing license headers'. Use addlicense to ensure license headers are included; exit 1; }
+    -
       name: Run Go Tests
       run: make test
 


### PR DESCRIPTION
### What does this PR do?
Adds a step in the PR check github action to check that all files have license headers.

### Is it tested? How?
Tested locally, :crossed_fingers: I got the action right.
