### PR TITLE
Ask confirmation before pushing next image

### DIFF
--- a/.ci/openshift_e2e.sh
+++ b/.ci/openshift_e2e.sh
@@ -35,7 +35,7 @@ export CI_COMPONENT="devworkspace-operator"
 # DEVWORKSPACE_OPERATOR env var exposed by Openshift CI in e2e test pod. More info about how images are builded in Openshift CI: https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
 # Dependencies environment are defined here: https://github.com/openshift/release/blob/master/ci-operator/config/devfile/devworkspace-operator/devfile-devworkspace-operator-master__v5.yaml#L36-L38
 
-export IMG=${DEVWORKSPACE_OPERATOR}
+export DWO_IMG=${DEVWORKSPACE_OPERATOR}
 
 # Pod created by openshift ci don't have user. Using this envs should avoid errors with git user.
 export GIT_COMMITTER_NAME="CI BOT"

--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,9 @@ docker-build:
 
 ### docker-push: Push the controller image
 docker-push:
+ifeq ($(IMG),quay.io/devfile/devworkspace-controller:next)
+	@echo -n "Are you sure we want to push $(IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
+endif
 	docker push ${IMG}
 
 ### controller-gen: find or download controller-gen

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The minimum version of cert-manager is `v1.0.4`.
 The controller can be deployed to a cluster provided you are logged in with cluster-admin credentials:
 
 ```bash
-export IMG=quay.io/devfile/devworkspace-controller:next
+export DWO_IMG=quay.io/devfile/devworkspace-controller:next
 make install
 ```
 
@@ -73,7 +73,7 @@ The repository contains a Makefile; building and deploying can be configured via
 
 |variable|purpose|default value|
 |---|---|---|
-| `IMG` | Image used for controller | `quay.io/devfile/devworkspace-controller:next` |
+| `DWO_IMG` | Image used for controller | `quay.io/devfile/devworkspace-controller:next` |
 | `NAMESPACE` | Namespace to use for deploying controller | `devworkspace-controller` |
 | `ROUTING_SUFFIX` | Cluster routing suffix (e.g. `$(minikube ip).nip.io`, `apps-crc.testing`). Required for Kubernetes | `192.168.99.100.nip.io` |
 | `PULL_POLICY` | Image pull policy for controller | `Always` |

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -81,7 +81,7 @@ done
 if $USE_DEFAULT_ENV; then
   echo "Using defaults for environment variables"
   export NAMESPACE=devworkspace-controller
-  export IMG=${DEFAULT_IMAGE:-"quay.io/devfile/devworkspace-controller:next"}
+  export DWO_IMG=${DEFAULT_IMAGE:-"quay.io/devfile/devworkspace-controller:next"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic
   export DEVWORKSPACE_API_VERSION=aeda60d4361911da85103f224644bfa792498499
@@ -96,7 +96,7 @@ OBJECTS_DIR="objects"
 
 mkdir -p "$KUBERNETES_DIR" "$OPENSHIFT_DIR"
 
-required_vars=(NAMESPACE IMG PULL_POLICY DEFAULT_ROUTING \
+required_vars=(NAMESPACE DWO_IMG PULL_POLICY DEFAULT_ROUTING \
   DEVWORKSPACE_API_VERSION)
 for var in "${required_vars[@]}"; do
   if [ -z "${!var}" ]; then

--- a/deploy/templates/base/manager_image_patch.yaml
+++ b/deploy/templates/base/manager_image_patch.yaml
@@ -9,8 +9,8 @@ spec:
     spec:
       containers:
       - name: devworkspace-controller
-        image: ${IMG}
+        image: ${DWO_IMG}
         imagePullPolicy: Always
         env:
           - name: RELATED_IMAGE_devworkspace_webhook_server
-            value: ${IMG}
+            value: ${DWO_IMG}

--- a/deploy/templates/kustomize.pu
+++ b/deploy/templates/kustomize.pu
@@ -43,7 +43,7 @@ object "templates/base" as base {
   - Create default configmap for
     controller
   - Patch image used for controller
-    and webhook server with ${IMG}
+    and webhook server with ${DWO_IMG}
   --Output--
   Basic controller with no webhooks;
   namespace and namePrefix unconfigured


### PR DESCRIPTION
### What does this PR do?
Someone pushed next tag occasionally from the PR, which broke all new installations which tried to use next image.
With make docker it's really easy to override occasionally next image which I also did a few times and had to quickly fix.
Now if you have locally set IMG with your own repo - everything will work as previously.
But when you try to push quay.io/devfile/devworkspace-controller:next, you'll need to confirm it.

I also thought about env var which would allow to avoid confirmation, but so far CI does not use make install.

It also helps to prevent another mistake, when I deployed https://github.com/che-incubator/devworkspace-che-operator I did not success since I have `IMG=sleshchenko/che-workspace-controller:local` in my bashrc, so, not to conflict, I renamed `IMG` to `DWO_IMG` to use unique name for that parameter.

### What issues does this PR fix or reference?
no issue is created

### Is it tested? How?
```
unset IMG
make docker
...
 ---> Using cache
 ---> 28aface1225a
Successfully built 28aface1225a
Successfully tagged quay.io/devfile/devworkspace-controller:next
Are you sure we want to push quay.io/devfile/devworkspace-controller:next? [y/N] n
Makefile:286: recipe for target 'docker-push' failed
make: *** [docker-push] Error 1
```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
