### PR TITLE
Allow RoutingSolver.GetSpecObjects to return an error

### DIFF
--- a/controllers/controller/workspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/workspacerouting/solvers/basic_solver.go
@@ -41,7 +41,7 @@ type BasicSolver struct{}
 
 var _ RoutingSolver = (*BasicSolver)(nil)
 
-func (s *BasicSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) RoutingObjects {
+func (s *BasicSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) (RoutingObjects, error) {
 	spec := routing.Spec
 	services := getServicesForEndpoints(spec.Endpoints, workspaceMeta)
 	services = append(services, getDiscoverableServicesForEndpoints(spec.Endpoints, workspaceMeta)...)
@@ -51,7 +51,7 @@ func (s *BasicSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRoutin
 		Services:  services,
 		Ingresses: ingresses,
 		Routes:    routes,
-	}
+	}, nil
 }
 
 func (s *BasicSolver) GetExposedEndpoints(

--- a/controllers/controller/workspacerouting/solvers/cluster_solver.go
+++ b/controllers/controller/workspacerouting/solvers/cluster_solver.go
@@ -33,7 +33,7 @@ type ClusterSolver struct {
 
 var _ RoutingSolver = (*ClusterSolver)(nil)
 
-func (s *ClusterSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) RoutingObjects {
+func (s *ClusterSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) (RoutingObjects, error) {
 	spec := routing.Spec
 	services := getServicesForEndpoints(spec.Endpoints, workspaceMeta)
 	podAdditions := &controllerv1alpha1.PodAdditions{}
@@ -64,7 +64,7 @@ func (s *ClusterSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRout
 	return RoutingObjects{
 		Services:     services,
 		PodAdditions: podAdditions,
-	}
+	}, nil
 }
 
 func (s *ClusterSolver) GetExposedEndpoints(

--- a/controllers/controller/workspacerouting/solvers/errors.go
+++ b/controllers/controller/workspacerouting/solvers/errors.go
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package solvers
+
+import (
+	"errors"
+	"time"
+)
+
+var _ error = (*RoutingNotReady)(nil)
+var _ error = (*RoutingInvalid)(nil)
+
+// RoutingNotSupported is used by the solvers when they supported the routingclass of the workspace they've been asked to route
+var RoutingNotSupported = errors.New("routingclass not supported by this controller")
+
+// RoutingNotReady is used by the solvers when they are not ready to route an otherwise OK workspace. They can also suggest the
+// duration after which to retry the workspace routing. If not specified, the retry is made after 1 second.
+type RoutingNotReady struct {
+	Retry time.Duration
+}
+
+func (*RoutingNotReady) Error() string {
+	return "controller not ready to resolve the workspace routing"
+}
+
+// RoutingInvalid is used by the solvers to report that they were asked to route a workspace that has the correct routingclass but
+// is invalid in some other sense - missing configuration, etc.
+type RoutingInvalid struct {
+	Reason string
+}
+
+func (e *RoutingInvalid) Error() string {
+	reason := "<no reason given>"
+	if len(e.Reason) > 0 {
+		reason = e.Reason
+	}
+	return "workspace routing is invalid: " + reason
+}

--- a/controllers/controller/workspacerouting/solvers/openshift_oauth_solver.go
+++ b/controllers/controller/workspacerouting/solvers/openshift_oauth_solver.go
@@ -37,7 +37,7 @@ type proxyEndpoint struct {
 	publicEndpointHttpPort int64
 }
 
-func (s *OpenShiftOAuthSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) RoutingObjects {
+func (s *OpenShiftOAuthSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) (RoutingObjects, error) {
 	spec := routing.Spec
 	proxy, noProxy := getProxiedEndpoints(spec)
 	defaultIngresses, defaultRoutes := getRoutingForSpec(noProxy, workspaceMeta)
@@ -85,7 +85,7 @@ func (s *OpenShiftOAuthSolver) GetSpecObjects(routing *controllerv1alpha1.Worksp
 		Routes:       append(routes, defaultRoutes...),
 		PodAdditions: podAdditions,
 		OAuthClient:  oauthClient,
-	}
+	}, nil
 }
 
 func (s *OpenShiftOAuthSolver) GetExposedEndpoints(

--- a/controllers/controller/workspacerouting/solvers/solver.go
+++ b/controllers/controller/workspacerouting/solvers/solver.go
@@ -13,7 +13,6 @@
 package solvers
 
 import (
-	"errors"
 	"fmt"
 
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
@@ -25,8 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var RoutingNotSupported = errors.New("routingclass not supported by this controller")
-
 type RoutingObjects struct {
 	Services     []v1.Service
 	Ingresses    []v1beta1.Ingress
@@ -37,6 +34,9 @@ type RoutingObjects struct {
 
 type RoutingSolver interface {
 	// GetSpecObjects constructs cluster routing objects which should be applied on the cluster
+	// This method should return RoutingNotReady error if the solver is not ready yet to process
+	// the workspace routing, RoutingInvalid error if there is a specific reason for the failure or
+	// any other error.
 	GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) (RoutingObjects, error)
 
 	// GetExposedEndpoints retreives the URL for each endpoint in a devfile spec from a set of RoutingObjects.

--- a/controllers/controller/workspacerouting/solvers/solver.go
+++ b/controllers/controller/workspacerouting/solvers/solver.go
@@ -37,7 +37,7 @@ type RoutingObjects struct {
 
 type RoutingSolver interface {
 	// GetSpecObjects constructs cluster routing objects which should be applied on the cluster
-	GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) RoutingObjects
+	GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) (RoutingObjects, error)
 
 	// GetExposedEndpoints retreives the URL for each endpoint in a devfile spec from a set of RoutingObjects.
 	// Returns is a map from component ids (as defined in the devfile) to the list of endpoints for that component

--- a/controllers/controller/workspacerouting/workspacerouting_controller.go
+++ b/controllers/controller/workspacerouting/workspacerouting_controller.go
@@ -114,7 +114,11 @@ func (r *WorkspaceRoutingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	}
 
 	restrictedAccess, setRestrictedAccess := instance.Annotations[config.WorkspaceRestrictedAccessAnnotation]
-	routingObjects := solver.GetSpecObjects(instance, workspaceMeta)
+	routingObjects, err := solver.GetSpecObjects(instance, workspaceMeta)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	services := routingObjects.Services
 	for idx := range services {
 		err := controllerutil.SetControllerReference(instance, &services[idx], r.Scheme)


### PR DESCRIPTION
### What does this PR do?
This adds the ability for the RoutingSolver.GetSpecObjects to also return an error.

This seems to be required in `devworkspace-che-operator` which needs to contact k8s API
during this call.

### What issues does this PR fix or reference?
eclipse/che#18153

### Is it tested? How?
No tests added as this just changes the method signature and no existing impl needs to
return the errors.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
