### PR TITLE
Remove need for componentDescriptions except for che-rest-apis sidecar

### DIFF
--- a/controllers/workspace/provision/routing.go
+++ b/controllers/workspace/provision/routing.go
@@ -60,10 +60,9 @@ var routingDiffOpts = cmp.Options{
 
 func SyncRoutingToCluster(
 	workspace *devworkspace.DevWorkspace,
-	components []v1alpha1.ComponentDescription,
 	clusterAPI ClusterAPI) RoutingProvisioningStatus {
 
-	specRouting, err := getSpecRouting(workspace, components, clusterAPI.Scheme)
+	specRouting, err := getSpecRouting(workspace, clusterAPI.Scheme)
 	if err != nil {
 		return RoutingProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{Err: err},
@@ -132,14 +131,16 @@ func SyncRoutingToCluster(
 
 func getSpecRouting(
 	workspace *devworkspace.DevWorkspace,
-	componentDescriptions []v1alpha1.ComponentDescription,
 	scheme *runtime.Scheme) (*v1alpha1.WorkspaceRouting, error) {
 
 	endpoints := map[string]v1alpha1.EndpointList{}
-	for _, desc := range componentDescriptions {
-		componentEndpoints := desc.ComponentMetadata.Endpoints
+	for _, component := range workspace.Spec.Template.Components {
+		if component.Container == nil {
+			continue
+		}
+		componentEndpoints := component.Container.Endpoints
 		if componentEndpoints != nil && len(componentEndpoints) > 0 {
-			endpoints[desc.Name] = append(endpoints[desc.Name], componentEndpoints...)
+			endpoints[component.Name] = append(endpoints[component.Name], componentEndpoints...)
 		}
 	}
 

--- a/pkg/library/shim/component.go
+++ b/pkg/library/shim/component.go
@@ -86,7 +86,7 @@ func GetComponentDescriptionsFromPodAdditions(podAdditions *v1alpha1.PodAddition
 	for _, mainContainer := range podAdditions.Containers {
 		component, err := GetComponentByName(mainContainer.Name, workspace)
 		if err != nil {
-			return nil, err
+			continue // Not all components in podAdditions come from the devfile
 		}
 		descriptions = append(descriptions, v1alpha1.ComponentDescription{
 			Name: component.Name,
@@ -100,7 +100,7 @@ func GetComponentDescriptionsFromPodAdditions(podAdditions *v1alpha1.PodAddition
 	for _, initContainer := range podAdditions.InitContainers {
 		component, err := GetComponentByName(initContainer.Name, workspace)
 		if err != nil {
-			return nil, err
+			continue // Not all components in podAdditions come from the devfile
 		}
 		descriptions = append(descriptions, v1alpha1.ComponentDescription{
 			Name: component.Name,


### PR DESCRIPTION
### What does this PR do?
Restrict the need to generate ComponentDescriptions so that they're only used in generating the che-rest-apis sidecar. This allows us to remove the legacy component descriptions struct once we remove che-rest-apis.

To support components that are not defined in the devfile, make the generate component descriptions library function ignore containers that don't come from the current DevWorkspace spec.

### What issues does this PR fix or reference?
Required step in https://github.com/devfile/devworkspace-operator/issues/288

### Is it tested? How?
Test as usual; this is an internal refactor so there should be no functional changes.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
