### PR TITLE
WIP Change default namespace to openshift-operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifndef VERBOSE
 MAKEFLAGS += --silent
 endif
 
-export NAMESPACE ?= devworkspace-controller
+export NAMESPACE ?= openshift-operators
 export IMG ?= quay.io/devfile/devworkspace-controller:next
 export ROUTING_SUFFIX ?= 192.168.99.100.nip.io
 export PULL_POLICY ?= Always

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -3426,7 +3426,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: devworkspace-controller/devworkspace-controller-serving-cert
+    cert-manager.io/inject-ca-from: openshift-operators/devworkspace-controller-serving-cert
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
@@ -3439,7 +3439,7 @@ spec:
         caBundle: Cg==
         service:
           name: devworkspace-webhookserver
-          namespace: devworkspace-controller
+          namespace: openshift-operators
           path: /convert
       conversionReviewVersions:
       - v1
@@ -8769,7 +8769,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: devworkspace-controller/devworkspace-controller-serving-cert
+    cert-manager.io/inject-ca-from: openshift-operators/devworkspace-controller-serving-cert
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
@@ -8782,7 +8782,7 @@ spec:
         caBundle: Cg==
         service:
           name: devworkspace-webhookserver
-          namespace: devworkspace-controller
+          namespace: openshift-operators
           path: /convert
       conversionReviewVersions:
       - v1
@@ -16412,7 +16412,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -16421,7 +16421,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-leader-election-role
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 rules:
 - apiGroups:
   - ""
@@ -16729,7 +16729,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-leader-election-rolebinding
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16737,7 +16737,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -16753,7 +16753,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -16769,7 +16769,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: v1
 data:
@@ -16786,7 +16786,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-configmap
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: v1
 kind: Service
@@ -16795,7 +16795,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-manager-metrics-service
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   ports:
   - name: https
@@ -16812,7 +16812,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-manager
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   replicas: 1
   selector:
@@ -16886,11 +16886,11 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-serving-cert
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   dnsNames:
-  - devworkspace-webhookserver.devworkspace-controller.svc
-  - devworkspace-webhookserver.devworkspace-controller.svc.cluster.local
+  - devworkspace-webhookserver.openshift-operators.svc
+  - devworkspace-webhookserver.openshift-operators.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: devworkspace-controller-selfsigned-issuer
@@ -16903,6 +16903,6 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-selfsigned-issuer
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   selfSigned: {}

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-configmap.ConfigMap.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-configmap.ConfigMap.yaml
@@ -13,4 +13,4 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-configmap
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-leader-election-role.Role.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-leader-election-role.Role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-leader-election-role
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 rules:
 - apiGroups:
   - ""

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-leader-election-rolebinding.RoleBinding.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-leader-election-rolebinding.RoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-leader-election-rolebinding
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager-metrics-service.Service.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager-metrics-service.Service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-manager-metrics-service
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   ports:
   - name: https

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-manager
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   replicas: 1
   selector:

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-proxy-rolebinding.ClusterRoleBinding.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-proxy-rolebinding.ClusterRoleBinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-rolebinding.ClusterRoleBinding.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-rolebinding.ClusterRoleBinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-selfsigned-issuer.Issuer.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-selfsigned-issuer.Issuer.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-selfsigned-issuer
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   selfSigned: {}

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-serviceaccount.ServiceAccount.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-serviceaccount.ServiceAccount.yaml
@@ -5,4 +5,4 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-serving-cert.Certificate.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-serving-cert.Certificate.yaml
@@ -5,11 +5,11 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-serving-cert
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   dnsNames:
-  - devworkspace-webhookserver.devworkspace-controller.svc
-  - devworkspace-webhookserver.devworkspace-controller.svc.cluster.local
+  - devworkspace-webhookserver.openshift-operators.svc
+  - devworkspace-webhookserver.openshift-operators.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: devworkspace-controller-selfsigned-issuer

--- a/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: devworkspace-controller/devworkspace-controller-serving-cert
+    cert-manager.io/inject-ca-from: openshift-operators/devworkspace-controller-serving-cert
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
@@ -15,7 +15,7 @@ spec:
         caBundle: Cg==
         service:
           name: devworkspace-webhookserver
-          namespace: devworkspace-controller
+          namespace: openshift-operators
           path: /convert
       conversionReviewVersions:
       - v1

