### PR TITLE
SingleHost + TLS on OpenShift

### DIFF
--- a/.ci/openshift_e2e.sh
+++ b/.ci/openshift_e2e.sh
@@ -58,19 +58,6 @@ function getDevWorkspaceOperatorLogs() {
     oc get events -n ${NAMESPACE}| tee get_events.log
 }
 
-# Check if operator-sdk is installed and if not install operator sdk in $GOPATH/bin dir
-if ! hash operator-sdk 2>/dev/null; then
-    mkdir -p $GOPATH/bin
-    export PATH="$PATH:$(pwd):$GOPATH/bin"
-    OPERATOR_SDK_VERSION=v0.17.0
-
-    curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
-
-    chmod +x operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu && \
-        cp operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu $GOPATH/bin/operator-sdk && \
-        rm operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
-fi
-
 # For some reason go on PROW force usage vendor folder
 # This workaround is here until we don't figure out cause
 go mod tidy

--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 Dev Workspace operator repository that contains the controller for the DevWorkspace Custom Resource. The Kubernetes API of the DevWorkspace is defined in the https://github.com/devfile/api repository.
 
+## DevWorkspace CR
+
+### Annotations
+
+You can add these Kubernetes annotations to specific DevWorkspace CR to customize their behavior.
+
+|Name|Value|
+|----|----|
+|[controller.devfile.io/restricted-access](#restricted-access)|true or false|
+
+#### Restricted Access
+
+Using `restricted-access` is possible to define that DevWorkspace needs additional(to RBAC) authorization that guarantee that the only DevWorkspace CR creators has access to the containers terminals and secure server.
+May be needed when personal information(like access tokens, ssh keys) is stored in the containers.
+
+Since it's powered by webhooks, DevWorkspaces with such annotations will fails to start when webhooks are disabled on Operator level. 
+
+Example:
+```yaml
+metadata:
+  annotations:
+    controller.devfile.io/restricted-access: true
+```
+
 ## Running the controller in a cluster
 
 The controller can be deployed to a cluster provided you are logged in with cluster-admin credentials:

--- a/controllers/controller/workspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/workspacerouting/solvers/basic_solver.go
@@ -14,14 +14,29 @@ package solvers
 
 import (
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/config"
 )
 
-var ingressAnnotations = map[string]string{
-	"kubernetes.io/ingress.class":                "nginx",
-	"nginx.ingress.kubernetes.io/rewrite-target": "/",
-	"nginx.ingress.kubernetes.io/ssl-redirect":   "false",
+var routeAnnotations = func(endpointName string) map[string]string {
+	return map[string]string{
+		"haproxy.router.openshift.io/rewrite-target": "/",
+		config.WorkspaceEndpointNameAnnotation:       endpointName,
+	}
 }
 
+var nginxIngressAnnotations = func(endpointName string) map[string]string {
+	return map[string]string{
+		"kubernetes.io/ingress.class":                "nginx",
+		"nginx.ingress.kubernetes.io/rewrite-target": "/",
+		"nginx.ingress.kubernetes.io/ssl-redirect":   "false",
+		config.WorkspaceEndpointNameAnnotation:       endpointName,
+	}
+}
+
+// Basic solver exposes endpoints without any authentication
+// According to the current cluster there is different behavior:
+// Kubernetes: use Ingresses without TLS
+// OpenShift: use Routes with TLS enabled
 type BasicSolver struct{}
 
 var _ RoutingSolver = (*BasicSolver)(nil)

--- a/controllers/controller/workspacerouting/solvers/common.go
+++ b/controllers/controller/workspacerouting/solvers/common.go
@@ -43,7 +43,7 @@ func getDiscoverableServicesForEndpoints(endpoints map[string]controllerv1alpha1
 					Name:       common.EndpointName(endpoint.Name),
 					Protocol:   corev1.ProtocolTCP,
 					Port:       int32(endpoint.TargetPort),
-					TargetPort: intstr.FromInt(int(endpoint.TargetPort)),
+					TargetPort: intstr.FromInt(endpoint.TargetPort),
 				}
 				services = append(services, corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
@@ -69,7 +69,6 @@ func getDiscoverableServicesForEndpoints(endpoints map[string]controllerv1alpha1
 }
 
 func getServicesForEndpoints(endpoints map[string]controllerv1alpha1.EndpointList, meta WorkspaceMetadata) []corev1.Service {
-	var services []corev1.Service
 	var servicePorts []corev1.ServicePort
 	for _, machineEndpoints := range endpoints {
 		for _, endpoint := range machineEndpoints {
@@ -95,22 +94,22 @@ func getServicesForEndpoints(endpoints map[string]controllerv1alpha1.EndpointLis
 		}
 	}
 
-	services = append(services, corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      common.ServiceName(meta.WorkspaceId),
-			Namespace: meta.Namespace,
-			Labels: map[string]string{
-				config.WorkspaceIDLabel: meta.WorkspaceId,
+	return []corev1.Service{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.ServiceName(meta.WorkspaceId),
+				Namespace: meta.Namespace,
+				Labels: map[string]string{
+					config.WorkspaceIDLabel: meta.WorkspaceId,
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:    servicePorts,
+				Selector: meta.PodSelector,
+				Type:     corev1.ServiceTypeClusterIP,
 			},
 		},
-		Spec: corev1.ServiceSpec{
-			Ports:    servicePorts,
-			Selector: meta.PodSelector,
-			Type:     corev1.ServiceTypeClusterIP,
-		},
-	})
-
-	return services
+	}
 }
 
 func getRoutingForSpec(endpoints map[string]controllerv1alpha1.EndpointList, meta WorkspaceMetadata) ([]v1beta1.Ingress, []routeV1.Route) {
@@ -132,7 +131,7 @@ func getRoutingForSpec(endpoints map[string]controllerv1alpha1.EndpointList, met
 }
 
 func getRouteForEndpoint(endpoint devworkspace.Endpoint, meta WorkspaceMetadata) routeV1.Route {
-	targetEndpoint := intstr.FromInt(int(endpoint.TargetPort))
+	targetEndpoint := intstr.FromInt(endpoint.TargetPort)
 	endpointName := common.EndpointName(endpoint.Name)
 	return routeV1.Route{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/controller/workspacerouting/solvers/openshift_oauth_solver.go
+++ b/controllers/controller/workspacerouting/solvers/openshift_oauth_solver.go
@@ -107,6 +107,10 @@ func (s *OpenShiftOAuthSolver) getProxyRoutes(
 				Termination:                   routeV1.TLSTerminationReencrypt,
 				InsecureEdgeTerminationPolicy: routeV1.InsecureEdgeTerminationPolicyRedirect,
 			}
+			// Reverting single host feature since OpenShift OAuth uses absolute references
+			route.Spec.Host = common.EndpointHostname(workspaceMeta.WorkspaceId, endpoint.Name, endpoint.TargetPort, workspaceMeta.RoutingSuffix)
+			route.Spec.Path = "/"
+
 			if route.Annotations == nil {
 				route.Annotations = map[string]string{}
 			}

--- a/controllers/controller/workspacerouting/solvers/resolve_endpoints.go
+++ b/controllers/controller/workspacerouting/solvers/resolve_endpoints.go
@@ -15,6 +15,7 @@ package solvers
 import (
 	"fmt"
 	"net/url"
+	"path"
 
 	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
@@ -60,13 +61,13 @@ func resolveURLForEndpoint(
 	routingObj RoutingObjects) (string, error) {
 	for _, route := range routingObj.Routes {
 		if route.Annotations[config.WorkspaceEndpointNameAnnotation] == endpoint.Name {
-			return getURLForEndpoint(endpoint, route.Spec.Host, route.Spec.TLS != nil), nil
+			return getURLForEndpoint(endpoint, route.Spec.Host, route.Spec.Path, route.Spec.TLS != nil), nil
 		}
 	}
 	for _, ingress := range routingObj.Ingresses {
 		if ingress.Annotations[config.WorkspaceEndpointNameAnnotation] == endpoint.Name {
 			if len(ingress.Spec.Rules) == 1 {
-				return getURLForEndpoint(endpoint, ingress.Spec.Rules[0].Host, false), nil // no TLS supported for ingresses yet
+				return getURLForEndpoint(endpoint, ingress.Spec.Rules[0].Host, "", false), nil // no TLS supported for ingresses yet
 			} else {
 				return "", fmt.Errorf("ingress %s contains multiple rules", ingress.Name)
 			}
@@ -75,16 +76,15 @@ func resolveURLForEndpoint(
 	return "", fmt.Errorf("could not find ingress/route for endpoint '%s'", endpoint.Name)
 }
 
-func getURLForEndpoint(endpoint devworkspace.Endpoint, host string, secure bool) string {
+func getURLForEndpoint(endpoint devworkspace.Endpoint, host, basePath string, secure bool) string {
 	protocol := endpoint.Protocol
 	if secure && endpoint.Secure {
 		protocol = devworkspace.EndpointProtocol(getSecureProtocol(string(protocol)))
 	}
-	path := endpoint.Path
 	u := url.URL{
 		Scheme: string(protocol),
 		Host:   host,
-		Path:   path,
+		Path:   path.Join(basePath, endpoint.Path),
 	}
 	return u.String()
 }

--- a/controllers/controller/workspacerouting/solvers/resolve_endpoints.go
+++ b/controllers/controller/workspacerouting/solvers/resolve_endpoints.go
@@ -15,7 +15,7 @@ package solvers
 import (
 	"fmt"
 	"net/url"
-	"path"
+	"strings"
 
 	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
@@ -81,10 +81,18 @@ func getURLForEndpoint(endpoint devworkspace.Endpoint, host, basePath string, se
 	if secure && endpoint.Secure {
 		protocol = devworkspace.EndpointProtocol(getSecureProtocol(string(protocol)))
 	}
+	var p string
+	if endpoint.Path != "" {
+		// the only one slash should be between these path segments.
+		// Path.join does not suite here since it eats trailing slash which may be critical for the application
+		p = fmt.Sprintf("%s/%s", strings.TrimRight(basePath, "/"), strings.TrimLeft(p, endpoint.Path))
+	} else {
+		p = basePath
+	}
 	u := url.URL{
 		Scheme: string(protocol),
 		Host:   host,
-		Path:   path.Join(basePath, endpoint.Path),
+		Path:   p,
 	}
 	return u.String()
 }

--- a/controllers/controller/workspacerouting/solvers/solver.go
+++ b/controllers/controller/workspacerouting/solvers/solver.go
@@ -29,6 +29,12 @@ type RoutingObjects struct {
 }
 
 type RoutingSolver interface {
+	// GetSpecObjects constructs cluster routing objects which should be applied on the cluster
 	GetSpecObjects(spec controllerv1alpha1.WorkspaceRoutingSpec, workspaceMeta WorkspaceMetadata) RoutingObjects
+
+	// GetExposedEndpoints retreives the URL for each endpoint in a devfile spec from a set of RoutingObjects.
+	// Returns is a map from component ids (as defined in the devfile) to the list of endpoints for that component
+	// Return value "ready" specifies if all endpoints are resolved on the cluster; if false it is necessary to retry, as
+	// URLs will be undefined.
 	GetExposedEndpoints(endpoints map[string]controllerv1alpha1.EndpointList, routingObj RoutingObjects) (exposedEndpoints map[string]controllerv1alpha1.ExposedEndpointList, ready bool, err error)
 }

--- a/controllers/controller/workspacerouting/workspacerouting_controller.go
+++ b/controllers/controller/workspacerouting/workspacerouting_controller.go
@@ -79,7 +79,7 @@ func (r *WorkspaceRoutingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	}
 
 	if instance.Status.Phase == controllerv1alpha1.RoutingFailed {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, nil
 	}
 
 	solver, err := getSolverForRoutingClass(instance.Spec.RoutingClass)

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -146,9 +146,9 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return reconcile.Result{Requeue: true}, err
 	}
 
-	immutable := workspace.Annotations[config.WorkspaceImmutableAnnotation]
-	if immutable == "true" && config.ControllerCfg.GetWebhooksEnabled() != "true" {
-		reqLogger.Info("Workspace is configured as immutable but webhooks are not enabled.")
+	restrictedAccess := workspace.Annotations[config.WorkspaceRestrictedAccessAnnotation]
+	if restrictedAccess == "true" && config.ControllerCfg.GetWebhooksEnabled() != "true" {
+		reqLogger.Info("Workspace is configured to have restricted access but webhooks are not enabled.")
 		reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
 		reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = "Workspace has restricted-access annotation " +
 			"applied but operator does not have webhooks enabled. " +

--- a/controllers/workspace/env/common_env_vars.go
+++ b/controllers/workspace/env/common_env_vars.go
@@ -55,10 +55,6 @@ func CommonEnvironmentVariables(workspaceName, workspaceId, namespace, creator s
 			Value: namespace,
 		},
 		{
-			Name:  "USE_BEARER_TOKEN",
-			Value: config.ControllerCfg.GetWebhooksEnabled(),
-		},
-		{
 			Name:  "DEVWORKSPACE_CREATOR",
 			Value: creator,
 		},

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -110,7 +110,7 @@ func checkServerStatus(workspace *devworkspace.DevWorkspace) (ok bool, err error
 	if err != nil {
 		return false, err
 	}
-	healthz.Path = "healthz"
+	healthz.Path = healthz.Path + "healthz"
 
 	resp, err := healthHttpClient.Get(healthz.String())
 	if err != nil {

--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -6,6 +6,8 @@ type: Che Editor
 displayName: Cloud Shell Editor
 title: Cloud Shell Editor
 description: Cloud Shell provides an ability to use terminal widget like an editor.
+  Requires OpenShift token to be propagated with requests. It's currently supported
+  only by openshift-oauth routing.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
 firstPublicationDate: "2020-01-29"
@@ -31,4 +33,5 @@ spec:
               "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
               "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
               "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
+              "--use-bearer-token",
               "--static", "/cloud-shell"]

--- a/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/4.5.0/meta.yaml
@@ -29,7 +29,8 @@ spec:
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
                 "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
-                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
+                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
+                "--use-bearer-token"]
       ports:
         - exposedPort: 4444
       env:

--- a/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/nightly/meta.yaml
@@ -29,7 +29,8 @@ spec:
       command: ["/go/bin/che-machine-exec",
                 "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
                 "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
-                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
+                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
+                "--use-bearer-token"]
       ports:
         - exposedPort: 4444
       env:

--- a/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/4.5.0/meta.yaml
@@ -28,6 +28,7 @@ spec:
                "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
                "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
+               "--use-bearer-token",
                "--use-tls"]
      ports:
        - exposedPort: 4444

--- a/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/nightly/meta.yaml
@@ -28,6 +28,7 @@ spec:
               "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
               "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
               "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
+              "--use-bearer-token",
               "--use-tls"]
     ports:
       - exposedPort: 4444

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -43,6 +43,20 @@ func EndpointHostname(workspaceId, endpointName string, endpointPort int, routin
 	return fmt.Sprintf("%s.%s", hostname, routingSuffix)
 }
 
+// WorkspaceHostname evaluates a single hostname for a workspace, and should be used for routing
+// when endpoints are distinguished by path rules
+func WorkspaceHostname(workspaceId, routingSuffix string) string {
+	hostname := workspaceId
+	if len(hostname) > 63 {
+		hostname = strings.TrimSuffix(hostname[:63], "-")
+	}
+	return fmt.Sprintf("%s.%s", hostname, routingSuffix)
+}
+
+func EndpointPath(endpointName string) string {
+	return "/" + endpointName + "/"
+}
+
 func RouteName(workspaceId, endpointName string) string {
 	return fmt.Sprintf("%s-%s", workspaceId, endpointName)
 }

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -49,9 +49,10 @@ const (
 	// WorkspaceCreatorLabel is the label key for storing the UID of the user who created the workspace
 	WorkspaceCreatorLabel = "controller.devfile.io/creator"
 
-	// WorkspaceImmutableAnnotation marks the intention that workspace access is restricted to only the creator; setting this
+	// WorkspaceRestrictedAccessAnnotation marks the intention that workspace access is restricted to only the creator; setting this
 	// annotation will cause workspace start to fail if webhooks are disabled.
-	WorkspaceImmutableAnnotation = "controller.devfile.io/restricted-access"
+	// Operator also propagates it to the workspace-related objects to perform authorization.
+	WorkspaceRestrictedAccessAnnotation = "controller.devfile.io/restricted-access"
 
 	// WorkspaceDiscoverableServiceAnnotation marks a service in a workspace as created for a discoverable endpoint,
 	// as opposed to a service created to support the workspace itself.

--- a/samples/cloud-shell.yaml
+++ b/samples/cloud-shell.yaml
@@ -2,8 +2,11 @@ kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha1
 metadata:
   name: cloud-shell
+  annotations:
+    controller.devfile.io/restricted-access: "true"
 spec:
   started: true
+  routingClass: openshift-oauth
   template:
     components:
       - plugin:

--- a/samples/theia-latest.yaml
+++ b/samples/theia-latest.yaml
@@ -1,0 +1,25 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: theia
+spec:
+  started: true
+  template:
+    projects:
+      - name: project
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    components:
+      - name: theia
+        plugin:
+          id: eclipse/che-theia/latest
+      - name: terminal
+        plugin:
+          id: eclipse/che-machine-exec-plugin/latest
+    commands:
+      - id: say hello
+        exec:
+          component: plugin
+          commandLine: echo "Hello from $(pwd)"
+          workingDir: ${PROJECTS_ROOT}/project/app

--- a/samples/theia-next.yaml
+++ b/samples/theia-next.yaml
@@ -1,10 +1,9 @@
 kind: DevWorkspace
-apiVersion: workspace.devfile.io/v1alpha1
+apiVersion: workspace.devfile.io/v1alpha2
 metadata:
   name: theia
 spec:
   started: true
-  routingClass: 'basic'
   template:
     projects:
       - name: project
@@ -12,13 +11,15 @@ spec:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
     components:
-      - plugin:
-          id: eclipse/che-theia/latest
-      - plugin:
-          id: eclipse/che-machine-exec-plugin/latest
+      - name: theia
+        plugin:
+          id: eclipse/che-theia/next
+      - name: terminal
+        plugin:
+          id: eclipse/che-machine-exec-plugin/nightly
     commands:
-      - exec:
-          id: say hello
+      - id: say hello
+        exec:
           component: plugin
           commandLine: echo "Hello from $(pwd)"
           workingDir: ${PROJECTS_ROOT}/project/app

--- a/samples/theia-nodejs.yaml
+++ b/samples/theia-nodejs.yaml
@@ -4,7 +4,6 @@ metadata:
   name: theia-nodejs
 spec:
   started: true
-  routingClass: 'openshift-oauth'
   template:
     projects:
       - name: project

--- a/samples/web-terminal-custom-tooling.yaml
+++ b/samples/web-terminal-custom-tooling.yaml
@@ -3,8 +3,6 @@ apiVersion: workspace.devfile.io/v1alpha1
 metadata:
   name: web-terminal
   annotations:
-    # it's important to make workspace immutable to make sure nobody with right access
-    # won't set custom editor to steal creator's token
     controller.devfile.io/restricted-access: "true"
   labels:
     # it's a label OpenShift console uses a flag to mark terminal's workspaces

--- a/samples/web-terminal-dev.yaml
+++ b/samples/web-terminal-dev.yaml
@@ -3,8 +3,6 @@ apiVersion: workspace.devfile.io/v1alpha1
 metadata:
   name: web-terminal-dev
   annotations:
-    # it's important to make workspace immutable to make sure nobody with right access
-    # won't set custom editor to steal creator's token
     controller.devfile.io/restricted-access: "true"
   labels:
     # it's a label OpenShift console uses a flag to mark terminal's workspaces

--- a/samples/web-terminal.yaml
+++ b/samples/web-terminal.yaml
@@ -3,8 +3,6 @@ apiVersion: workspace.devfile.io/v1alpha1
 metadata:
   name: web-terminal
   annotations:
-    # it's important to make workspace immutable to make sure nobody with right access
-    # won't set custom editor to steal creator's token
     controller.devfile.io/restricted-access: "true"
   labels:
     # it's a label OpenShift console uses a flag to mark terminal's workspaces

--- a/webhook/workspace/handler/exec.go
+++ b/webhook/workspace/handler/exec.go
@@ -44,7 +44,8 @@ func (h *WebhookHandler) ValidateExecOnConnect(ctx context.Context, req admissio
 		return admission.Denied("The workspace info is missing in the workspace-related pod")
 	}
 
-	if creator != req.UserInfo.UID {
+	if p.Annotations[config.WorkspaceRestrictedAccessAnnotation] == "true" &&
+		creator != req.UserInfo.UID {
 		return admission.Denied("The only workspace creator has exec access")
 	}
 

--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -56,7 +56,7 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha1OnUpdate(_ context.Context, req 
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	allowed, msg := h.handleImmutableWorkspaceV1alpha1(oldWksp, newWksp, req.UserInfo.UID)
+	allowed, msg := h.checkRestrictedAccessWorkspaceV1alpha1(oldWksp, newWksp, req.UserInfo.UID)
 	if !allowed {
 		return admission.Denied(msg)
 	}
@@ -86,7 +86,7 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnUpdate(_ context.Context, req 
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	allowed, msg := h.handleImmutableWorkspaceV1alpha2(oldWksp, newWksp, req.UserInfo.UID)
+	allowed, msg := h.checkRestrictedAccessWorkspaceV1alpha2(oldWksp, newWksp, req.UserInfo.UID)
 	if !allowed {
 		return admission.Denied(msg)
 	}


### PR DESCRIPTION
### What does this PR do?
This PR enables Single host + TLS on OpenShift for basic routing.
It has self-describing commits.

:warning: It worths noting that changes are done on creator access only.
Now creator access only access is provided only for workspaces annotated with `controller.devfile.io/restricted-access: true`
Now CloudShell workspace (not web-terminal) can be opened only with OpenShift OAuth routing.
CloudShell workspace also does not support single-host feature because it uses absolute references at this point.

### TODOs:

- [ ] Theia /che/cluster-ip is failing because it uses absolute reference. Artem will adapt that code to single-host;
**Theia Webview**
- [x] Theia Webview does not work on Chrome if you don't import CA into the browser. Artem will create an issue to expose this info and the most probable solution is just documenting it, or improve Theia to render the proper error page;
- [x] Theia Webview is not stable
![Screenshot_20201201_145712](https://user-images.githubusercontent.com/5887312/100743924-a729e480-33e5-11eb-853c-c5303ddcafbf.png)

```
2020-12-01 14:53:12.187 root ERROR Security problem: Unable to configure separate webviews domain:  Params: Error: Unable to get workspace containers. Cause: [object Object]
    at CheServerWorkspaceServiceImpl.<anonymous> (/home/theia/node_modules/@eclipse-che/theia-remote-api/lib/node/che-server-workspace-service-impl.js:193:31)
    at step (/home/theia/node_modules/@eclipse-che/theia-remote-api/lib/node/che-server-workspace-service-impl.js:62:23)
    at Object.throw (/home/theia/node_modules/@eclipse-che/theia-remote-api/lib/node/che-server-workspace-service-impl.js:43:53)
    at rejected (/home/theia/node_modules/@eclipse-che/theia-remote-api/lib/node/che-server-workspace-service-impl.js:35:65)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```
It works depending on the container startup sequence.
Theia needs to try again when Che is not available for such fundamental stuff like Webview or che-api-sidecar may be moved to a dedicated pod which we start first, but no one of them worths attention because Che API Sidecar is just a temporary solution and it should be reworked in a proper way where Theia access like K8s cluster to get needed info;

- [x] OpenShift OAuth expects to be the only application on the host and sends an absolute redirect
![Screenshot_20201201_145951](https://user-images.githubusercontent.com/5887312/100744098-f112ca80-33e5-11eb-9240-eadfeb58750f.png)

- [ ] Endpoint name is not unique. Should we include the component name to path rule as well?

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/200

### Is it tested? How?

#### Minikube
Verified that on minikube everything works as previously + now terminal works fine for:
```bash
make install

kubectl apply -f ./samples/theia-next.yaml

kubectl apply -f ./samples/all-in-one-theia-nodejs.devworkspace.yaml
```

#### CRC
Verified that on crc now:
- basic routing uses single-host approach;
- Theia works as expected (apart from Webview which is not stable and it's known issue described above);
- now terminal works fine;
for:
```bash
kubectl apply -f ./samples/theia-next.yaml

kc apply -f ./samples/all-in-one-theia-nodejs.devworkspace.yaml
```
![Screenshot_20201127_173303](https://user-images.githubusercontent.com/5887312/100464789-e222d400-30d6-11eb-842a-36cda948bc3e.png)

CloudShell works as it used to work with host per endpoint approach.

