### PR TITLE
Allow read for workspacerouting and watch/list for dw

### DIFF
--- a/controllers/workspace/provision/rbac.go
+++ b/controllers/workspace/provision/rbac.go
@@ -57,7 +57,7 @@ func generateRBAC(namespace string) []runtime.Object {
 				{
 					Resources: []string{"devworkspaces"},
 					APIGroups: []string{"workspace.devfile.io"},
-					Verbs:     []string{"patch", "get", "update", "watch"},
+					Verbs:     []string{"get", "watch", "list", "patch", "update"},
 				},
 				{
 					Resources: []string{"workspaceroutings"},

--- a/controllers/workspace/provision/rbac.go
+++ b/controllers/workspace/provision/rbac.go
@@ -57,7 +57,12 @@ func generateRBAC(namespace string) []runtime.Object {
 				{
 					Resources: []string{"devworkspaces"},
 					APIGroups: []string{"workspace.devfile.io"},
-					Verbs:     []string{"patch", "get", "update"},
+					Verbs:     []string{"patch", "get", "update", "watch"},
+				},
+				{
+					Resources: []string{"workspaceroutings"},
+					APIGroups: []string{"controller.devfile.io"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
 					Resources: []string{"devworkspacetemplates"},


### PR DESCRIPTION
### What does this PR do?
Allow read for workspacerouting and watch/list for dw

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/277

### Is it tested? How?
not yet
but the image with this is built as 
`export IMG=sleshchenko/che-workspace-controller:extended-rbac`

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
