### PR TITLE
Make basic routing working again

### DIFF
--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -15,3 +15,5 @@ data:
   # image pull policy that is applied to all workspace's containers
   devworkspace.sidecar.image_pull_policy: Always
   devworkspace.api_sidecar.image: quay.io/che-incubator/che-api-sidecar:next
+  # Do not enable it in production!!!
+  devworkspace.experimental_features_enabled: "true"

--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -14,3 +14,4 @@ data:
   devworkspace.default_routing_class: "basic"
   # image pull policy that is applied to all workspace's containers
   devworkspace.sidecar.image_pull_policy: Always
+  devworkspace.api_sidecar.image: quay.io/che-incubator/che-api-sidecar:next

--- a/deploy/registry/local/deployment.yaml
+++ b/deploy/registry/local/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         app.kubernetes.io/part-of: devworkspace-operator
     spec:
       containers:
-      - image: quay.io/eclipse/che-plugin-registry:7.8.0
+      - image: quay.io/eclipse/che-plugin-registry:nightly
         imagePullPolicy: Always
         name: che-plugin-registry
         ports:

--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -17,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/devfile/devworkspace-operator/pkg/adaptor/plugin_patch"
+
 	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/apis/controller/v1alpha1"
 
@@ -47,24 +49,8 @@ func AdaptPluginComponents(workspaceId, namespace string, devfileComponents []de
 	}
 
 	for _, plugin := range plugins {
-		if plugin.Name == "che-machine-exec-plugin" {
-			for _, value := range plugin.Containers {
-				for i, command := range value.Command {
-					if strings.Contains(command, "127.0.0.1:4444") {
-						value.Command[i] = "0.0.0.0:4444"
-					}
-				}
-			}
-		}
-
-		if plugin.Name == "che-theia" {
-			for _, container := range plugin.Containers {
-				for i, env := range container.Env {
-					if env.Name == "THEIA_HOST" {
-						container.Env[i].Value = "0.0.0.0"
-					}
-				}
-			}
+		if config.ControllerCfg.GetExperimentalFeaturesEnabled() {
+			plugin_patch.PublicAccessPatch(&plugin)
 		}
 
 		component, err := adaptChePluginToComponent(workspaceId, plugin)

--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -52,6 +52,7 @@ func AdaptPluginComponents(workspaceId, namespace string, devfileComponents []de
 		if config.ControllerCfg.GetExperimentalFeaturesEnabled() {
 			plugin_patch.PublicAccessPatch(&plugin)
 			plugin_patch.PatchMachineSelector(&plugin, workspaceId)
+			plugin_patch.AddMachineNameEnv(&plugin)
 		}
 
 		component, err := adaptChePluginToComponent(workspaceId, plugin)

--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -51,6 +51,7 @@ func AdaptPluginComponents(workspaceId, namespace string, devfileComponents []de
 	for _, plugin := range plugins {
 		if config.ControllerCfg.GetExperimentalFeaturesEnabled() {
 			plugin_patch.PublicAccessPatch(&plugin)
+			plugin_patch.PatchMachineSelector(&plugin, workspaceId)
 		}
 
 		component, err := adaptChePluginToComponent(workspaceId, plugin)

--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -47,6 +47,26 @@ func AdaptPluginComponents(workspaceId, namespace string, devfileComponents []de
 	}
 
 	for _, plugin := range plugins {
+		if plugin.Name == "che-machine-exec-plugin" {
+			for _, value := range plugin.Containers {
+				for i, command := range value.Command {
+					if strings.Contains(command, "127.0.0.1:4444") {
+						value.Command[i] = "0.0.0.0:4444"
+					}
+				}
+			}
+		}
+
+		if plugin.Name == "che-theia" {
+			for _, container := range plugin.Containers {
+				for i, env := range container.Env {
+					if env.Name == "THEIA_HOST" {
+						container.Env[i].Value = "0.0.0.0"
+					}
+				}
+			}
+		}
+
 		component, err := adaptChePluginToComponent(workspaceId, plugin)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/adaptor/plugin_patch/machine_exec_selector.go
+++ b/pkg/adaptor/plugin_patch/machine_exec_selector.go
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package plugin_patch
+
+import (
+	"fmt"
+
+	"github.com/eclipse/che-plugin-broker/model"
+)
+
+const (
+	podSelectorCmdLineArg = "--pod-selector"
+	podSelectorFmt        = "controller.devfile.io/workspace_id=%s"
+)
+
+// PatchMachineSelector overrides the pod selector used to find the workspace pod on the cluster, in order to
+// allow opening a terminal into the pod. This is required to enable compatability with existing plugin registries,
+// where the default value results in che-machine-exec attempting to use the `che.workspace_id` label.
+//
+// Function is a no-op if plugin is not named "che-machine-exec-plugin"
+func PatchMachineSelector(plugin *model.ChePlugin, workspaceId string) {
+	if plugin.Name != "che-machine-exec-plugin" {
+		return
+	}
+	for i, container := range plugin.Containers {
+		plugin.Containers[i].Command = append(container.Command, podSelectorCmdLineArg, fmt.Sprintf(podSelectorFmt, workspaceId))
+	}
+}

--- a/pkg/adaptor/plugin_patch/machine_name_env.go
+++ b/pkg/adaptor/plugin_patch/machine_name_env.go
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package plugin_patch
+
+import (
+	"github.com/eclipse/che-plugin-broker/model"
+)
+
+// AddMachineNameEnv Adds the environment variable CHE_MACHINE_NAME to a plugin, in order
+// to allow che-machine-exec to find the container within the workspace pod.
+//
+// Note this matching is fragile, as it is unclear how to handle aliases on components correctly.
+func AddMachineNameEnv(plugin *model.ChePlugin) {
+	for i, container := range plugin.Containers {
+		plugin.Containers[i].Env = append(container.Env, model.EnvVar{
+			Name:  "CHE_MACHINE_NAME",
+			Value: container.Name,
+		})
+	}
+}

--- a/pkg/adaptor/plugin_patch/public_access.go
+++ b/pkg/adaptor/plugin_patch/public_access.go
@@ -18,10 +18,10 @@ import (
 	"github.com/eclipse/che-plugin-broker/model"
 )
 
-//PublicAccessPatch patches plugin's configuration to make endpoints publicly available
-//Plugins are configured to listen to only localhost only since they don't provide any authentication
+// PublicAccessPatch patches plugin's configuration to make endpoints publicly available
+// Plugins are configured to listen to only localhost only since they don't provide any authentication
 // and their endpoint is supposed to be accessed though some proxy that provides authentication/authorization.
-//Since authentication is not solved for devworkspace endpoints, it's the workaround to make endpoints available somehow for testing
+// Since authentication is not solved for devworkspace endpoints, it's the workaround to make endpoints available somehow for testing
 func PublicAccessPatch(plugin *model.ChePlugin) {
 	if plugin.Name == "che-machine-exec-plugin" {
 		for _, value := range plugin.Containers {

--- a/pkg/adaptor/plugin_patch/public_access.go
+++ b/pkg/adaptor/plugin_patch/public_access.go
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package plugin_patch
+
+import (
+	"strings"
+
+	"github.com/eclipse/che-plugin-broker/model"
+)
+
+//PublicAccessPatch patches plugin's configuration to make endpoints publicly available
+//Plugins are configured to listen to only localhost only since they don't provide any authentication
+// and their endpoint is supposed to be accessed though some proxy that provides authentication/authorization.
+//Since authentication is not solved for devworkspace endpoints, it's the workaround to make endpoints available somehow for testing
+func PublicAccessPatch(plugin *model.ChePlugin) {
+	if plugin.Name == "che-machine-exec-plugin" {
+		for _, value := range plugin.Containers {
+			for i, command := range value.Command {
+				if strings.Contains(command, "127.0.0.1:4444") {
+					value.Command[i] = "0.0.0.0:4444"
+				}
+			}
+		}
+	}
+
+	if plugin.Name == "che-theia" {
+		for _, container := range plugin.Containers {
+			for i, env := range container.Env {
+				if env.Name == "THEIA_HOST" {
+					container.Env[i].Value = "0.0.0.0"
+				}
+			}
+		}
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,13 @@ func (wc *ControllerConfig) GetPluginRegistry() string {
 	return wc.GetPropertyOrDefault(pluginRegistryURL, "")
 }
 
+//GetExperimentalFeaturesEnabled returns true if experimental features should be enabled.
+//DO NOT TURN ON IT IN THE PRODUCTION.
+//Experimental features are not well tested and may be totally removed without announcement.
+func (wc *ControllerConfig) GetExperimentalFeaturesEnabled() bool {
+	return wc.GetPropertyOrDefault(experimentalFeaturesEnabled, defaultExperimentalFeaturesEnabled) == "true"
+}
+
 func (wc *ControllerConfig) GetRoutingSuffix() string {
 	return wc.GetPropertyOrDefault(routingSuffix, defaultRoutingSuffix)
 }

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -47,6 +47,9 @@ const (
 	routingSuffix        = "devworkspace.routing.cluster_host_suffix"
 	defaultRoutingSuffix = ""
 
+	experimentalFeaturesEnabled        = "devworkspace.experimental_features_enabled"
+	defaultExperimentalFeaturesEnabled = "false"
+
 	workspaceIdleTimeout        = "devworkspace.idle_timeout"
 	defaultWorkspaceIdleTimeout = "15m"
 

--- a/pkg/controller/workspace/restapis/configmap.go
+++ b/pkg/controller/workspace/restapis/configmap.go
@@ -144,7 +144,7 @@ func constructRuntimeAnnotation(components []v1alpha1.ComponentDescription, endp
 
 func getMachinesAnnotation(components []v1alpha1.ComponentDescription, endpoints map[string]v1alpha1.ExposedEndpointList) map[string]v1alpha1.CheWorkspaceMachine {
 	machines := map[string]v1alpha1.CheWorkspaceMachine{}
-
+	machineRunningString := v1alpha1.RunningMachineEventType
 	for _, component := range components {
 		for containerName, container := range component.ComponentMetadata.Containers {
 			servers := map[string]v1alpha1.CheWorkspaceServer{}
@@ -159,6 +159,7 @@ func getMachinesAnnotation(components []v1alpha1.ComponentDescription, endpoints
 			machines[containerName] = v1alpha1.CheWorkspaceMachine{
 				Attributes: container.Attributes,
 				Servers:    servers,
+				Status:     &machineRunningString,
 			}
 		}
 	}

--- a/samples/theia.yaml
+++ b/samples/theia.yaml
@@ -1,0 +1,24 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha1
+metadata:
+  name: theia
+spec:
+  started: true
+  routingClass: 'basic'
+  template:
+    projects:
+      - name: project
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    components:
+      - plugin:
+          id: eclipse/che-theia/latest
+      - plugin:
+          id: eclipse/che-machine-exec-plugin/latest
+    commands:
+      - exec:
+          id: say hello
+          component: plugin
+          commandLine: echo "Hello from $(pwd)"
+          workingDir: ${PROJECTS_ROOT}/project/app


### PR DESCRIPTION
### What does this PR do?
This PR hack the code to make basic routing working somehow again.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/168

Limitations:
- Theia webview does not work because of TLS leak + unique host requirement;
- ~~Containers view is empty, probably because of incompatibility with Che Rest API; Containers view populates but components aren't marked as running~~
- ~~Terminal is not working, `connect` websocket connection is closed because of 401 unauthorized;~~

### Is it tested? How?
```
export IMG=sleshchenko/che-workspace-controller:basic-routing
export WEBHOOK_ENABLED=false
export REGISTRY_ENABLED=true
make deploy
kubectl apply -f ./samples/theia.yaml
kubectl get devworkspace -w # & and wait until workspace is running
# Open a workspace URL
```
![Screenshot_20201007_143949](https://user-images.githubusercontent.com/5887312/95326321-0fa78a00-08ab-11eb-82ac-a911759a8042.png)
