### PR TITLE
feat(ingress): Check that ingress addon is enabled when using minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ endif
 
 # minikube handling
 ifeq ($(shell $(K8S_CLI) config current-context 2>&1),minikube)
+# check ingress addon is enabled
+ifeq ($(shell minikube addons list -o json | jq -r .ingress.Status), disabled)
+$(error ingress addon should be enabled on top of minikube)
+endif
 export ROUTING_SUFFIX := $(shell minikube ip).nip.io
 endif
 


### PR DESCRIPTION
### What does this PR do?
Check that ingress addon is enabled when using minikube

### What issues does this PR fix or reference?
Lot of ingresses resources are created and then not working

### Is it tested? How?
Make install and deploy an example like theia next 
<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