--- a/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: devworkspace-controller/devworkspace-controller-serving-cert
+    cert-manager.io/inject-ca-from: openshift-operators/devworkspace-controller-serving-cert
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
@@ -15,7 +15,7 @@ spec:
         caBundle: Cg==
         service:
           name: devworkspace-webhookserver
-          namespace: devworkspace-controller
+          namespace: openshift-operators
           path: /convert
       conversionReviewVersions:
       - v1

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -3439,7 +3439,7 @@ spec:
         caBundle: Cg==
         service:
           name: devworkspace-webhookserver
-          namespace: devworkspace-controller
+          namespace: openshift-operators
           path: /convert
       conversionReviewVersions:
       - v1
@@ -8782,7 +8782,7 @@ spec:
         caBundle: Cg==
         service:
           name: devworkspace-webhookserver
-          namespace: devworkspace-controller
+          namespace: openshift-operators
           path: /convert
       conversionReviewVersions:
       - v1
@@ -16412,7 +16412,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -16421,7 +16421,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-leader-election-role
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 rules:
 - apiGroups:
   - ""
@@ -16729,7 +16729,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-leader-election-rolebinding
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16737,7 +16737,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -16753,7 +16753,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -16769,7 +16769,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: v1
 data:
@@ -16786,7 +16786,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-configmap
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 ---
 apiVersion: v1
 kind: Service
@@ -16795,7 +16795,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-manager-metrics-service
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   ports:
   - name: https
@@ -16812,7 +16812,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-manager
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   replicas: 1
   selector:

--- a/deploy/deployment/openshift/objects/devworkspace-controller-configmap.ConfigMap.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-configmap.ConfigMap.yaml
@@ -13,4 +13,4 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-configmap
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/openshift/objects/devworkspace-controller-leader-election-role.Role.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-leader-election-role.Role.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-leader-election-role
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 rules:
 - apiGroups:
   - ""

--- a/deploy/deployment/openshift/objects/devworkspace-controller-leader-election-rolebinding.RoleBinding.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-leader-election-rolebinding.RoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-leader-election-rolebinding
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager-metrics-service.Service.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager-metrics-service.Service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-manager-metrics-service
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   ports:
   - name: https

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-manager
-  namespace: devworkspace-controller
+  namespace: openshift-operators
 spec:
   replicas: 1
   selector:

--- a/deploy/deployment/openshift/objects/devworkspace-controller-proxy-rolebinding.ClusterRoleBinding.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-proxy-rolebinding.ClusterRoleBinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/openshift/objects/devworkspace-controller-rolebinding.ClusterRoleBinding.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-rolebinding.ClusterRoleBinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/openshift/objects/devworkspace-controller-serviceaccount.ServiceAccount.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-serviceaccount.ServiceAccount.yaml
@@ -5,4 +5,4 @@ metadata:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
   name: devworkspace-controller-serviceaccount
-  namespace: devworkspace-controller
+  namespace: openshift-operators

--- a/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -15,7 +15,7 @@ spec:
         caBundle: Cg==
         service:
           name: devworkspace-webhookserver
-          namespace: devworkspace-controller
+          namespace: openshift-operators
           path: /convert
       conversionReviewVersions:
       - v1

--- a/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -15,7 +15,7 @@ spec:
         caBundle: Cg==
         service:
           name: devworkspace-webhookserver
-          namespace: devworkspace-controller
+          namespace: openshift-operators
           path: /convert
       conversionReviewVersions:
       - v1

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -69,7 +69,7 @@ done
 
 if $USE_DEFAULT_ENV; then
   echo "Using defaults for environment variables"
-  export NAMESPACE=devworkspace-controller
+  export NAMESPACE=openshift-operators
   export IMG=quay.io/devfile/devworkspace-controller:next
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic


### PR DESCRIPTION
### What does this PR do?
This PR changes default namespace to openshift-operators.
I did it since chectl start depends on our default namespace.
Because patching namespace on chectl side is tricky part, since it's needed to be updated in Certificate, CRDs annotations, CRDs spec, RoleBinding.

And I think openshift-operators is a better option, since it's always
all-cluster watching + WTO supports only it.
So, potentially chectl can rely on WTO objects(if they already are created) if it's updated to v1alpha2.
So, we have less conflicts.

### What issues does this PR fix or reference?
It's related to https://github.com/che-incubator/chectl/pull/1100#issuecomment-780679764

### Is it tested? How?
Not yet but changes are simple

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
