### PR TITLE
Initialize annotations if they are nil before setting the timer

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -372,6 +372,9 @@ func (r *DevWorkspaceReconciler) stopWorkspace(workspace *devworkspace.DevWorksp
 func (r *DevWorkspaceReconciler) syncTimingToCluster(
 	ctx context.Context, workspace *devworkspace.DevWorkspace, timingInfo map[string]string, reqLogger logr.Logger) {
 	if timing.IsEnabled() {
+		if workspace.Annotations == nil {
+			workspace.Annotations = map[string]string{}
+		}
 		for timingEvent, timestamp := range timingInfo {
 			if _, set := workspace.Annotations[timingEvent]; !set {
 				workspace.Annotations[timingEvent] = timestamp


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
Apparently, if you create a devworkspace through the rest api annotations aren't automatically initialized (they are when you're using kubectl/oc though) and that causes `Observed a panic: "assignment to entry in nil map" (assignment to entry in nil map)` when trying to set the timing information. This PR makes sure that `workspace.Annotations` is initialized before using

### What issues does this PR fix or reference?
None

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
I'm not sure an easy way to test this without requiring setting everything up. I can probably think of one tomorrow though
<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
