### PR TITLE
Implement clonePath according to the devfile API

### DIFF
--- a/apis/controller/v1alpha1/devfile.go
+++ b/apis/controller/v1alpha1/devfile.go
@@ -44,8 +44,9 @@ type DevfileAttributes struct {
 }
 
 type ProjectSpec struct {
-	Name   string            `json:"name" yaml:"name"`
-	Source ProjectSourceSpec `json:"source" yaml:"source"` // Describes the project's source - type and location
+	Name      string            `json:"name" yaml:"name"`
+	Source    ProjectSourceSpec `json:"source" yaml:"source"` // Describes the project's source - type and location
+	ClonePath string            `json:"clonePath" yaml:"clonePath"`
 }
 
 // Describes the project's source - type and location

--- a/controllers/workspace/restapis/devfilev1_test.go
+++ b/controllers/workspace/restapis/devfilev1_test.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package restapis
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestResolveClonePath(t *testing.T) {
+	t.Run("When path isn't specified it defaults to the project name", testResolveClonePathFunc("", "mySampleProject", "/projects", "mySampleProject"))
+	t.Run("When path is absolute then it defaults to the project name", testResolveClonePathFunc("/Documents/myProject", "mySampleProject", "/projects", "mySampleProject"))
+	t.Run("If path escapes the project root then default to the project name", testResolveClonePathFunc("../../..", "mySampleProject", "/projects", "mySampleProject"))
+	t.Run("If path escapes the project root then back in once then default to the project name", testResolveClonePathFunc("../projects/test", "mySampleProject", "/projects", "mySampleProject"))
+	t.Run("If path escapes the project root once then default to the project name", testResolveClonePathFunc("..", "mySampleProject", "/projects", "mySampleProject"))
+	t.Run("If path is valid then return the path", testResolveClonePathFunc("src/github.com/devfile/devworkspace-operator", "mySampleProject", "/projects", "src/github.com/devfile/devworkspace-operator"))
+}
+
+func testResolveClonePathFunc(path string, projectName string, projectRoot string, expected string) func(*testing.T) {
+	return func(t *testing.T) {
+		actual := resolveClonePath(path, projectName, projectRoot)
+		if actual != expected {
+			t.Error(fmt.Sprintf("Expected %s but got %s instead", expected, actual))
+		}
+	}
+}

--- a/controllers/workspace/restapis/devfilev1_test.go
+++ b/controllers/workspace/restapis/devfilev1_test.go
@@ -21,7 +21,7 @@ func TestResolveClonePath(t *testing.T) {
 	t.Run("When path isn't specified it defaults to the project name", testResolveClonePathFunc("", "mySampleProject", "/projects", "mySampleProject"))
 	t.Run("When path is absolute then it defaults to the project name", testResolveClonePathFunc("/Documents/myProject", "mySampleProject", "/projects", "mySampleProject"))
 	t.Run("If path escapes the project root then default to the project name", testResolveClonePathFunc("../../..", "mySampleProject", "/projects", "mySampleProject"))
-	t.Run("If path escapes the project root then back in once then default to the project name", testResolveClonePathFunc("../projects/test", "mySampleProject", "/projects", "mySampleProject"))
+	t.Run("If path escapes the project root then goes back in then then return the path", testResolveClonePathFunc("../projects/test", "mySampleProject", "/projects", "../projects/test"))
 	t.Run("If path escapes the project root once then default to the project name", testResolveClonePathFunc("..", "mySampleProject", "/projects", "mySampleProject"))
 	t.Run("If path is valid then return the path", testResolveClonePathFunc("src/github.com/devfile/devworkspace-operator", "mySampleProject", "/projects", "src/github.com/devfile/devworkspace-operator"))
 }


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR implements clonePath according to the devfile API spec. This is needed in order to dogfood https://github.com/che-incubator/advent-of-code-2020 using the devworkspace controller.


### What issues does this PR fix or reference?
No issue is open

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
I tried doing:
```
cat <<EOF | oc apply -f -
//...
EOF)
```
but it wasn't working so I just added the devfile itself.

To test just check that the clone happened in `src/github.com/che-incubator/advent-of-code-2020`.

