### PR TITLE
Propagate devworkspace CR reference as env vars

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -188,7 +188,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = fmt.Sprintf("Error processing devfile volumes: %s", err)
 		return reconcile.Result{}, nil
 	}
-	shimlib.FillDefaultEnvVars(devfilePodAdditions, workspace.Spec.Template)
+	shimlib.FillDefaultEnvVars(devfilePodAdditions, *workspace)
 	componentDescriptions, err := shimlib.GetComponentDescriptionsFromPodAdditions(devfilePodAdditions, workspace.Spec.Template)
 	if err != nil {
 		reqLogger.Info("DevWorkspace start failed")

--- a/controllers/workspace/env/common_env_vars.go
+++ b/controllers/workspace/env/common_env_vars.go
@@ -20,39 +20,16 @@ import (
 func CommonEnvironmentVariables(workspaceName, workspaceId, namespace, creator string) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
-			Name: "CHE_MACHINE_TOKEN",
+			Name:  "DEVWORKSPACE_NAMESPACE",
+			Value: namespace,
 		},
 		{
-			Name:  "CHE_PROJECTS_ROOT",
-			Value: config.DefaultProjectsSourcesRoot,
-		},
-		{
-			Name:  "CHE_API",
-			Value: config.DefaultApiEndpoint,
-		},
-		{
-			Name:  "CHE_API_INTERNAL",
-			Value: config.DefaultApiEndpoint,
-		},
-		{
-			Name:  "CHE_API_EXTERNAL",
-			Value: config.DefaultApiEndpoint,
-		},
-		{
-			Name:  "CHE_WORKSPACE_NAME",
+			Name:  "DEVWORKSPACE_NAME",
 			Value: workspaceName,
 		},
 		{
-			Name:  "CHE_WORKSPACE_ID",
+			Name:  "DEVWORKSPACE_ID",
 			Value: workspaceId,
-		},
-		{
-			Name:  "CHE_AUTH_ENABLED",
-			Value: config.AuthEnabled,
-		},
-		{
-			Name:  "CHE_WORKSPACE_NAMESPACE",
-			Value: namespace,
 		},
 		{
 			Name:  "DEVWORKSPACE_CREATOR",

--- a/pkg/library/shim/component.go
+++ b/pkg/library/shim/component.go
@@ -26,12 +26,57 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func FillDefaultEnvVars(podAdditions *v1alpha1.PodAdditions, workspace devworkspace.DevWorkspaceTemplateSpec) {
+func FillDefaultEnvVars(podAdditions *v1alpha1.PodAdditions, workspace devworkspace.DevWorkspace) {
 	for idx, mainContainer := range podAdditions.Containers {
-		podAdditions.Containers[idx].Env = append(mainContainer.Env, corev1.EnvVar{
+		podAdditions.Containers[idx].Env = append(mainContainer.Env, defaultEnvVars(mainContainer.Name, workspace)...)
+	}
+
+	for idx, mainContainer := range podAdditions.InitContainers {
+		podAdditions.Containers[idx].Env = append(mainContainer.Env, defaultEnvVars(mainContainer.Name, workspace)...)
+	}
+}
+
+func defaultEnvVars(containerName string, workspace devworkspace.DevWorkspace) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
 			Name:  "CHE_MACHINE_NAME",
-			Value: mainContainer.Name,
-		})
+			Value: containerName,
+		},
+		{
+			Name: "CHE_MACHINE_TOKEN",
+		},
+		{
+			Name:  "CHE_PROJECTS_ROOT",
+			Value: config.DefaultProjectsSourcesRoot,
+		},
+		{
+			Name:  "CHE_API",
+			Value: config.DefaultApiEndpoint,
+		},
+		{
+			Name:  "CHE_API_INTERNAL",
+			Value: config.DefaultApiEndpoint,
+		},
+		{
+			Name:  "CHE_API_EXTERNAL",
+			Value: config.DefaultApiEndpoint,
+		},
+		{
+			Name:  "CHE_WORKSPACE_NAME",
+			Value: workspace.Name,
+		},
+		{
+			Name:  "CHE_WORKSPACE_ID",
+			Value: workspace.Status.WorkspaceId,
+		},
+		{
+			Name:  "CHE_AUTH_ENABLED",
+			Value: config.AuthEnabled,
+		},
+		{
+			Name:  "CHE_WORKSPACE_NAMESPACE",
+			Value: workspace.Namespace,
+		},
 	}
 }
 

--- a/pkg/library/shim/component.go
+++ b/pkg/library/shim/component.go
@@ -32,7 +32,7 @@ func FillDefaultEnvVars(podAdditions *v1alpha1.PodAdditions, workspace devworksp
 	}
 
 	for idx, mainContainer := range podAdditions.InitContainers {
-		podAdditions.Containers[idx].Env = append(mainContainer.Env, defaultEnvVars(mainContainer.Name, workspace)...)
+		podAdditions.InitContainers[idx].Env = append(mainContainer.Env, defaultEnvVars(mainContainer.Name, workspace)...)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR moves every Che API sidecar env vars to the corresponding file + add propagating devworkspace CR reference as env vars: Name, Namespace, ID.

### What issues does this PR fix or reference?
No particular issue is created, but it's needed to help Theia access devworkspace related objects.

### Is it tested? How?
not yet

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
