### PR TITLE
Rework generate-deployment to take a default image parameter

### DIFF
--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -27,18 +27,25 @@ set -e
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 
 function print_help() {
-  echo "Usage: generate-deployment.sh [ARGS]"
-  echo "Arguments:"
-  echo "  --use-defaults"
-  echo "      Output deployment files to deploy/deployment, using default"
-  echo "      environment variables rather than current shell variables."
-  echo "      Implies '--split yaml'"
-  echo "  --split-yaml"
-  echo "      Parse output file combined.yaml into a yaml file for each record"
-  echo "      in combined yaml. Files are output to the 'objects' subdirectory"
-  echo "      for each platform and are named <object-name>.<kind>.yaml"
-  echo "  -h, --help"
-  echo "      Print this help description"
+  cat << EOF
+Usage: generate-deployment.sh [ARGS]
+Arguments:
+  --use-defaults
+      Output deployment files to deploy/deployment, using default
+      environment variables rather than current shell variables.
+      Implies '--split yaml'
+  --default-image
+      Controller (and webhook) image to use for the default deployment.
+      Used only when '--use-defaults' is passed; otherwise, the value of
+      the IMG environment variable is used. If unspecified, the default
+      value of 'quay.io/devfile/devworkspace-controller:next' is used
+  --split-yaml
+      Parse output file combined.yaml into a yaml file for each record
+      in combined yaml. Files are output to the 'objects' subdirectory
+      for each platform and are named <object-name>.<kind>.yaml
+  -h, --help
+      Print this help description
+EOF
 }
 
 USE_DEFAULT_ENV=false
@@ -50,6 +57,10 @@ while [[ "$#" -gt 0 ]]; do
       USE_DEFAULT_ENV=true
       SPLIT_YAMLS=true
       OUTPUT_DIR="${SCRIPT_DIR%/}/deployment"
+      ;;
+      --default-image)
+      DEFAULT_IMAGE=$2
+      shift
       ;;
       --split-yamls)
       SPLIT_YAMLS=true
@@ -70,7 +81,7 @@ done
 if $USE_DEFAULT_ENV; then
   echo "Using defaults for environment variables"
   export NAMESPACE=devworkspace-controller
-  export IMG=quay.io/devfile/devworkspace-controller:next
+  export IMG=${DEFAULT_IMAGE:-"quay.io/devfile/devworkspace-controller:next"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic
   export DEVWORKSPACE_API_VERSION=aeda60d4361911da85103f224644bfa792498499

--- a/make-release.sh
+++ b/make-release.sh
@@ -111,11 +111,8 @@ QUAY_REPO="quay.io/devfile/devworkspace-controller:${VERSION}"
 docker build -t "${QUAY_REPO}" -f ./build/Dockerfile .
 docker push "${QUAY_REPO}"
 
-# replace image version in default environment
-sed -i "s/IMG=quay.io\/devfile\/devworkspace-controller:.*/IMG=quay.io\/devfile\/devworkspace-controller:${VERSION}/" ./deploy/generate-deployment.sh
-
 set -x
-bash -x ./deploy/generate-deployment.sh --use-defaults
+bash -x ./deploy/generate-deployment.sh --use-defaults --default-image="quay.io/devfile/devworkspace-controller:${VERSION}"
 # tag the release
 git tag "${VERSION}"
 git push origin "${VERSION}"


### PR DESCRIPTION
### What does this PR do?
Since `generate-deployment.sh` is used to generate deploy yamls for releases, it's necessary to be able to specify an image to use when generating the "default" deployment.

This PR adds the `--default-image` parameter for generate-deployment.sh, to avoid the requirement of using sed in make-release.sh

One thing I didn't test is whether this breaks CI on version branches -- previously, make-release commits updated `generate-deployment.sh` so that rerunning it without parameters would generate the same yamls. With the current changes, running `make generate_default_deployment` on the tagged release would result in changes to `deploy/deployment`. We could potentially work around this by making the tag _not_ configurable again, but this would require setting up and maintaining a VERSION file.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/pull/306#pullrequestreview-607416057

### Is it tested? How?
Tested by running `./deploy/generate-deployment.sh --use-defaults --default-image test:test`

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