```
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  generateName: aoc2020
spec:
  started: true
  template:
    projects:
      - name: advent-of-code-2020
        git:
          remotes:
            origin: https://github.com/che-incubator/advent-of-code-2020.git
        clonePath: src/github.com/che-incubator/advent-of-code-2020

    components:

      - name: theia-ide
        attributes:
          "app.kubernetes.io/name": che-theia.eclipse.org
          "app.kubernetes.io/part-of": che.eclipse.org
          "app.kubernetes.io/component": editor

          # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
          # contains the vscode-pull-request-github vscode plugin.
          "che-theia.eclipse.org/vscode-extensions":
            - https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix

        container:
          image: "quay.io/eclipse/che-theia:7.20.0"
          env:
            - name: THEIA_PLUGINS
              value: local-dir:///plugins
            - name: HOSTED_PLUGIN_HOSTNAME
              value: 0.0.0.0
            - name: HOSTED_PLUGIN_PORT
              value: "3130"
            - name: THEIA_HOST
              value: 0.0.0.0
          volumeMounts:
            - path: "/plugins"
              name: plugins
          mountSources: true
          memoryLimit: "512M"
          endpoints:
            - name: "theia"
              exposure: public
              targetPort: 3100
              secure: true
              protocol: http
              attributes:
                type: ide
                cookiesAuthEnabled: "true"
            - name: "webviews"
              exposure: public
              targetPort: 3100
              protocol: http
              secure: true
              attributes:
                type: webview
                cookiesAuthEnabled: "true"
                unique: "true"
            - name: "theia-dev"
              exposure: public
              targetPort: 3130
              protocol: http
              attributes:
                type: ide-dev
            - name: "theia-redir-1"
              exposure: public
              targetPort: 13131
              protocol: http
            - name: "theia-redir-2"
              exposure: public
              targetPort: 13132
              protocol: http
            - name: "theia-redir-3"
              exposure: public
              targetPort: 13133
              protocol: http      

      - name: plugins
        volume: {}
          
      - name: vsx-installer
        attributes:
          "app.kubernetes.io/part-of": che-theia.eclipse.org
          "app.kubernetes.io/component": bootstrapper
        container:
          args:
            - /bin/sh
            - '-c'
            - >
              workspace=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}) && for container in $(echo $workspace | sed -e 's;[[,]\({"attributes":{"app.kubernetes.io\);\n\1;g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do dest=$(echo "$container" | sed 's;.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*;\1;' - ) ; urls=$(echo "$container" | sed 's;.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*;\1;' - ) ; mkdir -p $dest; for url in $(echo $urls | sed 's/[",]/ /g' - ); do echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url); done; done
          image: 'quay.io/samsahai/curl:latest'
          volumeMounts:
            - path: "/plugins"
              name: plugins

      - name: remote-endpoint
        volume: {}

      - name: remote-runtime-injector
        attributes:
          "app.kubernetes.io/part-of": che-theia.eclipse.org
          "app.kubernetes.io/component": bootstrapper
        container:
          image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0"
          volumeMounts:
            - path: "/remote-endpoint"
              name: remote-endpoint
          env:
            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
              value: /remote-endpoint/plugin-remote-endpoint
            - name: REMOTE_ENDPOINT_VOLUME_NAME
              value: remote-endpoint

      - name: che-machine-exec
        attributes:
          "app.kubernetes.io/name": che-terminal.eclipse.org
          "app.kubernetes.io/part-of": che.eclipse.org
          "app.kubernetes.io/component": terminal
        container:
          image: "quay.io/eclipse/che-machine-exec:7.20.0"
          command: ['/go/bin/che-machine-exec']
          args:
            - '--url'
            - '0.0.0.0:4444'
            - '--pod-selector'
            - controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)
          endpoints:
            - name: "che-mach-exec"
              exposure: public
              targetPort: 4444
              protocol: ws
              secure: true
              attributes:
                type: terminal
                cookiesAuthEnabled: "true"
     
      - name: vscode-go
        attributes:
          "app.kubernetes.io/part-of": che-theia.eclipse.org
          "app.kubernetes.io/component": vscode-plugin
          "che-theia.eclipse.org/vscode-extensions":
            - https://github.com/golang/vscode-go/releases/download/v0.16.1/go-0.16.1.vsix

        container:
          image: "quay.io/eclipse/che-sidecar-go:1.14.4-e8a574b"
          memoryLimit: '512Mi'
          env:
            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
              value: /remote-endpoint/plugin-remote-endpoint 
            - name: THEIA_PLUGINS
              value: local-dir:///plugins/sidecars/vscode-go
            - name: GOPATH
              value: /go:$(CHE_PROJECTS_ROOT)
          volumeMounts:
            - path: "/remote-endpoint"
              name: remote-endpoint
            - name: plugins
              path: /plugins

      # User runtime container 
      - name: tools
        container:
          image: quay.io/che-incubator/advent-of-code-2020:latest
          memoryLimit: 512Mi
          mountSources: true

    commands:

      # Commands coming from plugin editor
      - id: inject-theia-in-remote-sidecar
        apply:
          component: remote-runtime-injector
      - id: copy-vsx
        apply:
          component: vsx-installer

      # User commands
      - id: day-01-solution
        exec:
          component: tools
          commandLine: go run day-01.go
          workingDir: '${CHE_PROJECTS_ROOT}/advent-of-code-2020/day-01'
      - id: day-02-solution
        exec:
          component: tools
          commandLine: go run day-02.go
          workingDir: '${CHE_PROJECTS_ROOT}/advent-of-code-2020/day-02'
      - id: day-03-solution
        exec:
          component: tools
          commandLine: go run day-03.go
          workingDir: '${CHE_PROJECTS_ROOT}/advent-of-code-2020/day-03'
      - id: day-04-solution
        exec:
          component: tools
          commandLine: go run day-04.go
          workingDir: '${CHE_PROJECTS_ROOT}/advent-of-code-2020/day-04'
      - id: day-05-solution
        exec:
          component: tools
          commandLine: go run day-05.go
          workingDir: '${CHE_PROJECTS_ROOT}/advent-of-code-2020/day-05'
      - id: day-06-solution
        exec:
          component: tools
          commandLine: go run day-06.go
          workingDir: '${CHE_PROJECTS_ROOT}/advent-of-code-2020/day-06'
      - id: day-07-solution
        exec:
          component: tools
          commandLine: go run day-07.go
          workingDir: '${CHE_PROJECTS_ROOT}/advent-of-code-2020/day-07'
      - id: day-08-solution
        exec:
          component: tools
          commandLine: go run day-08.go
          workingDir: '${CHE_PROJECTS_ROOT}/advent-of-code-2020/day-08'
    events:
      preStart:
        - inject-theia-in-remote-sidecar
        - copy-vsx
```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
