### PR TITLE
Clean up DevWorkspaces PVC when a DevWorkspace is deleted.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,10 +211,9 @@ restart_webhook:
 uninstall: _kustomize
 # It's safer to delete all workspaces before deleting the controller; otherwise we could
 # leave workspaces in a hanging state if we add finalizers.
-	$(K8S_CLI) delete devworkspaces.workspace.devfile.io --all-namespaces --all | true
-	$(K8S_CLI) delete devworkspacetemplates.workspace.devfile.io --all-namespaces --all | true
-# Have to wait for routings to be deleted in case there are finalizers
-	$(K8S_CLI) delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait | true
+	$(K8S_CLI) delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait || true
+	$(K8S_CLI) delete devworkspacetemplates.workspace.devfile.io --all-namespaces --all || true
+	$(K8S_CLI) delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait || true
 ifeq ($(PLATFORM),kubernetes)
 	$(KUSTOMIZE) build config/cert-manager | $(K8S_CLI) delete --ignore-not-found -f -
 else

--- a/config/components/manager/manager.yaml
+++ b/config/components/manager/manager.yaml
@@ -53,3 +53,5 @@ spec:
             value: "quay.io/devfile/devworkspace-controller:next"
           - name: RELATED_IMAGE_default_tls_secrets_creation_job
             value: "quay.io/eclipse/che-tls-secret-creator:alpine-3029769"
+          - name: RELATED_IMAGE_pvc_cleanup_job
+            value: "quay.io/libpod/busybox:1.30.1"

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -22,6 +22,8 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -89,6 +89,8 @@ rules:
   - create
   - delete
   - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -272,7 +272,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	serviceAcctName := serviceAcctStatus.ServiceAccountName
 	reconcileStatus.Conditions[devworkspace.WorkspaceServiceAccountReady] = ""
 
-	// Step five: Create deployment and wait for it to be ready
+	// Step six: Create deployment and wait for it to be ready
 	timing.SetTime(workspace, timing.DeploymentCreated)
 	deploymentStatus := provision.SyncDeploymentToCluster(workspace, podAdditions, componentDescriptions, serviceAcctName, clusterAPI)
 	if !deploymentStatus.Continue {

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
@@ -68,10 +69,33 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 	if wait {
 		return reconcile.Result{Requeue: true}, nil
 	}
+
+	terminating, err := r.namespaceIsTerminating(ctx, workspace.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	} else if terminating {
+		//Namespace is terminating, it's redundant to clean PVC files since it's going to be removed
+		log.Info("Namespace is terminating; clearing storage finalizer")
+		clearFinalizer(workspace)
+		return reconcile.Result{}, r.Update(ctx, workspace)
+	}
+
+	pvcExists, err := r.pvcExists(ctx, workspace)
+	if err != nil {
+		return reconcile.Result{}, err
+	} else if !pvcExists {
+		//PVC does not exist. nothing to clean up
+		log.Info("PVC does not exit; clearing storage finalizer")
+		clearFinalizer(workspace)
+		// job will be clean up by k8s garbage collector
+		return reconcile.Result{}, r.Update(ctx, workspace)
+	}
+
 	specJob, err := r.getSpecCleanupJob(workspace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+
 	clusterJob, err := r.getClusterCleanupJob(ctx, workspace)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -111,7 +135,8 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 			return r.updateWorkspaceStatus(workspace, r.Log, failedStatus, reconcile.Result{}, nil)
 		}
 	}
-	return reconcile.Result{}, nil
+	// Requeue at least each 10 seconds to check if PVC is not removed by someone else
+	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
 func (r *DevWorkspaceReconciler) getSpecCleanupJob(workspace *v1alpha2.DevWorkspace) (*batchv1.Job, error) {
@@ -221,4 +246,34 @@ func clearFinalizer(workspace *v1alpha2.DevWorkspace) {
 		}
 	}
 	workspace.SetFinalizers(newFinalizers)
