### PR TITLE
Attach dockercfg secrets as pull image secret

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -304,7 +304,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	if !pullSecretStatus.Continue {
 		return reconcile.Result{Requeue: pullSecretStatus.Requeue}, pullSecretStatus.Err
 	}
-	podAdditions = append(podAdditions, pullSecretStatus.PodAdditions)
+	allPodAdditions = append(allPodAdditions, pullSecretStatus.PodAdditions)
 	reconcileStatus.Conditions[PullSecretsReadyCondition] = ""
 
 	// Step six: Create deployment and wait for it to be ready

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -305,6 +305,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return reconcile.Result{Requeue: pullSecretStatus.Requeue}, pullSecretStatus.Err
 	}
 	podAdditions = append(podAdditions, pullSecretStatus.PodAdditions)
+	reconcileStatus.Conditions[PullSecretsReadyCondition] = ""
 
 	// Step six: Create deployment and wait for it to be ready
 	timing.SetTime(timingInfo, timing.DeploymentCreated)

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -300,6 +300,12 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	serviceAcctName := serviceAcctStatus.ServiceAccountName
 	reconcileStatus.Conditions[devworkspace.WorkspaceServiceAccountReady] = ""
 
+	pullSecretStatus := provision.PullSecrets(clusterAPI)
+	if !pullSecretStatus.Continue {
+		return reconcile.Result{Requeue: pullSecretStatus.Requeue}, pullSecretStatus.Err
+	}
+	podAdditions = append(podAdditions, pullSecretStatus.PodAdditions)
+
 	// Step six: Create deployment and wait for it to be ready
 	timing.SetTime(timingInfo, timing.DeploymentCreated)
 	deploymentStatus := provision.SyncDeploymentToCluster(workspace, allPodAdditions, serviceAcctName, clusterAPI)

--- a/controllers/workspace/provision/pull_secret.go
+++ b/controllers/workspace/provision/pull_secret.go
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package provision
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type PullSecretsProvisioningStatus struct {
+	ProvisioningStatus
+	v1alpha1.PodAdditions
+}
+
+func PullSecrets(clusterAPI ClusterAPI) PullSecretsProvisioningStatus {
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", config.DevWorkspacePullSecretLabel, "true"))
+	if err != nil {
+		return PullSecretsProvisioningStatus{
+			ProvisioningStatus: ProvisioningStatus{
+				Err:     err,
+				Requeue: true,
+			},
+		}
+	}
+
+	secrets := corev1.SecretList{}
+	err = clusterAPI.Client.List(context.TODO(), &secrets, &client.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return PullSecretsProvisioningStatus{
+			ProvisioningStatus: ProvisioningStatus{
+				Err:     err,
+				Requeue: true,
+			},
+		}
+	}
+
+	var dockerCfgs []corev1.LocalObjectReference
+	for _, s := range secrets.Items {
+		if s.Type == corev1.SecretTypeDockercfg || s.Type == corev1.SecretTypeDockerConfigJson {
+			dockerCfgs = append(dockerCfgs, corev1.LocalObjectReference{Name: s.Name})
+		}
+	}
+	return PullSecretsProvisioningStatus{
+		ProvisioningStatus: ProvisioningStatus{
+			Continue: true,
+		},
+		PodAdditions: v1alpha1.PodAdditions{
+			PullSecrets: dockerCfgs,
+		},
+	}
+}

--- a/controllers/workspace/provision/pull_secret.go
+++ b/controllers/workspace/provision/pull_secret.go
@@ -33,8 +33,8 @@ func PullSecrets(clusterAPI ClusterAPI) PullSecretsProvisioningStatus {
 	if err != nil {
 		return PullSecretsProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{
-				Err:     err,
-				Requeue: true,
+				Err:         err,
+				FailStartup: true,
 			},
 		}
 	}
@@ -44,8 +44,7 @@ func PullSecrets(clusterAPI ClusterAPI) PullSecretsProvisioningStatus {
 	if err != nil {
 		return PullSecretsProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{
-				Err:     err,
-				Requeue: true,
+				Err: err,
 			},
 		}
 	}

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -32,6 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const PullSecretsReadyCondition devworkspace.WorkspaceConditionType = "PullSecretsReady"
+
 // clock is used to set status condition timestamps.
 // This variable makes it easier to test conditions.
 var clock kubeclock.Clock = &kubeclock.RealClock{}
