### PR TITLE
Set memory request and cpu request/limit for PVC clean up job

### DIFF
--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -45,10 +45,12 @@ const (
 )
 
 var (
-	cleanupJobCompletions  = int32(1)
-	cleanupJobBackoffLimit = int32(3)
-	// PVCCleanupPodMemoryLimit is the memory limit used for PVC clean up pods
-	PVCCleanupPodMemoryLimit = resource.MustParse("32Mi")
+	cleanupJobCompletions      = int32(1)
+	cleanupJobBackoffLimit     = int32(3)
+	PVCCleanupPodMemoryLimit   = resource.MustParse("32Mi")
+	PVCCleanupPodMemoryRequest = PVCCleanupPodMemoryLimit
+	PVCCleanupPodCPULimit      = resource.MustParse("50m")
+	PVCCleanupPodCPURequest    = resource.MustParse("5m")
 )
 
 func (r *DevWorkspaceReconciler) setFinalizer(ctx context.Context, workspace *v1alpha2.DevWorkspace) (ok bool, err error) {
@@ -189,8 +191,13 @@ func (r *DevWorkspaceReconciler) getSpecCleanupJob(workspace *v1alpha2.DevWorksp
 								fmt.Sprintf(cleanupCommandFmt, path.Join(pvcClaimMountPath, workspaceId)),
 							},
 							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: PVCCleanupPodMemoryRequest,
+									corev1.ResourceCPU:    PVCCleanupPodCPURequest,
+								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: PVCCleanupPodMemoryLimit,
+									corev1.ResourceCPU:    PVCCleanupPodCPULimit,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
### What does this PR do?
Set memory request and cpu request/limit for PVC clean up job.
It fixes issue I faced on RHDPS cluster, job pod can't be created:
```
container create failed: time=\"2021-02-25T10:50:49Z\" level=error msg=\"container_linux.go:366: starting container process caused: process_linux.go:351: getting the final child's pid from pipe caused: EOF\"\n"
```
I noticed pod has annotation with warning default CPU settings are set, and it's 50m request and 500m limit.

The proposed changes are tested and based on metrics:
![Screenshot_20210225_134617](https://user-images.githubusercontent.com/5887312/109151280-a00b3c00-7772-11eb-94d4-021cf0448ff3.png)
![Screenshot_20210225_134639](https://user-images.githubusercontent.com/5887312/109151282-a0a3d280-7772-11eb-8e06-eedfa5f697b7.png)
^ don't ask how I got 5/10 cpu from 3 :-D Feel free to propose yours.

What could be done better? We could have in addition default CPU settings which we apply to containers without any, as we do with memory (I am not sure).

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
tested and PVC clean up works on my RHPDS cluster

:notebook: despite of fact that this PR seems to have good quality and pretty good description, that solves nothing. I just noticed hanging job that can't create pod due:
```
Failed to create pod sandbox: rpc error: code = Unknown desc = container create failed: time="2021-02-25T15:08:47Z" level=error msg="container_linux.go:366: starting container process caused: process_linux.go:472: container init caused: read init-p: connection reset by peer"
...
Failed to create pod sandbox: rpc error: code = Unknown desc = Kubelet may be retrying requests that are timing out in CRI-O due to system load: error reserving pod name k8s_cleanup-workspace4dcb6313961548f7-6rv57_user7-che_b791e4f4-f450-4b6c-b286-2491ae18737c_0 for id 6566c6d0594e5c6a6d4d1b631fcb6dde0f088e6fef36a3b03f154e38b6d672a5: name is reserved
...
Failed to create pod sandbox: rpc error: code = Unknown desc = `/usr/bin/runc --root /run/runc start bae51d475f046e3df9a7e9df9083d0d0b8566179e6bce8023ff72afbf9d4674e` failed: time="2021-02-25T15:19:36Z" level=error msg="cannot start a container that has stopped" (exit status 1)
```
but it has the proposed CPU and memory settings. I'm investigating.
Maybe it caused by busybos, Che uses centos but it's 1.2MB vs 204MB. We need to find light-weight alternative and try if it's going to work better.

Thanks for reading to the end. I think this PR makes sense in any case.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
