### PR TITLE
Avoid updating webhooks service account unless required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ You can add these Kubernetes annotations to specific DevWorkspace CR to customiz
 
 #### Restricted Access
 
-Using `restricted-access` is possible to define that DevWorkspace needs additional(to RBAC) authorization that guarantee that the only DevWorkspace CR creators has access to the containers terminals and secure server.
-May be needed when personal information(like access tokens, ssh keys) is stored in the containers.
+The `controller.devfile.io/restricted-access` specifies that a DevWorkspace needs additional access control (in addition to RBAC). When a DevWorkspace is created with the `controller.devfile.io/restricted-access` annotation set to `true`, the webhook server will guarantee
+- Only the DevWorkspace Operator ServiceAccount or DevWorkspace creator can modify important fields in the devworksapce
+- Only the DevWorkspace creator can create `pods/exec` into workspace-related containers.
 
-Since it's powered by webhooks, DevWorkspaces with such annotations will fails to start when webhooks are disabled on Operator level.
+This annotation should be used when a DevWorkspace is expected to contain sensitive information that should be protect above the protection provided by standard RBAC rules (e.g. if the DevWorkspace will store the user's OpenShift token in-memory).
 
 Example:
 ```yaml
@@ -98,12 +99,10 @@ To see all rules supported by the makefile, run `make help`
 3. As soon as workspace is started you're able to get IDE url by executing `kubectl get devworkspace -n <namespace>`
 
 ### Run controller locally
-It's possible to run an instance of the controller locally while communicating with a cluster. However, this requires webhooks to be disabled, as the webhooks need to be able to access the service created by an in-cluster deployment
-
 ```bash
 make install
 oc patch deployment/devworkspace-controller-manager --patch "{\"spec\":{\"replicas\":0}}"
-make debug
+make run
 ```
 
 When running locally, only a single namespace is watched; as a result, all workspaces have to be deployed to `${NAMESPACE}`

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -143,11 +143,13 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return r.updateWorkspaceStatus(clusterWorkspace, reqLogger, &reconcileStatus, reconcileResult, err)
 	}()
 
-	msg, err := r.validateCreatorLabel(clusterWorkspace)
-	if err != nil {
-		reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
-		reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = msg
-		return reconcile.Result{}, err
+	if workspace.Annotations[config.WorkspaceRestrictedAccessAnnotation] == "true" {
+		msg, err := r.validateCreatorLabel(clusterWorkspace)
+		if err != nil {
+			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
+			reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = msg
+			return reconcile.Result{}, err
+		}
 	}
 
 	if _, ok := clusterWorkspace.Annotations[config.WorkspaceStopReasonAnnotation]; ok {

--- a/controllers/workspace/provision/deployment.go
+++ b/controllers/workspace/provision/deployment.go
@@ -243,17 +243,11 @@ func getSpecDeployment(
 		deployment.Labels[config.WorkspaceCreatorLabel] = workspaceCreator
 		deployment.Spec.Template.Labels[config.WorkspaceCreatorLabel] = workspaceCreator
 	} else {
-		if config.ControllerCfg.GetWebhooksEnabled() == "true" {
-			return nil, errors.New("workspace must have creator specified to be run. Recreate it to fix an issue")
-		}
+		return nil, errors.New("workspace must have creator specified to be run. Recreate it to fix an issue")
 	}
 
 	restrictedAccess, present := workspace.Annotations[config.WorkspaceRestrictedAccessAnnotation]
 	if present {
-		if config.ControllerCfg.GetWebhooksEnabled() == "false" {
-			return nil, errors.New("workspace is configured to have restricted access but webhooks are not enabled")
-		}
-
 		deployment.Annotations = maputils.Append(deployment.Annotations, config.WorkspaceRestrictedAccessAnnotation, restrictedAccess)
 		deployment.Spec.Template.Annotations = maputils.Append(deployment.Spec.Template.Annotations, config.WorkspaceRestrictedAccessAnnotation, restrictedAccess)
 	}

--- a/controllers/workspace/validation.go
+++ b/controllers/workspace/validation.go
@@ -20,15 +20,12 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/webhook"
 )
 
-// validateCreatorTimestamp checks that a devworkspace was created after workspace-related mutating webhooks
+// validateCreatorLabel checks that a devworkspace was created after workspace-related mutating webhooks
 // and ensures a creator ID label is applied to the workspace. If webhooks are disabled, validation succeeds by
 // default.
 //
 // If error is not nil, a user-readable message is returned that can be propagated to the user to explain the issue.
-func (r *DevWorkspaceReconciler) validateCreatorTimestamp(workspace *devworkspace.DevWorkspace) (msg string, err error) {
-	if config.ControllerCfg.GetWebhooksEnabled() != "true" {
-		return "", nil
-	}
+func (r *DevWorkspaceReconciler) validateCreatorLabel(workspace *devworkspace.DevWorkspace) (msg string, err error) {
 	if _, present := workspace.Labels[config.WorkspaceCreatorLabel]; !present {
 		return "DevWorkspace was created without creator ID label. It must be recreated to resolve the issue",
 			fmt.Errorf("devworkspace does not have creator label applied")

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -16848,7 +16848,6 @@ subjects:
 apiVersion: v1
 data:
   controller.plugin_artifacts_broker.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.4.0
-  controller.webhooks.enabled: "true"
   devworkspace.default_routing_class: basic
   devworkspace.experimental_features_enabled: "true"
   devworkspace.routing.cluster_host_suffix: ""

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-configmap.ConfigMap.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-configmap.ConfigMap.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 data:
   controller.plugin_artifacts_broker.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.4.0
-  controller.webhooks.enabled: "true"
   devworkspace.default_routing_class: basic
   devworkspace.experimental_features_enabled: "true"
   devworkspace.routing.cluster_host_suffix: ""

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -16848,7 +16848,6 @@ subjects:
 apiVersion: v1
 data:
   controller.plugin_artifacts_broker.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.4.0
-  controller.webhooks.enabled: "true"
   devworkspace.default_routing_class: basic
   devworkspace.experimental_features_enabled: "true"
   devworkspace.routing.cluster_host_suffix: ""

--- a/deploy/deployment/openshift/objects/devworkspace-controller-configmap.ConfigMap.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-configmap.ConfigMap.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 data:
   controller.plugin_artifacts_broker.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.4.0
-  controller.webhooks.enabled: "true"
   devworkspace.default_routing_class: basic
   devworkspace.experimental_features_enabled: "true"
   devworkspace.routing.cluster_host_suffix: ""

--- a/deploy/templates/base/config.properties
+++ b/deploy/templates/base/config.properties
@@ -1,5 +1,4 @@
 controller.plugin_artifacts_broker.image=quay.io/eclipse/che-plugin-artifacts-broker:v3.4.0
-controller.webhooks.enabled=true
 devworkspace.routing.cluster_host_suffix=${ROUTING_SUFFIX}
 devworkspace.default_routing_class=${DEFAULT_ROUTING}
 # image pull policy that is applied to all workspace's containers

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,10 +90,6 @@ func (wc *ControllerConfig) GetSidecarPullPolicy() string {
 	return wc.GetPropertyOrDefault(sidecarPullPolicy, defaultSidecarPullPolicy)
 }
 
-func (wc *ControllerConfig) GetWebhooksEnabled() string {
-	return wc.GetPropertyOrDefault(webhooksEnabled, defaultWebhooksEnabled)
-}
-
 func (wc *ControllerConfig) GetTlsInsecureSkipVerify() string {
 	return wc.GetPropertyOrDefault(tlsInsecureSkipVerify, defaultTlsInsecureSkipVerify)
 }

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -13,9 +13,6 @@
 package config
 
 const (
-	webhooksEnabled        = "controller.webhooks.enabled"
-	defaultWebhooksEnabled = "true"
-
 	// image pull policy that is applied to every container within workspace
 	sidecarPullPolicy        = "devworkspace.sidecar.image_pull_policy"
 	defaultSidecarPullPolicy = "Always"

--- a/pkg/webhook/create.go
+++ b/pkg/webhook/create.go
@@ -32,11 +32,6 @@ import (
 var log = logf.Log.WithName("webhook")
 
 func SetupWebhooks(ctx context.Context, cfg *rest.Config) error {
-	if config.ControllerCfg.GetWebhooksEnabled() == "false" {
-		log.Info("Webhooks are disabled. Skipping deploying webhook server")
-		return nil
-	}
-
 	namespace, err := cluster.GetOperatorNamespace()
 	if err != nil {
 		namespace = os.Getenv(cluster.WatchNamespaceEnvVar)


### PR DESCRIPTION
### What does this PR do?
* Remove checks for whether webhooks are enabled, since they're now required (for conversion at least)
* Only update the webhooks serviceAccount when necessary, as otherwise our update wipes out the `.secrets` field and causes k8s to create a new secret for the SA.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/199

### Is it tested? How?
1. Deploy operator
2. Run `make restart` a few times; after first run, log should contain `Webhook server service account up to date` instead of `Updated webhook server service account` and only one secret named `devworkspace-controller-serviceaccount-token-xxxxx` should exist.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
