### PR TITLE
Add support for ephemeral volumes

### DIFF
--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -51,8 +51,10 @@ var (
 	PVCCleanupPodMemoryLimit = resource.MustParse("32Mi")
 )
 
+// setFinalizer sets a finalizer on the workspace and syncs the changes to the cluster. No-op if the workspace already
+// has the finalizer set.
 func (r *DevWorkspaceReconciler) setFinalizer(ctx context.Context, workspace *v1alpha2.DevWorkspace) (ok bool, err error) {
-	if !isFinalizerNecessary(workspace) || hasFinalizer(workspace) {
+	if hasFinalizer(workspace) {
 		return true, nil
 	}
 	workspace.SetFinalizers(append(workspace.Finalizers, pvcCleanupFinalizer))

--- a/pkg/library/container/mountSources.go
+++ b/pkg/library/container/mountSources.go
@@ -34,6 +34,17 @@ func HasMountSources(devfileContainer *devworkspace.ContainerComponent) bool {
 	return mountSources
 }
 
+// AnyMountSources checks HasMountSources for each container component in a devfile. If a component in the slice
+// is not a ContainerComponent, it is ignored.
+func AnyMountSources(devfileComponents []devworkspace.Component) bool {
+	for _, component := range devfileComponents {
+		if component.Container != nil && HasMountSources(component.Container) {
+			return true
+		}
+	}
+	return false
+}
+
 // handleMountSources adds a volumeMount to a container if the corresponding devfile container has
 // mountSources enabled.
 func handleMountSources(k8sContainer *corev1.Container, devfileContainer *devworkspace.ContainerComponent) {

--- a/pkg/library/storage/commonStorage.go
+++ b/pkg/library/storage/commonStorage.go
@@ -25,6 +25,8 @@ package storage
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/devfile/devworkspace-operator/pkg/library/constants"
 	containerlib "github.com/devfile/devworkspace-operator/pkg/library/container"
 	corev1 "k8s.io/api/core/v1"
@@ -39,16 +41,18 @@ import (
 //
 // Also adds appropriate k8s Volumes to PodAdditions to accomodate the rewritten VolumeMounts.
 func RewriteContainerVolumeMounts(workspaceId string, podAdditions *v1alpha1.PodAdditions, workspace devworkspace.DevWorkspaceTemplateSpec) error {
-	if !NeedsStorage(workspace) {
-		return nil
-	}
 	devfileVolumes := map[string]devworkspace.VolumeComponent{}
+	var ephemeralVolumes []devworkspace.Component
+
 	for _, component := range workspace.Components {
 		if component.Volume != nil {
 			if _, exists := devfileVolumes[component.Name]; exists {
 				return fmt.Errorf("volume component '%s' is defined multiple times", component.Name)
 			}
 			devfileVolumes[component.Name] = *component.Volume
+			if component.Volume.Ephemeral {
+				ephemeralVolumes = append(ephemeralVolumes, component)
+			}
 		}
 	}
 	if _, exists := devfileVolumes[constants.ProjectsVolumeName]; !exists {
@@ -58,56 +62,81 @@ func RewriteContainerVolumeMounts(workspaceId string, podAdditions *v1alpha1.Pod
 		devfileVolumes[constants.ProjectsVolumeName] = projectsVolume
 	}
 
-	// TODO: Support more than the common PVC strategy here (storage provisioner interface?)
-	// TODO: What should we do when a volume isn't explicitly defined?
-	commonPVCName := config.ControllerCfg.GetWorkspacePVCName()
-	rewriteVolumeMounts := func(containers []corev1.Container) error {
-		for cIdx, container := range containers {
-			for vmIdx, vm := range container.VolumeMounts {
-				if _, ok := devfileVolumes[vm.Name]; !ok {
-					return fmt.Errorf("container '%s' references undefined volume '%s'", container.Name, vm.Name)
-				}
-				containers[cIdx].VolumeMounts[vmIdx].SubPath = fmt.Sprintf("%s/%s", workspaceId, vm.Name)
-				containers[cIdx].VolumeMounts[vmIdx].Name = commonPVCName
-			}
+	for _, component := range ephemeralVolumes {
+		vol := corev1.Volume{
+			Name: component.Name,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
 		}
-		return nil
-	}
-	if err := rewriteVolumeMounts(podAdditions.Containers); err != nil {
-		return err
-	}
-	if err := rewriteVolumeMounts(podAdditions.InitContainers); err != nil {
-		return err
+		if component.Volume.Size != "" {
+			sizeResource, err := resource.ParseQuantity(component.Volume.Size)
+			if err != nil {
+				return fmt.Errorf("failed to parse size for Volume %s: %w", component.Name, err)
+			}
+			vol.EmptyDir.SizeLimit = &sizeResource
+		}
+		podAdditions.Volumes = append(podAdditions.Volumes, vol)
 	}
 
-	podAdditions.Volumes = append(podAdditions.Volumes, corev1.Volume{
-		Name: commonPVCName,
-		VolumeSource: corev1.VolumeSource{
-			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: commonPVCName,
+	if NeedsStorage(workspace) {
+		// TODO: Support more than the common PVC strategy here (storage provisioner interface?)
+		// TODO: What should we do when a volume isn't explicitly defined?
+		commonPVCName := config.ControllerCfg.GetWorkspacePVCName()
+		rewriteVolumeMounts := func(containers []corev1.Container) error {
+			for cIdx, container := range containers {
+				for vmIdx, vm := range container.VolumeMounts {
+					volume, ok := devfileVolumes[vm.Name]
+					if !ok {
+						return fmt.Errorf("container '%s' references undefined volume '%s'", container.Name, vm.Name)
+					}
+					if !volume.Ephemeral {
+						containers[cIdx].VolumeMounts[vmIdx].SubPath = fmt.Sprintf("%s/%s", workspaceId, vm.Name)
+						containers[cIdx].VolumeMounts[vmIdx].Name = commonPVCName
+					}
+				}
+			}
+			return nil
+		}
+		if err := rewriteVolumeMounts(podAdditions.Containers); err != nil {
+			return err
+		}
+		if err := rewriteVolumeMounts(podAdditions.InitContainers); err != nil {
+			return err
+		}
+
+		podAdditions.Volumes = append(podAdditions.Volumes, corev1.Volume{
+			Name: commonPVCName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: commonPVCName,
+				},
 			},
-		},
-	})
+		})
+	}
+
 	return nil
 }
 
-// NeedsStorage returns true if storage will need to be provisioned for the current workspace
-// TODO:
-// - This function is used to decide if we need to create a PVC; need to figure out how to handle
-//   case of ephemeral storage only
+// NeedsStorage returns true if storage will need to be provisioned for the current workspace. Note that ephemeral volumes
+// do not need to provision storage
 func NeedsStorage(workspace devworkspace.DevWorkspaceTemplateSpec) bool {
+	projectsVolumeIsEphemeral := false
 	for _, component := range workspace.Components {
 		if component.Volume != nil {
-			return true
-		}
-		if component.Container != nil {
-			if len(component.Container.VolumeMounts) > 0 {
+			// If any non-ephemeral volumes are defined, we need to mount storage
+			if !component.Volume.Ephemeral {
 				return true
 			}
-			if containerlib.HasMountSources(component.Container) {
-				return true
+			if component.Name == constants.ProjectsVolumeName {
+				projectsVolumeIsEphemeral = component.Volume.Ephemeral
 			}
 		}
 	}
-	return false
+	if projectsVolumeIsEphemeral {
+		// No non-ephemeral volumes, and projects volume mount is ephemeral, so all volumes are ephemeral
+		return false
+	}
+	// Implicit projects volume is non-ephemeral, so any container that mounts sources requires storage
+	return containerlib.AnyMountSources(workspace.Components)
 }

--- a/pkg/library/storage/testdata/can-make-projects-ephemeral.yaml
+++ b/pkg/library/storage/testdata/can-make-projects-ephemeral.yaml
@@ -1,0 +1,35 @@
+name: "Can make projects volume ephemeral"
+
+input:
+  workspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true
+      - name: projects
+        volume:
+          ephemeral: true
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: projects
+            mountPath: "/projects-mountpath"
+
+    volumes:
+      - name: projects
+        emptyDir: {}

--- a/pkg/library/storage/testdata/can-set-ephemeral-volume-size.yaml
+++ b/pkg/library/storage/testdata/can-set-ephemeral-volume-size.yaml
@@ -1,0 +1,37 @@
+name: "Can make projects volume ephemeral"
+
+input:
+  workspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true
+      - name: projects
+        volume:
+          ephemeral: true
+          size: 512Mi
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: projects
+            mountPath: "/projects-mountpath"
+
+    volumes:
+      - name: projects
+        emptyDir:
+          sizeLimit: 512Mi

--- a/pkg/library/storage/testdata/error-unparseable-ephemeral-size.yaml
+++ b/pkg/library/storage/testdata/error-unparseable-ephemeral-size.yaml
@@ -1,0 +1,26 @@
+name: "Can make projects volume ephemeral"
+
+input:
+  workspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true
+      - name: projects
+        volume:
+          ephemeral: true
+          size: 512XX
+
+output:
+  errRegexp: "failed to parse size for Volume projects.*"

--- a/pkg/library/storage/testdata/handles-ephemeral-volumes.yaml
+++ b/pkg/library/storage/testdata/handles-ephemeral-volumes.yaml
@@ -1,0 +1,35 @@
+name: "Handles ephemeral volumes"
+
+input:
+  workspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: testvol
+            mountPath: "/projects-mountpath"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          mountSources: false
+
+      - name: testvol
+        volume:
+          ephemeral: true
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: testvol
+            mountPath: "/projects-mountpath"
+
+    volumes:
+      - name: testvol
+        emptyDir: {}

--- a/samples/flattened_theia-next.yaml
+++ b/samples/flattened_theia-next.yaml
@@ -38,7 +38,8 @@ spec:
       - name: plugins
         volume: {}
       - name: remote-endpoint
-        volume: {} # TODO: Fix this once ephemeral volumes are supported
+        volume:
+          ephemeral: true
       - name: vsx-installer  # Mainly reads the container objects and searches for those
                               # with che-theia.eclipse.org/vscode-extensions attributes to get VSX urls
                               # Those found in the dedicated containers components are with a sidecar,

--- a/samples/flattened_theia-nodejs.yaml
+++ b/samples/flattened_theia-nodejs.yaml
@@ -107,8 +107,8 @@ spec:
               name: plugins
 
       - name: remote-endpoint
-        volume: {}
-          # ephemeral: true                #### We should add it in the Devfile 2.0 spec ! Not critical to implement at start though
+        volume:
+          ephemeral: true
 
       - name: remote-runtime-injector
         attributes:

--- a/samples/plugins/theia-next.yaml
+++ b/samples/plugins/theia-next.yaml
@@ -7,7 +7,8 @@ spec:
     - name: plugins
       volume: {}
     - name: remote-endpoint
-      volume: {} # TODO: Fix this once ephemeral volumes are supported
+      volume:
+        ephemeral: true
     - name: vsx-installer
       plugin:
         kubernetes:

--- a/samples/with-k8s-ref/emptyDir-theia.yaml
+++ b/samples/with-k8s-ref/emptyDir-theia.yaml
@@ -1,0 +1,25 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: theia
+spec:
+  started: true
+  template:
+    components:
+      - name: theia
+        plugin:
+          kubernetes:
+            name: theia-next
+            namespace: devworkspace-plugins
+          components:
+            - name: plugins
+              volume:
+                ephemeral: true
+      - name: terminal
+        plugin:
+          kubernetes:
+            name: machine-exec
+            namespace: devworkspace-plugins
+      - name: projects
+        volume:
+          ephemeral: true


### PR DESCRIPTION
### What does this PR do?
Adds support for volume components with `ephemeral: true`, which are provisioned as emptyDir volumes in the workspace pod.

This PR updates the logic for determining whether a container needs storage. The new logic is:
- If any non-ephemeral volumes are defined, we need storage
- If any container component has `mountSources: true`, we need storage *unless* there's an explicit projects volume with `ephemeral: true`
this new check does not check that any container has mountSources as before, since that is covered by the first case, or an error (a container mounting a volume that is not defined)

I had to update the relevant test to support this change, and also added tests to cover the ephemeral volume use cases.

I've also added a sample that showcases some of the ways to use ephemeral volumes:
- We can override the default projects volume to be ephemeral
- We can override volumes in plugins to be ephemeral (we make the theia `plugins` volume ephemeral)

### What issues does this PR fix or reference?
Closes https://github.com/devfile/api/issues/310

### Is it tested? How?
1. Deploy controller, *make sure CRDs are updated* to include support for ephemeral volumes (I made that mistake...) (see: https://github.com/devfile/devworkspace-operator/pull/270)
2. Deploy plugin templates (`make install_plugin_templates`)
    - Note some of the templates have been updated to e.g. use an ephemeral volume for remote runtime
3. Deploy sample that uses emptyDir
    ```bash
    kubectl apply -f samples/with-k8s-ref/emptyDir-theia.yaml
    ```
4. Verify:
    - All volumes in workspace pod are emptyDir (`kubectl get po <workspace> -o yaml | yq -y '.spec.volumes')
    - All volumeMounts in containers refer to these emptyDir containers
    - No finalizer is set on the workspace
    - The workspace runs normally

I had a strange issue testing locally that I'm currently blaming minikube for: when I initially apply the sample, the volumes in the devworkspace are simply
```
      - name: projects
        volume: {}
```
but applying twice correctly shows the ephemeral field. No idea why that's happening and praying it doesn't reproduce elsewhere.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
