### PR TITLE
Remove no-op mkdir init container

### DIFF
--- a/controllers/workspace/provision/deployment.go
+++ b/controllers/workspace/provision/deployment.go
@@ -201,7 +201,6 @@ func getSpecDeployment(
 	}
 
 	if IsPVCRequired(components) {
-		deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, precreateSubpathsInitContainer(workspace.Status.WorkspaceId))
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, getPersistentVolumeClaim())
 	}
 
@@ -319,29 +318,4 @@ func getPersistentVolumeClaim() corev1.Volume {
 		},
 	}
 	return pvcVolume
-}
-
-func precreateSubpathsInitContainer(workspaceId string) corev1.Container {
-	initContainer := corev1.Container{
-		Name:    "precreate-subpaths",
-		Image:   "registry.access.redhat.com/ubi8/ubi-minimal",
-		Command: []string{"/usr/bin/mkdir"},
-		Args: []string{
-			"-p",
-			"-v",
-			"-m",
-			"777",
-			"/tmp/devworkspaces/" + workspaceId,
-		},
-		ImagePullPolicy: corev1.PullPolicy(config.ControllerCfg.GetSidecarPullPolicy()),
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				MountPath: "/tmp/devworkspaces",
-				Name:      config.ControllerCfg.GetWorkspacePVCName(),
-				ReadOnly:  false,
-			},
-		},
-		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
-	}
-	return initContainer
 }


### PR DESCRIPTION
### What does this PR do?
Since we mount subpaths to other init containers, like https://github.com/devfile/devworkspace-operator/blob/master/samples/all-in-one-theia-nodejs.devworkspace.yaml#L112, this mkdir init containers is no-op and does nothing. See example from real Theia-Next pod
```json
{
  "image": "quay.io/eclipse/che-theia-endpoint-runtime-binary:next",
  "imagePullPolicy": "Always",
  "name": "remote-runtime-injector",
  "volumeMounts": [
    {
      "mountPath": "/remote-endpoint",
      "name": "claim-devworkspace",
      "subPath": "workspace0dbcaccab5834328/remote-endpoint/"
    }
  ]
}
{
  "args": [
    "-p",
    "-v",
    "-m",
    "777",
    "/tmp/devworkspaces/workspace0dbcaccab5834328" !!! <- it's no op because kubelet already should init this for remote-endpoint
  ],
  "command": [
    "/usr/bin/mkdir"
  ],
  "image": "registry.access.redhat.com/ubi8/ubi-minimal",
  "imagePullPolicy": "Always",
  "name": "precreate-subpaths",
  "volumeMounts": [
    {
      "mountPath": "/tmp/devworkspaces",
      "name": "claim-devworkspace"
    },
  ]
}

```

So, this PR just simply removes that init container and if we really need precreate subpaths on some of K8s clusters, we need to implement it with a dedicated pod that will be run before main workspace Deployment. 

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/198

### Is it tested? How?
It's not tested yet.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
