### PR TITLE
Do not fail webhook server if some of API is not available

### DIFF
--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -57,15 +57,16 @@ func ConfigureWebhookServer(mgr manager.Manager) error {
 	enabled, err := cluster.IsWebhookConfigurationEnabled()
 
 	if err != nil {
-		log.Info("ERROR: Could not evaluate if admission webhook configurations are available", "error", err)
-		return err
-	}
-
-	if !enabled {
-		log.Info("WARN: AdmissionWebhooks are not configured at your cluster." +
-			"    To make your workspaces more secure, please configure them." +
-			"    Skipping setting up Webhook Server")
-		return nil
+		log.Info("ERROR: Could not evaluate if admission webhook configurations are available."+
+			" Fix the reported error or make sure admission webhook are enabled on your cluster manually."+
+			" If they are not enabled configure them otherwise workspace security mechanisms won't work properly", "error", err)
+	} else {
+		if !enabled {
+			log.Info("WARN: AdmissionWebhooks are not configured at your cluster." +
+				"    To make your workspaces more secure, please configure them." +
+				"    Skipping setting up Webhook Server")
+			return nil
+		}
 	}
 
 	CABundle, err = ioutil.ReadFile(WebhookServerCertDir + "/tls.crt")


### PR DESCRIPTION
### What does this PR do?
Do not fail webhook server if some of API is not available

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/221

### Is it tested? How?
It's tested but does not work as expected yet.
Webhook server went further but webhook server failed to start with the following error:
```
2020-12-07T15:36:48.940Z        ERROR   cmd     Manager exited non-zero {"error": "listen tcp :443: bind: permission denied"}
main.main
        /devworkspace-operator/webhook/main.go:94
runtime.main
        /usr/local/go/src/runtime/proc.go:20
```

<details>
<summary>Full Webhook server logs</summary>

```
I1207 15:36:30.168624       1 request.go:621] Throttling request took 1.040625116s, request: GET:https://172.30.0.1:443/apis/policy/v1beta1?timeout=32s
2020-12-07T15:36:35.723Z        INFO    controller-runtime.metrics      metrics server is starting to listen    {"addr": ":8080"}
2020-12-07T15:36:35.723Z        INFO    cmd     Configuring Webhook Server
I1207 15:36:40.174392       1 request.go:621] Throttling request took 1.797993125s, request: GET:https://172.30.0.1:443/apis/tuned.openshift.io/v1?timeout=32s
2020-12-07T15:36:42.325Z        INFO    webhook.server  ERROR: Could not evaluate if admission webhook configurations are available.    Fix the reported error or make sure admission webhook are enabled on your cluster manually.    If they are not enabled configure them otherwise workspace security mechanisms won't work properly   {"error": "unable to retrieve the complete list of server APIs: packages.operators.coreos.com/v1: the server is currently unable to handle the request"}
2020-12-07T15:36:42.325Z        INFO    webhook.server  WARN: AdmissionWebhooks are not configured at your cluster.    To make your workspaces more secure, please configure them.    Skipping setting up Webhook Server
2020-12-07T15:36:42.325Z        INFO    cmd     Configuring Webhooks
2020-12-07T15:36:42.325Z        INFO    webhook.workspace       Configuring workspace webhooks
2020-12-07T15:36:48.937Z        INFO    controller-runtime.builder      skip registering a mutating webhook, admission.Defaulter interface is not implemented   {"GVK": "workspace.devfile.io/v1alpha1, Kind=DevWorkspace"}
2020-12-07T15:36:48.937Z        INFO    controller-runtime.builder      skip registering a validating webhook, admission.Validator interface is not implemented {"GVK": "workspace.devfile.io/v1alpha1, Kind=DevWorkspace"}
2020-12-07T15:36:48.937Z        INFO    controller-runtime.webhook      registering webhook     {"path": "/convert"}
2020-12-07T15:36:48.937Z        INFO    controller-runtime.builder      conversion webhook enabled      {"object": {"metadata":{"creationTimestamp":null},"spec":{"started":false,"template":{}},"status":{"workspaceId":""}}}
2020-12-07T15:36:48.938Z        INFO    controller-runtime.builder      skip registering a mutating webhook, admission.Defaulter interface is not implemented   {"GVK": "workspace.devfile.io/v1alpha2, Kind=DevWorkspace"}
2020-12-07T15:36:48.938Z        INFO    controller-runtime.builder      skip registering a validating webhook, admission.Validator interface is not implemented {"GVK": "workspace.devfile.io/v1alpha2, Kind=DevWorkspace"}
2020-12-07T15:36:48.938Z        INFO    controller-runtime.builder      conversion webhook enabled      {"object": {"metadata":{"creationTimestamp":null},"spec":{"started":false,"template":{}},"status":{"workspaceId":""}}}
2020-12-07T15:36:48.939Z        INFO    cmd     Starting manager
2020-12-07T15:36:48.940Z        INFO    controller-runtime.manager      starting metrics server {"path": "/metrics"}
2020-12-07T15:36:48.940Z        INFO    controller-runtime.webhook.webhooks     starting webhook server
2020-12-07T15:36:48.940Z        INFO    controller-runtime.certwatcher  Updated current TLS certificate
2020-12-07T15:36:48.940Z        INFO    controller-runtime.certwatcher  Starting certificate watcher
2020-12-07T15:36:48.940Z        ERROR   cmd     Manager exited non-zero {"error": "listen tcp :443: bind: permission denied"}
main.main
        /devworkspace-operator/webhook/main.go:94
runtime.main
        /usr/local/go/src/runtime/proc.go:203

```

</details>

Something really bad happened with my cluster.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
