### PR TITLE
Enable the solvers to do the finalization of a workspace routing themselves.

### DIFF
--- a/controllers/controller/workspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/workspacerouting/solvers/basic_solver.go
@@ -41,6 +41,14 @@ type BasicSolver struct{}
 
 var _ RoutingSolver = (*BasicSolver)(nil)
 
+func (s *BasicSolver) FinalizerRequired(routing *controllerv1alpha1.WorkspaceRouting) bool {
+	return false
+}
+
+func (s *BasicSolver) Finalize(routing *controllerv1alpha1.WorkspaceRouting) error {
+	return nil
+}
+
 func (s *BasicSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) (RoutingObjects, error) {
 	spec := routing.Spec
 	services := getServicesForEndpoints(spec.Endpoints, workspaceMeta)

--- a/controllers/controller/workspacerouting/solvers/cluster_solver.go
+++ b/controllers/controller/workspacerouting/solvers/cluster_solver.go
@@ -33,6 +33,14 @@ type ClusterSolver struct {
 
 var _ RoutingSolver = (*ClusterSolver)(nil)
 
+func (s *ClusterSolver) FinalizerRequired(routing *controllerv1alpha1.WorkspaceRouting) bool {
+	return false
+}
+
+func (s *ClusterSolver) Finalize(routing *controllerv1alpha1.WorkspaceRouting) error {
+	return nil
+}
+
 func (s *ClusterSolver) GetSpecObjects(routing *controllerv1alpha1.WorkspaceRouting, workspaceMeta WorkspaceMetadata) (RoutingObjects, error) {
 	spec := routing.Spec
 	services := getServicesForEndpoints(spec.Endpoints, workspaceMeta)


### PR DESCRIPTION
### What does this PR do?
The motivation for doing this is the need of the devworkspace-che-operator
to do a custom finalization of the routing - it needs to delete
the configmaps for the gateway configuration which need to live in
a different namespace than the workspace.

For this to make sense, the openshift oauth solver is now in charge of
managing the oauthclient for the workspace. As such the oauthclient is no
longer part of the ResolvedObjects struct.

### What issues does this PR fix or reference?
eclipse/che#18583

### Is it tested? How?
