### PR TITLE
Add Stopped By Annotation to ignored immutable fields

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -57,6 +57,9 @@ const (
 	// as opposed to a service created to support the workspace itself.
 	WorkspaceDiscoverableServiceAnnotation = "controller.devfile.io/discoverable-service"
 
+	// Stopped by Annotation holds the information as to why a workspace has stopped
+	StoppedByAnnotation = "controller.devfile.io/stopped-by"
+
 	// ControllerServiceAccountNameEnvVar stores the name of the serviceaccount used in the controller.
 	ControllerServiceAccountNameEnvVar = "CONTROLLER_SERVICE_ACCOUNT_NAME"
 )

--- a/webhook/workspace/handler/immutable.go
+++ b/webhook/workspace/handler/immutable.go
@@ -33,6 +33,9 @@ var ImmutableWorkspaceDiffOptions = []cmp.Option{
 	// field managed by cluster and should be ignored while comparing
 	cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ManagedFields", "Finalizers", "DeletionTimestamp"),
 	cmpopts.IgnoreFields(devworkspace.DevWorkspaceSpec{}, "Started"),
+	cmpopts.IgnoreMapEntries(func(k string, v string) bool {
+		return k == config.StoppedByAnnotation
+	}),
 }
 
 func (h *WebhookHandler) HandleImmutableMutate(_ context.Context, req admission.Request) admission.Response {


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR makes it so that the stopped-by annotation is ignored when evaluating an update in the webhook server

### What issues does this PR fix or reference?
No issue created, I just noticed it when creating the WTO 1.2 blog

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
```
make docker deploy
# create web terminal
# web-terminal should terminate
```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
