### PR TITLE
Use same image for webhooks deployment when developing

### DIFF
--- a/config/devel/manager_image_patch.yaml
+++ b/config/devel/manager_image_patch.yaml
@@ -10,3 +10,6 @@ spec:
       - name: devworkspace-controller
         image: ${IMG}
         imagePullPolicy: Always
+        env:
+          - name: RELATED_IMAGE_devworkspace_webhook_server
+            value: "${IMG}"


### PR DESCRIPTION
### What does this PR do?
Makes `make deploy` configure the operator to use the same image for the operator and webhook deployments.

### Is it tested? How?
```
export IMG=<your-image>
export WEBHOOK_ENABLED=true
make deploy
# Verify that `devworkspace-webhook-server uses `<your-image>`
```