@@ -164,6 +166,9 @@ func getInfoMessage(workspace *devworkspace.DevWorkspace, conditions map[devwork
 	}
 	if _, ok := conditions[devworkspace.WorkspaceServiceAccountReady]; ok {
 		return "Waiting for deployment to be ready"
+	}
+	if _, ok := conditions[PullSecretsReadyCondition]; ok {
+		return "Waiting for workspace pull secrets"
 	}
 	if _, ok := conditions[devworkspace.WorkspaceRoutingReady]; ok {
 		return "Waiting for workspace serviceaccount"

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -145,6 +145,36 @@ func getIdeUrl(exposedEndpoints map[string]v1alpha1.ExposedEndpointList) string 
 	return ""
 }
 
+type PhaseStatus struct {
+	Condition devworkspace.WorkspaceConditionType
+	Message   string
+}
+
+// Defines the order in which DevWorkspace Controller processes phases on reconcile
+// The last unready condition should be shown
+var PhaseStatusesOrder = []PhaseStatus{
+	{
+		devworkspace.WorkspaceComponentsReady,
+		"Processing DevWorkspace components",
+	},
+	{
+		devworkspace.WorkspaceRoutingReady,
+		"Waiting for workspace routing objects",
+	},
+	{
+		devworkspace.WorkspaceServiceAccountReady,
+		"Waiting for workspace serviceaccount",
+	},
+	{
+		PullSecretsReadyCondition,
+		"Waiting for workspace pull secrets",
+	},
+	{
+		devworkspace.WorkspaceReady,
+		"Waiting for deployment to be ready",
+	},
+}
+
 func getInfoMessage(workspace *devworkspace.DevWorkspace, conditions map[devworkspace.WorkspaceConditionType]string) string {
 	// Check for errors and failure
 	if msg, ok := conditions[devworkspace.WorkspaceError]; ok {
@@ -160,21 +190,12 @@ func getInfoMessage(workspace *devworkspace.DevWorkspace, conditions map[devwork
 		return string(workspace.Status.Phase)
 	}
 
-	// Check for progress
-	if _, ok := conditions[devworkspace.WorkspaceReady]; ok {
-		return "Waiting on editor to start"
+	for _, phaseStatus := range PhaseStatusesOrder {
+		if _, present := conditions[phaseStatus.Condition]; !present {
+			return phaseStatus.Message
+		}
 	}
-	if _, ok := conditions[devworkspace.WorkspaceServiceAccountReady]; ok {
-		return "Waiting for deployment to be ready"
-	}
-	if _, ok := conditions[PullSecretsReadyCondition]; ok {
-		return "Waiting for workspace pull secrets"
-	}
-	if _, ok := conditions[devworkspace.WorkspaceRoutingReady]; ok {
-		return "Waiting for workspace serviceaccount"
-	}
-	if _, ok := conditions[devworkspace.WorkspaceComponentsReady]; ok {
-		return "Waiting for workspace routing objects"
-	}
-	return "Processing DevWorkspace components"
+
+	//All listed conditions are true, if workspace is not started yet, it's due editor server health check
+	return "Waiting on editor to start"
 }

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -46,6 +46,11 @@ const (
 	// WorkspaceNameLabel is label key to store workspace name
 	WorkspaceNameLabel = "controller.devfile.io/workspace_name"
 
+	// PullSecretLabel marks the intention that secret should be used as pull secret for devworkspaces withing namespace
+	// Only secrets with 'true' value will be mount as pull secret
+	// Should be assigned to secrets with type docker config types (kubernetes.io/dockercfg and kubernetes.io/dockerconfigjson)
+	DevWorkspacePullSecretLabel = "controller.devfile.io/workspace_pull_secret"
+
 	// WorkspaceCreatorLabel is the label key for storing the UID of the user who created the workspace
 	WorkspaceCreatorLabel = "controller.devfile.io/creator"
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -49,7 +49,7 @@ const (
 	// PullSecretLabel marks the intention that secret should be used as pull secret for devworkspaces withing namespace
 	// Only secrets with 'true' value will be mount as pull secret
 	// Should be assigned to secrets with type docker config types (kubernetes.io/dockercfg and kubernetes.io/dockerconfigjson)
-	DevWorkspacePullSecretLabel = "controller.devfile.io/workspace_pull_secret"
+	DevWorkspacePullSecretLabel = "controller.devfile.io/devworkspace_pullsecret"
 
 	// WorkspaceCreatorLabel is the label key for storing the UID of the user who created the workspace
 	WorkspaceCreatorLabel = "controller.devfile.io/creator"

--- a/samples/flattened_theia-next.yaml
+++ b/samples/flattened_theia-next.yaml
@@ -37,62 +37,11 @@ spec:
     ### BEGIN Contributions from Theia plugin ###
       - name: plugins
         volume: {}
-      - name: remote-endpoint
-        volume:
-          ephemeral: true
-      - name: vsx-installer  # Mainly reads the container objects and searches for those
-                              # with che-theia.eclipse.org/vscode-extensions attributes to get VSX urls
-                              # Those found in the dedicated containers components are with a sidecar,
-                              # Those found in the che-theia container are without a sidecar.
-        attributes:
-          "app.kubernetes.io/part-of": che-theia.eclipse.org
-          "app.kubernetes.io/component": bootstrapper
-        container:
-          args:
-            - /bin/sh
-            - '-c'
-            - |
-              KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}" &&\
-              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\
-              WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" $KUBE_API_ENDPOINT) &&\
-              IFS=$'\n' &&\
-              for container in $(echo $WORKSPACE | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
-                dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - ) ;\
-                urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - ) ;\
-                mkdir -p $dest ;\
-                unset IFS &&\
-                for url in $(echo $urls | sed 's/[",]/ /g' - ); do \
-                  echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\
-                done \
-              done \
-          image: 'quay.io/samsahai/curl:latest'
-          volumeMounts:
-            - path: "/plugins"
-              name: plugins
-      - name: remote-runtime-injector
-        attributes:
-          "app.kubernetes.io/part-of": che-theia.eclipse.org
-          "app.kubernetes.io/component": bootstrapper
-        container:                          #### corresponds to `initContainer` definition in old meta.yaml.
-          image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0"
-          volumeMounts:
-            - path: "/remote-endpoint"
-              name: remote-endpoint
-          env:
-            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
-              value: /remote-endpoint/plugin-remote-endpoint
-            - name: REMOTE_ENDPOINT_VOLUME_NAME
-              value: remote-endpoint
       - name: theia-ide
         attributes:
           "app.kubernetes.io/name": che-theia.eclipse.org
           "app.kubernetes.io/part-of": che.eclipse.org
           "app.kubernetes.io/component": editor
-
-          # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
-          # contains the vscode-pull-request-github vscode plugin.
-          "che-theia.eclipse.org/vscode-extensions":
-            - https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix
         container:
           image: "quay.io/eclipse/che-theia:next"
           env:
@@ -143,24 +92,9 @@ spec:
               exposure: public
               targetPort: 13133
               protocol: http
-    ### END Contributions from Theia plugin ###
-
     commands:
       - id: say-hello
         exec:
           component: plugin
           commandLine: echo "Hello from $(pwd)"
           workingDir: ${PROJECTS_ROOT}/project/app
-    ### BEGIN Contributions from Theia plugin ###
-      # Commands coming from plugin editor
-      - id: inject-theia-in-remote-sidecar
-        apply:
-          component: remote-runtime-injector
-      - id: copy-vsx
-        apply:
-          component: vsx-installer
-    events:
-      preStart:
-        - inject-theia-in-remote-sidecar
-        - copy-vsx
-    ### END Contributions from Theia plugin ###


### PR DESCRIPTION
### What does this PR do?
This PR add an ability to label secrets with types `kubernetes.io/dockercfg` and `kubernetes.io/dockerconfigjson` which `controller.devfile.io/workspace_pull_secret: true` and it will be used as pull secret for DevWorkspace-related deployment.

### What issues does this PR fix or reference?
fixes https://github.com/devfile/devworkspace-operator/issues/264

### Is it tested? How?
I created two robots and mirror che theia in my private repo, so, they can be used for testing:

```bash
# 1. Created patched sample with private image
sed -e 's|image: "quay.io/eclipse/che-theia:next"|image: "quay.io/sleshche/che-theia:latest"|g' ./samples/flattened_theia-next.yaml \
  | kubectl apply -f -

# 2. it won't be started due
#         message: 'rpc error: code = Unknown desc = Error response from daemon: unauthorized:
#         access to the requested resource is not authorized'


# 3. Create tests robots
# Robot without any permissions, just to check that it's ignored since there is no needed label
cat <<EOF | kubectl apply -f -
apiVersion: v1
data:
  .dockerconfigjson: ewoJImF1dGhzIjogewoJCSJxdWF5LmlvIjogewoJCQkiYXV0aCI6ICJjMnhsYzJoamFHVXJhVjlqWVc1ZmJtOTBhR2x1WnpwUE4xcFVSRVExVUZvMFFWVlNWRGxEVlU5VVNEUlZSVXBhUWxBMVRVUXdOVGd5UVRGR1RFWk5NbGxKVkZGQ1R6QTNSMXBEUmtrelZUYzBVRmxTTWpNMCIKCQl9Cgl9Cn0=
kind: Secret
metadata:
  name: blank-robot
  labels: {}
type: kubernetes.io/dockerconfigjson
EOF

# Robot with read access to private quay.io/sleshche/che-theia
cat <<EOF | kubectl apply -f -
apiVersion: v1
data:
  .dockerconfigjson: ewoJImF1dGhzIjogewoJCSJxdWF5LmlvIjogewoJCQkiYXV0aCI6ICJjMnhsYzJoamFHVXJZMmhsWDNSb1pXbGhYM0psWVdSdmJteDVPa1ZOV1ZJeE5sRlRORXBVVVUweFdUZFROVkZHUVZaWlJFazNOME5KVWtaSFVsaGFRMFJVVms0MlUwVXpXRWRSVTFZNVZqTktTVEJXUVZoT09GTTBTVkk9IgoJCX0KCX0KfQ==
kind: Secret
metadata:
  name: che-theia-readonly
  labels:
    controller.devfile.io/devworkspace_pullsecret: "true"
type: kubernetes.io/dockerconfigjson
EOF

# 4. Restart a workspace 

kubectl patch dw theia --type merge --patch '                                     
spec:
  started: false
'
kubectl patch dw theia --type merge --patch '                                     
spec:
  started: true
'

# 5. Workspace now is started.
```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
