### PR TITLE
Ensure created clusterrole and binding apply to controller deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ endif
 
 ### manifests: Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." \
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=role webhook paths="./..." \
 			output:crd:artifacts:config=config/crd/bases \
 			output:rbac:artifacts:config=config/components/rbac
 	patch/patch_crds.sh

--- a/config/components/manager/kustomization.yaml
+++ b/config/components/manager/kustomization.yaml
@@ -1,2 +1,13 @@
 resources:
 - manager.yaml
+- serviceaccount.yaml
+
+vars:
+- name: CONTROLLER_SERVICE_ACCOUNT
+  objref:
+    kind: ServiceAccount
+    version: v1
+    name: serviceaccount
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/components/manager/kustomizeconfig.yaml
+++ b/config/components/manager/kustomizeconfig.yaml
@@ -1,0 +1,4 @@
+varReference:
+- kind: Deployment
+  group: apps
+  path: spec/template/spec/serviceAccountName

--- a/config/components/manager/manager.yaml
+++ b/config/components/manager/manager.yaml
@@ -8,6 +8,7 @@ spec:
   template:
     spec:
       terminationGracePeriodSeconds: 10
+      serviceAccountName: $(CONTROLLER_SERVICE_ACCOUNT)
       containers:
       - image: quay.io/devfile/devworkspace-controller:next
         name: devworkspace-controller

--- a/config/components/manager/serviceaccount.yaml
+++ b/config/components/manager/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: serviceaccount

--- a/config/components/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/components/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/config/components/rbac/auth_proxy_role_binding.yaml
+++ b/config/components/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: $(CONTROLLER_SERVICE_ACCOUNT)
   namespace: system

--- a/config/components/rbac/kustomization.yaml
+++ b/config/components/rbac/kustomization.yaml
@@ -13,3 +13,6 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/components/rbac/kustomizeconfig.yaml
+++ b/config/components/rbac/kustomizeconfig.yaml
@@ -1,0 +1,9 @@
+varReference:
+- kind: ClusterRoleBinding
+  group: rbac.authorization.k8s.io
+  path: subjects/name
+
+namespace:
+- kind: ClusterRoleBinding
+  group: rbac.authorization.k8s.io
+  path: subjects/namespace

--- a/config/components/rbac/kustomizeconfig.yaml
+++ b/config/components/rbac/kustomizeconfig.yaml
@@ -2,8 +2,14 @@ varReference:
 - kind: ClusterRoleBinding
   group: rbac.authorization.k8s.io
   path: subjects/name
+- kind: RoleBinding
+  group: rbac.authorization.k8s.io
+  path: subjects/name
 
 namespace:
 - kind: ClusterRoleBinding
+  group: rbac.authorization.k8s.io
+  path: subjects/namespace
+- kind: RoleBinding
   group: rbac.authorization.k8s.io
   path: subjects/namespace

--- a/config/components/rbac/leader_election_role_binding.yaml
+++ b/config/components/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: $(CONTROLLER_SERVICE_ACCOUNT)
   namespace: system

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: role
 rules:
 - apiGroups:
   - ""

--- a/config/components/rbac/role_binding.yaml
+++ b/config/components/rbac/role_binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: $(CONTROLLER_SERVICE_ACCOUNT)
   namespace: system


### PR DESCRIPTION
### What does this PR do?
Update kustomize configs to ensure subjects in clusterrole binding match
serviceaccount used for controller deployment

### What issues does this PR fix or reference?
ClusterRoleBinding created for the controller references the default service account.

### Is it tested? How?
`make install`, but make sure you uninstall from the main branch first to clean up all resources.