### PR TITLE
Add makefile rule for checking formatting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,9 +51,8 @@ jobs:
         go get -u golang.org/x/tools/cmd/goimports
         git reset HEAD --hard
 
-        make fmt
-        make fmt_license
-        if [[ ! -z $(git status -s) ]]
+        make check_fmt
+        if [[ $? != 0 ]]
         then
           echo "not well formatted sources are found"
           exit 1

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ endif
 		if [[ $$(find . -name '*.go' -exec goimports -l {} \;) != "" ]]; then \
 			echo "Files not formatted; run 'make fmt'"; exit 1 ;\
 		fi ;\
-		if ! addlicense -c -f license_header.txt $$(find . -name '*.go'); then \
+		if ! addlicense -check -f license_header.txt $$(find . -name '*.go'); then \
 			echo "Licenses are not formatted; run 'make fmt_license'"; exit 1 ;\
 		fi \
 	}

--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,23 @@ else
 	$(error addlicense must be installed for this rule: go get -u github.com/google/addlicense)
 endif
 
+### check_fmt: check formatting on files in repo
+check_fmt:
+ifeq ($(shell command -v goimports 2> /dev/null),)
+	$(error "goimports must be installed for this rule" && exit 1)
+endif
+ifeq ($(shell command -v addlicense 2> /dev/null),)
+	$(error "error addlicense must be installed for this rule: go get -u github.com/google/addlicense")
+endif
+	@{
+		if [[ $$(find . -name '*.go' -exec goimports -l {} \;) != "" ]]; then \
+			echo "Files not formatted; run 'make fmt'"; exit 1 ;\
+		fi ;\
+		if ! addlicense -c -f license_header.txt $$(find . -name '*.go'); then \
+			echo "Licenses are not formatted; run 'make fmt_license'"; exit 1 ;\
+		fi \
+	}
+
 ### vet: Run go vet against code
 vet:
 	go vet ./...


### PR DESCRIPTION
### What does this PR do?
Adds Makefile rule `check_fmt` which exits with a non-zero exit code if formatting (`make fmt fmt_license`) needs to be updated. I've updated the PR check to use this rule instead of the previous, but the rule is also useful as a precommit hook in local repos:

- `./git/hooks/pre-commit`
```bash
#!/usr/bin/bash

set -e

# Redirect output to stderr.
exec 1>&2

# If there are whitespace errors, print the offending file names and fail.
git diff-index --check --cached HEAD --

# Check formatting
make check_fmt
```

### What issues does this PR fix or reference?
The issue of @sleshchenko having to fix formatting on my PRs when I forget :smile: 

### Is it tested? How?
Tested it locally, only meaningful change is the PR check CI, which should be functionally the same.
