### PR TITLE
Download required version of kustomize to bin/kustomize/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
-      - name: Setup Kustomize & yq
+      - name: Setup yq
         run: |
           python -m pip install --upgrade pip
           pip install yq
 
-          cd /usr/bin
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v4.0.5/hack/install_kustomize.sh" | bash
           cd ${GITHUB_WORKSPACE}
       - name: Build image, generate deployments and push git tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           pip install yq
 
           cd /usr/bin
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v4.0.4/hack/install_kustomize.sh"  | bash
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v4.0.5/hack/install_kustomize.sh" | bash
           cd ${GITHUB_WORKSPACE}
       - name: Build image, generate deployments and push git tag
         run: |
@@ -39,4 +39,5 @@ jobs:
           git config --global user.email "mkuznets@redhat.com"
 
           export GITHUB_TOKEN=${{ secrets.CHE_INCUBATOR_BOT_GITHUB_TOKEN }}
+          export KUSTOMIZE=/usr/bin/kustomize
           ./make-release.sh --version ${{ github.event.inputs.version}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,4 @@ jobs:
           git config --global user.email "mkuznets@redhat.com"
 
           export GITHUB_TOKEN=${{ secrets.CHE_INCUBATOR_BOT_GITHUB_TOKEN }}
-          export KUSTOMIZE=/usr/bin/kustomize
           ./make-release.sh --version ${{ github.event.inputs.version}}

--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,10 @@ devworkspace-crds
 deploy/templates/crd/bases/workspace.devfile.io_devworkspaces.yaml
 deploy/templates/crd/bases/workspace.devfile.io_devworkspacetemplates.yaml
 deploy/current
-testbin
 .vscode
 __debug_bin
 
 # Ignore cached kustomize for makefile
-.kustomize
 
 # Binaries for programs and plugins
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ testbin
 .vscode
 __debug_bin
 
+# Ignore cached kustomize for makefile
+.kustomize
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,6 @@ DEVWORKSPACE_CTRL_SA=devworkspace-controller-serviceaccount
 INTERNAL_TMP_DIR=/tmp/devworkspace-controller
 BUMPED_KUBECONFIG=$(INTERNAL_TMP_DIR)/kubeconfig
 RELATED_IMAGES_FILE=$(INTERNAL_TMP_DIR)/environment
-KUSTOMIZE_VER=4.0.5
-export KUSTOMIZE_DIR=./bin/kustomize
-export KUSTOMIZE=./bin/kustomize/kustomize
 
 ifeq (,$(shell which kubectl))
 ifeq (,$(shell which oc))
@@ -185,11 +182,11 @@ else
 endif
 
 ### generate_deployment: Generate files used for deployment from kustomize templates, using environment variables
-generate_deployment: _kustomize
+generate_deployment:
 	deploy/generate-deployment.sh
 
 ### generate_default_deployment: Generate files used for deployment from kustomize templates with default values
-generate_default_deployment: _kustomize
+generate_default_deployment:
 	deploy/generate-deployment.sh --use-defaults
 
 ### install_plugin_templates: Deploy sample plugin templates to namespace devworkspace-plugins:
@@ -311,18 +308,6 @@ endif
 ### install_cert_manager: install Cert Mananger v1.0.4 on the cluster
 install_cert_manager:
 	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.yaml
-
-_kustomize:
-	mkdir -p $(KUSTOMIZE_DIR)
-	if [ ! -f $(KUSTOMIZE) ]; then \
-		curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
-			| bash -s $(KUSTOMIZE_VER) $(KUSTOMIZE_DIR) ;\
-	elif [ $$($(KUSTOMIZE) version | grep -o 'Version:[^ ]*') != "Version:kustomize/v$(KUSTOMIZE_VER)" ]; then \
-		echo "Wrong version of kustomize at $(KUSTOMIZE). Redownloading." ;\
-		rm $(KUSTOMIZE) ;\
-		curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
-			| bash -s $(KUSTOMIZE_VER) $(KUSTOMIZE_DIR) ;\
-	fi
 
 _operator_sdk:
 	@{ \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ INTERNAL_TMP_DIR=/tmp/devworkspace-controller
 BUMPED_KUBECONFIG=$(INTERNAL_TMP_DIR)/kubeconfig
 RELATED_IMAGES_FILE=$(INTERNAL_TMP_DIR)/environment
 KUSTOMIZE_VER=4.0.5
-KUSTOMIZE=./.kustomize/kustomize
+export KUSTOMIZE_DIR=./bin/kustomize
+export KUSTOMIZE=./bin/kustomize/kustomize
 
 ifeq (,$(shell which kubectl))
 ifeq (,$(shell which oc))
@@ -125,7 +126,7 @@ update_devworkspace_crds:
 ###### End rules for dealing with devfile/api
 
 ### test: Run tests
-ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
+ENVTEST_ASSETS_DIR = $(shell pwd)/bin/testbin
 test: generate fmt vet manifests
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.6.3/hack/setup-envtest.sh
@@ -312,15 +313,15 @@ install_cert_manager:
 	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.yaml
 
 _kustomize:
-	mkdir -p .kustomize
-	if [ ! -f .kustomize/kustomize ]; then \
+	mkdir -p $(KUSTOMIZE_DIR)
+	if [ ! -f $(KUSTOMIZE) ]; then \
 		curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
-			| bash -s $(KUSTOMIZE_VER) .kustomize ;\
-	elif [ $$(.kustomize/kustomize version | grep -o 'Version:[^ ]*') != "Version:kustomize/v$(KUSTOMIZE_VER)" ]; then \
-		echo "Wrong version of kustomize at .kustomize/kustomize. Redownloading." ;\
-		rm .kustomize/kustomize ;\
+			| bash -s $(KUSTOMIZE_VER) $(KUSTOMIZE_DIR) ;\
+	elif [ $$($(KUSTOMIZE) version | grep -o 'Version:[^ ]*') != "Version:kustomize/v$(KUSTOMIZE_VER)" ]; then \
+		echo "Wrong version of kustomize at $(KUSTOMIZE). Redownloading." ;\
+		rm $(KUSTOMIZE) ;\
 		curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
-			| bash -s $(KUSTOMIZE_VER) .kustomize ;\
+			| bash -s $(KUSTOMIZE_VER) $(KUSTOMIZE_DIR) ;\
 	fi
 
 _operator_sdk:

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ metadata:
 ## Prerequisites
 - go
 - git
-- kustomize.io
 - sed
 - jq
 - yq (python-yq from https://github.com/kislyuk/yq#installation, other distributions may not work)
 - docker
+
+Note: kustomize `v4.0.5` is required for most tasks. It is downloaded automatically to the `.kustomize` folder in this repo when required. This downloaded version is used regardless of whether or not kustomize is already installed on the system.
 
 ## Running the controller in a cluster
 

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -106,7 +106,14 @@ for var in "${required_vars[@]}"; do
   fi
 done
 
-required_bin=(kustomize envsubst csplit yq)
+KUSTOMIZE_BIN=".kustomize/kustomize"
+if [ ! -f ${KUSTOMIZE_BIN} ]; then
+  echo "Kustomize not found in .kustomize. Run this script using the makefile (make generate_default_deployment)"
+  echo "or manually run the 'make _kustomize' rule to initialize kustomize binaries"
+  exit 1
+fi
+
+required_bin=(envsubst csplit yq)
 for bin in "${required_bin[@]}"; do
   if ! which "$bin" &>/dev/null; then
     echo "ERROR: Program $bin is required for this script"
@@ -137,10 +144,10 @@ envsubst < "${SCRIPT_DIR}/templates/base/manager_image_patch.yaml.bak" > "${SCRI
 
 # Run kustomize to build yamls
 echo "Generating config for Kubernetes"
-kustomize build "${SCRIPT_DIR}/templates/cert-manager" > "${KUBERNETES_DIR}/${COMBINED_FILENAME}"
+${KUSTOMIZE_BIN} build "${SCRIPT_DIR}/templates/cert-manager" > "${KUBERNETES_DIR}/${COMBINED_FILENAME}"
 echo "File saved to ${KUBERNETES_DIR}/${COMBINED_FILENAME}"
 echo "Generating config for OpenShift"
-kustomize build "${SCRIPT_DIR}/templates/service-ca" > "${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
+${KUSTOMIZE_BIN} build "${SCRIPT_DIR}/templates/service-ca" > "${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
 echo "File saved to ${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
 
 # Restore backups to not change templates

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -106,8 +106,10 @@ for var in "${required_vars[@]}"; do
   fi
 done
 
-KUSTOMIZE_BIN=".kustomize/kustomize"
-if [ ! -f ${KUSTOMIZE_BIN} ]; then
+if [ -z ${KUSTOMIZE} ]; then
+  echo "Required env var KUSTOMIZE not set. Set KUSTOMIZE to point to a kustomize v4.0.5 binary"
+fi
+if [ ! -f ${KUSTOMIZE} ]; then
   echo "Kustomize not found in .kustomize. Run this script using the makefile (make generate_default_deployment)"
   echo "or manually run the 'make _kustomize' rule to initialize kustomize binaries"
   exit 1
@@ -144,10 +146,10 @@ envsubst < "${SCRIPT_DIR}/templates/base/manager_image_patch.yaml.bak" > "${SCRI
 
 # Run kustomize to build yamls
 echo "Generating config for Kubernetes"
-${KUSTOMIZE_BIN} build "${SCRIPT_DIR}/templates/cert-manager" > "${KUBERNETES_DIR}/${COMBINED_FILENAME}"
+${KUSTOMIZE} build "${SCRIPT_DIR}/templates/cert-manager" > "${KUBERNETES_DIR}/${COMBINED_FILENAME}"
 echo "File saved to ${KUBERNETES_DIR}/${COMBINED_FILENAME}"
 echo "Generating config for OpenShift"
-${KUSTOMIZE_BIN} build "${SCRIPT_DIR}/templates/service-ca" > "${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
+${KUSTOMIZE} build "${SCRIPT_DIR}/templates/service-ca" > "${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
 echo "File saved to ${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
 
 # Restore backups to not change templates


### PR DESCRIPTION
### What does this PR do?
Make the `_kustomize` rule download kustomize to `.kustomize/kustomize`, and use this version of kustomize for all Makefile-related calls. This is required since different versions of kustomize output differently formatted yaml templates, resulting in spurious changes to files in deploy/.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/294

### Is it tested? How?
Tested three cases: 
1. Nothing in `.kustomize` or folder does not exist -> download kustomize v4.0.5 there
2. Wrong version kustomize in `.kustomize/kustomize` -> delete current and redownload
3. Kustomize present and correct version -> do nothing

cc: @benoitf Could you also test these changes to make sure it works as expect on macOS? 

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
