### PR TITLE
Fix go modules when not using proxy.golang.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ ifeq ($(TOOL),oc)
 	rm ./deploy/os/controller.yaml.bak
 else
 	sed -i.bak -e "s|image: .*|image: $(IMG)|g" ./deploy/k8s/controller.yaml
-	sed -i.bak -e "s|value: \"quay.io/devfile/devworkspace-controller:next\"|value: $(IMG)|g" ./deploy/os/controller.yaml
+	sed -i.bak -e "s|value: \"quay.io/devfile/devworkspace-controller:next\"|value: $(IMG)|g" ./deploy/k8s/controller.yaml
 	sed -i.bak -e "s|imagePullPolicy: Always|imagePullPolicy: $(PULL_POLICY)|g" ./deploy/k8s/controller.yaml
 	sed -i.bak -e "s|kubectl.kubernetes.io/restartedAt: .*|kubectl.kubernetes.io/restartedAt: '$$(date +%Y-%m-%dT%H:%M:%S%z)'|g" ./deploy/k8s/controller.yaml
 	rm ./deploy/k8s/controller.yaml.bak

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/devworkspace-operator
 go 1.12
 
 // Che Plugin Broker v3.1.1
-require github.com/eclipse/che-plugin-broker v3.1.1-0.20200207223144-b20597f15e4c+incompatible
+require github.com/eclipse/che-plugin-broker v3.4.0+incompatible
 
 // Devfile 2.0 APIs
 require github.com/devfile/api v0.0.0-20200826083800-9e2280a95680
@@ -14,7 +14,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.1.1
-	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
+	github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87
 	gopkg.in/yaml.v2 v2.2.8
 )
 

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eclipse/che-go-jsonrpc v0.0.0-20181205102516-87cdb8da2597 h1:OWSaGPBUlwGHxQS8Dsib2GX20FS77VD4iCoA4djdA08=
 github.com/eclipse/che-go-jsonrpc v0.0.0-20181205102516-87cdb8da2597/go.mod h1:6xlEQ1tM4Ago8A2jPjTrHy60Oy7Kv28DcefZPZMlwWE=
-github.com/eclipse/che-plugin-broker v3.1.1-0.20200207223144-b20597f15e4c+incompatible h1:NqK3U/AwW4+ohmM/sF0s0Nfkt1CvEKGeQ/qRRTF2XOI=
-github.com/eclipse/che-plugin-broker v3.1.1-0.20200207223144-b20597f15e4c+incompatible/go.mod h1:V5mZYiAFCw8aQ3VCCs6a4FwO7qeVOLixY2baT6bMJI8=
+github.com/eclipse/che-plugin-broker v3.4.0+incompatible h1:5jV67XReIZqkTTMzaEMblgIta5AJST4xmU5lXAvHEh4=
+github.com/eclipse/che-plugin-broker v3.4.0+incompatible/go.mod h1:V5mZYiAFCw8aQ3VCCs6a4FwO7qeVOLixY2baT6bMJI8=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/go-sysinfo v1.0.1/go.mod h1:O/D5m1VpYLwGjCYzEt63g3Z1uO3jXfwyzzjiW90t8cY=
@@ -656,9 +656,8 @@ github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5X
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
+github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87 h1:L/fZlWB7DdYCd09r9LvBa44xRH42Dx80ybxfN1h5C8Y=
 github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
-github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible h1:q2JBuObKafI7B4Eli6eLd+2T5JsU9ioWZ82zQwyjJPg=
-github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
@@ -1304,6 +1303,7 @@ sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
+sigs.k8s.io/structured-merge-diff v1.0.2 h1:WiMoyniAVAYm03w+ImfF9IE2G23GLR/SwDnQyaNZvPk=
 sigs.k8s.io/structured-merge-diff v1.0.2/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=


### PR DESCRIPTION
### What does this PR do?
Updates dependencies to resolve a few issues:
- Update `che-plugin-broker` to version `v3.4.0`, since the previous commit we relied on is not in any branch in the repo.
- Don't refer to openshift/api version via tag, as tags were removed from that repo at some point (https://github.com/openshift/api/issues/456). Updated dependency uses the same commit.

This PR also includes to minor fixups I needed to implement to get things working on k8s:
- Fix issue where makefile was updating the openshift version of `controller.yaml` when using `kubectl`
- Fix issue where it was possible to attempt to start a workspace with `openshift-oauth` routing on kubernetes. Doing so caused workspaceRoutings to never have their finalizer removed and the controller to loop on an error.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/166

### Is it tested? How?
Tested on `minikube`
