### PR TITLE
Mount flattened devfile in devworkspace containers

### DIFF
--- a/internal/map/map.go
+++ b/internal/map/map.go
@@ -19,3 +19,17 @@ func Append(target map[string]string, key, value string) map[string]string {
 	target[key] = value
 	return target
 }
+
+// Equal compares string maps for equality, regardless of order. Note that it treats
+// a nil map as equal to an empty (but not nil) map.
+func Equal(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bval, ok := b[k]; !ok || bval != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -76,3 +76,7 @@ func ServingCertVolumeName(serviceName string) string {
 func PVCCleanupJobName(workspaceId string) string {
 	return fmt.Sprintf("cleanup-%s", workspaceId)
 }
+
+func MetadataConfigMapName(workspaceId string) string {
+	return fmt.Sprintf("%s-metadata", workspaceId)
+}

--- a/pkg/library/annotate/annotations.go
+++ b/pkg/library/annotate/annotations.go
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package annotate
+
+const (
+	PluginSourceAttribute = "controller.devfile.io/imported-by"
+	EndpointURLAttribute  = "controller.devfile.io/endpoint-url"
+)

--- a/pkg/library/annotate/plugins.go
+++ b/pkg/library/annotate/plugins.go
@@ -17,10 +17,6 @@ import (
 	"github.com/devfile/api/v2/pkg/attributes"
 )
 
-const (
-	PluginSourceAttribute = "controller.devfile.io/imported-by"
-)
-
 // AddSourceAttributesForPlugin adds an attribute 'controller.devfile.io/imported-by=sourceID' to all elements of
 // a plugin that support attributes.
 func AddSourceAttributesForPlugin(sourceID string, plugin *dw.DevWorkspaceTemplateSpec) {

--- a/pkg/library/annotate/plugins.go
+++ b/pkg/library/annotate/plugins.go
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package annotate
+
+import (
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/attributes"
+)
+
+const (
+	PluginSourceAttribute = "controller.devfile.io/imported-by"
+)
+
+// AddSourceAttributesForPlugin adds an attribute 'controller.devfile.io/imported-by=sourceID' to all elements of
+// a plugin that support attributes.
+func AddSourceAttributesForPlugin(sourceID string, plugin *dw.DevWorkspaceTemplateSpec) {
+	for idx, component := range plugin.Components {
+		if component.Attributes == nil {
+			plugin.Components[idx].Attributes = attributes.Attributes{}
+		}
+		plugin.Components[idx].Attributes.PutString(PluginSourceAttribute, sourceID)
+	}
+	for idx, command := range plugin.Commands {
+		if command.Attributes == nil {
+			plugin.Commands[idx].Attributes = attributes.Attributes{}
+		}
+		plugin.Commands[idx].Attributes.PutString(PluginSourceAttribute, sourceID)
+	}
+	for idx, project := range plugin.Projects {
+		if project.Attributes == nil {
+			plugin.Projects[idx].Attributes = attributes.Attributes{}
+		}
+		plugin.Projects[idx].Attributes.PutString(PluginSourceAttribute, sourceID)
+	}
+	for idx, project := range plugin.StarterProjects {
+		if project.Attributes == nil {
+			plugin.Projects[idx].Attributes = attributes.Attributes{}
+		}
+		plugin.Projects[idx].Attributes.PutString(PluginSourceAttribute, sourceID)
+	}
+}

--- a/pkg/library/annotate/urls.go
+++ b/pkg/library/annotate/urls.go
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package annotate
+
+import (
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/attributes"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+)
+
+func AddURLAttributesToEndpoints(workspace *dw.DevWorkspaceTemplateSpec, exposedEndpoints map[string]v1alpha1.ExposedEndpointList) {
+	for _, component := range workspace.Components {
+		if component.Container == nil {
+			continue
+		}
+		container := component.Container
+		endpoints := exposedEndpoints[component.Name]
+		for _, exposedEndpoint := range endpoints {
+			if containerEndpoint := getContainerEndpointByName(exposedEndpoint.Name, container); containerEndpoint != nil {
+				if containerEndpoint.Attributes == nil {
+					containerEndpoint.Attributes = attributes.Attributes{}
+				}
+				containerEndpoint.Attributes.PutString(EndpointURLAttribute, exposedEndpoint.Url)
+			}
+		}
+	}
+}
+
+func getContainerEndpointByName(name string, container *dw.ContainerComponent) *dw.Endpoint {
+	for idx, endpoint := range container.Endpoints {
+		if endpoint.Name == name {
+			return &container.Endpoints[idx]
+		}
+	}
+	return nil
+}

--- a/pkg/library/flatten/flatten.go
+++ b/pkg/library/flatten/flatten.go
@@ -20,6 +20,7 @@ import (
 
 	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/api/v2/pkg/utils/overriding"
+	"github.com/devfile/devworkspace-operator/pkg/library/annotate"
 	registry "github.com/devfile/devworkspace-operator/pkg/library/flatten/internal_registry"
 	"github.com/devfile/devworkspace-operator/pkg/library/flatten/network"
 	"github.com/devfile/devworkspace-operator/pkg/library/flatten/web_terminal"
@@ -89,6 +90,8 @@ func recursiveResolve(workspace devworkspace.DevWorkspaceTemplateSpec, tooling R
 			if err != nil {
 				return nil, err
 			}
+
+			annotate.AddSourceAttributesForPlugin(component.Name, resolvedPlugin)
 			pluginSpecContents = append(pluginSpecContents, &resolvedPlugin.DevWorkspaceTemplateSpecContent)
 		}
 	}

--- a/pkg/library/flatten/testdata/internal-registry/defaulting-web-terminal-component.yaml
+++ b/pkg/library/flatten/testdata/internal-registry/defaulting-web-terminal-component.yaml
@@ -24,6 +24,8 @@ output:
   workspace:
     components:
       - name: web-terminal-plugin
+        attributes:
+          controller.devfile.io/imported-by: "web-terminal"
         container:
           name: test-container
           image: test-image

--- a/pkg/library/flatten/testdata/internal-registry/plugin-in-internal-registry.yaml
+++ b/pkg/library/flatten/testdata/internal-registry/plugin-in-internal-registry.yaml
@@ -23,6 +23,8 @@ output:
   workspace:
     components:
       - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
         container:
           name: test-container
           image: test-image

--- a/pkg/library/flatten/testdata/k8s-ref/nested-plugins-annotation.yaml
+++ b/pkg/library/flatten/testdata/k8s-ref/nested-plugins-annotation.yaml
@@ -1,0 +1,44 @@
+name: "DevWorkspace annotates nested plugins with the first plugin"
+
+input:
+  workspace:
+    components:
+      - name: root-plugin
+        plugin:
+          kubernetes:
+            name: test-plugin-a
+            namespace: test-ns
+  plugins:
+    test-plugin-a:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-a
+      spec:
+        components:
+          - name: plugin-b
+            plugin:
+              kubernetes:
+                name: test-plugin-b
+                namespace: test-ns
+    test-plugin-b:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-b
+      spec:
+        components:
+          - name: plugin-b-container
+            container:
+              name: test-container
+              image: test-img
+
+output:
+  workspace:
+    components:
+      - name: plugin-b-container
+        attributes:
+          controller.devfile.io/imported-by: "root-plugin"
+        container:
+          name: test-container
+          image: test-img

--- a/pkg/library/flatten/testdata/k8s-ref/nodejs-workspace.yaml
+++ b/pkg/library/flatten/testdata/k8s-ref/nodejs-workspace.yaml
@@ -291,7 +291,7 @@ output:
           # contains the vscode-pull-request-github vscode plugin.
           "che-theia.eclipse.org/vscode-extensions":
             - https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix
-
+          controller.devfile.io/imported-by: "che-theia"
         container:
           image: "quay.io/eclipse/che-theia:next"
           env:
@@ -344,6 +344,8 @@ output:
               protocol: http
 
       - name: plugins
+        attributes:
+          controller.devfile.io/imported-by: "che-theia"
         volume: {}
 
       - name: vsx-installer  # Mainly reads the container objects and searches for those
@@ -353,6 +355,7 @@ output:
         attributes:
           "app.kubernetes.io/part-of": che-theia.eclipse.org
           "app.kubernetes.io/component": bootstrapper
+          controller.devfile.io/imported-by: "che-theia"
         container:
           args:
             - /bin/sh
@@ -377,6 +380,8 @@ output:
               name: plugins
 
       - name: remote-endpoint
+        attributes:
+          controller.devfile.io/imported-by: "che-theia"
         volume: {}
           # ephemeral: true                #### We should add it in the Devfile 2.0 spec ! Not critical to implement at start though
 
@@ -384,6 +389,7 @@ output:
         attributes:
           "app.kubernetes.io/part-of": che-theia.eclipse.org
           "app.kubernetes.io/component": bootstrapper
+          controller.devfile.io/imported-by: "che-theia"
         container:                          #### corresponds to `initContainer` definition in old meta.yaml.
           image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0"
           volumeMounts:
@@ -400,6 +406,7 @@ output:
           "app.kubernetes.io/name": che-terminal.eclipse.org
           "app.kubernetes.io/part-of": che.eclipse.org
           "app.kubernetes.io/component": terminal
+          controller.devfile.io/imported-by: "machine-exec"
         container:
           image: "quay.io/eclipse/che-machine-exec:7.20.0"
           command: ['/go/bin/che-machine-exec']
@@ -425,6 +432,8 @@ output:
           # contains the typescript vscode plugin.
           "che-theia.eclipse.org/vscode-extensions":
             - https://download.jboss.org/jbosstools/vscode/3rdparty/ms-code.typescript/che-typescript-language-1.35.1.vsix
+
+          controller.devfile.io/imported-by: "typescript"
 
         container:
           image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"
@@ -455,9 +464,13 @@ output:
 
       # Commands coming from plugin editor
       - id: inject-theia-in-remote-sidecar
+        attributes:
+          controller.devfile.io/imported-by: "che-theia"
         apply:
           component: remote-runtime-injector
       - id: copy-vsx
+        attributes:
+          controller.devfile.io/imported-by: "che-theia"
         apply:
           component: vsx-installer
 

--- a/pkg/library/flatten/testdata/k8s-ref/web-terminal-with-plugin.yaml
+++ b/pkg/library/flatten/testdata/k8s-ref/web-terminal-with-plugin.yaml
@@ -59,6 +59,8 @@ output:
             - value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
               name: PS1
       - name: web-terminal
+        attributes:
+          controller.devfile.io/imported-by: "web-terminal"
         container:
           image: quay.io/eclipse/che-machine-exec:nightly
           command: ["/go/bin/che-machine-exec",

--- a/pkg/library/flatten/testdata/plugin-id/resolve-plugin-by-id.yaml
+++ b/pkg/library/flatten/testdata/plugin-id/resolve-plugin-by-id.yaml
@@ -22,6 +22,8 @@ output:
   workspace:
     components:
       - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
         container:
           name: test-container
           image: test-image

--- a/pkg/library/flatten/testdata/plugin-id/resolve-plugin-multiple-registries.yaml
+++ b/pkg/library/flatten/testdata/plugin-id/resolve-plugin-multiple-registries.yaml
@@ -35,10 +35,14 @@ output:
   workspace:
     components:
       - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
         container:
           name: test-container
           image: test-image
       - name: plugin-b
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin-2"
         container:
           name: test-container-b
           image: test-image

--- a/pkg/library/flatten/testdata/plugin-uri/resolve-multiple-plugins-by-uri.yaml
+++ b/pkg/library/flatten/testdata/plugin-uri/resolve-multiple-plugins-by-uri.yaml
@@ -33,10 +33,14 @@ output:
   workspace:
     components:
       - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
         container:
           name: test-container
           image: test-image
       - name: plugin-b
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin-2"
         container:
           name: test-container-b
           image: test-image

--- a/pkg/library/flatten/testdata/plugin-uri/resolve-plugin-by-uri.yaml
+++ b/pkg/library/flatten/testdata/plugin-uri/resolve-plugin-by-uri.yaml
@@ -21,6 +21,8 @@ output:
   workspace:
     components:
       - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
         container:
           name: test-container
           image: test-image

--- a/pkg/provision/metadata/envvar.go
+++ b/pkg/provision/metadata/envvar.go
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package metadata
+
+import (
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// metadataMountPathEnvVar is the name of an env var added to all containers to specify where workspace yamls are mounted.
+	metadataMountPathEnvVar = "DEVWORKSPACE_METADATA"
+
+	// flattenedDevfileMountPathEnvVar is an environment variable holding the path to the flattened devworkspace template spec
+	flattenedDevfileMountPathEnvVar = "DEVWORKSPACE_FLATTENED_DEVFILE"
+
+	// originalDevfileMountPathEnvVar is an environment variable holding the path to the original devworkspace template spec
+	originalDevfileMountPathEnvVar = "DEVWORKSPACE_ORIGINAL_DEVFILE"
+)
+
+func getWorkspaceMetaEnvVar() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  metadataMountPathEnvVar,
+			Value: metadataMountPath,
+		},
+		{
+			Name:  flattenedDevfileMountPathEnvVar,
+			Value: path.Join(metadataMountPath, flattenedYamlFilename),
+		},
+		{
+			Name:  originalDevfileMountPathEnvVar,
+			Value: path.Join(metadataMountPath, originalYamlFilename),
+		},
+	}
+}

--- a/pkg/provision/metadata/errors.go
+++ b/pkg/provision/metadata/errors.go
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package metadata
+
+import (
+	"fmt"
+	"time"
+)
+
+// NotReadyError represents the state where no unexpected issues occurred but the provisioning
+// required for the DevWorkspace is not ready
+type NotReadyError struct {
+	// Message is a user-friendly string explaining why the error occurred
+	Message string
+	// RequeueAfter represents how long we should wait before checking if storage is ready
+	RequeueAfter time.Duration
+}
+
+func (e *NotReadyError) Error() string {
+	return e.Message
+}
+
+// ProvisioningError represents an unrecoverable issue in provisioning a DevWorkspace.
+type ProvisioningError struct {
+	// Err is the underlying error causing the problem. If nil, it is not included in the output of Error()
+	Err error
+	// Message is a user-friendly string explaining why the error occurred
+	Message string
+}
+
+func (e *ProvisioningError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s", e.Message, e.Err)
+	}
+	return e.Message
+}

--- a/pkg/provision/metadata/metadata.go
+++ b/pkg/provision/metadata/metadata.go
@@ -1,0 +1,162 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package metadata
+
+import (
+	"context"
+	"fmt"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
+	maputils "github.com/devfile/devworkspace-operator/internal/map"
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+)
+
+const (
+	// workspaceMetadataMountPath is where files containing workspace metadata are mounted
+	workspaceMetadataMountPath = "/devworkspace-metadata"
+
+	// workspaceMetadataMountPathEnvVar is the name of an env var added to all containers to specify where workspace yamls are mounted.
+	workspaceMetadataMountPathEnvVar = "DEVWORKSPACE_METADATA"
+
+	// workspaceOriginalYamlFilename is the filename mounted to workspace containers which contains the current DevWorkspace yaml
+	workspaceOriginalYamlFilename = "original.devworkspace.yaml"
+
+	// workspaceFlattenedYamlFilename is the filename mounted to workspace containers which contains the flattened (i.e.
+	// resolved plugins and parent) DevWorkspace yaml
+	workspaceFlattenedYamlFilename = "flattened.devworkspace.yaml"
+)
+
+// ProvisionWorkspaceMetadata creates a configmap on the cluster that stores metadata about the workspace and configures all
+// workspace containers to mount that configmap at /devworkspace-metadata. Each container has the environment
+// variable DEVWORKSPACE_METADATA set to the mount path for the configmap
+func ProvisionWorkspaceMetadata(podAdditions *v1alpha1.PodAdditions, original, flattened *dw.DevWorkspace, api *provision.ClusterAPI) error {
+	cm, err := getSpecMetadataConfigMap(original, flattened)
+	if err != nil {
+		return err
+	}
+	err = controllerutil.SetControllerReference(original, cm, api.Scheme)
+	if err != nil {
+		return err
+	}
+	if inSync, err := syncConfigMapToCluster(cm, api); err != nil {
+		return err
+	} else if !inSync {
+		return &NotReadyError{
+			Message: "Waiting for DevWorkspace metadata configmap to be ready",
+		}
+	}
+
+	vol := getVolumeFromConfigMap(cm)
+	podAdditions.Volumes = append(podAdditions.Volumes, *vol)
+	vm := getVolumeMountFromVolume(vol)
+	podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, *vm)
+
+	for idx := range podAdditions.Containers {
+		podAdditions.Containers[idx].Env = append(podAdditions.Containers[idx].Env, corev1.EnvVar{
+			Name:  workspaceMetadataMountPathEnvVar,
+			Value: workspaceMetadataMountPath,
+		})
+	}
+
+	for idx := range podAdditions.InitContainers {
+		podAdditions.InitContainers[idx].Env = append(podAdditions.InitContainers[idx].Env, corev1.EnvVar{
+			Name:  workspaceMetadataMountPathEnvVar,
+			Value: workspaceMetadataMountPath,
+		})
+	}
+
+	return nil
+}
+
+func syncConfigMapToCluster(specCM *corev1.ConfigMap, api *provision.ClusterAPI) (inSync bool, err error) {
+	clusterCM := &corev1.ConfigMap{}
+	err = api.Client.Get(context.TODO(), types.NamespacedName{Name: specCM.Name, Namespace: specCM.Namespace}, clusterCM)
+
+	switch {
+	case err == nil:
+		if maputils.Equal(specCM.Data, clusterCM.Data) {
+			return true, nil
+		}
+		clusterCM.Data = specCM.Data
+		err = api.Client.Update(context.TODO(), clusterCM)
+	case k8sErrors.IsNotFound(err):
+		err = api.Client.Create(context.TODO(), specCM)
+	default:
+		return false, err
+	}
+	if k8sErrors.IsConflict(err) || k8sErrors.IsAlreadyExists(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func getSpecMetadataConfigMap(original, flattened *dw.DevWorkspace) (*corev1.ConfigMap, error) {
+	originalYaml, err := yaml.Marshal(original.Spec.Template)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal original DevWorkspace yaml: %w", err)
+	}
+
+	flattenedYaml, err := yaml.Marshal(flattened.Spec.Template)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal flattened DevWorkspace yaml: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.MetadataConfigMapName(original.Status.WorkspaceId),
+			Namespace: original.Namespace,
+			Labels:    constants.ControllerAppLabels(),
+		},
+		Data: map[string]string{
+			workspaceOriginalYamlFilename:  string(originalYaml),
+			workspaceFlattenedYamlFilename: string(flattenedYaml),
+		},
+	}
+
+	return cm, nil
+}
+
+func getVolumeFromConfigMap(cm *corev1.ConfigMap) *corev1.Volume {
+	boolTrue := true
+	defaultMode := int32(0644)
+	return &corev1.Volume{
+		Name: "workspace-metadata",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: cm.Name,
+				},
+				Optional:    &boolTrue,
+				DefaultMode: &defaultMode,
+			},
+		},
+	}
+}
+
+func getVolumeMountFromVolume(vol *corev1.Volume) *corev1.VolumeMount {
+	return &corev1.VolumeMount{
+		Name:      vol.Name,
+		ReadOnly:  true,
+		MountPath: workspaceMetadataMountPath,
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Mount files to each container in a devworkspace, via a configmap:
```
/devworkspace-metadata/flattened.devworkspace.yaml - the flattened DevWorkspaceTemplateSpec used to create the actual deployment
/devworkspace-metadata/original.devworkspace.yaml - the original DevWorkspaceTemplateSpec that exists on the cluster
```

Additionally, this PR annotates the flattened DevWorkspace with some additional info:
- Components/Commands/Projects added by a plugin are annotated with `controller.devfile.io/imported-by=<plugin-id>`, where `<plugin-id>` is the ID of the plugin component that resolved to that Component/etc.
- Endpoints on Container components are annotated with `controller.devfile.io/endpoint-url=<url>` to more easily match created routes/ingresses on the cluster with devfile endpoints.

### What issues does this PR fix or reference?
I don't know that we created an issue for this, but the closest is probably https://github.com/devfile/devworkspace-operator/issues/162

### Is it tested? How?
Tested as usual. Once a DevWorkspace is started, you can issue commands like `cat $DEVWORKSPACE_METADATA/flattened.devworkspace.yaml` to check the mounted files.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->

cc: @benoitf I can't add you as a reviewer here for some reason but your comments are welcome.