### PR TITLE
Remove trailing whitespace from make-release.sh

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -15,68 +15,68 @@ REPO=git@github.com:devfile/devworkspace-operator
 MAIN_BRANCH="main"
 TMP=""
 
-while [[ "$#" -gt 0 ]]; do	
-  case $1 in	
-    '-v'|'--version') VERSION="$2"; shift 1;;		
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-v'|'--version') VERSION="$2"; shift 1;;
     '-tmp'|'--use-tmp-dir') TMP=$(mktemp -d); shift 0;;
-  esac	
-  shift 1	
-done	
+  esac
+  shift 1
+done
 
-bump_version () {	
-  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)	
+bump_version () {
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-  NEXT_VERSION=$1	
-  BUMP_BRANCH=$2	
+  NEXT_VERSION=$1
+  BUMP_BRANCH=$2
 
-  git checkout "${BUMP_BRANCH}"	
+  git checkout "${BUMP_BRANCH}"
 
-  echo "Updating project version to ${NEXT_VERSION}"	
-  echo "${VERSION}" > VERSION 
-  if [[ ${NOCOMMIT} -eq 0 ]]; then	
-    COMMIT_MSG="[release] Bump to ${NEXT_VERSION} in ${BUMP_BRANCH}"	
-    git commit -asm "${COMMIT_MSG}"	
-    git pull origin "${BUMP_BRANCH}"	
+  echo "Updating project version to ${NEXT_VERSION}"
+  echo "${VERSION}" > VERSION
+  if [[ ${NOCOMMIT} -eq 0 ]]; then
+    COMMIT_MSG="[release] Bump to ${NEXT_VERSION} in ${BUMP_BRANCH}"
+    git commit -asm "${COMMIT_MSG}"
+    git pull origin "${BUMP_BRANCH}"
 
     set +e
-    PUSH_TRY="$(git push origin "${BUMP_BRANCH}")"	
-    # shellcheck disable=SC2181	
-    if [[ $? -gt 0 ]] || [[ $PUSH_TRY == *"protected branch hook declined"* ]]; then	
-      PR_BRANCH=pr-${BUMP_BRANCH}-to-${NEXT_VERSION}	
-      # create pull request for the main branch branch, as branch is restricted	
-      git branch "${PR_BRANCH}"	
-      git checkout "${PR_BRANCH}"	
-      git pull origin "${PR_BRANCH}"	
-      git push origin "${PR_BRANCH}"	
-      lastCommitComment="$(git log -1 --pretty=%B)"	
-      hub pull-request -f -m "${lastCommitComment}" -b "${BUMP_BRANCH}" -h "${PR_BRANCH}"	
-    fi 	
+    PUSH_TRY="$(git push origin "${BUMP_BRANCH}")"
+    # shellcheck disable=SC2181
+    if [[ $? -gt 0 ]] || [[ $PUSH_TRY == *"protected branch hook declined"* ]]; then
+      PR_BRANCH=pr-${BUMP_BRANCH}-to-${NEXT_VERSION}
+      # create pull request for the main branch branch, as branch is restricted
+      git branch "${PR_BRANCH}"
+      git checkout "${PR_BRANCH}"
+      git pull origin "${PR_BRANCH}"
+      git push origin "${PR_BRANCH}"
+      lastCommitComment="$(git log -1 --pretty=%B)"
+      hub pull-request -f -m "${lastCommitComment}" -b "${BUMP_BRANCH}" -h "${PR_BRANCH}"
+    fi
     set -e
-  fi	
-  git checkout "${CURRENT_BRANCH}"	
-}	
+  fi
+  git checkout "${CURRENT_BRANCH}"
+}
 
-usage ()	
-{	
-  echo "Usage: $0 --version [VERSION TO RELEASE]"	
-  echo "Example: $0 --version 0.1.0"; echo	
-}	
+usage ()
+{
+  echo "Usage: $0 --version [VERSION TO RELEASE]"
+  echo "Example: $0 --version 0.1.0"; echo
+}
 
-if [[ ! ${VERSION} ]]; then	
-  usage	
-  exit 1	
-fi	
+if [[ ! ${VERSION} ]]; then
+  usage
+  exit 1
+fi
 
 
-# derive branch from version	
-BRANCH=${VERSION%.*}.x	
+# derive branch from version
+BRANCH=${VERSION%.*}.x
 
