### PR TITLE
Remove set -x from update_devworkspace_crds.sh

### DIFF
--- a/update_devworkspace_crds.sh
+++ b/update_devworkspace_crds.sh
@@ -10,7 +10,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-set -ex
+set -e
 
 DEVWORKSPACE_API_VERSION=v1alpha1
 INIT_ONLY=0


### PR DESCRIPTION
### What does this PR do?
Removes `set -x` from the `update_devworkspace_crds.sh` script:
```
make install_crds 
/home/amisevsk/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." \
		output:crd:artifacts:config=config/crd/bases \
		output:rbac:artifacts:config=config/components/rbac
patch/patch_crds.sh
/home/amisevsk/.local/bin/yq
Updated CRD config/crd/bases/controller.devfile.io_components.yaml
Updated CRD config/crd/bases/controller.devfile.io_components.yaml
Updated CRD config/crd/bases/controller.devfile.io_workspaceroutings.yaml
Updated CRD config/crd/bases/controller.devfile.io_workspaceroutings.yaml
./update_devworkspace_crds.sh --init --api-version v1alpha1
+ DEVWORKSPACE_API_VERSION=v1alpha1
+ INIT_ONLY=0
+ [[ 3 -gt 0 ]]
+ case $1 in
+ INIT_ONLY=1
+ shift 0
+ shift 1
+ [[ 2 -gt 0 ]]
+ case $1 in
+ DEVWORKSPACE_API_VERSION=v1alpha1
+ shift 1
+ shift 1
+ [[ 0 -gt 0 ]]
+++ dirname ./update_devworkspace_crds.sh
++ cd .
++ pwd
+ SCRIPT_DIR=/home/amisevsk/git/devworkspace-operator
+ [[ 1 -eq 1 ]]
+ [[ -f /home/amisevsk/git/devworkspace-operator/config/crd/bases/workspace.devfile.io_devworkspaces.yaml ]]
+ exit 0
/home/amisevsk/go/bin/kustomize build config/crd | kubectl apply -f -
customresourcedefinition.apiextensions.k8s.io/devworkspaces.workspace.devfile.io created
customresourcedefinition.apiextensions.k8s.io/components.controller.devfile.io created
customresourcedefinition.apiextensions.k8s.io/workspaceroutings.controller.devfile.io created
```
The output here is not helpful.