### PR TITLE
Fix debug and run locally after regenerating with controller-gen

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,3 +6,5 @@
 
 ### Is it tested? How?
 <!-- Please provide instructions here how reviewer can test your changes if applicable -->
+
+<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->

--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,8 @@ debug: _print_vars _generate_related_images_env
 install_crds: manifests _kustomize _init_devworkspace_crds
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
-### deploy: Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: _print_vars _kustomize _init_devworkspace_crds _create_namespace deploy_registry
+### install: Install controller in the configured Kubernetes cluster in ~/.kube/config
+install: _print_vars _kustomize _init_devworkspace_crds _create_namespace deploy_registry
 	mv config/devel/kustomization.yaml config/devel/kustomization.yaml.bak
 	mv config/devel/config.properties config/devel/config.properties.bak
 	mv config/devel/manager_image_patch.yaml config/devel/manager_image_patch.yaml.bak

--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,11 @@ _create_namespace:
 
 _generate_related_images_env:
 	@mkdir -p $(INTERNAL_TMP_DIR)
+	echo "export RELATED_IMAGE_devworkspace_webhook_server=$(IMG)" > $(RELATED_IMAGES_FILE)
 	cat ./config/components/manager/manager.yaml \
 		| yq -r \
 			'.spec.template.spec.containers[]?.env[] | select(.name | startswith("RELATED_IMAGE")) | "export \(.name)=\"$${\(.name):-\(.value)}\""' \
-		> $(RELATED_IMAGES_FILE)
+		>> $(RELATED_IMAGES_FILE)
 	cat $(RELATED_IMAGES_FILE)
 
 ##### Rules for dealing with devfile/api

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,5 @@ help: Makefile
 	@echo '    ROUTING_SUFFIX             - Cluster routing suffix (e.g. $$(minikube ip).nip.io, apps-crc.testing)'
 	@echo '    PULL_POLICY                - Image pull policy for controller'
 	@echo '    WEBHOOK_ENABLED            - Whether webhooks should be enabled in the deployment'
-	@echo '    ADMIN_CTX                  - Kubectx entry that should be used during work with cluster. The current will be used if omitted'
 	@echo '    REGISTRY_ENABLED           - Whether the plugin registry should be deployed'
 	@echo '    DEVWORKSPACE_API_VERSION   - Branch or tag of the github.com/devfile/api to depend on. Defaults to master'

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
+	GOFLAGS="" go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
@@ -275,7 +275,7 @@ ifeq (, $(shell which kustomize))
 	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
+	GOFLAGS="" go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
 	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
 	}
 KUSTOMIZE=$(GOBIN)/kustomize

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ debug: _print_vars _generate_related_images_env _bump_kubeconfig _login_with_dev
 		dlv debug --listen=:2345 --headless=true --api-version=2 ./main.go --
 
 ### install_crds: Install CRDs into a cluster
-install_crds: manifests _kustomize _init_devworkspace_crds
+install_crds: _kustomize _init_devworkspace_crds
 	$(KUSTOMIZE) build config/crd | $(K8S_CLI) apply -f -
 
 ### install: Install controller in the configured Kubernetes cluster in ~/.kube/config

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ test: generate fmt vet manifests
 	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test $(shell go list ./... | grep -v test/e2e) -coverprofile cover.out
 
 ### test_e2e: runs e2e test on the cluster set in context. Includes deploying devworkspace-controller, run test workspace, uninstall devworkspace-controller
-test_e2e: generate fmt vet manifests
+test_e2e:
 	CGO_ENABLED=0 go test -v -c -o bin/devworkspace-controller-e2e ./test/e2e/cmd/workspaces_test.go
 	./bin/devworkspace-controller-e2e
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 
 SHELL := bash
 .SHELLFLAGS = -ec
+.ONESHELL:
 
 export NAMESPACE ?= devworkspace-controller
 export IMG ?= quay.io/devfile/devworkspace-controller:next

--- a/config/devel/manager_image_patch.yaml
+++ b/config/devel/manager_image_patch.yaml
@@ -10,3 +10,6 @@ spec:
       - name: devworkspace-controller
         image: ${IMG}
         imagePullPolicy: Always
+        env:
+        - name: RELATED_IMAGE_devworkspace_webhook_server
+          value: ${IMG}

--- a/pkg/webhook/create.go
+++ b/pkg/webhook/create.go
@@ -38,7 +38,8 @@ func SetupWebhooks(ctx context.Context, cfg *rest.Config) error {
 
 	namespace, err := cluster.GetOperatorNamespace()
 	if err != nil {
-		config.ConfigMapReference.Namespace = os.Getenv(cluster.WatchNamespaceEnvVar)
+		namespace = os.Getenv(cluster.WatchNamespaceEnvVar)
+		config.ConfigMapReference.Namespace = namespace
 	}
 
 	client, err := crclient.New(cfg, crclient.Options{})

--- a/test/e2e/pkg/deploy/controller.go
+++ b/test/e2e/pkg/deploy/controller.go
@@ -40,7 +40,7 @@ func (w *Deployment) CreateNamespace() error {
 
 func (w *Deployment) DeployWorkspacesController() error {
 	label := "app.kubernetes.io/name=devworkspace-controller"
-	cmd := exec.Command("make", "deploy")
+	cmd := exec.Command("make", "install")
 	output, err := cmd.CombinedOutput()
 	fmt.Println(string(output))
 	if err != nil && !strings.Contains(string(output), "AlreadyExists") {
@@ -66,7 +66,7 @@ func (w *Deployment) DeployWorkspacesController() error {
 }
 
 func (w *Deployment) CustomResourceDefinitions() error {
-	devWorkspaceCRD := exec.Command("make", "install")
+	devWorkspaceCRD := exec.Command("make", "install_crds")
 	output, err := devWorkspaceCRD.CombinedOutput()
 	if err != nil && !strings.Contains(string(output), "AlreadyExists") {
 		fmt.Println(err)

--- a/webhook/main.go
+++ b/webhook/main.go
@@ -33,7 +33,7 @@ import (
 var log = logf.Log.WithName("cmd")
 
 func main() {
-	logf.SetLogger(zap.New(zap.UseDevMode(false)))
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/webhook/main.go
+++ b/webhook/main.go
@@ -53,13 +53,13 @@ func main() {
 		Namespace: namespace,
 	})
 	if err != nil {
-		log.Error(err, "Failed to get create manager")
+		log.Error(err, "Failed to create manager")
 		os.Exit(1)
 	}
 
 	err = createWebhooks(mgr, cfg)
 	if err != nil {
-		log.Error(err, "Failed to get create webhooks")
+		log.Error(err, "Failed to create webhooks")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes debug and run locally after regenerating with controller-gen.

I've moved these changes out from https://github.com/devfile/devworkspace-operator/pull/193 since here is something to discuss:
1. without `.ONESHELL` env vars are not properly propagated to the dvl and eventually to controller. So, we should enable `.ONSHELL` or alernative - create script that will set env vars and run dvl or controller directly.
2. I've figured out that we modify default service account in namespace instead of created devworkspace specific one. I think that it's better to have a dedicated SA (if multiple operators are deployed in the same namespace, they may conflict due default roles modifications) but I did not manage to archive it properly with all deployment,roles,rolesbinding patching via kustomize. It can be solved independently from this PR.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
```
make deploy
oc patch deployment/devworkspace-controller-manager --patch "{\"spec\":{\"replicas\":0}}" -n devworkspace-controller
make debug
#or make run
#make sure everything works
```
:warning: that's not well tested after the latest changes, but it'll be done before merge