### PR TITLE
Add support for configuring the workspace routing controllers through annotations on DevWorkspace.

### DIFF
--- a/controllers/workspace/provision/routing.go
+++ b/controllers/workspace/provision/routing.go
@@ -149,7 +149,7 @@ func getSpecRouting(
 	}
 
 	// copy the annotations for the specific routingClass from the workspace object to the routing
-	expectedAnnotationPrefix := workspace.Spec.RoutingClass + config.RoutingClassAnnotationInfix
+	expectedAnnotationPrefix := workspace.Spec.RoutingClass + config.RoutingAnnotationInfix
 	for k, v := range workspace.GetAnnotations() {
 		if strings.HasPrefix(k, expectedAnnotationPrefix) {
 			annotations[k] = v

--- a/controllers/workspace/provision/routing.go
+++ b/controllers/workspace/provision/routing.go
@@ -15,6 +15,7 @@ package provision
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	devworkspace "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
@@ -145,6 +146,14 @@ func getSpecRouting(
 	if val, ok := workspace.Annotations[config.WorkspaceRestrictedAccessAnnotation]; ok {
 		annotations = map[string]string{}
 		annotations[config.WorkspaceRestrictedAccessAnnotation] = val
+	}
+
+	// copy the annotations for the specific routingClass from the workspace object to the routing
+	expectedAnnotationPrefix := workspace.Spec.RoutingClass + config.RoutingClassAnnotationInfix
+	for k, v := range workspace.GetAnnotations() {
+		if strings.Index(k, expectedAnnotationPrefix) == 0 {
+			annotations[k] = v
+		}
 	}
 
 	routing := &v1alpha1.WorkspaceRouting{

--- a/controllers/workspace/provision/routing.go
+++ b/controllers/workspace/provision/routing.go
@@ -151,7 +151,7 @@ func getSpecRouting(
 	// copy the annotations for the specific routingClass from the workspace object to the routing
 	expectedAnnotationPrefix := workspace.Spec.RoutingClass + config.RoutingClassAnnotationInfix
 	for k, v := range workspace.GetAnnotations() {
-		if strings.Index(k, expectedAnnotationPrefix) == 0 {
+		if strings.HasPrefix(k, expectedAnnotationPrefix) {
 			annotations[k] = v
 		}
 	}

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -71,9 +71,9 @@ const (
 	// PVCCleanupPodMemoryLimit is the memory limit used for PVC clean up pods
 	PVCCleanupPodMemoryLimit = "32Mi"
 
-	// RoutingClassAnnotationInfix is the infix of the annotations of DevWorkspace that are passed down as annotation to the WorkspaceRouting objects.
-	// The full annotation name is supposed to be "<routingClass>.routingclass.controller.devfile.io/<anything>"
-	RoutingClassAnnotationInfix = ".routingclass.controller.devfile.io/"
+	// RoutingAnnotationInfix is the infix of the annotations of DevWorkspace that are passed down as annotation to the WorkspaceRouting objects.
+	// The full annotation name is supposed to be "<routingClass>.routing.controller.devfile.io/<anything>"
+	RoutingAnnotationInfix = ".routing.controller.devfile.io/"
 )
 
 // Constants for che-rest-apis

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -70,6 +70,10 @@ const (
 
 	// PVCCleanupPodMemoryLimit is the memory limit used for PVC clean up pods
 	PVCCleanupPodMemoryLimit = "32Mi"
+
+	// RoutingClassAnnotationInfix is the infix of the annotations of DevWorkspace that are passed down as annotation to the WorkspaceRouting objects.
+	// The full annotation name is supposed to be "<routingClass>.routingclass.controller.devfile.io/<anything>"
+	RoutingClassAnnotationInfix = ".routingclass.controller.devfile.io/"
 )
 
 // Constants for che-rest-apis


### PR DESCRIPTION
### What does this PR do?
It copies annotations with certain format to the workspace routing objects expecting them to contain the configuration of the external routing controller in question.

### What issues does this PR fix or reference?
#243
