### PR TITLE
Add support for basic timing information on devworkspace start

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/devfile/devworkspace-operator/internal/cluster"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"
+	"github.com/devfile/devworkspace-operator/pkg/timing"
 	appsv1 "k8s.io/api/apps/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -114,6 +115,8 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	}
 
 	if !workspace.Spec.Started {
+		timing.ClearAnnotations(workspace)
+		r.syncTimingToCluster(ctx, workspace, reqLogger)
 		return r.stopWorkspace(workspace, reqLogger)
 	}
 
@@ -128,7 +131,9 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		Conditions: map[devworkspace.WorkspaceConditionType]string{},
 		Phase:      devworkspace.WorkspaceStatusStarting,
 	}
+	timing.SetTime(workspace, timing.WorkspaceStarted)
 	defer func() (reconcile.Result, error) {
+		r.syncTimingToCluster(ctx, workspace, reqLogger)
 		return r.updateWorkspaceStatus(workspace, reqLogger, &reconcileStatus, reconcileResult, err)
 	}()
 
@@ -158,6 +163,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	}
 
 	// Step one: Create components, and wait for their states to be ready.
+	timing.SetTime(workspace, timing.ComponentsCreated)
 	componentsStatus := provision.SyncComponentsToCluster(workspace, clusterAPI)
 	if !componentsStatus.Continue {
 		if componentsStatus.FailStartup {
@@ -172,6 +178,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	}
 	componentDescriptions := componentsStatus.ComponentDescriptions
 	reconcileStatus.Conditions[devworkspace.WorkspaceReady] = ""
+	timing.SetTime(workspace, timing.ComponentsReady)
 
 	// Only add che rest apis if Theia editor is present in the devfile
 	if restapis.IsCheRestApisRequired(workspace.Spec.Template.Components) {
@@ -196,6 +203,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	}
 
 	// Step two: Create routing, and wait for routing to be ready
+	timing.SetTime(workspace, timing.RoutingCreated)
 	routingStatus := provision.SyncRoutingToCluster(workspace, componentDescriptions, clusterAPI)
 	if !routingStatus.Continue {
 		if routingStatus.FailStartup {
@@ -209,6 +217,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return reconcile.Result{Requeue: routingStatus.Requeue}, routingStatus.Err
 	}
 	reconcileStatus.Conditions[devworkspace.WorkspaceRoutingReady] = ""
+	timing.SetTime(workspace, timing.RoutingReady)
 
 	statusOk, err := syncWorkspaceIdeURL(workspace, routingStatus.ExposedEndpoints, clusterAPI)
 	if err != nil {
@@ -254,6 +263,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	reconcileStatus.Conditions[devworkspace.WorkspaceServiceAccountReady] = ""
 
 	// Step five: Create deployment and wait for it to be ready
+	timing.SetTime(workspace, timing.DeploymentCreated)
 	deploymentStatus := provision.SyncDeploymentToCluster(workspace, podAdditions, componentDescriptions, serviceAcctName, clusterAPI)
 	if !deploymentStatus.Continue {
 		if deploymentStatus.FailStartup {
@@ -266,6 +276,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return reconcile.Result{Requeue: deploymentStatus.Requeue}, deploymentStatus.Err
 	}
 	reconcileStatus.Conditions[devworkspace.WorkspaceReady] = ""
+	timing.SetTime(workspace, timing.DeploymentReady)
 
 	serverReady, err := checkServerStatus(workspace)
 	if err != nil {
@@ -274,6 +285,8 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	if !serverReady {
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}
+	timing.SetTime(workspace, timing.ServersReady)
+	timing.SummarizeStartup(workspace)
 	reconcileStatus.Phase = devworkspace.WorkspaceStatusRunning
 	return reconcile.Result{}, nil
 }
@@ -313,6 +326,19 @@ func (r *DevWorkspaceReconciler) stopWorkspace(workspace *devworkspace.DevWorksp
 		status.Phase = devworkspace.WorkspaceStatusStopped
 	}
 	return r.updateWorkspaceStatus(workspace, logger, status, reconcile.Result{}, nil)
+}
+
+func (r *DevWorkspaceReconciler) syncTimingToCluster(
+	ctx context.Context, workspace *devworkspace.DevWorkspace, reqLogger logr.Logger) {
+	if timing.IsEnabled() {
+		if err := r.Update(ctx, workspace); err != nil {
+			if k8sErrors.IsConflict(err) {
+				reqLogger.Info("Got conflict when trying to apply timing annotations to workspace")
+			} else {
+				reqLogger.Error(err, "Error trying to apply timing annotations to devworkspace")
+			}
+		}
+	}
 }
 
 func getWorkspaceId(instance *devworkspace.DevWorkspace) (string, error) {

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -285,7 +285,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	if !serverReady {
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}
-	timing.SetTime(workspace, timing.ServersReady)
+	timing.SetTime(workspace, timing.WorkspaceReady)
 	timing.SummarizeStartup(workspace)
 	reconcileStatus.Phase = devworkspace.WorkspaceStatusRunning
 	return reconcile.Result{}, nil

--- a/pkg/timing/annotations.go
+++ b/pkg/timing/annotations.go
@@ -22,27 +22,27 @@ const (
 	// WorkspaceStarted denotes when a workspace was first started
 	WorkspaceStarted = "controller.devfile.io/timing.started"
 	// ComponentsCreated denotes when components were created for the workspace
-	ComponentsCreated = "controller.devfile.io/timing.components_created"
+	ComponentsCreated = "controller.devfile.io/timing.components.created"
 	// ComponentsReady denotes when components were ready for the workspace
-	ComponentsReady = "controller.devfile.io/timing.components_ready"
+	ComponentsReady = "controller.devfile.io/timing.components.ready"
 	// RoutingCreated denotes when the workspacerouting was created for the workspace
-	RoutingCreated = "controller.devfile.io/timing.routing_created"
+	RoutingCreated = "controller.devfile.io/timing.routing.created"
 	// RoutingReady denotes when the workspacerouting was ready for the workspace
-	RoutingReady = "controller.devfile.io/timing.routing_ready"
+	RoutingReady = "controller.devfile.io/timing.routing.ready"
 	// DeploymentCreated denotes when the deployment was created for the workspace
-	DeploymentCreated = "controller.devfile.io/timing.deployment_created"
+	DeploymentCreated = "controller.devfile.io/timing.deployment.created"
 	// DeploymentReady denotes when the deployment was ready for the workspace
-	DeploymentReady = "controller.devfile.io/timing.deployment_ready"
-	// ServersReady denotes when all health checks were completed and the workspace was ready
-	ServersReady = "controller.devfile.io/timing.servers_ready"
+	DeploymentReady = "controller.devfile.io/timing.deployment.ready"
+	// WorkspaceReady denotes when all health checks were completed and the workspace was ready
+	WorkspaceReady = "controller.devfile.io/timing.ready"
 )
 
 const (
-	workspaceTotalTime      = "controller.devfile.io/timing.total_time"
-	workspaceComponentsTime = "controller.devfile.io/timing.wait_components"
-	workspaceRoutingsTime   = "controller.devfile.io/timing.wait_routing"
-	workspaceDeploymentTime = "controller.devfile.io/timing.wait_deployment"
-	workspaceServersTime    = "controller.devfile.io/timing.wait_servers"
+	workspaceTotalTime      = "controller.devfile.io/timing.duration"
+	workspaceComponentsTime = "controller.devfile.io/timing.components.duration"
+	workspaceRoutingsTime   = "controller.devfile.io/timing.routing.duration"
+	workspaceDeploymentTime = "controller.devfile.io/timing.deployment.duration"
+	workspaceServersTime    = "controller.devfile.io/timing.healthchecks.duration"
 )
 
 type workspaceTimes struct {
@@ -94,7 +94,7 @@ func getTimestamps(workspace *devworkspace.DevWorkspace) (*workspaceTimes, error
 		return nil, err
 	}
 	times.deploymentReady = t
-	t, err = strconv.ParseInt(workspace.Annotations[ServersReady], 10, 0)
+	t, err = strconv.ParseInt(workspace.Annotations[WorkspaceReady], 10, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/timing/annotations.go
+++ b/pkg/timing/annotations.go
@@ -1,0 +1,103 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package timing
+
+import (
+	"strconv"
+
+	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+)
+
+const (
+	// WorkspaceStarted denotes when a workspace was first started
+	WorkspaceStarted = "controller.devfile.io/timing.started"
+	// ComponentsCreated denotes when components were created for the workspace
+	ComponentsCreated = "controller.devfile.io/timing.components_created"
+	// ComponentsReady denotes when components were ready for the workspace
+	ComponentsReady = "controller.devfile.io/timing.components_ready"
+	// RoutingCreated denotes when the workspacerouting was created for the workspace
+	RoutingCreated = "controller.devfile.io/timing.routing_created"
+	// RoutingReady denotes when the workspacerouting was ready for the workspace
+	RoutingReady = "controller.devfile.io/timing.routing_ready"
+	// DeploymentCreated denotes when the deployment was created for the workspace
+	DeploymentCreated = "controller.devfile.io/timing.deployment_created"
+	// DeploymentReady denotes when the deployment was ready for the workspace
+	DeploymentReady = "controller.devfile.io/timing.deployment_ready"
+	// ServersReady denotes when all health checks were completed and the workspace was ready
+	ServersReady = "controller.devfile.io/timing.servers_ready"
+)
+
+const (
+	workspaceTotalTime      = "controller.devfile.io/timing.total_time"
+	workspaceComponentsTime = "controller.devfile.io/timing.wait_components"
+	workspaceRoutingsTime   = "controller.devfile.io/timing.wait_routing"
+	workspaceDeploymentTime = "controller.devfile.io/timing.wait_deployment"
+	workspaceServersTime    = "controller.devfile.io/timing.wait_servers"
+)
+
+type workspaceTimes struct {
+	workspaceStarted  int64
+	componentsCreated int64
+	componentsReady   int64
+	routingCreated    int64
+	routingReady      int64
+	deploymentCreated int64
+	deploymentReady   int64
+	serversReady      int64
+}
+
+func getTimestamps(workspace *devworkspace.DevWorkspace) (*workspaceTimes, error) {
+	times := &workspaceTimes{}
+	// Will return an error if the annotation is unset
+	t, err := strconv.ParseInt(workspace.Annotations[WorkspaceStarted], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	times.workspaceStarted = t
+	t, err = strconv.ParseInt(workspace.Annotations[ComponentsCreated], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	times.componentsCreated = t
+	t, err = strconv.ParseInt(workspace.Annotations[ComponentsReady], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	times.componentsReady = t
+	t, err = strconv.ParseInt(workspace.Annotations[RoutingCreated], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	times.routingCreated = t
+	t, err = strconv.ParseInt(workspace.Annotations[RoutingReady], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	times.routingReady = t
+	t, err = strconv.ParseInt(workspace.Annotations[DeploymentCreated], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	times.deploymentCreated = t
+	t, err = strconv.ParseInt(workspace.Annotations[DeploymentReady], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	times.deploymentReady = t
+	t, err = strconv.ParseInt(workspace.Annotations[ServersReady], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+	times.serversReady = t
+	return times, nil
+}

--- a/pkg/timing/timing.go
+++ b/pkg/timing/timing.go
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package timing
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/config"
+)
+
+// IsEnabled returns whether storing timing info is enabled for the operator
+func IsEnabled() bool {
+	return config.ControllerCfg.GetExperimentalFeaturesEnabled()
+}
+
+// SetTime applies a given event annotation to the devworkspace with the current
+// timestamp. No-op if timing is disabled or the annotation is already set, meaning
+// this function can be called without additional checks.
+func SetTime(workspace *devworkspace.DevWorkspace, event string) {
+	if !IsEnabled() {
+		return
+	}
+	if _, set := workspace.Annotations[event]; set {
+		return
+	}
+	if workspace.Annotations == nil {
+		workspace.Annotations = map[string]string{}
+	}
+	workspace.Annotations[event] = strconv.FormatInt(time.Now().UnixNano()/1e6, 10)
+}
+
+// SummarizeStartup applies aggregate annotations based off event annotations set by
+// SetTime(). No-op if timing is disabled or if not all event annotations are present
+// on the devworkspace.
+func SummarizeStartup(workspace *devworkspace.DevWorkspace) {
+	if !IsEnabled() {
+		return
+	}
+	times, err := getTimestamps(workspace)
+	if err != nil {
+		return
+	}
+	totalTime := times.serversReady - times.workspaceStarted
+	workspace.Annotations[workspaceTotalTime] = fmt.Sprintf("%d ms", totalTime)
+	componentsTime := times.componentsReady - times.componentsCreated
+	workspace.Annotations[workspaceComponentsTime] = fmt.Sprintf("%d ms", componentsTime)
+	routingsTime := times.routingReady - times.routingCreated
+	workspace.Annotations[workspaceRoutingsTime] = fmt.Sprintf("%d ms", routingsTime)
+	deploymentTime := times.deploymentReady - times.deploymentCreated
+	workspace.Annotations[workspaceDeploymentTime] = fmt.Sprintf("%d ms", deploymentTime)
+	serversTime := times.serversReady - times.deploymentReady
+	workspace.Annotations[workspaceServersTime] = fmt.Sprintf("%d ms", serversTime)
+}
+
+// ClearAnnotations removes all timing-related annotations from a DevWorkspace.
+// It's necessary to call this before setting new times via SetTime(), as SetTime()
+// does not overwrite existing annotations.
+func ClearAnnotations(workspace *devworkspace.DevWorkspace) {
+	if !IsEnabled() {
+		return
+	}
+	delete(workspace.Annotations, WorkspaceStarted)
+	delete(workspace.Annotations, ComponentsCreated)
+	delete(workspace.Annotations, ComponentsReady)
+	delete(workspace.Annotations, RoutingCreated)
+	delete(workspace.Annotations, RoutingReady)
+	delete(workspace.Annotations, DeploymentCreated)
+	delete(workspace.Annotations, DeploymentReady)
+	delete(workspace.Annotations, ServersReady)
+	delete(workspace.Annotations, workspaceTotalTime)
+	delete(workspace.Annotations, workspaceComponentsTime)
+	delete(workspace.Annotations, workspaceRoutingsTime)
+	delete(workspace.Annotations, workspaceDeploymentTime)
+	delete(workspace.Annotations, workspaceServersTime)
+}

--- a/pkg/timing/timing.go
+++ b/pkg/timing/timing.go
@@ -79,7 +79,7 @@ func ClearAnnotations(workspace *devworkspace.DevWorkspace) {
 	delete(workspace.Annotations, RoutingReady)
 	delete(workspace.Annotations, DeploymentCreated)
 	delete(workspace.Annotations, DeploymentReady)
-	delete(workspace.Annotations, ServersReady)
+	delete(workspace.Annotations, WorkspaceReady)
 	delete(workspace.Annotations, workspaceTotalTime)
 	delete(workspace.Annotations, workspaceComponentsTime)
 	delete(workspace.Annotations, workspaceRoutingsTime)


### PR DESCRIPTION
### What does this PR do?
Apply annotations to devworkspaces (when 'experimental features' is enabled) to allow for basic information about how long different steps in workspace startup take.

While a workspace is starting up, certain checkpoints in the main reconcile loop apply annotations with millisecond timestamps to the devworkspace. Once the workspace is running, more annotations are added to summarize some details of the start process (e.g. time waiting on routing, time it takes for the deployment to be ready, etc.)

Example annotations running on `crc`:
```
basic theia:
  "controller.devfile.io/timing.components_created": "1606854314822",
  "controller.devfile.io/timing.components_ready": "1606854314893",
  "controller.devfile.io/timing.deployment_created": "1606854316952",
  "controller.devfile.io/timing.deployment_ready": "1606854329499",
  "controller.devfile.io/timing.routing_created": "1606854314894",
  "controller.devfile.io/timing.routing_ready": "1606854315598",
  "controller.devfile.io/timing.servers_ready": "1606854336136",
  "controller.devfile.io/timing.started": "1606854314822",
  "controller.devfile.io/timing.total_time": "21314 ms",
  "controller.devfile.io/timing.wait_components": "71 ms",
  "controller.devfile.io/timing.wait_deployment": "12547 ms",
  "controller.devfile.io/timing.wait_routing": "704 ms",
  "controller.devfile.io/timing.wait_servers": "6637 ms",

cloud-shell:
  "controller.devfile.io/timing.components_created": "1606855092217",
  "controller.devfile.io/timing.components_ready": "1606855093209",
  "controller.devfile.io/timing.deployment_created": "1606855095154",
  "controller.devfile.io/timing.deployment_ready": "1606855101751",
  "controller.devfile.io/timing.routing_created": "1606855093209",
  "controller.devfile.io/timing.routing_ready": "1606855094676",
  "controller.devfile.io/timing.servers_ready": "1606855103096",
  "controller.devfile.io/timing.started": "1606855092116",
  "controller.devfile.io/timing.total_time": "10980 ms",
  "controller.devfile.io/timing.wait_components": "992 ms",
  "controller.devfile.io/timing.wait_deployment": "6597 ms",
  "controller.devfile.io/timing.wait_routing": "1467 ms",
  "controller.devfile.io/timing.wait_servers": "1345 ms",
```
Note there are some limitations in resolution here:
- Timestamps are applied when the operator notices a condition is true (i.e. a deployment might be ready and the operator only detects it later). This shouldn't be a huge issue, since the workspace isn't running until the controller says it is.
- Timestamps can be inaccurate if there's an error patching the devworkspace to contain new annotations. We currently do it when returning from the reconcile loop to avoid complicating the reconcile flow, but if a conflict arises, annotations will be reset on the next reconcile cycle.

### What issues does this PR fix or reference?
It's a step forward to speed up workspace start-up time withing https://github.com/devfile/devworkspace-operator/issues/209

### Is it tested? How?
I've tested on `crc` but don't see there being much difference with kubernetes.
```bash
make docker install
kubectl apply -f samples/cloud-shell.yaml
kubectl apply -f samples/theia.yaml
# wait for devworkspaces to be running ...
kubectl get dw cloud-shell -o yaml | yq '.metadata.annotations'
kubectl get dw theia -o yaml | yq '.metadata.annotations'
```
Disable experimental features in the configmap and check that annotations are not applied:
```
kubectl edit cm devworkspace-controller-configmap # set devworkspace.experimental_features_enabled=false
make restart
kubectl apply -f samples/theia.yaml
kubectl get dw theia -o yaml | yq '.metadata.annotations'
```