### PR TITLE
Increase memoryLimit on PVC cleanup job to prevent failures

### DIFF
--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -46,10 +46,10 @@ const (
 var (
 	cleanupJobCompletions      = int32(1)
 	cleanupJobBackoffLimit     = int32(3)
-	PVCCleanupPodMemoryLimit   = resource.MustParse(config.PVCCleanupPodMemoryLimit)
-	PVCCleanupPodMemoryRequest = PVCCleanupPodMemoryLimit
-	PVCCleanupPodCPULimit      = resource.MustParse(config.PVCCleanupPodCPULimit)
-	PVCCleanupPodCPURequest    = resource.MustParse(config.PVCCleanupPodCPURequest)
+	pvcCleanupPodMemoryLimit   = resource.MustParse(config.PVCCleanupPodMemoryLimit)
+	pvcCleanupPodMemoryRequest = resource.MustParse(config.PVCCleanupPodMemoryRequest)
+	pvcCleanupPodCPULimit      = resource.MustParse(config.PVCCleanupPodCPULimit)
+	pvcCleanupPodCPURequest    = resource.MustParse(config.PVCCleanupPodCPURequest)
 )
 
 // setFinalizer sets a finalizer on the workspace and syncs the changes to the cluster. No-op if the workspace already
@@ -193,12 +193,12 @@ func (r *DevWorkspaceReconciler) getSpecCleanupJob(workspace *devworkspace.DevWo
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: PVCCleanupPodMemoryRequest,
-									corev1.ResourceCPU:    PVCCleanupPodCPURequest,
+									corev1.ResourceMemory: pvcCleanupPodMemoryRequest,
+									corev1.ResourceCPU:    pvcCleanupPodCPURequest,
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: PVCCleanupPodMemoryLimit,
-									corev1.ResourceCPU:    PVCCleanupPodCPULimit,
+									corev1.ResourceMemory: pvcCleanupPodMemoryLimit,
+									corev1.ResourceCPU:    pvcCleanupPodCPULimit,
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -119,7 +120,8 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 		return reconcile.Result{Requeue: true}, nil
 	}
 	if !equality.Semantic.DeepDerivative(specJob.Spec, clusterJob.Spec) {
-		err := r.Delete(ctx, clusterJob)
+		propagationPolicy := metav1.DeletePropagationBackground
+		err := r.Delete(ctx, clusterJob, &client.DeleteOptions{PropagationPolicy: &propagationPolicy})
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -66,7 +66,10 @@ const (
 	WorkspaceStopReasonAnnotation = "controller.devfile.io/stopped-by"
 
 	// PVCCleanupPodMemoryLimit is the memory limit used for PVC clean up pods
-	PVCCleanupPodMemoryLimit = "32Mi"
+	PVCCleanupPodMemoryLimit = "100Mi"
+
+	// PVCCleanupPodMemoryRequest is the memory request used for PVC clean up pods
+	PVCCleanupPodMemoryRequest = "32Mi"
 
 	// PVCCleanupPodCPULimit is the cpu limit used for PVC clean up pods
 	PVCCleanupPodCPULimit = "50m"


### PR DESCRIPTION
### What does this PR do?
This PR is kind of a shot in the dark for resolving https://github.com/devfile/devworkspace-operator/issues/301: after some searching, there's a few bugzillas suggesting that the process being used to create the pod might be bumping into the memory limit (e.g. [here](https://bugzilla.redhat.com/show_bug.cgi?id=1826723)). I've increased the memoryLimit to 100Mi and tested a few times on one of the clusters that reproduces the issue consistently and did not see it.

Please test thoroughly to make sure this fixes the problem.

### What issues does this PR fix or reference?
Fixes #301

### Is it tested? How?
1. Apply `samples/flattened_theia-next.yaml`
2. Delete `theia` devworkspace and make sure job completes successfully, finalizer is cleared.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
