### PR TITLE
Fix endpoints handling

### DIFF
--- a/controllers/controller/workspacerouting/solvers/cluster_solver.go
+++ b/controllers/controller/workspacerouting/solvers/cluster_solver.go
@@ -83,7 +83,7 @@ func (s *ClusterSolver) GetExposedEndpoints(
 
 	for machineName, machineEndpoints := range endpoints {
 		for _, endpoint := range machineEndpoints {
-			if endpoint.Exposure != devworkspace.PublicEndpointExposure {
+			if endpoint.Exposure == devworkspace.NoneEndpointExposure {
 				continue
 			}
 			url, err := resolveServiceHostnameForEndpoint(endpoint, routingObj.Services)

--- a/samples/flattened_web-terminal-dev.yaml
+++ b/samples/flattened_web-terminal-dev.yaml
@@ -34,11 +34,11 @@ spec:
           endpoints:
             - name: web-terminal
               targetPort: 4444
+              secure: true
+              exposure: internal
+              protocol: http
               attributes:
-                protocol: http
                 type: ide
-                discoverable: "false"
-                secure: "true"
                 cookiesAuthEnabled: "true"
           env:
             - name: USE_BEARER_TOKEN

--- a/samples/flattened_web-terminal.yaml
+++ b/samples/flattened_web-terminal.yaml
@@ -35,11 +35,11 @@ spec:
           endpoints:
             - name: web-terminal
               targetPort: 4444
+              secure: true
+              protocol: http
+              exposure: internal
               attributes:
-                protocol: http
                 type: ide
-                discoverable: "false"
-                secure: "true"
                 cookiesAuthEnabled: "true"
           env:
             - name: USE_BEARER_TOKEN

--- a/samples/plugins/web-terminal-dev.yaml
+++ b/samples/plugins/web-terminal-dev.yaml
@@ -7,6 +7,7 @@ spec:
     - name: web-terminal
       container:
         image: quay.io/eclipse/che-machine-exec:nightly
+        mountSources: false
         command: ["/go/bin/che-machine-exec",
                   "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
                   "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",

--- a/samples/plugins/web-terminal-dev.yaml
+++ b/samples/plugins/web-terminal-dev.yaml
@@ -15,11 +15,11 @@ spec:
         endpoints:
           - name: web-terminal
             targetPort: 4444
+            secure: true
+            exposure: internal
+            protocol: http
             attributes:
-              protocol: http
               type: ide
-              discoverable: "false"
-              secure: "true"
               cookiesAuthEnabled: "true"
         env:
           - name: USE_BEARER_TOKEN

--- a/samples/plugins/web-terminal.yaml
+++ b/samples/plugins/web-terminal.yaml
@@ -16,11 +16,11 @@ spec:
         endpoints:
           - name: web-terminal
             targetPort: 4444
+            secure: true
+            protocol: http
+            exposure: internal
             attributes:
-              protocol: http
               type: ide
-              discoverable: "false"
-              secure: "true"
               cookiesAuthEnabled: "true"
         env:
           - name: USE_BEARER_TOKEN

--- a/samples/plugins/web-terminal.yaml
+++ b/samples/plugins/web-terminal.yaml
@@ -7,6 +7,7 @@ spec:
     - name: web-terminal
       container:
         image: quay.io/eclipse/che-machine-exec:nightly
+        mountSources: false
         command: ["/go/bin/che-machine-exec",
                   "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
                   "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",

--- a/samples/web-terminal-custom-tooling.yaml
+++ b/samples/web-terminal-custom-tooling.yaml
@@ -19,6 +19,7 @@ spec:
           memoryLimit: "256Mi"
           name: tooling
           image: quay.io/wto/web-terminal-tooling:latest
+          mountSources: false
           args: ["tail", "-f", "/dev/null"]
           env:
             - name: PS1

--- a/samples/with-k8s-ref/web-terminal-custom-tooling.yaml
+++ b/samples/with-k8s-ref/web-terminal-custom-tooling.yaml
@@ -21,6 +21,7 @@ spec:
           memoryLimit: "256Mi"
           name: tooling
           image: quay.io/wto/web-terminal-tooling:latest
+          mountSources: false
           args: ["tail", "-f", "/dev/null"]
           env:
             - name: PS1


### PR DESCRIPTION
### What does this PR do?
The web terminal samples were out of date compared to the devfile API -- endpoints did not specify `exposure` and were using `protocol` and `secure` as attributes rather than fields.

### What issues does this PR fix or reference?
I didn't create one

### Is it tested? How?
Tested new yamls on `crc` using the web terminal operator flow (using `samples/flattened_web_terminal.yaml`
