### PR TITLE
Using cert manager for webhook certs

### DIFF
--- a/deploy/k8s_webhook/cert_manager.yaml
+++ b/deploy/k8s_webhook/cert_manager.yaml
@@ -1,0 +1,21 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: devworkspace-webhook-certificate
+  namespace: devworkspace-controller
+spec:
+  secretName: devworkspace-webhookserver-tls
+  dnsNames:
+    - devworkspace-webhookserver.devworkspace-controller.svc
+  issuerRef:
+    name: selfsignedissuer
+  duration: 1h
+  renewBefore: 5m
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsignedissuer
+  namespace: devworkspace-controller
+spec:
+  selfSigned: {}

--- a/pkg/webhook/cluster_roles.go
+++ b/pkg/webhook/cluster_roles.go
@@ -93,6 +93,7 @@ func getSpecClusterRole() (*v1.ClusterRole, error) {
 				},
 				Resources: []string{
 					"pods",
+					"secrets",
 				},
 				Verbs: []string{
 					"get",

--- a/pkg/webhook/create.go
+++ b/pkg/webhook/create.go
@@ -78,7 +78,6 @@ func SetupWebhooks(ctx context.Context, cfg *rest.Config) error {
 		if err != nil {
 			return err
 		}
-		log.Info("Warning: the webhook server cert in use is not suitable for production. If you want to use this in production please set up certs with a certificate manager")
 	}
 
 	// Set up the deployment

--- a/pkg/webhook/init_cfg.go
+++ b/pkg/webhook/init_cfg.go
@@ -24,9 +24,15 @@ import (
 
 // WebhookCfgsInit initializes the webhook that denies everything until webhook server is started successfully
 func WebhookCfgsInit(client crclient.Client, ctx context.Context, namespace string) error {
-	configuration := workspace.BuildMutateWebhookCfg(namespace)
 
-	err := client.Create(ctx, configuration, &crclient.CreateOptions{})
+	webhookAnnotations, err := workspace.GetWebhookAnnotations(client, namespace)
+	if err != nil {
+		return err
+	}
+
+	configuration := workspace.BuildMutateWebhookCfg(namespace, webhookAnnotations)
+
+	err = client.Create(ctx, configuration, &crclient.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			log.Info(fmt.Sprintf("Mutating webhooks configuration %s already exists", configuration.Name))

--- a/pkg/webhook/kubernetes/tls.go
+++ b/pkg/webhook/kubernetes/tls.go
@@ -15,16 +15,14 @@ package webhook_k8s
 import (
 	"context"
 
-	"github.com/devfile/devworkspace-operator/pkg/webhook/service"
-
 	"github.com/devfile/devworkspace-operator/pkg/kubernetes/tls"
+	"github.com/devfile/devworkspace-operator/pkg/webhook/service"
 	"github.com/devfile/devworkspace-operator/webhook/server"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var log = logf.Log.WithName("webhook-k8s")
@@ -54,6 +52,7 @@ func SetupSecureService(client crclient.Client, ctx context.Context, namespace s
 			if err != nil {
 				return err
 			}
+			log.Info("Warning: the webhook server cert in use is not suitable for production. If you want to use this in production please set up certs with a certificate manager")
 		}
 	}
 

--- a/scripts/webhook.sh
+++ b/scripts/webhook.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+NAMESPACE=""
+printHelp="false"
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-n'|'--namespace') NAMESPACE="$2"; shift 1;;
+    '-h'|'--help') printHelp="true"; shift 0;;
+  esac
+  shift 1
+done
+
+if [[ "$printHelp" == "true" ]]; then
+  echo "Usage:"
+  echo "-n, --namespace - The namespace where the webhooks will live"
+  echo "-h, --help - print this message"
+  exit 0
+fi
+
+if [[ "$NAMESPACE" == "" ]]; then
+  echo "Namespace cannot be empty"
+  exit 1
+fi
+
+IS_NOT_FOUND=$(kubectl get namespace cert-manager 2>&1 | grep -q "not found"; echo $?)
+if [ "$IS_NOT_FOUND" = "0" ]; then
+  echo "Cert Manager has not been found.";
+else
+  echo "$NAMESPACE"
+  sed -i.bak -e "s|namespace: .*|namespace: $NAMESPACE|" \
+           -e "s|devworkspace-webhookserver.devworkspace-controller.svc|devworkspace-webhookserver.$NAMESPACE.svc|" \
+            deploy/k8s_webhook/cert_manager.yaml
+  kubectl apply -f deploy/k8s_webhook/cert_manager.yaml -n "$NAMESPACE"
+  mv deploy/k8s_webhook/cert_manager.yaml.bak deploy/k8s_webhook/cert_manager.yaml
+fi

--- a/webhook/main.go
+++ b/webhook/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/devfile/devworkspace-operator/webhook/server"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -57,7 +56,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = createWebhooks(mgr, cfg)
+	err = createWebhooks(mgr)
 	if err != nil {
 		log.Error(err, "Failed to get create webhooks")
 		os.Exit(1)
@@ -73,8 +72,7 @@ func main() {
 	}
 }
 
-func createWebhooks(mgr manager.Manager, clusterConfig *rest.Config) error {
-	log.Info("Configuring Webhook Server")
+func createWebhooks(mgr manager.Manager) error {
 	err := server.ConfigureWebhookServer(mgr)
 	if err != nil {
 		return err

--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -40,6 +40,9 @@ const (
 
 	//Secret name with TLS certs inside (tls.crt + tls.key) that is mounted to webhook server
 	WebhookServerTLSSecretName = "devworkspace-webhookserver-tls"
+
+	// Holds the name of the certificate used for managing webhooks
+	WebhookServerCertManagerCertificateName = "devworkspace-webhook-certificate"
 )
 
 var log = logf.Log.WithName("webhook.server")

--- a/webhook/workspace/annotations.go
+++ b/webhook/workspace/annotations.go
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package workspace
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/devfile/devworkspace-operator/webhook/server"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	CertManagerAnnotationName = "cert-manager.io"
+	CertManagerInjectKey      = "cert-manager.io/inject-ca-from"
+)
+
+func GetWebhookAnnotations(client crclient.Client, namespace string) (map[string]string, error) {
+	webhookAnnotations := make(map[string]string)
+
+	certManagerSecret, err := isCertManagerSecret(client, namespace)
+	if err != nil {
+		log.Error(err, "Failed when attempting to check if the secret is annotated with cert manager")
+		return webhookAnnotations, err
+	}
+
+	if certManagerSecret {
+		webhookAnnotations[CertManagerInjectKey] = fmt.Sprintf("%s/%s", namespace, server.WebhookServerCertManagerCertificateName)
+	}
+
+	return webhookAnnotations, nil
+}
+
+func hasCertManagerAnnotation(annotations map[string]string) bool {
+	for key, _ := range annotations {
+		if strings.HasPrefix(key, CertManagerAnnotationName) {
+			return true
+		}
+	}
+	return false
+}

--- a/webhook/workspace/config.go
+++ b/webhook/workspace/config.go
@@ -32,7 +32,6 @@ import (
 
 //Configure configures mutate/validating webhooks that provides exec access into workspace for creator only
 func Configure(ctx context.Context) error {
-	log.Info("Configuring workspace webhooks")
 	c, err := controller.CreateClient()
 	if err != nil {
 		return err
@@ -43,8 +42,13 @@ func Configure(ctx context.Context) error {
 		return err
 	}
 
-	mutateWebhookCfg := BuildMutateWebhookCfg(namespace)
-	validateWebhookCfg := buildValidatingWebhookCfg(namespace)
+	webhookAnnotations, err := GetWebhookAnnotations(c, namespace)
+	if err != nil {
+		return err
+	}
+
+	mutateWebhookCfg := BuildMutateWebhookCfg(namespace, webhookAnnotations)
+	validateWebhookCfg := buildValidatingWebhookCfg(namespace, webhookAnnotations)
 
 	if !server.IsSetUp() {
 		_, mutatingWebhookErr := getMutatingWebhook(ctx, c, mutateWebhookCfg)

--- a/webhook/workspace/secret.go
+++ b/webhook/workspace/secret.go
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package workspace
+
+import (
+	context "context"
+
+	"github.com/devfile/devworkspace-operator/webhook/server"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func isCertManagerSecret(client crclient.Client, namespace string) (bool, error) {
+	secret, err := getSecret(client, namespace, server.WebhookServerTLSSecretName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	isCertManagerAnnotated := hasCertManagerAnnotation(secret.GetAnnotations())
+	return isCertManagerAnnotated, nil
+}
+
+func getSecret(client crclient.Client, namespace string, name string) (*corev1.Secret, error) {
+	secret := corev1.Secret{}
+	err := client.Get(context.TODO(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, &secret)
+	if err != nil {
+		return nil, err
+	}
+	return &secret, nil
+}


### PR DESCRIPTION
### What does this PR do?
This PR introduces cert manager use for webhook certs on kubernetes.

The way this works is a cert manager certificate needs to be created in the same namespace with the name devworkspace-webhook-certificate. This certificate then needs to configured to create a secret named devworkspace-webhookserver-tls.
Then inside of the controller if there is already a devworkspace-webhookserver-tls secret by the time the controller is looking for certs then the cert generation Job WON'T be activated and devworkspace-webhookserver-tls will only contain data
from cert-manager. Then, on the webhook server deployment side the validating and mutating webhooks will be annotated
with `cert-manager.io/inject-ca-from` and inject devworkspace-webhook-certificate CABundles. These CABundles will
automatically be rotated when they are supposed to be renewed.

On kubernetes if cert-manager is not available it will use the cert generation job

On openshift it still uses the secure service.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested both on kubernetes and openshift. For minikube:
```bash
# First install cert-manager
kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.2/cert-manager.yaml
# Then build and test PR changes
export IMG={my_ctrl_img}
# Make sure that RELATED_IMAGE_devworkspace_webhook_server is set to $IMG so the webhook changes are picked up
make uninstall; make docker; make deploy;
```

For openshift:
```bash
make uninstall; make docker; make deploy
```

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>