### PR TITLE
Evaluate plugin registry URL depending on the cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,12 @@ ifeq ($(PLATFORM),kubernetes)
 else
 	$(K8S_CLI) apply -f config/registry/local/os -n $(NAMESPACE)
 endif
+#evaluate plugin registry URL to use in other targets
+ifeq ($(PLATFORM),kubernetes)
+export PLUGIN_REGISTRY_URL=http://che-plugin-registry.$(ROUTING_SUFFIX)/v3)
+else
+export PLUGIN_REGISTRY_URL=http://$(shell $(K8S_CLI) get route -n $(NAMESPACE) che-plugin-registry -o=yaml | yq -r '.status.ingress[].host')/v3
+endif
 
 ### manifests: Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/config/base/config.properties
+++ b/config/base/config.properties
@@ -1,5 +1,5 @@
 devworkspace.routing.cluster_host_suffix=${ROUTING_SUFFIX}
-controller.plugin_registry.url=http://che-plugin-registry.${ROUTING_SUFFIX}/v3
+controller.plugin_registry.url=${PLUGIN_REGISTRY_URL}
 controller.plugin_artifacts_broker.image=quay.io/eclipse/che-plugin-artifacts-broker:v3.4.0
 controller.webhooks.enabled=${WEBHOOK_ENABLED}
 devworkspace.default_routing_class=${DEFAULT_ROUTING}


### PR DESCRIPTION
### What does this PR do?
`make install` sets the right value for plugin registry URL for minikube, but for OpenShift clusters it's needed to be provided manually into configmap. This PR adds evaluating plugin registry URL depending on the cluster. So, for OpenShift users should not set anything, for k8s - ROUTING_SUFFIX is needed (which is evaluated automatically if it's minikube).

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
```bash
make install
#minikube
NAMESPACE=devworkspace-controller
kc get ingress -n ${NAMESPACE} che-plugin-registry -o=yaml | yq -r '.spec.rules[].host'          
kubectl get configmaps -n ${NAMESPACE} devworkspace-controller-configmap -o=yaml | yq '.data["controller.plugin_registry.url"]'

# crc
# make sure the following values have the same host
NAMESPACE=devworkspace-controller
kc get route -n ${NAMESPACE} che-plugin-registry -o=yaml | yq -r '.status.ingress[].host'
kubectl get configmaps -n ${NAMESPACE} devworkspace-controller-configmap -o=yaml | yq '.data["controller.plugin_registry.url"]'
```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
