### PR TITLE
Add support for workspacerouting managed by external controller

### DIFF
--- a/controllers/controller/workspacerouting/predictes.go
+++ b/controllers/controller/workspacerouting/predictes.go
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package workspacerouting
+
+import (
+	"errors"
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var routingPredicates = predicate.Funcs{
+	CreateFunc: func(ev event.CreateEvent) bool {
+		obj, ok := ev.Object.(*controllerv1alpha1.WorkspaceRouting)
+		if !ok {
+			return true
+		}
+		if _, err := getSolverForRoutingClass(obj.Spec.RoutingClass); errors.Is(err, externalRoutingError) {
+			return false
+		}
+		return true
+	},
+	DeleteFunc: func(_ event.DeleteEvent) bool {
+		// Return true to ensure finalizers are removed
+		return true
+	},
+	UpdateFunc: func(ev event.UpdateEvent) bool {
+		newObj, ok := ev.ObjectNew.(*controllerv1alpha1.WorkspaceRouting)
+		if !ok {
+			return true
+		}
+		if _, err := getSolverForRoutingClass(newObj.Spec.RoutingClass); errors.Is(err, externalRoutingError) {
+			return false
+		}
+		return true
+	},
+	GenericFunc: func(ev event.GenericEvent) bool {
+		obj, ok := ev.Object.(*controllerv1alpha1.WorkspaceRouting)
+		if !ok {
+			return true
+		}
+		if _, err := getSolverForRoutingClass(obj.Spec.RoutingClass); errors.Is(err, externalRoutingError) {
+			return false
+		}
+		return true
+	},
+}

--- a/controllers/controller/workspacerouting/predictes.go
+++ b/controllers/controller/workspacerouting/predictes.go
@@ -14,6 +14,7 @@ package workspacerouting
 
 import (
 	"errors"
+
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"

--- a/controllers/controller/workspacerouting/workspacerouting_controller.go
+++ b/controllers/controller/workspacerouting/workspacerouting_controller.go
@@ -74,10 +74,6 @@ func (r *WorkspaceRoutingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 		return reconcile.Result{}, err
 	}
 
-	if instance.Annotations[config.WorkspaceExternalRoutingAnnotation] != "" {
-		return reconcile.Result{}, nil
-	}
-
 	// Check if the WorkspaceRouting instance is marked to be deleted, which is
 	// indicated by the deletion timestamp being set.
 	if instance.GetDeletionTimestamp() != nil {

--- a/controllers/controller/workspacerouting/workspacerouting_controller.go
+++ b/controllers/controller/workspacerouting/workspacerouting_controller.go
@@ -82,7 +82,7 @@ func (r *WorkspaceRoutingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	}
 
 	solver, err := getSolverForRoutingClass(instance.Spec.RoutingClass)
-	if err != nil && !errors.Is(err, externalRoutingError) {
+	if err != nil {
 		reqLogger.Error(err, "Could not get solver for routingClass")
 		instance.Status.Phase = controllerv1alpha1.RoutingFailed
 		statusErr := r.Status().Update(ctx, instance)

--- a/controllers/controller/workspacerouting/workspacerouting_controller.go
+++ b/controllers/controller/workspacerouting/workspacerouting_controller.go
@@ -81,16 +81,16 @@ func (r *WorkspaceRoutingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 		return reconcile.Result{}, r.finalize(instance)
 	}
 
+	if instance.Status.Phase == controllerv1alpha1.RoutingFailed {
+		return reconcile.Result{}, nil
+	}
+
 	solver, err := getSolverForRoutingClass(instance.Spec.RoutingClass)
 	if err != nil {
 		reqLogger.Error(err, "Could not get solver for routingClass")
 		instance.Status.Phase = controllerv1alpha1.RoutingFailed
 		statusErr := r.Status().Update(ctx, instance)
 		return reconcile.Result{}, statusErr
-	}
-
-	if instance.Status.Phase == controllerv1alpha1.RoutingFailed {
-		return reconcile.Result{}, nil
 	}
 
 	// Add finalizer for this CR if not already present
@@ -228,7 +228,7 @@ func (r *WorkspaceRoutingReconciler) reconcileStatus(
 	return r.Status().Update(context.TODO(), instance)
 }
 
-func getSolverForRoutingClass(routingClass controllerv1alpha1.WorkspaceRoutingClass) (solver solvers.RoutingSolver, err error) {
+func getSolverForRoutingClass(routingClass controllerv1alpha1.WorkspaceRoutingClass) (solvers.RoutingSolver, error) {
 	if routingClass == "" {
 		routingClass = controllerv1alpha1.WorkspaceRoutingClass(config.ControllerCfg.GetDefaultRoutingClass())
 	}

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -54,10 +54,6 @@ const (
 	// Operator also propagates it to the workspace-related objects to perform authorization.
 	WorkspaceRestrictedAccessAnnotation = "controller.devfile.io/restricted-access"
 
-	// WorkspaceExternalRoutingAnnotation is the annotation applied to workspace routing objects when they are expected
-	// to be handled by an independent controller.
-	WorkspaceExternalRoutingAnnotation = "controller.devfile.io/external_routing"
-
 	// WorkspaceDiscoverableServiceAnnotation marks a service in a workspace as created for a discoverable endpoint,
 	// as opposed to a service created to support the workspace itself.
 	WorkspaceDiscoverableServiceAnnotation = "controller.devfile.io/discoverable-service"

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -54,6 +54,10 @@ const (
 	// Operator also propagates it to the workspace-related objects to perform authorization.
 	WorkspaceRestrictedAccessAnnotation = "controller.devfile.io/restricted-access"
 
+	// WorkspaceExternalRoutingAnnotation is the annotation applied to workspace routing objects when they are expected
+	// to be handled by an independent controller.
+	WorkspaceExternalRoutingAnnotation = "controller.devfile.io/external_routing"
+
 	// WorkspaceDiscoverableServiceAnnotation marks a service in a workspace as created for a discoverable endpoint,
 	// as opposed to a service created to support the workspace itself.
 	WorkspaceDiscoverableServiceAnnotation = "controller.devfile.io/discoverable-service"


### PR DESCRIPTION
### What does this PR do?
Instead of failing a workspace when the routingClass is unsupported, apply an annotation (`controller.devfile.io/external_routing`) to signify that we expect something else to reconcile the object.

This is to allow an implementation-specific controller to reconcile a workspace routing and have it still be used by the devworkspace controller.

### What issues does this PR fix or reference?
Resolves https://github.com/eclipse/che/issues/18520

### Is it tested? How?
```bash
cat <<EOF | oc apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-failed
spec:
  routingClass: does-not-exist
  started: true
  template:
    projects:
      - name: project
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: theia
        plugin:
          id: eclipse/che-theia/next
      - name: terminal
        plugin:
          id: eclipse/che-machine-exec-plugin/nightly
    commands:
      - id: say hello
        exec:
          component: plugin
          commandLine: echo "Hello from $(pwd)"
          workingDir: ${PROJECTS_ROOT}/project/app
EOF
```

1. Message `Could not find solver for routing class` is logged by workspacerouting controller
2. Workspace is stuck in "Starting" phase (as no controller for `routingClass: does-not-exist` exists)
3. Workspace has annotation `controller.devfile.io/external_routing`:
    ```
    $ kc get workspacerouting -o yaml | yq '.items[].metadata.annotations'
    {controller.devfile.io/external_routing
      "controller.devfile.io/external_routing": "true"
    }
    ```