### PR TITLE
Fix predicates to force reconciles of deleted resources

### DIFF
--- a/controllers/workspace/predicates.go
+++ b/controllers/workspace/predicates.go
@@ -38,6 +38,10 @@ var predicates = predicate.Funcs{
 			// Should never happen
 			return true
 		}
+		// always reconcile if resource is deleted
+		if newObj.GetDeletionTimestamp() != nil {
+			return true
+		}
 		// Trigger a reconcile on failed workspaces if spec is updated.
 		return !equality.Semantic.DeepEqual(oldObj.Spec, newObj.Spec)
 	},


### PR DESCRIPTION
### What does this PR do?
Update predicates to trigger reconciles if a devworkspace has been deleted. Otherwise, failed workspaces do not trigger reconciles as often as they should.

### What issues does this PR fix or reference?
Deleting a failed workspace hangs as reconciles related to the PVC cleanup job don't trigger.

### Is it tested? How?
Easiest to test on minikube:
```bash
make deploy # etc...
kubectl apply -f samples/web-terminal.yaml
kubectl get dw web-terminal # verify that workspace is failed
kubectl delete dw web-terminal # should delete successfully (does not on master branch)
```
