### PR TITLE
Make routing attributes allign with devfile attributes

### DIFF
--- a/apis/controller/v1alpha1/workspacerouting_types.go
+++ b/apis/controller/v1alpha1/workspacerouting_types.go
@@ -14,6 +14,7 @@ package v1alpha1
 
 import (
 	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	devfileAttr "github.com/devfile/api/v2/pkg/attributes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -68,7 +69,8 @@ type ExposedEndpoint struct {
 	// Public URL of the exposed endpoint
 	Url string `json:"url"`
 	// Attributes of the exposed endpoint
-	Attributes map[string]string `json:"attributes"`
+	// +optional
+	Attributes devfileAttr.Attributes `json:"attributes,omitempty"`
 }
 
 type EndpointList []devworkspace.Endpoint

--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/attributes"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -513,9 +514,9 @@ func (in *ExposedEndpoint) DeepCopyInto(out *ExposedEndpoint) {
 	*out = *in
 	if in.Attributes != nil {
 		in, out := &in.Attributes, &out.Attributes
-		*out = make(map[string]string, len(*in))
+		*out = make(attributes.Attributes, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 }

--- a/controllers/controller/workspacerouting/solvers/cluster_solver.go
+++ b/controllers/controller/workspacerouting/solvers/cluster_solver.go
@@ -91,14 +91,10 @@ func (s *ClusterSolver) GetExposedEndpoints(
 				return nil, false, err
 			}
 
-			endpointAttributes := endpoint.Attributes.Strings(&err)
-			if err != nil {
-				return nil, false, err
-			}
 			exposedEndpoints[machineName] = append(exposedEndpoints[machineName], controllerv1alpha1.ExposedEndpoint{
 				Name:       endpoint.Name,
 				Url:        url,
-				Attributes: endpointAttributes,
+				Attributes: endpoint.Attributes,
 			})
 		}
 	}

--- a/controllers/controller/workspacerouting/solvers/resolve_endpoints.go
+++ b/controllers/controller/workspacerouting/solvers/resolve_endpoints.go
@@ -31,11 +31,6 @@ func getExposedEndpoints(
 
 	for machineName, machineEndpoints := range endpoints {
 		for _, endpoint := range machineEndpoints {
-			endpointAttributes := map[string]string{}
-			err := endpoint.Attributes.Into(&endpointAttributes)
-			if err != nil {
-				return nil, false, err
-			}
 			if endpoint.Exposure != devworkspace.PublicEndpointExposure {
 				continue
 			}
@@ -49,7 +44,7 @@ func getExposedEndpoints(
 			exposedEndpoints[machineName] = append(exposedEndpoints[machineName], controllerv1alpha1.ExposedEndpoint{
 				Name:       endpoint.Name,
 				Url:        endpointUrl,
-				Attributes: endpointAttributes,
+				Attributes: endpoint.Attributes,
 			})
 		}
 	}

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -136,7 +136,7 @@ func checkServerStatus(workspace *devworkspace.DevWorkspace) (ok bool, err error
 func getIdeUrl(exposedEndpoints map[string]v1alpha1.ExposedEndpointList) string {
 	for _, endpoints := range exposedEndpoints {
 		for _, endpoint := range endpoints {
-			if endpoint.Attributes[string(v1alpha1.TYPE_ENDPOINT_ATTRIBUTE)] == "ide" {
+			if endpoint.Attributes.GetString(string(v1alpha1.TYPE_ENDPOINT_ATTRIBUTE), nil) == "ide" {
 				return endpoint.Url
 			}
 		}

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -14158,9 +14158,10 @@ spec:
                     properties:
                       attributes:
                         additionalProperties:
-                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
                         description: Attributes of the exposed endpoint
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
                         description: Name of the exposed endpoint
                         type: string
@@ -14168,7 +14169,6 @@ spec:
                         description: Public URL of the exposed endpoint
                         type: string
                     required:
-                    - attributes
                     - name
                     - url
                     type: object

--- a/deploy/deployment/kubernetes/objects/workspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/workspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
@@ -110,9 +110,10 @@ spec:
                     properties:
                       attributes:
                         additionalProperties:
-                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
                         description: Attributes of the exposed endpoint
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
                         description: Name of the exposed endpoint
                         type: string
@@ -120,7 +121,6 @@ spec:
                         description: Public URL of the exposed endpoint
                         type: string
                     required:
-                    - attributes
                     - name
                     - url
                     type: object

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -14158,9 +14158,10 @@ spec:
                     properties:
                       attributes:
                         additionalProperties:
-                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
                         description: Attributes of the exposed endpoint
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
                         description: Name of the exposed endpoint
                         type: string
@@ -14168,7 +14169,6 @@ spec:
                         description: Public URL of the exposed endpoint
                         type: string
                     required:
-                    - attributes
                     - name
                     - url
                     type: object

--- a/deploy/deployment/openshift/objects/workspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/workspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
@@ -110,9 +110,10 @@ spec:
                     properties:
                       attributes:
                         additionalProperties:
-                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
                         description: Attributes of the exposed endpoint
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
                         description: Name of the exposed endpoint
                         type: string
@@ -120,7 +121,6 @@ spec:
                         description: Public URL of the exposed endpoint
                         type: string
                     required:
-                    - attributes
                     - name
                     - url
                     type: object

--- a/deploy/templates/crd/bases/controller.devfile.io_workspaceroutings.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_workspaceroutings.yaml
@@ -143,9 +143,10 @@ spec:
                       properties:
                         attributes:
                           additionalProperties:
-                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
                           description: Attributes of the exposed endpoint
                           type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         name:
                           description: Name of the exposed endpoint
                           type: string
@@ -153,7 +154,6 @@ spec:
                           description: Public URL of the exposed endpoint
                           type: string
                       required:
-                        - attributes
                         - name
                         - url
                       type: object


### PR DESCRIPTION
### What does this PR do?
Make routing attributes align with devfile attributes

### What issues does this PR fix or reference?
It fixes https://github.com/devfile/devworkspace-operator/issues/302

### Is it tested? How?
Tested as usual `kc apply -f ./samples/flattened_theia-next.yaml`

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