-# if doing a .0 release, use main branch; if doing a .z release, use $BRANCH	
-if [[ ${VERSION} == *".0" ]]; then	
-  BASEBRANCH="${MAIN_BRANCH}"	
-else 	
-  BASEBRANCH="${BRANCH}"	
-fi	
+# if doing a .0 release, use main branch; if doing a .z release, use $BRANCH
+if [[ ${VERSION} == *".0" ]]; then
+  BASEBRANCH="${MAIN_BRANCH}"
+else
+  BASEBRANCH="${BRANCH}"
+fi
 
 # work in tmp dir
 if [[ $TMP ]] && [[ -d $TMP ]]; then
@@ -88,9 +88,9 @@ if [[ $TMP ]] && [[ -d $TMP ]]; then
 fi
 
 
-# get sources from ${BASEBRANCH} branch	
+# get sources from ${BASEBRANCH} branch
 git fetch origin "${BASEBRANCH}":"${BASEBRANCH}" || true
-git checkout "${BASEBRANCH}"	
+git checkout "${BASEBRANCH}"
 
 # create new branch off ${BASEBRANCH} (or check out latest commits if branch already exists), then push to origin
 if [[ "${BASEBRANCH}" != "${BRANCH}" ]]; then
@@ -104,7 +104,7 @@ else
 fi
 set -e
 
-# change VERSION file	
+# change VERSION file
 echo "${VERSION}" > VERSION
 
 QUAY_REPO="quay.io/devfile/devworkspace-controller:${VERSION}"
@@ -116,25 +116,25 @@ sed -i "s/IMG=quay.io\/devfile\/devworkspace-controller:.*/IMG=quay.io\/devfile\
 
 set -x
 bash -x ./deploy/generate-deployment.sh --use-defaults
-# tag the release	
-git tag "${VERSION}"	
-git push origin "${VERSION}"	
-COMMIT_MSG="[release] Release ${VERSION}"	
-git commit -asm "${COMMIT_MSG}"	
+# tag the release
+git tag "${VERSION}"
+git push origin "${VERSION}"
+COMMIT_MSG="[release] Release ${VERSION}"
+git commit -asm "${COMMIT_MSG}"
 
-# now update ${BASEBRANCH} to the new snapshot version	
-git checkout "${BASEBRANCH}"	
+# now update ${BASEBRANCH} to the new snapshot version
+git checkout "${BASEBRANCH}"
 
-# change VERSION file + commit change into ${BASEBRANCH} branch	
-if [[ "${BASEBRANCH}" != "${BRANCH}" ]]; then	
-  # bump the y digit, if it is a major release	
-  [[ $BRANCH =~ ^([0-9]+)\.([0-9]+)\.x ]] && BASE=${BASH_REMATCH[1]}; NEXT=${BASH_REMATCH[2]}; (( NEXT=NEXT+1 )) # for BRANCH=0.1.x, get BASE=0, NEXT=2	
-  NEXT_VERSION_Y="${BASE}.${NEXT}.0-SNAPSHOT"	
-  bump_version "${NEXT_VERSION_Y}" "${BASEBRANCH}"	
-fi	
-# bump the z digit	
-[[ $VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]] && BASE="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"; NEXT="${BASH_REMATCH[3]}"; (( NEXT=NEXT+1 )) # for VERSION=0.1.2, get BASE=0.1, NEXT=3	
-NEXT_VERSION_Z="${BASE}.${NEXT}-SNAPSHOT"	
+# change VERSION file + commit change into ${BASEBRANCH} branch
+if [[ "${BASEBRANCH}" != "${BRANCH}" ]]; then
+  # bump the y digit, if it is a major release
+  [[ $BRANCH =~ ^([0-9]+)\.([0-9]+)\.x ]] && BASE=${BASH_REMATCH[1]}; NEXT=${BASH_REMATCH[2]}; (( NEXT=NEXT+1 )) # for BRANCH=0.1.x, get BASE=0, NEXT=2
+  NEXT_VERSION_Y="${BASE}.${NEXT}.0-SNAPSHOT"
+  bump_version "${NEXT_VERSION_Y}" "${BASEBRANCH}"
+fi
+# bump the z digit
+[[ $VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]] && BASE="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"; NEXT="${BASH_REMATCH[3]}"; (( NEXT=NEXT+1 )) # for VERSION=0.1.2, get BASE=0.1, NEXT=3
+NEXT_VERSION_Z="${BASE}.${NEXT}-SNAPSHOT"
 bump_version "${NEXT_VERSION_Z}" "${BRANCH}"
 
 popd > /dev/null || exit


### PR DESCRIPTION
### What does this PR do?
Trim trailing whitespace from make-release.sh, which I noticed while rebasing https://github.com/devfile/devworkspace-operator/pull/296

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
