### PR TITLE
Use nightly machine execs for all webterminal plugin versions

### DIFF
--- a/config/components/manager/manager.yaml
+++ b/config/components/manager/manager.yaml
@@ -36,11 +36,11 @@ spec:
               fieldRef:
                 fieldPath: spec.serviceAccountName
           - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-            value: "quay.io/wto/web-terminal-exec:1.0"
+            value: "quay.io/eclipse/che-machine-exec:nightly"
           - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_nightly
             value: "quay.io/eclipse/che-machine-exec:nightly"
           - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_4_5_0
-            value: "quay.io/wto/web-terminal-exec:1.0"
+            value: "quay.io/eclipse/che-machine-exec:nightly"
           - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_dev_nightly
             value: "quay.io/eclipse/che-machine-exec:nightly"
           - name: RELATED_IMAGE_plugin_eclipse_cloud_shell_nightly


### PR DESCRIPTION
### What does this PR do?
Initially, we planned that each OpenShift Console version will use the OpenShift version-specific web terminal plugin. It's `RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0` was stick to `"quay.io/wto/web-terminal-exec:1.0"`. But we did not manage to finalize that process and it does not make sense to stick `redhat_developer_web_terminal_4_5_0` to `1.0` at least on devworkspace operators side + until we develop a plan on how we manage web terminal plugins versions.

So, this PR uses nightlies and fixes the issue with idling you can face if you deploy DevWorkspace Operators from master and create a terminal using OpenShift Console.

### What issues does this PR fix or reference?
There is no one created yet but I'll create on WTO side to develop a plan on how we manage web terminal plugins versions.

### Is it tested? How?
not yet but I expect that after these changes idling works

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