+}
+
+func (r *DevWorkspaceReconciler) namespaceIsTerminating(ctx context.Context, namespace string) (bool, error) {
+	namespacedName := types.NamespacedName{
+		Name: namespace,
+	}
+	n := &corev1.Namespace{}
+
+	err := r.Get(ctx, namespacedName, n)
+	if err != nil {
+		return false, err
+	}
+
+	return n.Status.Phase == corev1.NamespaceTerminating, nil
+}
+
+func (r *DevWorkspaceReconciler) pvcExists(ctx context.Context, workspace *v1alpha2.DevWorkspace) (bool, error) {
+	namespacedName := types.NamespacedName{
+		Name:      config.ControllerCfg.GetWorkspacePVCName(),
+		Namespace: workspace.Namespace,
+	}
+	err := r.Get(ctx, namespacedName, &corev1.PersistentVolumeClaim{})
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+	return true, nil
 }

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -1,0 +1,208 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
+	"github.com/devfile/devworkspace-operator/pkg/config"
+
+	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	pvcClaimMountPath   = "/tmp/devworkspaces/"
+	cleanupCommandFmt   = "rm -rf %s"
+	pvcCleanupFinalizer = "storage.controller.devfile.io"
+)
+
+var (
+	cleanupJobCompletions  = int32(1)
+	cleanupJobBackoffLimit = int32(3)
+)
+
+func (r *DevWorkspaceReconciler) setFinalizer(ctx context.Context, workspace *v1alpha2.DevWorkspace) (ok bool, err error) {
+	if !isFinalizerNecessary(workspace) || hasFinalizer(workspace) {
+		return true, nil
+	}
+	workspace.SetFinalizers(append(workspace.Finalizers, pvcCleanupFinalizer))
+	return false, r.Update(ctx, workspace)
+}
+
+func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, workspace *v1alpha2.DevWorkspace) (reconcile.Result, error) {
+	if !hasFinalizer(workspace) {
+		return reconcile.Result{}, nil
+	}
+	// Need to make sure Deployment is cleaned up before starting job to avoid mounting issues for RWO PVCs
+	wait, err := provision.DeleteWorkspaceDeployment(ctx, workspace, r.Client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if wait {
+		return reconcile.Result{Requeue: true}, nil
+	}
+	specJob, err := r.getSpecCleanupJob(workspace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	clusterJob, err := r.getClusterCleanupJob(ctx, workspace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if clusterJob == nil {
+		err := r.Create(ctx, specJob)
+		if err != nil && !k8sErrors.IsAlreadyExists(err) {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{Requeue: true}, nil
+	}
+	if !equality.Semantic.DeepDerivative(specJob.Spec, clusterJob.Spec) {
+		err := r.Delete(ctx, clusterJob)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{Requeue: true}, nil
+	}
+	for _, condition := range clusterJob.Status.Conditions {
+		if condition.Status != corev1.ConditionTrue {
+			continue
+		}
+		switch condition.Type {
+		case batchv1.JobComplete:
+			log.Info("PVC clean up job successful; clearing finalizer")
+			clearFinalizer(workspace)
+			return reconcile.Result{}, r.Update(ctx, workspace)
+		case batchv1.JobFailed:
+			log.Error(fmt.Errorf("PVC clean up job failed: message %q", condition.Message),
+				"Failed to clean PVC on workspace deletion")
+			return reconcile.Result{}, nil
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *DevWorkspaceReconciler) getSpecCleanupJob(workspace *v1alpha2.DevWorkspace) (*batchv1.Job, error) {
+	workspaceId := workspace.Status.WorkspaceId
+	pvcName := config.ControllerCfg.GetWorkspacePVCName()
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cleanup-" + workspaceId, // TODO
+			Namespace: workspace.Namespace,
+			Labels: map[string]string{
+				config.WorkspaceIDLabel: workspaceId,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			Completions:  &cleanupJobCompletions,
+			BackoffLimit: &cleanupJobBackoffLimit,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: "Never",
+					Volumes: []corev1.Volume{
+						{
+							Name: pvcName,
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvcName,
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:    "cleanup-" + workspaceId,   // TODO,
+							Image:   "quay.io/fedora/fedora:34", // TODO
+							Command: []string{"/bin/sh"},
+							Args: []string{
+								"-c",
+								fmt.Sprintf(cleanupCommandFmt, path.Join(pvcClaimMountPath, workspaceId)),
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("64Mi"), // TODO
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      pvcName,
+									MountPath: pvcClaimMountPath,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := controllerutil.SetControllerReference(workspace, job, r.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	return job, nil
+}
+
+func (r *DevWorkspaceReconciler) getClusterCleanupJob(ctx context.Context, workspace *v1alpha2.DevWorkspace) (*batchv1.Job, error) {
+	namespacedName := types.NamespacedName{
+		Name:      "cleanup-" + workspace.Status.WorkspaceId,
+		Namespace: workspace.Namespace,
+	}
+	clusterJob := &batchv1.Job{}
+
+	err := r.Get(ctx, namespacedName, clusterJob)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return clusterJob, nil
+}
+
+func isFinalizerNecessary(_ *v1alpha2.DevWorkspace) bool {
+	// TODO: Implement checking whether persistent storage is used (once other choices are possible)
+	return true
+}
+
+func hasFinalizer(workspace *v1alpha2.DevWorkspace) bool {
+	for _, finalizer := range workspace.Finalizers {
+		if finalizer == pvcCleanupFinalizer {
+			return true
+		}
+	}
+	return false
+}
+
+func clearFinalizer(workspace *v1alpha2.DevWorkspace) {
+	var newFinalizers []string
+	for _, finalizer := range workspace.Finalizers {
+		if finalizer != pvcCleanupFinalizer {
+			newFinalizers = append(newFinalizers, finalizer)
+		}
+	}
+	workspace.SetFinalizers(newFinalizers)
+}

--- a/controllers/workspace/provision/pvc.go
+++ b/controllers/workspace/provision/pvc.go
@@ -74,6 +74,13 @@ func IsPVCRequired(components []v1alpha1.ComponentDescription) bool {
 				}
 			}
 		}
+		for _, cont := range comp.PodAdditions.InitContainers {
+			for _, vm := range cont.VolumeMounts {
+				if vm.Name == volumeName {
+					return true
+				}
+			}
+		}
 	}
 	return false
 }

--- a/internal/images/image.go
+++ b/internal/images/image.go
@@ -38,6 +38,7 @@ const (
 	openshiftOAuthProxyImageEnvVar      = "RELATED_IMAGE_openshift_oauth_proxy"
 	webhookServerImageEnvVar            = "RELATED_IMAGE_devworkspace_webhook_server"
 	webhookKubernetesCertJobImageEnvVar = "RELATED_IMAGE_default_tls_secrets_creation_job"
+	pvcCleanupJobImageEnvVar            = "RELATED_IMAGE_pvc_cleanup_job"
 )
 
 // GetWebTerminalToolingImage returns the image reference for the webhook server image. Returns
@@ -80,6 +81,17 @@ func GetWebhookCertJobImage() string {
 	val, ok := os.LookupEnv(webhookKubernetesCertJobImageEnvVar)
 	if !ok {
 		log.Error(fmt.Errorf("environment variable %s is not set", webhookKubernetesCertJobImageEnvVar), "Could not get webhook cert job image")
+		return ""
+	}
+	return val
+}
+
+// GetPVCCleanupJobImage returns the image reference for the PVC cleanup job used to clean workspace
+// files from the common PVC in a namespace.
+func GetPVCCleanupJobImage() string {
+	val, ok := os.LookupEnv(pvcCleanupJobImageEnvVar)
+	if !ok {
+		log.Error(fmt.Errorf("environment variable %s is not set", pvcCleanupJobImageEnvVar), "Could not get PVC cleanup job image")
 		return ""
 	}
 	return val

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -80,3 +80,7 @@ func DeploymentName(workspaceId string) string {
 func ServingCertVolumeName(serviceName string) string {
 	return fmt.Sprintf("workspace-serving-cert-%s", serviceName)
 }
+
+func PVCCleanupJobName(workspaceId string) string {
+	return fmt.Sprintf("cleanup-%s", workspaceId)
+}

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -64,6 +64,9 @@ const (
 	// WorkspaceStopReasonAnnotation marks the reason why the workspace was stopped; when a workspace is restarted
 	// this annotation will be cleared
 	WorkspaceStopReasonAnnotation = "controller.devfile.io/stopped-by"
+
+	// PVCCleanupPodMemoryLimit is the memory limit used for PVC clean up pods
+	PVCCleanupPodMemoryLimit = "32Mi"
 )
 
 // Constants for che-rest-apis

--- a/test/e2e/pkg/client/namespace.go
+++ b/test/e2e/pkg/client/namespace.go
@@ -51,7 +51,7 @@ func (w *K8sClient) WaitNamespaceIsTerminated(namespace string) (err error) {
 	for {
 		select {
 		case <-timeoutC:
-			return errors.New(fmt.Sprintf("The namespace %s is not terminated and removed after %d.", namespace, timeoutC))
+			return errors.New(fmt.Sprintf("The namespace %s is not terminated and removed after %ds.", namespace, timeout))
 		case <-tickC:
 			var ns *corev1.Namespace
 			ns, err = w.kubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})

--- a/webhook/workspace/handler/kind.go
+++ b/webhook/workspace/handler/kind.go
@@ -11,7 +11,9 @@
 //
 package handler
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 var (
 	V1alpha1DevWorkspaceKind     = metav1.GroupVersionKind{Kind: "DevWorkspace", Group: "workspace.devfile.io", Version: "v1alpha1"}
@@ -23,5 +25,6 @@ var (
 	V1PodKind            = metav1.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}
 	V1ServiceKind        = metav1.GroupVersionKind{Kind: "Service", Group: "", Version: "v1"}
 	V1beta1IngressKind   = metav1.GroupVersionKind{Kind: "Ingress", Group: "extensions", Version: "v1beta1"}
+	V1JobKind            = metav1.GroupVersionKind{Kind: "Job", Group: "batch", Version: "v1"}
 	V1RouteKind          = metav1.GroupVersionKind{Kind: "Route", Group: "route.openshift.io", Version: "v1"}
 )

--- a/webhook/workspace/mutate.go
+++ b/webhook/workspace/mutate.go
@@ -45,7 +45,7 @@ func (m *ResourcesMutator) Handle(ctx context.Context, req admission.Request) ad
 				return m.MutatePodOnCreate(ctx, req)
 			case handler.AppsV1DeploymentKind:
 				return m.MutateDeploymentOnCreate(ctx, req)
-			case handler.V1ServiceKind, handler.V1beta1IngressKind, handler.V1RouteKind,
+			case handler.V1ServiceKind, handler.V1beta1IngressKind, handler.V1RouteKind, handler.V1JobKind,
 				handler.V1alpha1ComponentKind, handler.V1alpha1WorkspaceRoutingKind:
 
 				return m.HandleRestrictedAccessCreate(ctx, req)
@@ -62,7 +62,7 @@ func (m *ResourcesMutator) Handle(ctx context.Context, req admission.Request) ad
 				return m.MutatePodOnUpdate(ctx, req)
 			case handler.AppsV1DeploymentKind:
 				return m.MutateDeploymentOnUpdate(ctx, req)
-			case handler.V1ServiceKind, handler.V1beta1IngressKind, handler.V1RouteKind,
+			case handler.V1ServiceKind, handler.V1beta1IngressKind, handler.V1RouteKind, handler.V1JobKind,
 				handler.V1alpha1ComponentKind, handler.V1alpha1WorkspaceRoutingKind:
 
 				return m.HandleRestrictedAccessUpdate(ctx, req)

--- a/webhook/workspace/mutating_cfg.go
+++ b/webhook/workspace/mutating_cfg.go
@@ -109,6 +109,14 @@ func BuildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfigurati
 					Resources:   []string{"ingresses"},
 				},
 			},
+			{
+				Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
+				Rule: v1beta1.Rule{
+					APIGroups:   []string{"batch"},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"jobs"},
+				},
+			},
 		},
 	}
 	// n.b. Routes do not get UserInfo.UID filled in webhooks for some reason


### PR DESCRIPTION
### What does this PR do?
Runs a similar job to Eclipse Che, which removes workspace files from the common PVC when the workspace is deleted.

~~**Note:** It's expected that this will likely fail on OpenShift as-is, due to the PVC subpath problem (https://github.com/devfile/devworkspace-operator/issues/198). On minikube, it seems pods can run as root and so the problem doesn't manifest.~~ This should be resolved now.

### What issues does this PR fix or reference?
Resolves https://github.com/devfile/devworkspace-operator/issues/214

### Is it tested? How?
```bash
# Deploy controller as normal
make docker install
# Create Theia DevWorkspace
kubectl apply -f samples/theia-next
# Delete DevWorkspace
kubectl delete dw theia
# Repeat create and delete a few times for good measure
# Check that workspace files are cleaned up
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: cleanup
  labels:
    app: cleanup
spec:
  containers:
    - image: quay.io/libpod/busybox:1.30.1
      name: cleanup
      volumeMounts:
        - mountPath: /tmp/claim-devworkspace
          name: claim-devworkspace
      command: ["sleep"]
      args: ["1d"]
  volumes:
    - name: claim-devworkspace
      persistentVolumeClaim:
        claimName: claim-devworkspace
EOF
# Output should be just `.` and `..`
kubectl exec -it cleanup -- ls -al /tmp/claim-devworkspace
kubectl delete po cleanup
```
There *may* be a weird race condition where the job completes successfully but paths still exist in the PVC -- I can't reproduce it consistently. Interestingly, kubernetes seems to create subpaths in a mounted volume even if it's mounted to another pod, which may be related.