### PR TITLE
Add CI check that generated files are up-to-date

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,6 +58,19 @@ jobs:
           exit 1
         fi
     -
+      name: Check manifests
+      run: |
+        git reset HEAD --hard
+        pip install yq
+        # Note: fmt is necessary after generate since generated sources will
+        #       fail format check by default.
+        make generate fmt manifests
+        if [[ ! -z $(git status -s) ]]
+        then
+          echo "generated sources are not up to date"
+          exit 1
+        fi
+    -
       name: Run Go Tests
       run: |
         python -m pip install --upgrade pip yq

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ PLATFORM := kubernetes
 endif
 
 # minikube handling
-ifeq ($(shell $(K8S_CLI) config current-context),minikube)
+ifeq ($(shell $(K8S_CLI) config current-context 2>&1),minikube)
 export ROUTING_SUFFIX := $(shell minikube ip).nip.io
 endif
 
@@ -340,6 +340,18 @@ KUSTOMIZE=$(shell which kustomize)
 endif
 
 _operator_sdk:
+	@{ \
+		if ! command -v operator-sdk &> /dev/null; then \
+			echo 'operator-sdk $(OPERATOR_SDK_VERSION) is expected to be used for this target but it is not installed' ;\
+			exit 1 ;\
+		else \
+			SDK_VER=$$(operator-sdk version | cut -d , -f 1 | cut -d : -f 2 | cut -d \" -f 2) && \
+			if [ "$${SDK_VER}" != $(OPERATOR_SDK_VERSION) ]; then \
+				echo "WARN: operator-sdk $(OPERATOR_SDK_VERSION) is expected to be used for this target but $${SDK_VER} found"
+				echo "WARN: Please use the recommended operator-sdk if you face any issue"
+			fi \
+		fi \
+	}
 ifneq ($(shell operator-sdk version | cut -d , -f 1 | cut -d : -f 2 | cut -d \" -f 2),$(OPERATOR_SDK_VERSION))
 	@echo 'WARN: operator-sdk $(OPERATOR_SDK_VERSION) is expected to be used for this target but $(shell operator-sdk version | cut -d , -f 1 | cut -d : -f 2 | cut -d \" -f 2) found.'
 	@echo 'WARN: Please use the recommended operator-sdk if you face any issue.'

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -62,7 +62,7 @@ type DevWorkspaceReconciler struct {
 /////// Required permissions for controller
 // +kubebuilder:rbac:groups=apps;extensions,resources=deployments;replicasets,verbs=*
 // +kubebuilder:rbac:groups="",resources=pods;serviceaccounts;secrets;configmaps;persistentvolumeclaims,verbs=*
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;create;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update


### PR DESCRIPTION
### What does this PR do?
Add a step to the GitHub CI jobs to check that `make generate manifests` does not change repo (ensure that generated yaml manifests and deepcopy functions are up to date).

Update annotations on devworkspace reconciler to make sure we generate the RBAC we currently are using.

### What issues does this PR fix or reference?
Running `make manifests` changes role.yaml

### Is it tested? How?

