### PR TITLE
Fix temporary vsx-installer entrypoint after adding messages

### DIFF
--- a/pkg/library/flatten/testdata/k8s-ref/nodejs-workspace.yaml
+++ b/pkg/library/flatten/testdata/k8s-ref/nodejs-workspace.yaml
@@ -105,14 +105,16 @@ input:
                   KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}" &&\
                   TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\
                   WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" $KUBE_API_ENDPOINT) &&\
-                  for container in $(echo $WORKSPACE | sed -e 's;[[,]\({"attributes":{"app.kubernetes.io\);\n\1;g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
-                    dest=$(echo "$container" | sed 's;.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*;\1;' - ) ;\
-                    urls=$(echo "$container" | sed 's;.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*;\1;' - ) ;\
+                  IFS=$'\n' &&\
+                  for container in $(echo $WORKSPACE | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
+                    dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - ) ;\
+                    urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - ) ;\
                     mkdir -p $dest ;\
+                    unset IFS &&\
                     for url in $(echo $urls | sed 's/[",]/ /g' - ); do \
                       echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\
                     done \
-                  done
+                  done \
               image: 'quay.io/samsahai/curl:latest'
               volumeMounts:
                 - path: "/plugins"
@@ -359,14 +361,16 @@ output:
               KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}" &&\
               TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\
               WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" $KUBE_API_ENDPOINT) &&\
-              for container in $(echo $WORKSPACE | sed -e 's;[[,]\({"attributes":{"app.kubernetes.io\);\n\1;g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
-                dest=$(echo "$container" | sed 's;.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*;\1;' - ) ;\
-                urls=$(echo "$container" | sed 's;.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*;\1;' - ) ;\
+              IFS=$'\n' &&\
+              for container in $(echo $WORKSPACE | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
+                dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - ) ;\
+                urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - ) ;\
                 mkdir -p $dest ;\
+                unset IFS &&\
                 for url in $(echo $urls | sed 's/[",]/ /g' - ); do \
                   echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\
                 done \
-              done
+              done \
           image: 'quay.io/samsahai/curl:latest'
           volumeMounts:
             - path: "/plugins"

--- a/samples/flattened_theia-next.yaml
+++ b/samples/flattened_theia-next.yaml
@@ -55,10 +55,12 @@ spec:
               KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}" &&\
               TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\
               WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" $KUBE_API_ENDPOINT) &&\
-              for container in $(echo $WORKSPACE | sed -e 's;[[,]\({"attributes":{"app.kubernetes.io\);\n\1;g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
-                dest=$(echo "$container" | sed 's;.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*;\1;' - ) ;\
-                urls=$(echo "$container" | sed 's;.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*;\1;' - ) ;\
+              IFS=$'\n' &&\
+              for container in $(echo $WORKSPACE | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
+                dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - ) ;\
+                urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - ) ;\
                 mkdir -p $dest ;\
+                unset IFS &&\
                 for url in $(echo $urls | sed 's/[",]/ /g' - ); do \
                   echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\
                 done \

--- a/samples/flattened_theia-nodejs.yaml
+++ b/samples/flattened_theia-nodejs.yaml
@@ -93,10 +93,12 @@ spec:
               KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}" &&\
               TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\
               WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" $KUBE_API_ENDPOINT) &&\
-              for container in $(echo $WORKSPACE | sed -e 's;[[,]\({"attributes":{"app.kubernetes.io\);\n\1;g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
-                dest=$(echo "$container" | sed 's;.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*;\1;' - ) ;\
-                urls=$(echo "$container" | sed 's;.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*;\1;' - ) ;\
+              IFS=$'\n' &&\
+              for container in $(echo $WORKSPACE | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
+                dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - ) ;\
+                urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - ) ;\
                 mkdir -p $dest ;\
+                unset IFS &&\
                 for url in $(echo $urls | sed 's/[",]/ /g' - ); do \
                   echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\
                 done \

--- a/samples/plugins/vsx-installer.yaml
+++ b/samples/plugins/vsx-installer.yaml
@@ -23,10 +23,12 @@ spec:
             KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}" &&\
             TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\
             WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" $KUBE_API_ENDPOINT) &&\
-            for container in $(echo $WORKSPACE | sed -e 's;[[,]\({"attributes":{"app.kubernetes.io\);\n\1;g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
-              dest=$(echo "$container" | sed 's;.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*;\1;' - ) ;\
-              urls=$(echo "$container" | sed 's;.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*;\1;' - ) ;\
+            IFS=$'\n' &&\
+            for container in $(echo $WORKSPACE | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
+              dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - ) ;\
+              urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - ) ;\
               mkdir -p $dest ;\
+              unset IFS &&\
               for url in $(echo $urls | sed 's/[",]/ /g' - ); do \
                 echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\
               done \


### PR DESCRIPTION
### What does this PR do?
Adding a message field to status that contained spaces broke some splitting in the vsx-installer entrypoint. This is a fixup to avoid that issue by setting IFS correctly.

### What issues does this PR fix or reference?
Applying theia-nodejs samples fails.

### Is it tested? How?
`kubectl apply -f samples/flattened_theia-nodejs.yaml`

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
