### PR TITLE
Explicitly set the routing class in the workspace routings so that external solvers can be used if specified as the default routing class

### DIFF
--- a/controllers/controller/workspacerouting/solvers/solver.go
+++ b/controllers/controller/workspacerouting/solvers/solver.go
@@ -98,9 +98,6 @@ func (_ *SolverGetter) HasSolver(routingClass controllerv1alpha1.WorkspaceRoutin
 }
 
 func (_ *SolverGetter) GetSolver(client client.Client, routingClass controllerv1alpha1.WorkspaceRoutingClass) (RoutingSolver, error) {
-	if routingClass == "" {
-		routingClass = controllerv1alpha1.WorkspaceRoutingClass(config.ControllerCfg.GetDefaultRoutingClass())
-	}
 	switch routingClass {
 	case controllerv1alpha1.WorkspaceRoutingBasic:
 		return &BasicSolver{}, nil

--- a/controllers/controller/workspacerouting/workspacerouting_controller.go
+++ b/controllers/controller/workspacerouting/workspacerouting_controller.go
@@ -80,6 +80,11 @@ func (r *WorkspaceRoutingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	reqLogger = reqLogger.WithValues(config.WorkspaceIDLoggerKey, instance.Spec.WorkspaceId)
 	reqLogger.Info("Reconciling WorkspaceRouting")
 
+	if instance.Spec.RoutingClass == "" {
+		reqLogger.Info("workspace routing without an explicit routing class is invalid", "name", instance.Name, "namespace", instance.Namespace)
+		return reconcile.Result{}, r.markRoutingFailed(instance)
+	}
+
 	solver, err := r.SolverGetter.GetSolver(r.Client, instance.Spec.RoutingClass)
 	if err != nil {
 		if errors.Is(err, solvers.RoutingNotSupported) {

--- a/controllers/workspace/provision/routing.go
+++ b/controllers/workspace/provision/routing.go
@@ -156,6 +156,11 @@ func getSpecRouting(
 		}
 	}
 
+	routingClass := workspace.Spec.RoutingClass
+	if routingClass == "" {
+		routingClass = config.ControllerCfg.GetDefaultRoutingClass()
+	}
+
 	routing := &v1alpha1.WorkspaceRouting{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("routing-%s", workspace.Status.WorkspaceId),
@@ -167,7 +172,7 @@ func getSpecRouting(
 		},
 		Spec: v1alpha1.WorkspaceRoutingSpec{
 			WorkspaceId:   workspace.Status.WorkspaceId,
-			RoutingClass:  v1alpha1.WorkspaceRoutingClass(workspace.Spec.RoutingClass),
+			RoutingClass:  v1alpha1.WorkspaceRoutingClass(routingClass),
 			RoutingSuffix: config.ControllerCfg.GetRoutingSuffix(),
 			Endpoints:     endpoints,
 			PodSelector: map[string]string{


### PR DESCRIPTION
### What does this PR do?
This makes sure that the workspace routing always contains an explicit routing class. This in turn makes sure that the default routing class configured in the devworkspace-operator's configuration can be handled by an external solver.

Without this, the external solver cannot know the routing class unless it reads the configuration of the main devworkspace-operator, which seems quite hacky.

### What issues does this PR fix or reference?
#271 
