### PR TITLE
Add annotation label for setting the reason why the web terminal was …

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -59,6 +59,10 @@ const (
 
 	// ControllerServiceAccountNameEnvVar stores the name of the serviceaccount used in the controller.
 	ControllerServiceAccountNameEnvVar = "CONTROLLER_SERVICE_ACCOUNT_NAME"
+
+	// WorkspaceStopReasonAnnotation marks the reason why the workspace was stopped; when a workspace is restarted
+	// this annotation will be cleared
+	WorkspaceStopReasonAnnotation = "controller.devfile.io/stopped-by"
 )
 
 // Constants for che-rest-apis

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -218,6 +218,13 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 		return reconcile.Result{}, err
 	}
 
+	_, ok := workspace.Annotations[config.WorkspaceStopReasonAnnotation]
+	if ok {
+		delete(workspace.Annotations, config.WorkspaceStopReasonAnnotation)
+		err = r.client.Update(context.TODO(), workspace)
+		return reconcile.Result{Requeue: true}, err
+	}
+
 	immutable := workspace.Annotations[config.WorkspaceImmutableAnnotation]
 	if immutable == "true" && config.ControllerCfg.GetWebhooksEnabled() != "true" {
 		reqLogger.Info("Workspace is configured as immutable but webhooks are not enabled.")

--- a/webhook/workspace/handler/immutable.go
+++ b/webhook/workspace/handler/immutable.go
@@ -33,6 +33,7 @@ var ImmutableWorkspaceDiffOptions = []cmp.Option{
 	// field managed by cluster and should be ignored while comparing
 	cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ManagedFields", "Finalizers", "DeletionTimestamp"),
 	cmpopts.IgnoreFields(devworkspace.DevWorkspaceSpec{}, "Started"),
+	cmpopts.IgnoreMapEntries(func(key string, value string) bool { return key == config.WorkspaceStopReasonAnnotation }),
 }
 
 func (h *WebhookHandler) HandleImmutableMutate(_ context.Context, req admission.Request) admission.Response {


### PR DESCRIPTION
…stopped

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR (and the che-machine-exec PR that goes with it) add an annotation that shows the reason why the workspace was stopped. Related che-machine-exec PR: https://github.com/eclipse/che-machine-exec/pull/117.

### What issues does this PR fix or reference?
https://issues.redhat.com/projects/WTO/issues/WTO-47

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
```
# Update the controller.yaml to point to the new che-machine-exec and make sure that the correct webhook image is deployed
make uninstall
make build
make deploy

# Navigate to the console and open a web terminal in the ui then
oc describe devworkspace
# See that io.devfile.devworkspace.stopped-by is empty

# Wait for the terminal to stop (I change my default timeout to 2m when testing so it was much easier)
oc describe devworkspace
# See that the annotation io.devfile.devworkspace.stopped-by is set to "inactivity"

# Open a new web terminal on the ui
oc describe devworkspace
# See that io.devfile.devworkspace.stopped-by is empty
```
