### PR TITLE
Fail devworkspace startup if we fail to download plugin metadata

### DIFF
--- a/apis/controller/v1alpha1/component_types.go
+++ b/apis/controller/v1alpha1/component_types.go
@@ -33,10 +33,16 @@ type WorkspaceComponentSpec struct {
 // ComponentStatus defines the observed state of Component
 // +k8s:openapi-gen=true
 type WorkspaceComponentStatus struct {
-	// Whether the component has finished processing its spec
+	// Ready indicates whether the component has finished processing its spec
 	Ready bool `json:"ready"`
-	// Descriptions of processed components from spec
-	ComponentDescriptions []ComponentDescription `json:"componentDescriptions"`
+	// Failed indicates that an unresolvable problem prevents this component
+	// from being ready.
+	Failed bool `json:"failed,omitempty"`
+	// Message stores additional context about the Component's current state (e.g.
+	// reason for failure)
+	Message string `json:"message,omitempty"`
+	// ComponentDescriptions of processed components from spec
+	ComponentDescriptions []ComponentDescription `json:"componentDescriptions,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/config/crd/bases/controller.devfile.io_components.yaml
+++ b/config/crd/bases/controller.devfile.io_components.yaml
@@ -1483,7 +1483,8 @@ spec:
               description: ComponentStatus defines the observed state of Component
               properties:
                 componentDescriptions:
-                  description: Descriptions of processed components from spec
+                  description: ComponentDescriptions of processed components from
+                    spec
                   items:
                     description: Description of a devfile component's workspace additions
                     properties:
@@ -5434,11 +5435,19 @@ spec:
                       - podAdditions
                     type: object
                   type: array
+                failed:
+                  description: Failed indicates that an unresolvable problem prevents
+                    this component from being ready.
+                  type: boolean
+                message:
+                  description: Message stores additional context about the Component's
+                    current state (e.g. reason for failure)
+                  type: string
                 ready:
-                  description: Whether the component has finished processing its spec
+                  description: Ready indicates whether the component has finished
+                    processing its spec
                   type: boolean
               required:
-                - componentDescriptions
                 - ready
               type: object
           type: object

--- a/controllers/controller/component/component_controller.go
+++ b/controllers/controller/component/component_controller.go
@@ -14,6 +14,7 @@ package component
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/devfile/devworkspace-operator/pkg/adaptor"
@@ -102,8 +103,14 @@ func (r *ComponentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	pluginComponents, brokerConfigMap, err := adaptor.AdaptPluginComponents(instance.Spec.WorkspaceId, instance.Namespace, pluginDevfileComponents)
 	if err != nil {
-		reqLogger.Info("Failed to adapt plugin components")
-		return reconcile.Result{}, err
+		var downloadErr *adaptor.DownloadMetasError
+		if errors.As(err, &downloadErr) {
+			reqLogger.Info("Failed to download plugin metas", "err", downloadErr.Unwrap())
+			return reconcile.Result{}, r.FailComponent(instance, downloadErr.Error())
+		} else {
+			reqLogger.Info("Failed to adapt plugin components")
+			return reconcile.Result{}, err
+		}
 	}
 	components = append(components, pluginComponents...)
 
@@ -165,6 +172,12 @@ func (r *ComponentReconciler) reconcileStatus(instance *controllerv1alpha1.Compo
 	}
 	instance.Status.ComponentDescriptions = components
 	instance.Status.Ready = true
+	return r.Status().Update(context.TODO(), instance)
+}
+
+func (r *ComponentReconciler) FailComponent(instance *controllerv1alpha1.Component, message string) error {
+	instance.Status.Failed = true
+	instance.Status.Message = message
 	return r.Status().Update(context.TODO(), instance)
 }
 

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -163,8 +163,11 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		if componentsStatus.FailStartup {
 			reqLogger.Info("DevWorkspace start failed")
 			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
-			// TODO: Propagate more information from sync step to show a more useful message -- which plugin couldn't be installed?
-			reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = "Could not find plugins for devworkspace"
+			if componentsStatus.Message != "" {
+				reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = componentsStatus.Message
+			} else {
+				reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = "Could not find plugins for devworkspace"
+			}
 		} else {
 			reqLogger.Info("Waiting on components to be ready")
 		}

--- a/controllers/workspace/provision/components.go
+++ b/controllers/workspace/provision/components.go
@@ -111,6 +111,14 @@ func SyncComponentsToCluster(
 func checkComponentsReadiness(components []v1alpha1.Component) ComponentProvisioningStatus {
 	var componentDescriptions []v1alpha1.ComponentDescription
 	for _, component := range components {
+		if component.Status.Failed {
+			return ComponentProvisioningStatus{
+				ProvisioningStatus: ProvisioningStatus{
+					FailStartup: true,
+					Message:     component.Status.Message,
+				},
+			}
+		}
 		if !component.Status.Ready {
 			return ComponentProvisioningStatus{
 				ProvisioningStatus: ProvisioningStatus{},

--- a/controllers/workspace/provision/data_types.go
+++ b/controllers/workspace/provision/data_types.go
@@ -24,6 +24,7 @@ type ProvisioningStatus struct {
 	Requeue     bool
 	FailStartup bool
 	Err         error
+	Message     string
 }
 
 type ClusterAPI struct {

--- a/pkg/adaptor/errors.go
+++ b/pkg/adaptor/errors.go
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package adaptor
+
+// DownloadMetasError represents an error that occurs while downloading plugin meta.yamls
+// This error wraps the underlying error that caused the failure.
+type DownloadMetasError struct {
+	Plugin string
+	Err    error
+}
+
+var _ error = (*DownloadMetasError)(nil)
+
+func (e *DownloadMetasError) Error() string {
+	return "Failed to download plugin meta.yaml for " + e.Plugin
+}
+func (e *DownloadMetasError) Unwrap() error { return e.Err }

--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -247,7 +247,7 @@ func getMetasForComponents(components []devworkspace.Component) (metas []brokerM
 		}
 
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, &DownloadMetasError{Plugin: component.Name, Err: err}
 		}
 		metas = append(metas, *meta)
 		aliases[meta.ID] = component.Name


### PR DESCRIPTION
### What does this PR do?
Add structure to Components subresource to allow unrecoverable errors to be propagated to the DevWorkspace controller, and make the DevWorkspace controller fail DevWorkspace startup if an unrecoverable error occurs

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/165

### Is it tested? How?
Tested on `crc`:
1. Deploy controller as normal
2. Apply theia devworkspace with nonexisting plugin:
    ```yaml
    kind: DevWorkspace
    apiVersion: workspace.devfile.io/v1alpha1
    metadata:
      name: theia
    spec:
      started: true
      routingClass: 'basic'
      template:
        projects:
          - name: project
            git:
              remotes:
                origin: "https://github.com/che-samples/web-nodejs-sample.git"
        components:
          - plugin:
              id: eclipse/che-does-not-exist/latest
          - plugin:
              id: eclipse/che-machine-exec-plugin/latest
        commands:
          - exec:
              id: say hello
              component: plugin
              commandLine: echo "Hello from $(pwd)"
              workingDir: ${PROJECTS_ROOT}/project/app
    ```
3. DevWorkspace status should be "Failed", and failed condition should mention that the plugin failed to download:
    ```
    ❯ kc get dw theia -o yaml | yq -y .status
    conditions:
      - lastTransitionTime: '2020-12-02T20:16:30Z'
        message: Failed to download plugin meta.yaml for eclipse/che-does-not-exist/latest
        status: 'True'
        type: FailedStart
    phase: Failed
    workspaceId: workspace1aff901509704461
    ```