### PR TITLE
Make the service definition for endpoints public and make it slightly more versatile.

### DIFF
--- a/controllers/controller/workspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/workspacerouting/solvers/basic_solver.go
@@ -44,7 +44,7 @@ var _ RoutingSolver = (*BasicSolver)(nil)
 func (s *BasicSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) (RoutingObjects, error) {
 	spec := routing.Spec
 	services := getServicesForEndpoints(spec.Endpoints, workspaceMeta)
-	services = append(services, getDiscoverableServicesForEndpoints(spec.Endpoints, workspaceMeta)...)
+	services = append(services, GetDiscoverableServicesForEndpoints(spec.Endpoints, workspaceMeta)...)
 	ingresses, routes := getRoutingForSpec(spec.Endpoints, workspaceMeta)
 
 	return RoutingObjects{

--- a/controllers/controller/workspacerouting/solvers/common.go
+++ b/controllers/controller/workspacerouting/solvers/common.go
@@ -92,22 +92,22 @@ func GetServiceForEndpoints(endpoints map[string]controllerv1alpha1.EndpointList
 	}
 
 	// "set" of ports that are still left for exposure
-	ports := map[int]struct{}{}
+	ports := map[int]bool{}
 	for _, es := range endpoints {
 		for _, endpoint := range es {
-			ports[endpoint.TargetPort] = struct{}{}
+			ports[endpoint.TargetPort] = true
 		}
 	}
 
 	// "set" of exposure types that are allowed
-	validExposures := map[v1alpha2.EndpointExposure]struct{}{}
+	validExposures := map[v1alpha2.EndpointExposure]bool{}
 	for _, exp := range exposureType {
-		validExposures[exp] = struct{}{}
+		validExposures[exp] = true
 	}
 
 	for _, es := range endpoints {
 		for _, endpoint := range es {
-			if _, ok := validExposures[endpoint.Exposure]; !ok {
+			if !validExposures[endpoint.Exposure] {
 				continue
 			}
 
@@ -115,9 +115,9 @@ func GetServiceForEndpoints(endpoints map[string]controllerv1alpha1.EndpointList
 				continue
 			}
 
-			if _, ok := ports[endpoint.TargetPort]; ok {
+			if ports[endpoint.TargetPort] {
 				// make sure we don't mention the same port twice
-				delete(ports, endpoint.TargetPort)
+				ports[endpoint.TargetPort] = false
 				service.Spec.Ports = append(service.Spec.Ports, corev1.ServicePort{
 					Name:       common.EndpointName(endpoint.Name),
 					Protocol:   corev1.ProtocolTCP,

--- a/controllers/controller/workspacerouting/solvers/openshift_oauth_solver.go
+++ b/controllers/controller/workspacerouting/solvers/openshift_oauth_solver.go
@@ -57,7 +57,7 @@ func (s *OpenShiftOAuthSolver) GetSpecObjects(routing *controllerv1alpha1.Worksp
 			"service.alpha.openshift.io/serving-cert-secret-name": common.OAuthProxySecretName(workspaceMeta.WorkspaceId),
 		}
 	}
-	discoverableServices := getDiscoverableServicesForEndpoints(proxyPorts, workspaceMeta)
+	discoverableServices := GetDiscoverableServicesForEndpoints(proxyPorts, workspaceMeta)
 	services := append(proxyServices, discoverableServices...)
 
 	routes, podAdditions := s.getProxyRoutes(proxy, workspaceMeta, portMappings)


### PR DESCRIPTION
### What does this PR do?
`$TITLE`.

The functions commonly used in the solvers contained within the main operator prove to be useful also outside in the external operators. This PR makes these functions public and adds a little bit more versatility to them.

Also, it makes sure that no service is created for a discoverable endpoint that also has "none" exposure (and hence no service should exist for it).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18583

### Is it tested? How?
Manually by making sure a workspace can still be deployed after the changes.