### PR TITLE
Derive Web Terminal Tooling image from OpenShift version

### DIFF
--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -49,6 +49,8 @@ spec:
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_web_terminal_tooling
               value: "quay.io/wto/web-terminal-tooling:latest"
+            - name: RELATED_IMAGE_web_terminal_tooling_default
+              value: "quay.io/wto/web-terminal-tooling:1.0.0"
             - name: RELATED_IMAGE_web_terminal_tooling_4_5
               value: "quay.io/wto/web-terminal-tooling:1.0.0"
             - name: RELATED_IMAGE_web_terminal_tooling_4_6

--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -49,6 +49,10 @@ spec:
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_web_terminal_tooling
               value: "quay.io/wto/web-terminal-tooling:latest"
+            - name: RELATED_IMAGE_web_terminal_tooling_4_5
+              value: "quay.io/wto/web-terminal-tooling:1.0.0"
+            - name: RELATED_IMAGE_web_terminal_tooling_4_6
+              value: "quay.io/wto/web-terminal-tooling:latest"
             - name: RELATED_IMAGE_openshift_oauth_proxy
               value: "openshift/oauth-proxy:latest"
             - name: RELATED_IMAGE_devworkspace_webhook_server

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -161,3 +161,9 @@ rules:
   - watch
   - update
   - delete
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  verbs:
+  - get

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
+	github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.17.4

--- a/go.sum
+++ b/go.sum
@@ -658,6 +658,7 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.m
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87 h1:L/fZlWB7DdYCd09r9LvBa44xRH42Dx80ybxfN1h5C8Y=
 github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
+github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b h1:E++qQ7W1/EdvuMo+YGVbMPn4HihEp7YT5Rghh0VmA9A=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=

--- a/internal/cluster/openshift.go
+++ b/internal/cluster/openshift.go
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package cluster
+
+import (
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+// Create a new openshift client using the in cluster config
+func openShiftClient() (*configv1client.ConfigV1Client, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if config != nil {
+		client, err := configv1client.NewForConfig(config)
+		if err != nil {
+			return client, err
+		}
+		return client, nil
+	}
+	return nil, nil
+}
+
+// Get the version of the current running OpenShift cluster in semver format E.g. 4.5.9
+func OpenshiftVersion() (string, error) {
+	client, err := openShiftClient()
+	if err != nil {
+		return "", err
+	}
+
+	openshiftAPIServer, err := client.ClusterOperators().Get("openshift-apiserver", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if openshiftAPIServer != nil {
+		for _, ver := range openshiftAPIServer.Status.Versions {
+			if ver.Name == "operator" {
+				// Apparently only openshift-apiserver clusteroperator reports the version number
+				return ver.Version, nil
+			}
+		}
+	}
+	return "", nil
+}

--- a/internal/cluster/openshift.go
+++ b/internal/cluster/openshift.go
@@ -25,14 +25,11 @@ func openShiftClient() (*configv1client.ConfigV1Client, error) {
 		return nil, err
 	}
 
-	if config != nil {
-		client, err := configv1client.NewForConfig(config)
-		if err != nil {
-			return client, err
-		}
-		return client, nil
+	client, err := configv1client.NewForConfig(config)
+	if err != nil {
+		return client, err
 	}
-	return nil, nil
+	return client, nil
 }
 
 // Get the version of the current running OpenShift cluster in semver format E.g. 4.5.9


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR makes it so that you can have different tooling versions on different versions of OpenShift. With this change we can have RELATED_IMAGE_web_terminal_tooling_4_5 that will only be picked up on a 4.5 cluster and RELATED_IMAGE_web_terminal_tooling_4_6 that will only be picked up on a 4.6 cluster

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
