### PR TITLE
Skip ideUrl health check when DW does not specify ideURL

### DIFF
--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -108,7 +108,8 @@ func syncWorkspaceIdeURL(workspace *devworkspace.DevWorkspace, exposedEndpoints 
 func checkServerStatus(workspace *devworkspace.DevWorkspace) (ok bool, err error) {
 	ideUrl := workspace.Status.IdeUrl
 	if ideUrl == "" {
-		return false, nil
+		// Support DevWorkspaces that do not specify an ideUrl
+		return true, nil
 	}
 	healthz, err := url.Parse(ideUrl)
 	if err != nil {
@@ -153,6 +154,9 @@ func getInfoMessage(workspace *devworkspace.DevWorkspace, conditions map[devwork
 	}
 	switch workspace.Status.Phase {
 	case devworkspace.WorkspaceStatusRunning:
+		if workspace.Status.IdeUrl == "" {
+			return "Workspace is running"
+		}
 		return workspace.Status.IdeUrl
 	case devworkspace.WorkspaceStatusStopped, devworkspace.WorkspaceStatusStopping:
 		return string(workspace.Status.Phase)


### PR DESCRIPTION
### What does this PR do?
Skip `checkServerStatus` step for DevWorkspaces that do not specify an ideURL, to allow such workspaces to reach the running state. Since these workspaces do not have any URL to show the user currently, the `INFO` message is set to `Workspace is running`

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/274

### Is it tested? How?
The sample below should start correctly and display
```
❯ kc get dw
NAME          WORKSPACE ID                PHASE     INFO
java-sample   workspace8f4c94aeada245c0   Running   Workspace is running
```

```bash
cat <<EOF | kubectl apply -f - 
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: java-sample
spec:
  started: true
  template:
    projects:
      - name: frontend
        git:
          remotes:
            origin: https://github.com/spring-projects/spring-petclinic
    components:
    - name: maven
      container:
        image: quay.io/eclipse/che-java8-maven:nightly
EOF
```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
