### PR TITLE
Let the solver getter set up the controller manager

### DIFF
--- a/controllers/controller/workspacerouting/solvers/solver.go
+++ b/controllers/controller/workspacerouting/solvers/solver.go
@@ -21,6 +21,7 @@ import (
 	routeV1 "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,6 +48,10 @@ type RoutingSolver interface {
 }
 
 type RoutingSolverGetter interface {
+	// SetupControllerManager is called during the setup of the controller and can modify the controller manager with additional
+	// watches, etc., needed for the correct operation of the solver.
+	SetupControllerManager(mgr *builder.Builder) error
+
 	// HasSolver returns whether the provided routingClass is supported by this RoutingSolverGetter. Returns false if
 	// calling GetSolver with routingClass will return a RoutingNotSupported error. Can be used to check if a routingClass
 	// is supported without having to provide a runtime client. Note that GetSolver may still return another error, if e.g.
@@ -104,4 +109,8 @@ func (_ *SolverGetter) GetSolver(_ client.Client, routingClass controllerv1alpha
 	default:
 		return nil, RoutingNotSupported
 	}
+}
+
+func (*SolverGetter) SetupControllerManager(mgr *builder.Builder) error {
+	return nil
 }

--- a/controllers/controller/workspacerouting/workspacerouting_controller.go
+++ b/controllers/controller/workspacerouting/workspacerouting_controller.go
@@ -316,6 +316,11 @@ func (r *WorkspaceRoutingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.SolverGetter == nil {
 		return NoSolversEnabled
 	}
+
+	if err := r.SolverGetter.SetupControllerManager(bld); err != nil {
+		return err
+	}
+
 	bld.WithEventFilter(getRoutingPredicatesForSolverFunc(r.SolverGetter))
 
 	return bld.Complete(r)


### PR DESCRIPTION
### What does this PR do?
This enables the solver to reconcile different kinds of objects that it might be managing.

I specifically allowed full control over the manager builder, because in the `devworkspace-che-operator` I need to react on objects in different namespace than the one where workspace-routing objects live and so `Owns()` would not work for me.

### What issues does this PR fix or reference?
eclipse/che#18583
