### PR TITLE
Improve logging in controller

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
 
 patchesStrategicMerge:
 - manager_image_patch.yaml
+- manager_dev_mode_patch.yaml
 
 vars:
 - name: OPERATOR_NAMESPACE

--- a/config/base/manager_dev_mode_patch.yaml
+++ b/config/base/manager_dev_mode_patch.yaml
@@ -1,0 +1,15 @@
+# This patch adds an environment variable to the workspace deployment
+# to enable dev mode
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: devworkspace-controller
+        env:
+        - name: DEVELOPMENT_MODE
+          value: "true"

--- a/controllers/controller/component/component_controller.go
+++ b/controllers/controller/component/component_controller.go
@@ -17,6 +17,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/devfile/devworkspace-operator/pkg/config"
+
 	"github.com/devfile/devworkspace-operator/pkg/adaptor"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -56,7 +58,6 @@ func (r *ComponentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 
 	reqLogger := r.Log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
-	reqLogger.Info("Reconciling Component")
 
 	// Fetch the Component instance
 	instance := &controllerv1alpha1.Component{}
@@ -71,6 +72,8 @@ func (r *ComponentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	reqLogger = reqLogger.WithValues(config.WorkspaceIDLoggerKey, instance.Spec.WorkspaceId)
+	reqLogger.Info("Reconciling Component")
 
 	if instance.DeletionTimestamp != nil {
 		reqLogger.V(5).Info("Skipping reconcile of deleted resource")

--- a/controllers/controller/workspacerouting/workspacerouting_controller.go
+++ b/controllers/controller/workspacerouting/workspacerouting_controller.go
@@ -62,7 +62,6 @@ func (r *WorkspaceRoutingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	ctx := context.Background()
 
 	reqLogger := r.Log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
-	reqLogger.Info("Reconciling WorkspaceRouting")
 
 	// Fetch the WorkspaceRouting instance
 	instance := &controllerv1alpha1.WorkspaceRouting{}
@@ -77,6 +76,8 @@ func (r *WorkspaceRoutingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	reqLogger = reqLogger.WithValues(config.WorkspaceIDLoggerKey, instance.Spec.WorkspaceId)
+	reqLogger.Info("Reconciling WorkspaceRouting")
 
 	// Check if the WorkspaceRouting instance is marked to be deleted, which is
 	// indicated by the deletion timestamp being set.

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -40,6 +40,9 @@ const (
 	// WorkspaceIDLabel is label key to store workspace identifier
 	WorkspaceIDLabel = "controller.devfile.io/workspace_id"
 
+	// WorkspaceIDLoggerKey is the key used to log workspace ID in the reconcile
+	WorkspaceIDLoggerKey = "workspace_id"
+
 	// WorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
 	WorkspaceEndpointNameAnnotation = "controller.devfile.io/endpoint_name"
 

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -22,6 +22,7 @@ type ControllerEnv struct{}
 const (
 	webhooksSecretNameEnvVar      = "WEBHOOK_SECRET_NAME"
 	webhooksCertificateNameEnvVar = "WEBHOOK_CERTIFICATE_NAME"
+	developmentModeEnvVar         = "DEVELOPMENT_MODE"
 )
 
 func GetWebhooksSecretName() (string, error) {
@@ -38,4 +39,8 @@ func GetWebhooksCertName() (string, error) {
 		return "", fmt.Errorf("environment variable %s is unset", webhooksCertificateNameEnvVar)
 	}
 	return env, nil
+}
+
+func GetDevModeEnabled() bool {
+	return os.Getenv(developmentModeEnvVar) == "true"
 }

--- a/webhook/main.go
+++ b/webhook/main.go
@@ -23,12 +23,13 @@ import (
 	workspacev1alpha1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha1"
 	workspacev1alpha2 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/internal/cluster"
+	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/webhook/server"
 	"github.com/devfile/devworkspace-operator/webhook/workspace"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	clientconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -47,10 +48,10 @@ func init() {
 }
 
 func main() {
-	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.UseDevMode(config.GetDevModeEnabled())))
 
 	// Get a config to talk to the apiserver
-	cfg, err := config.GetConfig()
+	cfg, err := clientconfig.GetConfig()
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)


### PR DESCRIPTION
### What does this PR do?
* Add env var ($DEVELOPMENT_MODE) to deployment to enable/disable development mode; default to true for now
* Set dev mode in default logging according to $DEVELOPMENT_MODE
* Log workspace ID with all log lines in controller, to allow matching reconciles for e.g. workspaceRouting with the actual DevWorkspace
* Move controller config initialization into main.go to ensure it is completed before starting any controllers

At some point, my IDE modified whitespace in `import` blocks, causing our imports to shuffle around meaninglessly.

### What issues does this PR fix or reference?
Minor frustrations I had with our logs:
- We had dev-mode logging hardcoded to enabled (now it's hard-coded, but in yaml! :smile:)
- It wasn't straightforward to match a log for a component/routing with the workspace that owned it

### Is it tested? How?
Tested on minikube
