### PR TITLE
Place Che API Sidecar as the first container

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -192,7 +192,8 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		}
 		// TODO: first half of provisioning rest-apis
 		cheRestApisComponent := restapis.GetCheRestApisComponent(workspace.Name, workspace.Status.WorkspaceId, workspace.Namespace)
-		componentDescriptions = append(componentDescriptions, cheRestApisComponent)
+		// some of containers, like theia needs Che API Sidecar be availble just after start up. So, putting Che API Sidecar first before all
+		componentDescriptions = append([]controllerv1alpha1.ComponentDescription{cheRestApisComponent}, componentDescriptions...)
 	}
 
 	pvcStatus := provision.SyncPVC(workspace, componentDescriptions, r.Client, reqLogger)

--- a/samples/all-in-one-theia-nodejs.devworkspace.yaml
+++ b/samples/all-in-one-theia-nodejs.devworkspace.yaml
@@ -25,7 +25,7 @@ spec:
             - https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix
 
         container:
-          image: "quay.io/eclipse/che-theia:7.20.0"
+          image: "quay.io/eclipse/che-theia:next"
           env:
             - name: THEIA_PLUGINS
               value: local-dir:///plugins


### PR DESCRIPTION
### What does this PR do?
This PR places Che API Sidecar as the first container to workaround an issue where Che Theia fails to access it just after startup.

Also, the next Theia is used here since the webview with 7.20 does not work due bug that is fixed on the next version:
![Screenshot_20201208_112632](https://user-images.githubusercontent.com/5887312/101494617-4021a800-3970-11eb-9478-895a2fb55b85.png)


### What issues does this PR fix or reference?
The workaround proposed here https://github.com/devfile/devworkspace-operator/pull/201#issuecomment-736759534

### Is it tested? How?
```bash
# 1. Deploy controller as usual
#export IMG=mylocal:local
make docker
make install

# 2. Run all in one sample
kubectl apply -f samples/all-in-one-theia-nodejs.devworkspace.yaml

# 3. Once workspace is started. Open it and make sure Welcome Page powered by Theia Webview is displayed at least sometimes :-D I did not manage to get it working stable, I assume it's because of cluster-ip issue but I may be wrong and maybe that PR did not work properly. In any case, it should increase the chance to get working Webview
```
![Screenshot_20201208_161143](https://user-images.githubusercontent.com/5887312/101494501-1a949e80-3970-11eb-97dd-ed87f07faf9d.png)

More often it's not displayed:
![Screenshot_20201208_111927](https://user-images.githubusercontent.com/5887312/101494529-25e7ca00-3970-11eb-824c-273ce77d2f8b.png)
