### PR TITLE
Update devfile/api dependency and populate devworkspace.status.message with info about failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ export WEBHOOK_ENABLED ?= true
 export DEFAULT_ROUTING ?= basic
 export KUBECONFIG ?= ${HOME}/.kube/config
 REGISTRY_ENABLED ?= true
-DEVWORKSPACE_API_VERSION ?= aeda60d4361911da85103f224644bfa792498499
+DEVWORKSPACE_API_VERSION ?= f33d2987d137225cd1e8975f6fdfdd2663195a37
 
 #internal params
 DEVWORKSPACE_CTRL_SA=devworkspace-controller-serviceaccount
@@ -110,7 +110,7 @@ endif
 ##### Rules for dealing with devfile/api
 ### update_devworkspace_api: update version of devworkspace crds in go.mod
 update_devworkspace_api:
-	go mod edit --require github.com/devfile/api@$(DEVWORKSPACE_API_VERSION)
+	go mod edit --require github.com/devfile/api/v2@$(DEVWORKSPACE_API_VERSION)
 	go mod download
 	go mod tidy
 

--- a/apis/controller/v1alpha1/component.go
+++ b/apis/controller/v1alpha1/component.go
@@ -13,7 +13,7 @@
 package v1alpha1
 
 import (
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 // Description of a devfile component's workspace additions

--- a/apis/controller/v1alpha1/component_types.go
+++ b/apis/controller/v1alpha1/component_types.go
@@ -13,7 +13,7 @@
 package v1alpha1
 
 import (
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/controller/v1alpha1/workspacerouting_types.go
+++ b/apis/controller/v1alpha1/workspacerouting_types.go
@@ -13,7 +13,7 @@
 package v1alpha1
 
 import (
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -17,7 +17,7 @@
 package v1alpha1
 
 import (
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/controllers/controller/component/cmd_terminal/cmd_terminal.go
+++ b/controllers/controller/component/cmd_terminal/cmd_terminal.go
@@ -15,7 +15,7 @@ package cmd_terminal
 import (
 	"strings"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 const (

--- a/controllers/controller/component/component_controller.go
+++ b/controllers/controller/component/component_controller.go
@@ -35,7 +35,7 @@ import (
 
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/library"
 )
 

--- a/controllers/controller/workspacerouting/solvers/cluster_solver.go
+++ b/controllers/controller/workspacerouting/solvers/cluster_solver.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/controller/workspacerouting/solvers/common.go
+++ b/controllers/controller/workspacerouting/solvers/common.go
@@ -13,7 +13,7 @@
 package solvers
 
 import (
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"

--- a/controllers/controller/workspacerouting/solvers/openshift_oauth_solver.go
+++ b/controllers/controller/workspacerouting/solvers/openshift_oauth_solver.go
@@ -17,7 +17,7 @@ import (
 
 	maputils "github.com/devfile/devworkspace-operator/internal/map"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"

--- a/controllers/controller/workspacerouting/solvers/resolve_endpoints.go
+++ b/controllers/controller/workspacerouting/solvers/resolve_endpoints.go
@@ -17,7 +17,7 @@ import (
 	"net/url"
 	"strings"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 )

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/restapis"
 )

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -18,7 +18,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
 	"github.com/devfile/devworkspace-operator/internal/images"
 	"github.com/devfile/devworkspace-operator/pkg/common"

--- a/controllers/workspace/predicates.go
+++ b/controllers/workspace/predicates.go
@@ -13,7 +13,7 @@
 package controllers
 
 import (
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"

--- a/controllers/workspace/provision/components.go
+++ b/controllers/workspace/provision/components.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"fmt"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/controller/component/cmd_terminal"
 	"github.com/devfile/devworkspace-operator/pkg/adaptor"

--- a/controllers/workspace/provision/deployment.go
+++ b/controllers/workspace/provision/deployment.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/env"
 	"github.com/devfile/devworkspace-operator/pkg/config"

--- a/controllers/workspace/provision/pvc.go
+++ b/controllers/workspace/provision/pvc.go
@@ -13,7 +13,7 @@
 package provision
 
 import (
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/go-logr/logr"

--- a/controllers/workspace/provision/rbac.go
+++ b/controllers/workspace/provision/rbac.go
@@ -13,7 +13,7 @@
 package provision
 
 import (
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/go-logr/logr"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/controllers/workspace/provision/routing.go
+++ b/controllers/workspace/provision/routing.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"fmt"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/google/go-cmp/cmp"

--- a/controllers/workspace/provision/serviceaccount.go
+++ b/controllers/workspace/provision/serviceaccount.go
@@ -15,7 +15,7 @@ package provision
 import (
 	"context"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/workspace/restapis/component.go
+++ b/controllers/workspace/restapis/component.go
@@ -15,7 +15,7 @@ package restapis
 import (
 	"strings"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"

--- a/controllers/workspace/restapis/configmap.go
+++ b/controllers/workspace/restapis/configmap.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"encoding/json"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
 	"github.com/devfile/devworkspace-operator/pkg/common"

--- a/controllers/workspace/restapis/devfilev1.go
+++ b/controllers/workspace/restapis/devfilev1.go
@@ -17,7 +17,7 @@ import (
 	"path"
 	"strings"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	workspaceApi "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 )

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -79,6 +79,8 @@ func (r *DevWorkspaceReconciler) updateWorkspaceStatus(workspace *devworkspace.D
 	sort.SliceStable(workspace.Status.Conditions, func(i, j int) bool {
 		return strings.Compare(string(workspace.Status.Conditions[i].Type), string(workspace.Status.Conditions[j].Type)) > 0
 	})
+	infoMessage := getInfoMessage(status.Conditions)
+	workspace.Status.Message = infoMessage
 
 	err := r.Status().Update(context.TODO(), workspace)
 	if err != nil {
@@ -137,4 +139,18 @@ func getIdeUrl(exposedEndpoints map[string]v1alpha1.ExposedEndpointList) string 
 		}
 	}
 	return ""
+}
+
+func getInfoMessage(conditions map[devworkspace.WorkspaceConditionType]string) string {
+	var failedStartMsg string
+	for conditionType, conditionMessage := range conditions {
+		switch conditionType {
+		// Take error condition message as overriding failed start message
+		case "Error":
+			return conditionMessage
+		case devworkspace.WorkspaceFailedStart:
+			failedStartMsg = conditionMessage
+		}
+	}
+	return failedStartMsg
 }

--- a/controllers/workspace/validation.go
+++ b/controllers/workspace/validation.go
@@ -15,7 +15,7 @@ package controllers
 import (
 	"fmt"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/webhook"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/devworkspace-operator
 go 1.13
 
 require (
-	github.com/devfile/api v0.0.0-20201125082321-aeda60d43619
+	github.com/devfile/api/v2 v2.0.0-20210105203253-f33d2987d137
 	github.com/eclipse/che-go-jsonrpc v0.0.0-20200317130110-931966b891fe // indirect
 	github.com/eclipse/che-plugin-broker v3.4.0+incompatible
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api v0.0.0-20201125082321-aeda60d43619 h1:1pTtDONDby55+kqHhvSqPiVKIGf1OJRY1vXCeHFG+wU=
-github.com/devfile/api v0.0.0-20201125082321-aeda60d43619/go.mod h1:/aDiwWjDEW/fY1/Ig8umVtmneAXKZImnLvWqzMlcfrY=
+github.com/devfile/api/v2 v2.0.0-20210105203253-f33d2987d137 h1:9uT8z84dYIg3ROSB1CMXIS/b/7Ddev4lxSEOXeMkvWU=
+github.com/devfile/api/v2 v2.0.0-20210105203253-f33d2987d137/go.mod h1:ujP0i3nip2g/aSOXGEy3A7vTC6EIe1kZf9Cteja6OJg=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=

--- a/main.go
+++ b/main.go
@@ -24,8 +24,8 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/webhook"
 
-	workspacev1alpha1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha1"
-	workspacev1alpha2 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspacev1alpha1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
+	workspacev1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	workspacecontroller "github.com/devfile/devworkspace-operator/controllers/workspace"
 

--- a/pkg/adaptor/artifacts_broker.go
+++ b/pkg/adaptor/artifacts_broker.go
@@ -16,7 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"

--- a/pkg/adaptor/common.go
+++ b/pkg/adaptor/common.go
@@ -13,7 +13,7 @@
 package adaptor
 
 import (
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/adaptor/dockerimage.go
+++ b/pkg/adaptor/dockerimage.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"strings"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"

--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -16,11 +16,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/devfile/api/pkg/attributes"
+	"github.com/devfile/api/v2/pkg/attributes"
 
 	"github.com/devfile/devworkspace-operator/pkg/adaptor/plugin_patch"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 
 	"github.com/devfile/devworkspace-operator/pkg/common"

--- a/pkg/config/cmd_terminal.go
+++ b/pkg/config/cmd_terminal.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/devfile/devworkspace-operator/internal/images"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/library/command.go
+++ b/pkg/library/command.go
@@ -15,7 +15,7 @@ package library
 import (
 	"fmt"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 func getCommandType(command devworkspace.Command) (devworkspace.CommandType, error) {

--- a/pkg/library/lifecycle.go
+++ b/pkg/library/lifecycle.go
@@ -15,7 +15,7 @@ package library
 import (
 	"fmt"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 // GetInitContainers partitions the components in a devfile's flattened spec into initContainer and non-initContainer lists

--- a/pkg/library/lifecycle_test.go
+++ b/pkg/library/lifecycle_test.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/timing/annotations.go
+++ b/pkg/timing/annotations.go
@@ -15,7 +15,7 @@ package timing
 import (
 	"strconv"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 const (

--- a/pkg/timing/timing.go
+++ b/pkg/timing/timing.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 	"time"
 
-	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 )
 

--- a/samples/all-in-one-theia-nodejs.devworkspace.yaml
+++ b/samples/all-in-one-theia-nodejs.devworkspace.yaml
@@ -214,29 +214,29 @@ spec:
           component: vsx-installer
 
       # User commands
-      - id: download dependencies
+      - id: download-dependencies
         exec:
           component: nodejs
           commandLine: npm install
           workingDir: ${PROJECTS_ROOT}/project/app
-      - id: run the app
+      - id: run-the-app
         exec:
           component: nodejs
           commandLine: nodemon app.js
           workingDir: ${PROJECTS_ROOT}/project/app
-      - id: run the app (debugging enabled)
+      - id: run-the-app-with-debugging-enabled
         exec:
           component: nodejs
           commandLine: nodemon --inspect app.js
           workingDir: ${PROJECTS_ROOT}/project/app
-      - id: stop the app
+      - id: stop-the-app
         exec:
           component: nodejs
           commandLine: >-
               node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
               echo "Stopping node server with PIDs: ${node_server_pids}" &&
               kill -15 ${node_server_pids} &>/dev/null && echo 'Done.'
-      - id: Attach remote debugger
+      - id: attach-remote-debugger
         vscodeLaunch:
           inlined: |
             {

--- a/samples/theia-latest.yaml
+++ b/samples/theia-latest.yaml
@@ -18,7 +18,7 @@ spec:
         plugin:
           id: eclipse/che-machine-exec-plugin/latest
     commands:
-      - id: say hello
+      - id: say-hello
         exec:
           component: plugin
           commandLine: echo "Hello from $(pwd)"

--- a/samples/theia-next.yaml
+++ b/samples/theia-next.yaml
@@ -18,7 +18,7 @@ spec:
         plugin:
           id: eclipse/che-machine-exec-plugin/nightly
     commands:
-      - id: say hello
+      - id: say-hello
         exec:
           component: plugin
           commandLine: echo "Hello from $(pwd)"

--- a/samples/theia-nodejs.yaml
+++ b/samples/theia-nodejs.yaml
@@ -33,29 +33,29 @@ spec:
           mountSources: true
     commands:
       - exec:
-          id: download dependencies
+          id: download-dependencies
           component: nodejs
           commandLine: npm install
           workingDir: ${PROJECTS_ROOT}/project/app
       - exec:
-          id: run the app
+          id: run-the-app
           component: nodejs
           commandLine: nodemon app.js
           workingDir: ${PROJECTS_ROOT}/project/app
       - exec:
-          id: run the app (debugging enabled)
+          id: run-the-app-with-debugging-enabled
           component: nodejs
           commandLine: nodemon --inspect app.js
           workingDir: ${PROJECTS_ROOT}/project/app
       - exec:
-          id: stop the app
+          id: stop-the-app
           component: nodejs
           commandLine: >-
               node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
               echo "Stopping node server with PIDs: ${node_server_pids}" &&
               kill -15 ${node_server_pids} &>/dev/null && echo 'Done.'
       - vscodeLaunch:
-          id: Attach remote debugger
+          id: Attach-remote-debugger
           inlined: |
             {
               "version": "0.2.0",

--- a/test/e2e/pkg/client/client.go
+++ b/test/e2e/pkg/client/client.go
@@ -15,7 +15,7 @@ package client
 import (
 	"fmt"
 
-	workspacev1v1alpha2 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspacev1v1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"

--- a/test/e2e/pkg/client/devws.go
+++ b/test/e2e/pkg/client/devws.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"time"
 
-	workspacev1alpha2 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspacev1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/test/e2e/pkg/tests/devworkspaces_tests.go
+++ b/test/e2e/pkg/tests/devworkspaces_tests.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"strings"
 
-	workspacesv1alpha2 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspacesv1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/test/e2e/pkg/config"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"

--- a/webhook/main.go
+++ b/webhook/main.go
@@ -20,8 +20,8 @@ import (
 
 	"syscall"
 
-	workspacev1alpha1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha1"
-	workspacev1alpha2 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspacev1alpha1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
+	workspacev1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/internal/cluster"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/webhook/server"

--- a/webhook/workspace/handler/immutable.go
+++ b/webhook/workspace/handler/immutable.go
@@ -16,8 +16,8 @@ import (
 	"fmt"
 	"reflect"
 
-	devworkspacev1alpha1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha1"
-	devworkspacev1alpha2 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspacev1alpha1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
+	devworkspacev1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -17,8 +17,8 @@ import (
 
 	maputils "github.com/devfile/devworkspace-operator/internal/map"
 
-	devworkspacev1alpha1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha1"
-	devworkspacev1alpha2 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	devworkspacev1alpha1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
+	devworkspacev1alpha2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )

--- a/webhook/workspace/mutating_cfg.go
+++ b/webhook/workspace/mutating_cfg.go
@@ -30,6 +30,7 @@ func BuildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfigurati
 	mutateWebhookPath := mutateWebhookPath
 	labelExistsOp := metav1.LabelSelectorOpExists
 	equivalentMatchPolicy := v1beta1.Equivalent
+	sideEffectsNone := v1beta1.SideEffectClassNone
 	webhookClientConfig := v1beta1.WebhookClientConfig{
 		Service: &v1beta1.ServiceReference{
 			Name:      server.WebhookServerServiceName,
@@ -43,6 +44,7 @@ func BuildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfigurati
 		Name:          "mutate.devworkspace-controller.svc",
 		FailurePolicy: &mutateWebhookFailurePolicy,
 		ClientConfig:  webhookClientConfig,
+		SideEffects:   &sideEffectsNone,
 		Rules: []v1beta1.RuleWithOperations{
 			{
 				Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},

--- a/webhook/workspace/validating_cfg.go
+++ b/webhook/workspace/validating_cfg.go
@@ -26,6 +26,7 @@ const (
 func buildValidatingWebhookCfg(namespace string) *v1beta1.ValidatingWebhookConfiguration {
 	validateWebhookFailurePolicy := validateWebhookFailurePolicy
 	validateWebhookPath := validateWebhookPath
+	sideEffectsNone := v1beta1.SideEffectClassNone
 	return &v1beta1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   ValidateWebhookCfgName,
@@ -35,6 +36,7 @@ func buildValidatingWebhookCfg(namespace string) *v1beta1.ValidatingWebhookConfi
 			{
 				Name:          "validate-exec.devworkspace-controller.svc",
 				FailurePolicy: &validateWebhookFailurePolicy,
+				SideEffects:   &sideEffectsNone,
 				ClientConfig: v1beta1.WebhookClientConfig{
 					Service: &v1beta1.ServiceReference{
 						Name:      server.WebhookServerServiceName,


### PR DESCRIPTION
### What does this PR do?
1. Update dependency to latest commit in devfile/api 
2. Update samples to follow updated devfile/api spec (restrictions on command.id formatting)
3. Update webhooks to specify that they have no side-effects
    - This probably could be a separate PR, but it's a minor change I realized we needed while testing our samples. Note that `v1` webhooks support only `None` and `NoneOnDryRun`.
4. Propagate the message from any "FailedStart" or "Error" condition to devworkspace.status.message. Error overrides FailedStart if both happen to be present (they should never be)

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/232

### Is it tested? How?
Before testing, it's necessary to run `make update_devworkspace_crds` to the latest devfile/api CRDs (and `make install` to deploy them).

Easiest to test on minikube:

```bash
$ kubectl apply -f samples/theia-next.yaml
$ kubectl apply -f samples/web-terminal.yaml
# wait a bit...
$ kubectl get dw

NAME           WORKSPACE ID                PHASE     INFO                                                          URL
theia          workspace8af91dfdf1f1417f   Running                                                                 http://workspace8af91dfdf1f1417f-theia-3100.192.168.49.2.nip.io
web-terminal   workspace32d4b43e65e64e64   Failed    Failed to install network objects required for devworkspace   
```

We should probably move INFO to be the last column

### Additional info
Kubernetes docs on webhooks with side effects: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects