### PR TITLE
Switch base builder image to quay.io

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM quay.io/libpod/golang:1.13 as builder
 
 RUN go env GOPROXY
 WORKDIR /devworkspace-operator


### PR DESCRIPTION

### What does this PR do?
Switch from golang:1.13 to quay.io/libpod/golang:1.13 to avoid dockerhub rate limits and fix CI jobs. The images should be identical otherwise.

### What issues does this PR fix or reference?
We've started seeing CI failures due to being unable to pull `golang:1.13`:

```
error: build error: error creating build container: The following failures happened while trying to pull image specified by "golang:1.13" based on search registries in /var/run/configs/openshift.io/build-system/registries.conf:
* "localhost/golang:1.13": Error initializing source docker://localhost/golang:1.13: error pinging docker registry localhost: Get "https://localhost/v2/": dial tcp [::1]:443: connect: connection refused
* "docker.io/library/golang:1.13": Error determining manifest MIME type for docker://golang:1.13: Error reading manifest sha256:24bd48a274920bf47ead96c5a2db8e6a3fbe26e8ae27557c2caa9aeae562a998 in docker.io/library/golang: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
2020/12/21 19:42:55 No custom metadata found and prow metadata already exists. Not updating the metadata.
2020/12/21 19:42:55 Ran for 2m56s 
```

### Is it tested? How?
At the time of writing, the two images `golang:1.13` and `quay.io/libpod/golang:1.13` have identical hashes. We can look into moving to a different image in the future if needed (e.g. the `go-toolset` UBI8 image).