### PR TITLE
Use predicates to handle failed devworkspaces

### DIFF
--- a/controllers/controller/component/component_controller.go
+++ b/controllers/controller/component/component_controller.go
@@ -167,11 +167,13 @@ func (r *ComponentReconciler) reconcileConfigMap(instance *controllerv1alpha1.Co
 }
 
 func (r *ComponentReconciler) reconcileStatus(instance *controllerv1alpha1.Component, components []controllerv1alpha1.ComponentDescription) error {
-	if instance.Status.Ready && cmp.Equal(instance.Status.ComponentDescriptions, components) {
+	if !instance.Status.Failed && instance.Status.Message == "" && instance.Status.Ready && cmp.Equal(instance.Status.ComponentDescriptions, components) {
 		return nil
 	}
 	instance.Status.ComponentDescriptions = components
 	instance.Status.Ready = true
+	instance.Status.Failed = false
+	instance.Status.Message = ""
 	return r.Status().Update(context.TODO(), instance)
 }
 

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -120,12 +120,6 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return r.stopWorkspace(workspace, reqLogger)
 	}
 
-	if workspace.Status.Phase == devworkspace.WorkspaceStatusFailed {
-		// TODO: Figure out when workspace spec is changed and clear failed status to allow reconcile to continue
-		reqLogger.Info("Workspace startup is failed; not attempting to update.")
-		return reconcile.Result{}, nil
-	}
-
 	// Prepare handling workspace status and condition
 	reconcileStatus := currentStatus{
 		Conditions: map[devworkspace.WorkspaceConditionType]string{},
@@ -386,5 +380,6 @@ func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&controllerv1alpha1.Component{}).
 		Owns(&controllerv1alpha1.WorkspaceRouting{}).
+		WithEventFilter(predicates).
 		Complete(r)
 }

--- a/controllers/workspace/predicates.go
+++ b/controllers/workspace/predicates.go
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package controllers
+
+import (
+	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var predicates = predicate.Funcs{
+	CreateFunc: func(_ event.CreateEvent) bool { return true },
+	DeleteFunc: func(_ event.DeleteEvent) bool { return true },
+	UpdateFunc: func(ev event.UpdateEvent) bool {
+		newObj, ok := ev.ObjectNew.(*v1alpha2.DevWorkspace)
+		if !ok {
+			return true
+		}
+		if newObj.Status.Phase != v1alpha2.WorkspaceStatusFailed {
+			return true
+		}
+		oldObj, ok := ev.ObjectOld.(*v1alpha2.DevWorkspace)
+		if !ok {
+			// Should never happen
+			return true
+		}
+		// Trigger a reconcile on failed workspaces if routingClass is updated.
+		return oldObj.Spec.RoutingClass != newObj.Spec.RoutingClass
+	},
+	GenericFunc: func(_ event.GenericEvent) bool { return true },
+}

--- a/controllers/workspace/predicates.go
+++ b/controllers/workspace/predicates.go
@@ -14,10 +14,14 @@ package controllers
 
 import (
 	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// predicates filters incoming events to avoid unnecessary reconciles to failed workspaces.
+// If a workspace failed and its spec is changed, we trigger reconciles to allow for fixing
+// issues in the workspace spec.
 var predicates = predicate.Funcs{
 	CreateFunc: func(_ event.CreateEvent) bool { return true },
 	DeleteFunc: func(_ event.DeleteEvent) bool { return true },
@@ -34,8 +38,8 @@ var predicates = predicate.Funcs{
 			// Should never happen
 			return true
 		}
-		// Trigger a reconcile on failed workspaces if routingClass is updated.
-		return oldObj.Spec.RoutingClass != newObj.Spec.RoutingClass
+		// Trigger a reconcile on failed workspaces if spec is updated.
+		return !equality.Semantic.DeepEqual(oldObj.Spec, newObj.Spec)
 	},
 	GenericFunc: func(_ event.GenericEvent) bool { return true },
 }


### PR DESCRIPTION
### What does this PR do?
Update how failed workspaces are handled
- Predicates filter events so that failed workspaces do not trigger reconciles
- ...unless the routingClass is updated.

### What issues does this PR fix or reference?
Don't recall if we had an issue for this one

### Is it tested? How?
Easiest to test on k8s:
```bash
make docker install # or restart if already running
kubectl apply -f samples/cloud-shell
kubectl get dw # cloud shell is failed
kubectl edit dw cloud-shell # editing devworkspace does not trigger reconciles
kubectl patch dw cloud-shell --type merge --patch '{"spec": {"routingClass": "basic"}}'
kubectl get dw # cloud-shell is starting
```
