### PR TITLE
WIP: initial implementation of support for developing the controller in-cluster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git
+devworkspace-crds/.git
 testbin
+bin

--- a/build/dev/Dockerfile
+++ b/build/dev/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     git \
     vim nano \
     jq \
+    gettext-base \
     python3-pip \
     # podman \ # TODO: podman not available in golang:1.14-stretch which is upstream for quay.io/eclipse/che-golang-1.14:nightly
     && apt-get clean \

--- a/build/dev/Dockerfile
+++ b/build/dev/Dockerfile
@@ -1,0 +1,39 @@
+FROM quay.io/eclipse/che-golang-1.14:nightly
+
+USER 0
+
+RUN apt-get update && apt-get install -y \
+    make \
+    git \
+    vim nano \
+    jq \
+    python3-pip \
+    # podman \ # TODO: podman not available in golang:1.14-stretch which is upstream for quay.io/eclipse/che-golang-1.14:nightly
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --user yq
+
+RUN mkdir "${HOME}/bin" \
+    && curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && chmod 770 ./kubectl && mv ./kubectl ${HOME}/bin/kubectl \
+    && curl -LO "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz" \
+    && tar -xf openshift-client-linux.tar.gz && mv ./oc ${HOME}/bin/oc \
+    && curl -LO "https://github.com/operator-framework/operator-sdk/releases/download/v1.1.0/operator-sdk-v1.1.0-x86_64-linux-gnu" \
+    && chmod 770 operator-sdk-v1.1.0-x86_64-linux-gnu && mv ./operator-sdk-v1.1.0-x86_64-linux-gnu ${HOME}/bin/operator-sdk \
+    && chmod -R g+rwX ${HOME}
+
+ENV GOPATH=/go
+
+RUN mkdir /tmp/build && cd /tmp/build \
+    && go mod init temp \
+    && go get -u github.com/google/addlicense \
+    && GOFLAGS="" go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 \
+    && curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash \
+    && chmod -R 777 /go
+
+USER 1001
+
+ENV PATH=$PATH:${HOME}/bin:${HOME}/.local/bin:/go/bin
+
+RUN kubectl version --client && \
+    oc version --client

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -120,6 +120,14 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return r.stopWorkspace(workspace, reqLogger)
 	}
 
