### PR TITLE
Support poststart events in devworkspaces

### DIFF
--- a/pkg/library/container/container.go
+++ b/pkg/library/container/container.go
@@ -72,5 +72,9 @@ func GetKubeContainersFromDevfile(workspace devworkspace.DevWorkspaceTemplateSpe
 		podAdditions.InitContainers = append(podAdditions.InitContainers, *k8sContainer)
 	}
 
+	err = lifecycle.ApplyPostStartCommands(&workspace.DevWorkspaceTemplateSpecContent, podAdditions.Containers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process postStart event: %w", err)
+	}
 	return podAdditions, nil
 }

--- a/samples/plugins/theia-next.yaml
+++ b/samples/plugins/theia-next.yaml
@@ -8,11 +8,6 @@ spec:
       volume: {}
     - name: remote-endpoint
       volume: {} # TODO: Fix this once ephemeral volumes are supported
-    - name: vsx-installer
-      plugin:
-        kubernetes:
-          name: vsx-installer
-          namespace: devworkspace-plugins
     - name: remote-runtime-injector
       plugin:
         kubernetes:

--- a/samples/plugins/vscode-typescript.yaml
+++ b/samples/plugins/vscode-typescript.yaml
@@ -27,3 +27,15 @@ spec:
             name: remote-endpoint
           - name: plugins
             path: /plugins
+  commands:
+    - id: install-vscode-typescript-vsx
+      exec:
+        component: theia-ide
+        commandLine: |-
+          mkdir -p /plugins/sidecars/vscode-typescript && \
+          if [ ! -f /plugins/sidecars/vscode-typescript/che-typescript-language-1.35.1.vsix ]; then \
+            wget https://download.jboss.org/jbosstools/vscode/3rdparty/ms-code.typescript/che-typescript-language-1.35.1.vsix \
+              -O /plugins/sidecars/vscode-typescript/che-typescript-language-1.35.1.vsix ;\
+          fi
+  events:
+    postStart: ["install-vscode-typescript-vsx"]

--- a/samples/plugins/vscode-vim.yaml
+++ b/samples/plugins/vscode-vim.yaml
@@ -1,0 +1,17 @@
+kind: DevWorkspaceTemplate
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: vscode-vim
+spec:
+  commands:
+    - id: install-vscode-vim-vsx
+      exec:
+        component: theia-ide
+        commandLine: |-
+          mkdir -p /plugins/sidecars/vscode-typescript && \
+          if [ ! -f /plugins/vim-1.16.0.vsix ]; then \
+            wget https://github.com/VSCodeVim/Vim/releases/download/v1.16.0/vim-1.16.0.vsix \
+              -O /plugins/vim-1.16.0.vsix ;\
+          fi
+  events:
+    postStart: ["install-vscode-vim-vsx"]


### PR DESCRIPTION
### What does this PR do?
Add support for `events.postStart` in devfiles by converting the command to a postStart lifecycle hook on the relevant container.

One rough spot in the implementation is that there can only be one postStart command per container. I get around this by using `"/bin/bash" "-c"` and concatenating the command with `&&`. If we can restrict postStart commands to one per container, then this could be cleaner.

There's a known issue here too: Theia doesn't handle loading plugins if the vsix isn't downloaded when Theia starts. To get e.g. the vim plugin to be recognized, I had to stop and start the workspace. This is a Theia issue, IMO.

Draft PR until:
- [ ] Implement preStop as well, since it's basically the same logic
- [ ] Add test cases to cover new code

### What issues does this PR fix or reference?
I can't seem to find it

### Is it tested? How?
```bash
make docker install install_plugin-templates
cat <<EOF | kubectl apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-nodejs
spec:
  started: true
  template:
    projects:
      - name: project
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: che-theia
        plugin:
          kubernetes:
            name: theia-next
            namespace: devworkspace-plugins
      - name: machine-exec
        plugin:
          kubernetes:
            name: machine-exec
            namespace: devworkspace-plugins
      - name: typescript
        plugin:
          kubernetes:
            name: vscode-typescript
            namespace: devworkspace-plugins
          components:
            - name: sidecar-typescript
              container:
                memoryLimit: 512Mi
      - name: vscode-vim
        plugin:
          kubernetes:
            name: vscode-vim
            namespace: devworkspace-plugins
      - name: nodejs
        container:
          image: quay.io/eclipse/che-nodejs10-ubi:nightly
          memoryLimit: 512Mi
          endpoints:
            - name: nodejs
              protocol: http
              targetPort: 3000
          mountSources: true
EOF
# wait until pod is running, open Theia in browser and open terminal in e.g. Theia container:
ls -alR /plugins # should show two downloaded vsixes, one in /plugins and one in /plugins/sidecar/<plugin-name>
```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
