### PR TITLE
Fail any DevWorkspace when webhooks are not present on cluster

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -144,7 +144,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	}()
 
 	if workspace.Annotations[config.WorkspaceRestrictedAccessAnnotation] == "true" {
-		msg, err := r.validateCreatorLabel(clusterWorkspace)
+		msg, err := r.validateRestrictedWorkspace(clusterWorkspace)
 		if err != nil {
 			reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
 			reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = msg

--- a/controllers/workspace/validation.go
+++ b/controllers/workspace/validation.go
@@ -15,31 +15,49 @@ package controllers
 import (
 	"fmt"
 
+	"github.com/devfile/devworkspace-operator/pkg/webhook"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+
 	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/config"
-	"github.com/devfile/devworkspace-operator/pkg/webhook"
 )
 
-// validateCreatorLabel checks that a devworkspace was created after workspace-related mutating webhooks
-// and ensures a creator ID label is applied to the workspace. If webhooks are disabled, validation succeeds by
-// default.
+// validateRestrictedWorkspace checks that a devworkspace was created after workspace-related mutating webhooks
+// and ensures a creator ID label is applied to the workspace.
 //
 // If error is not nil, a user-readable message is returned that can be propagated to the user to explain the issue.
-func (r *DevWorkspaceReconciler) validateCreatorLabel(workspace *devworkspace.DevWorkspace) (msg string, err error) {
+func (r *DevWorkspaceReconciler) validateRestrictedWorkspace(workspace *devworkspace.DevWorkspace) (msg string, err error) {
+	mutatingWebhook, err := webhook.GetMutatingWebhook(r.Client)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return "Restricted access workspace require webhooks to be installed, but they are not found on the cluster. " +
+					"Contact an administrator to fix Operator installation.",
+				fmt.Errorf("failed to read mutating webhook configuration: %w", err)
+		}
+		return "Failed to read webhooks on cluster.", fmt.Errorf("failed to read mutating webhook configuration: %w", err)
+	}
+	if workspace.CreationTimestamp.Before(&mutatingWebhook.CreationTimestamp) {
+		return "DevWorkspace was created before current webhooks were installed and must be recreated to successfully start",
+			fmt.Errorf("devworkspace created before webhooks")
+	}
+
+	validatingWebhook, err := webhook.GetValidatingWebhook(r.Client)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return "Restricted access workspace require webhooks to be installed, but they are not found on the cluster. " +
+					"Contact an administrator to fix Operator installation.",
+				fmt.Errorf("failed to read validating webhook configuration: %w", err)
+		}
+		return "Failed to read webhooks on cluster.", fmt.Errorf("failed to read validating webhook configuration: %w", err)
+	}
+	if workspace.CreationTimestamp.Before(&validatingWebhook.CreationTimestamp) {
+		return "DevWorkspace was created before current webhooks were installed and must be recreated to successfully start",
+			fmt.Errorf("devworkspace created before webhooks")
+	}
+
 	if _, present := workspace.Labels[config.WorkspaceCreatorLabel]; !present {
 		return "DevWorkspace was created without creator ID label. It must be recreated to resolve the issue",
 			fmt.Errorf("devworkspace does not have creator label applied")
-	}
-
-	webhooksTimestamp, err := webhook.GetWebhooksCreationTimestamp(r.Client)
-	if err != nil {
-		return "Could not read devworkspace webhooks on cluster. Contact an administrator " +
-				"to check logs and fix Operator installation.",
-			fmt.Errorf("failed getting webhooks creation timestamp: %w", err)
-	}
-	if workspace.CreationTimestamp.Before(&webhooksTimestamp) {
-		return "DevWorkspace was created before current webhooks were installed and must be recreated to successfully start",
-			fmt.Errorf("devworkspace created before webhooks")
 	}
 
 	return "", nil

--- a/pkg/webhook/info.go
+++ b/pkg/webhook/info.go
@@ -14,7 +14,6 @@ package webhook
 
 import (
 	"context"
-	"fmt"
 
 	webhookCfg "github.com/devfile/devworkspace-operator/webhook/workspace"
 	"k8s.io/api/admissionregistration/v1beta1"
@@ -25,14 +24,18 @@ import (
 
 var webhooksCreationTimestamp = metav1.Time{}
 
-func GetWebhooksCreationTimestamp(client client.Client) (metav1.Time, error) {
-	if webhooksCreationTimestamp.IsZero() {
-		webhook := &v1beta1.MutatingWebhookConfiguration{}
-		err := client.Get(context.TODO(), types.NamespacedName{Name: webhookCfg.MutateWebhookCfgName}, webhook)
-		if err != nil {
-			return metav1.Time{}, fmt.Errorf("failed to get webhook: %w", err)
-		}
-		webhooksCreationTimestamp = webhook.CreationTimestamp
-	}
-	return webhooksCreationTimestamp, nil
+// GetMutatingWebhook returns the mutating webhook used by the controller, or a kubernetes error if an
+// error is encountered while retrieving webhooks. The returned error can be checked via IsNotFound()
+func GetMutatingWebhook(client client.Client) (*v1beta1.MutatingWebhookConfiguration, error) {
+	webhook := &v1beta1.MutatingWebhookConfiguration{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: webhookCfg.MutateWebhookCfgName}, webhook)
+	return webhook, err
+}
+
+// GetValidatingWebhook returns the validating webhook used by the controller, or a kubernetes error if an
+// error is encountered while retrieving webhooks. The returned error can be checked via IsNotFound()
+func GetValidatingWebhook(client client.Client) (*v1beta1.ValidatingWebhookConfiguration, error) {
+	webhook := &v1beta1.ValidatingWebhookConfiguration{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: webhookCfg.ValidateWebhookCfgName}, webhook)
+	return webhook, err
 }


### PR DESCRIPTION
**Note**: I'm not sure this PR should even be merged. The added checks may catch some simple configuration errors (e.g. webhooks accidentally get deleted) but does nothing to address the main reason we do any checking for webhooks (i.e. preventing unauthorized access). I'm opening this PR for discussion in case there's something I'm missing, but it seems kind of pointless IMO.

### What does this PR do?
* Validate that webhooks exist on cluster when reconciling a DevWorkspace, and fail the workspace if they're not present
* Rework validateCreatorID check to check that both mutating and validating webhooks exist and that they're older than the DevWorkspace. 
* Extract two functions: `killWorkspace`, which deletes a workspace's deployment and marks it as failed, and `failWorkspace` which just cuts out the four lines we use to fail workspaces everywhere in the main reconcile loop.

The PR is split into two commits:
- The first commit is a half-way solution, doing the detailed check when a workspace has the `restricted-access` annotation set.
- The second commit extends the check above to all DevWorkspaces and does some light refactoring

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/305

### Is it tested? How?
1. Create a DevWorkspace on the cluster
2. Delete the mutating webhook: `kc delete mutatingwebhookconfigurations.admissionregistration.k8s.io controller.devfile.io`
3. Edit the DevWorkspace created in step 1
4. Workspace should be failed, workspace deployment should be deleted.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