+	// If the workspace is marked as "start only", we stop reconcile here. This is to enable the use case
+	// where a DevWorkspace is used to develop the DevWorkspace controller.
+	if config.ControllerCfg.GetExperimentalFeaturesEnabled() &&
+		workspace.Annotations[config.WorkspaceStartOnlyLabel] == "true" &&
+		workspace.Status.Phase == devworkspace.WorkspaceStatusRunning {
+		return reconcile.Result{}, nil
+	}
+
 	if workspace.Status.Phase == devworkspace.WorkspaceStatusFailed {
 		// TODO: Figure out when workspace spec is changed and clear failed status to allow reconcile to continue
 		reqLogger.Info("Workspace startup is failed; not attempting to update.")

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -37,6 +37,11 @@ const (
 	SidecarDefaultMemoryLimit = "128M"
 	PVCStorageSize            = "1Gi"
 
+	// WorkspaceStartOnlyLabel is used to specify that the DevWorkspace should not be reconciled further once
+	// it has entered the "Running" phase. This is to enable development of the DevWorkspace operator from within
+	// a DevWorkspace. This label is ignored when `devworkspace.experimental_features_enabled` is set to false.
+	WorkspaceStartOnlyLabel = "controller.devfile.io/development.start_only"
+
 	// WorkspaceIDLabel is label key to store workspace identifier
 	WorkspaceIDLabel = "controller.devfile.io/workspace_id"
 

--- a/samples/devworkspace-controller.yaml
+++ b/samples/devworkspace-controller.yaml
@@ -49,7 +49,6 @@ spec:
               protocol: http
               attributes:
                 type: ide
-                cookiesAuthEnabled: "true"
             - name: "webviews"
               exposure: public
               targetPort: 3100
@@ -57,7 +56,6 @@ spec:
               secure: true
               attributes:
                 type: webview
-                cookiesAuthEnabled: "true"
                 unique: "true"
             - name: "theia-dev"
               exposure: public
@@ -141,7 +139,6 @@ spec:
               secure: true
               attributes:
                 type: terminal
-                cookiesAuthEnabled: "true"
       - name: vscode-go
         attributes:
           "app.kubernetes.io/part-of": che-theia.eclipse.org

--- a/samples/devworkspace-controller.yaml
+++ b/samples/devworkspace-controller.yaml
@@ -159,7 +159,7 @@ spec:
             - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
               value: /remote-endpoint/plugin-remote-endpoint 
             - name: THEIA_PLUGINS
-              value: local-dir:///plugins/sidecars/vscode-typescript
+              value: local-dir:///plugins/sidecars/vscode-go
             - name: PROJECTS_ROOT # Automatically adding this built-in is not implemented yet
               value: "/projects"
           volumeMounts:

--- a/samples/devworkspace-controller.yaml
+++ b/samples/devworkspace-controller.yaml
@@ -1,0 +1,209 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: devworkspace-operator-dev
+  labels:
+    controller.devfile.io/development.start_only: "true"
+spec:
+  started: true
+  template:
+    projects:
+      - name: devworkspace-operator
+        git:
+          remotes:
+            origin: "https://github.com/devfile/devworkspace-operator.git"
+    components:
+
+      - name: theia-ide
+        attributes:
+          "app.kubernetes.io/name": che-theia.eclipse.org
+          "app.kubernetes.io/part-of": che.eclipse.org
+          "app.kubernetes.io/component": editor
+
+          # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
+          # contains the vscode-pull-request-github vscode plugin.
+          "che-theia.eclipse.org/vscode-extensions":
+            - https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix
+
+        container:
+          image: "quay.io/eclipse/che-theia:7.20.0"
+          env:
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins
+            - name: HOSTED_PLUGIN_HOSTNAME
+              value: 0.0.0.0
+            - name: HOSTED_PLUGIN_PORT
+              value: "3130"
+            - name: THEIA_HOST
+              value: 0.0.0.0
+          volumeMounts:
+            - path: "/plugins"
+              name: plugins
+          mountSources: true
+          memoryLimit: "512M"
+          endpoints:
+            - name: "theia"
+              exposure: public
+              targetPort: 3100
+              secure: true
+              protocol: http
+              attributes:
+                type: ide
+                cookiesAuthEnabled: "true"
+            - name: "webviews"
+              exposure: public
+              targetPort: 3100
+              protocol: http
+              secure: true
+              attributes:
+                type: webview
+                cookiesAuthEnabled: "true"
+                unique: "true"
+            - name: "theia-dev"
+              exposure: public
+              targetPort: 3130
+              protocol: http
+              attributes:
+                type: ide-dev
+            - name: "theia-redir-1"
+              exposure: public
+              targetPort: 13131
+              protocol: http
+            - name: "theia-redir-2"
+              exposure: public
+              targetPort: 13132
+              protocol: http
+            - name: "theia-redir-3"
+              exposure: public
+              targetPort: 13133
+              protocol: http      
+
+      - name: plugins
+        volume: {} 
+          
+      - name: vsx-installer # Mainly reads the container objects and searches for those
+                            # with che-theia.eclipse.org/vscode-extensions attributes to get VSX urls
+                            # Those found in the dedicated containers components are with a sidecar,
+                            # Those found in the che-theia container are without a sidecar.
+        attributes:
+          "app.kubernetes.io/part-of": che-theia.eclipse.org
+          "app.kubernetes.io/component": bootstrapper
+        container:
+          args:
+            - /bin/sh
+            - '-c'
+            - >
+              workspace=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}) && for container in $(echo $workspace | sed -e 's;[[,]\({"attributes":{"app.kubernetes.io\);\n\1;g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do dest=$(echo "$container" | sed 's;.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*;\1;' - ) ; urls=$(echo "$container" | sed 's;.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*;\1;' - ) ; mkdir -p $dest; for url in $(echo $urls | sed 's/[",]/ /g' - ); do echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url); done; done
+          image: 'quay.io/samsahai/curl:latest'
+          volumeMounts:
+            - path: "/plugins"
+              name: plugins
+
+      - name: remote-endpoint
+        volume: {}
+          # ephemeral: true                #### We should add it in the Devfile 2.0 spec ! Not critical to implement at start though
+
+      - name: remote-runtime-injector
+        attributes:
+          "app.kubernetes.io/part-of": che-theia.eclipse.org
+          "app.kubernetes.io/component": bootstrapper
+        container:                          #### corresponds to `initContainer` definition in old meta.yaml.
+          image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0"
+          volumeMounts:
+            - path: "/remote-endpoint"
+              name: remote-endpoint
+          env:
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint
+            - name: REMOTE_ENDPOINT_VOLUME_NAME
+              value: remote-endpoint
+            - name: PROJECTS_ROOT # Automatically adding this built-in is not implemented yet
+              value: "/projects"
+
+      - name: che-machine-exec
+        attributes:
+          "app.kubernetes.io/name": che-terminal.eclipse.org
+          "app.kubernetes.io/part-of": che.eclipse.org
+          "app.kubernetes.io/component": terminal
+        container:
+          image: "quay.io/eclipse/che-machine-exec:7.20.0"
+          command: ['/go/bin/che-machine-exec']
+          args:
+            - '--url'
+            - '0.0.0.0:4444'
+            - '--pod-selector'
+            - controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)
+          endpoints:
+            - name: "che-mach-exec"
+              exposure: public
+              targetPort: 4444
+              protocol: ws
+              secure: true
+              attributes:
+                type: terminal
+                cookiesAuthEnabled: "true"
+      - name: vscode-go
+        attributes:
+          "app.kubernetes.io/part-of": che-theia.eclipse.org
+          "app.kubernetes.io/component": vscode-plugin
+          
+          # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
+          # contains the typescript vscode plugin.
+          "che-theia.eclipse.org/vscode-extensions":
+            - https://github.com/golang/vscode-go/releases/download/v0.16.1/go-0.16.1.vsix
+
+        container:
+          image: "quay.io/eclipse/che-sidecar-go:1.14.4-e8a574b"
+          memoryLimit: '512Mi'
+          mountSources: true
+          env:
+            - name: GOPATH
+              value: /go
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint 
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins/sidecars/vscode-typescript
+            - name: PROJECTS_ROOT # Automatically adding this built-in is not implemented yet
+              value: "/projects"
+          volumeMounts:
+            - path: "/remote-endpoint"
+              name: remote-endpoint
+            - name: plugins
+              path: /plugins
+
+      # User runtime container 
+      - name: go-cli
+        container:
+          image: quay.io/amisevsk/devworkspace-operator-dev
+          memoryLimit: 2Gi
+          mountSources: true
+          env:
+          - name: PROJECTS_ROOT # Automatically adding this built-in is not implemented yet
+            value: "/projects"
+    commands:
+      # Commands coming from plugin editor
+      - id: inject-theia-in-remote-sidecar
+        apply:
+          component: remote-runtime-injector
+      - id: copy-vsx
+        apply:
+          component: vsx-installer
+      - id: run-local
+        exec:
+          component: go-cli
+          commandLine: make run
+          workingDir: ${PROJECTS_ROOT}/devworkspace-operator
+      - id: debug-local
+        exec:
+          component: go-cli
+          commandLine: make debug
+          workingDir: ${PROJECTS_ROOT}/devworkspace-operator
+      - id: get-devworkspace-crds
+        exec:
+          component: go-cli
+          commandLine: make update_devworkspace_crds
+          workingDir: ${PROJECTS_ROOT}/devworkspace-operator
+    events:
+      preStart:
+        - inject-theia-in-remote-sidecar
+        - copy-vsx


### PR DESCRIPTION
### What does this PR do?
Adds the beginning of an implementation that enables us to use a DevWorkspace to develop the DevWorkspace controller. This is done by 
1. Adding a label that can be applied to stop controllers from reconciling a workspace once it is running
2. Add a dockerfile for building the "dev" image
3. Add a sample devworkspace CR spec for the development workspace

There are still some todos:
- [ ] Prompted to install go-pls on start, even though it is installed
- [ ] Errors logged for go plugin on start
    ```
    ERROR:Remote plugin in vscode-go: promise rejection is not handled in two seconds: TypeError: Cannot read property 'id' of undefined
    ERROR:Remote plugin in vscode-go: promise rejection stack trace: TypeError: Cannot read property 'id' of undefined
    ```
- [ ] No easy mechanism for logging in to cluster when using k8s
- [ ] No podman/docker support, as podman package isn't available in Debian-stretch AFAICT.

### What issues does this PR fix or reference?
Solves https://github.com/devfile/devworkspace-operator/issues/217
Part of https://github.com/devfile/devworkspace-operator/issues/210

### Is it tested? How?
```
make docker install && kubectl apply -f samples/devworkspace-controller.yaml
```