### PR TITLE
Remove stopped-by annotation when a workspace is restarted

### DIFF
--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -218,6 +218,12 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcileResu
 		return reconcile.Result{}, err
 	}
 
+	if _, ok := workspace.Annotations[config.StoppedByAnnotation]; ok {
+		delete(workspace.Annotations, config.StoppedByAnnotation)
+		err = r.client.Update(context.TODO(), workspace)
+		return reconcile.Result{Requeue: true}, err
+	}
+
 	immutable := workspace.Annotations[config.WorkspaceImmutableAnnotation]
 	if immutable == "true" && config.ControllerCfg.GetWebhooksEnabled() != "true" {
 		reqLogger.Info("Workspace is configured as immutable but webhooks are not enabled.")


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR makes it so that the stopped by annotation is removed when a workspace is restarted. This PR ports back the changes that are in master to v1.0.0-alphax.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
```
# change RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0 to use quay.io/jpinkney/web-terminal-exec:1.2
make docker deploy
# Start terminal and wait for it to timeout
# See that the stopped-by annotation is set
# Re-open the terminal and see that the stopped-by annotation is not set
```
<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
