### PR TITLE
Sync makefile and default deployment CRDs versions

### DIFF
--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -7074,6 +7074,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -7124,6 +7129,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -8837,6 +8846,11 @@ spec:
                                         description: Configuration overriding for
                                           a Volume component in a plugin
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           name:
                                             description: Mandatory name that allows
                                               referencing the Volume component in
@@ -8890,6 +8904,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 name:
                                   description: Mandatory name that allows referencing
                                     the Volume component in Container volume mounts
@@ -9480,6 +9498,10 @@ spec:
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
                 type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
+                type: string
               phase:
                 type: string
               workspaceId:
@@ -9502,9 +9524,9 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: Url endpoint for accessing workspace
-      jsonPath: .status.ideUrl
-      name: URL
+    - description: Additional information about the workspace
+      jsonPath: .status.message
+      name: Info
       type: string
     name: v1alpha2
     schema:
@@ -9767,6 +9789,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -9911,6 +9935,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            cpuLimit:
+                              type: string
+                            cpuRequest:
+                              type: string
                             dedicatedPod:
                               description: "Specify if a container should run in its
                                 own separated pod, instead of running as part of the
@@ -9949,6 +9977,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -9975,14 +10005,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -10011,6 +10044,8 @@ spec:
                               type: string
                             memoryLimit:
                               type: string
+                            memoryRequest:
+                              type: string
                             mountSources:
                               description: "Toggles whether or not the project source
                                 code should be mounted in the component. \n Defaults
@@ -10037,6 +10072,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -10114,6 +10151,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -10140,14 +10179,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -10174,6 +10216,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -10218,6 +10262,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -10244,14 +10290,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -10345,6 +10394,11 @@ spec:
                                           UI menus for example
                                         type: string
                                     type: object
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   commandType:
                                     description: Type of workspace command
                                     enum:
@@ -10471,6 +10525,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -10579,6 +10635,11 @@ spec:
                                 - required:
                                   - volume
                                 properties:
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   componentType:
                                     description: Type of component
                                     enum:
@@ -10610,6 +10671,10 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      cpuLimit:
+                                        type: string
+                                      cpuRequest:
+                                        type: string
                                       dedicatedPod:
                                         description: "Specify if a container should
                                           run in its own separated pod, instead of
@@ -10651,6 +10716,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -10681,14 +10748,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -10714,6 +10785,8 @@ spec:
                                       image:
                                         type: string
                                       memoryLimit:
+                                        type: string
+                                      memoryRequest:
                                         type: string
                                       mountSources:
                                         description: "Toggles whether or not the project
@@ -10743,6 +10816,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -10802,6 +10877,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -10832,14 +10909,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -10866,6 +10947,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -10914,6 +10997,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -10944,14 +11029,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -10977,6 +11066,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -11017,6 +11111,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -11126,6 +11224,11 @@ spec:
                                     for example
                                   type: string
                               type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             commandType:
                               description: Type of workspace command
                               enum:
@@ -11249,6 +11352,8 @@ spec:
                               description: Mandatory identifier that allows referencing
                                 this command in composite commands, from a parent,
                                 or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             vscodeLaunch:
                               description: Command providing the definition of a VsCode
@@ -11355,6 +11460,11 @@ spec:
                           - required:
                             - plugin
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             componentType:
                               description: Type of component
                               enum:
@@ -11386,6 +11496,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
                                 dedicatedPod:
                                   description: "Specify if a container should run
                                     in its own separated pod, instead of running as
@@ -11424,6 +11538,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -11451,14 +11567,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -11484,6 +11603,8 @@ spec:
                                 image:
                                   type: string
                                 memoryLimit:
+                                  type: string
+                                memoryRequest:
                                   type: string
                                 mountSources:
                                   description: "Toggles whether or not the project
@@ -11512,6 +11633,8 @@ spec:
                                           If several containers mount the same volume
                                           name then they will reuse the same volume
                                           and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -11567,6 +11690,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -11594,14 +11719,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -11627,6 +11755,8 @@ spec:
                                 the component from other elements (such as commands)
                                 or from an external devfile that may reference this
                                 component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             openshift:
                               description: Allows importing into the workspace the
@@ -11671,6 +11801,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -11698,14 +11830,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -11800,6 +11935,11 @@ spec:
                                               in Editor UI menus for example
                                             type: string
                                         type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
                                       commandType:
                                         description: Type of workspace command
                                         enum:
@@ -11930,6 +12070,8 @@ spec:
                                         description: Mandatory identifier that allows
                                           referencing this command in composite commands,
                                           from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       vscodeLaunch:
                                         description: Command providing the definition
@@ -12039,6 +12181,11 @@ spec:
                                     - required:
                                       - volume
                                     properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
                                       componentType:
                                         description: Type of component
                                         enum:
@@ -12071,6 +12218,10 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
                                           dedicatedPod:
                                             description: "Specify if a container should
                                               run in its own separated pod, instead
@@ -12114,6 +12265,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -12148,7 +12301,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -12156,7 +12311,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -12183,6 +12339,8 @@ spec:
                                           image:
                                             type: string
                                           memoryLimit:
+                                            type: string
+                                          memoryRequest:
                                             type: string
                                           mountSources:
                                             description: "Toggles whether or not the
@@ -12215,6 +12373,8 @@ spec:
                                                     they will reuse the same volume
                                                     and will be able to access to
                                                     the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: The path in the component
@@ -12275,6 +12435,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -12309,7 +12471,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -12317,7 +12481,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -12345,6 +12510,8 @@ spec:
                                           as commands) or from an external devfile
                                           that may reference this component through
                                           a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       openshift:
                                         description: Allows importing into the workspace
@@ -12394,6 +12561,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -12428,7 +12597,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -12436,7 +12607,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -12462,6 +12634,11 @@ spec:
                                         description: Allows specifying the definition
                                           of a volume shared by several other components
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           size:
                                             description: Size of the volume
                                             type: string
@@ -12501,6 +12678,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 size:
                                   description: Size of the volume
                                   type: string
@@ -12544,6 +12725,11 @@ spec:
                           - required:
                             - zip
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             clonePath:
                               description: Path relative to the root of the projects
                                 to which this project should be cloned into. This
@@ -12610,6 +12796,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -12651,6 +12839,11 @@ spec:
                           - required:
                             - zip
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             description:
                               description: Description of a starter project
                               type: string
@@ -12712,6 +12905,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -12840,6 +13035,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -12962,6 +13159,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -13029,6 +13228,10 @@ spec:
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
                 type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
+                type: string
               phase:
                 type: string
               workspaceId:
@@ -13075,6 +13278,8 @@ spec:
     kind: DevWorkspaceTemplate
     listKind: DevWorkspaceTemplateList
     plural: devworkspacetemplates
+    shortNames:
+    - dwt
     singular: devworkspacetemplate
   scope: Namespaced
   versions:
@@ -14646,6 +14851,10 @@ spec:
                                 description: Configuration overriding for a Volume
                                   component in a plugin
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   name:
                                     description: Mandatory name that allows referencing
                                       the Volume component in Container volume mounts
@@ -14696,6 +14905,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         name:
                           description: Mandatory name that allows referencing the
                             Volume component in Container volume mounts or inside
@@ -16350,6 +16563,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -16400,6 +16618,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -17176,6 +17398,8 @@ spec:
                     id:
                       description: Mandatory identifier that allows referencing this
                         command in composite commands, from a parent, or in events.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     vscodeLaunch:
                       description: Command providing the definition of a VsCode launch
@@ -17316,6 +17540,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        cpuLimit:
+                          type: string
+                        cpuRequest:
+                          type: string
                         dedicatedPod:
                           description: "Specify if a container should run in its own
                             separated pod, instead of running as part of the main
@@ -17351,6 +17579,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -17375,14 +17605,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -17410,6 +17643,8 @@ spec:
                           type: string
                         memoryLimit:
                           type: string
+                        memoryRequest:
+                          type: string
                         mountSources:
                           description: "Toggles whether or not the project source
                             code should be mounted in the component. \n Defaults to
@@ -17436,6 +17671,8 @@ spec:
                                   mount the same volume name then they will reuse
                                   the same volume and will be able to access to the
                                   same files.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: The path in the component container where
@@ -17511,6 +17748,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -17535,14 +17774,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -17569,6 +17811,8 @@ spec:
                         from other elements (such as commands) or from an external
                         devfile that may reference this component through a parent
                         or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     openshift:
                       description: Allows importing into the workspace the OpenShift
@@ -17611,6 +17855,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -17635,14 +17881,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -17735,6 +17984,11 @@ spec:
                                       for example
                                     type: string
                                 type: object
+                              attributes:
+                                description: Map of implementation-dependant free-form
+                                  YAML attributes.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               commandType:
                                 description: Type of workspace command
                                 enum:
@@ -17859,6 +18113,8 @@ spec:
                                 description: Mandatory identifier that allows referencing
                                   this command in composite commands, from a parent,
                                   or in events.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               vscodeLaunch:
                                 description: Command providing the definition of a
@@ -17965,6 +18221,11 @@ spec:
                             - required:
                               - volume
                             properties:
+                              attributes:
+                                description: Map of implementation-dependant free-form
+                                  YAML attributes.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               componentType:
                                 description: Type of component
                                 enum:
@@ -17995,6 +18256,10 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  cpuLimit:
+                                    type: string
+                                  cpuRequest:
+                                    type: string
                                   dedicatedPod:
                                     description: "Specify if a container should run
                                       in its own separated pod, instead of running
@@ -18033,6 +18298,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -18061,14 +18328,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -18094,6 +18364,8 @@ spec:
                                   image:
                                     type: string
                                   memoryLimit:
+                                    type: string
+                                  memoryRequest:
                                     type: string
                                   mountSources:
                                     description: "Toggles whether or not the project
@@ -18123,6 +18395,8 @@ spec:
                                             name then they will reuse the same volume
                                             and will be able to access to the same
                                             files.
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: The path in the component container
@@ -18178,6 +18452,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -18206,14 +18482,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -18240,6 +18519,8 @@ spec:
                                   the component from other elements (such as commands)
                                   or from an external devfile that may reference this
                                   component through a parent or a plugin.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               openshift:
                                 description: Allows importing into the workspace the
@@ -18284,6 +18565,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -18312,14 +18595,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -18345,6 +18631,10 @@ spec:
                                 description: Allows specifying the definition of a
                                   volume shared by several other components
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   size:
                                     description: Size of the volume
                                     type: string
@@ -18385,6 +18675,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         size:
                           description: Size of the volume
                           type: string
@@ -18490,6 +18784,11 @@ spec:
                                 this command to be used in Editor UI menus for example
                               type: string
                           type: object
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         commandType:
                           description: Type of workspace command
                           enum:
@@ -18608,6 +18907,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -18710,6 +19011,11 @@ spec:
                       - required:
                         - plugin
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         componentType:
                           description: Type of component
                           enum:
@@ -18741,6 +19047,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            cpuLimit:
+                              type: string
+                            cpuRequest:
+                              type: string
                             dedicatedPod:
                               description: "Specify if a container should run in its
                                 own separated pod, instead of running as part of the
@@ -18778,6 +19088,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -18803,14 +19115,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -18837,6 +19152,8 @@ spec:
                               type: string
                             memoryLimit:
                               type: string
+                            memoryRequest:
+                              type: string
                             mountSources:
                               description: "Toggles whether or not the project source
                                 code should be mounted in the component. \n Defaults
@@ -18862,6 +19179,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -18915,6 +19234,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -18940,14 +19261,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -18973,6 +19297,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -19016,6 +19342,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -19041,14 +19369,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -19141,6 +19472,11 @@ spec:
                                           UI menus for example
                                         type: string
                                     type: object
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   commandType:
                                     description: Type of workspace command
                                     enum:
@@ -19267,6 +19603,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -19375,6 +19713,11 @@ spec:
                                 - required:
                                   - volume
                                 properties:
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   componentType:
                                     description: Type of component
                                     enum:
@@ -19406,6 +19749,10 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      cpuLimit:
+                                        type: string
+                                      cpuRequest:
+                                        type: string
                                       dedicatedPod:
                                         description: "Specify if a container should
                                           run in its own separated pod, instead of
@@ -19447,6 +19794,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -19477,14 +19826,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -19510,6 +19863,8 @@ spec:
                                       image:
                                         type: string
                                       memoryLimit:
+                                        type: string
+                                      memoryRequest:
                                         type: string
                                       mountSources:
                                         description: "Toggles whether or not the project
@@ -19539,6 +19894,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -19598,6 +19955,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -19628,14 +19987,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -19662,6 +20025,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -19710,6 +20075,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -19740,14 +20107,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -19773,6 +20144,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -19811,6 +20187,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -19853,6 +20233,11 @@ spec:
                       - required:
                         - zip
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         clonePath:
                           description: Path relative to the root of the projects to
                             which this project should be cloned into. This is a unix-style
@@ -19917,6 +20302,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -19958,6 +20345,11 @@ spec:
                       - required:
                         - zip
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         description:
                           description: Description of a starter project
                           type: string
@@ -20017,6 +20409,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -20138,6 +20532,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source
@@ -20253,6 +20649,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source

--- a/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -1666,6 +1666,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -1716,6 +1721,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -3429,6 +3438,11 @@ spec:
                                         description: Configuration overriding for
                                           a Volume component in a plugin
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           name:
                                             description: Mandatory name that allows
                                               referencing the Volume component in
@@ -3482,6 +3496,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 name:
                                   description: Mandatory name that allows referencing
                                     the Volume component in Container volume mounts
@@ -4072,6 +4090,10 @@ spec:
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
                 type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
+                type: string
               phase:
                 type: string
               workspaceId:
@@ -4094,9 +4116,9 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: Url endpoint for accessing workspace
-      jsonPath: .status.ideUrl
-      name: URL
+    - description: Additional information about the workspace
+      jsonPath: .status.message
+      name: Info
       type: string
     name: v1alpha2
     schema:
@@ -4359,6 +4381,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -4503,6 +4527,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            cpuLimit:
+                              type: string
+                            cpuRequest:
+                              type: string
                             dedicatedPod:
                               description: "Specify if a container should run in its
                                 own separated pod, instead of running as part of the
@@ -4541,6 +4569,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4567,14 +4597,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -4603,6 +4636,8 @@ spec:
                               type: string
                             memoryLimit:
                               type: string
+                            memoryRequest:
+                              type: string
                             mountSources:
                               description: "Toggles whether or not the project source
                                 code should be mounted in the component. \n Defaults
@@ -4629,6 +4664,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -4706,6 +4743,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4732,14 +4771,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -4766,6 +4808,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -4810,6 +4854,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4836,14 +4882,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -4937,6 +4986,11 @@ spec:
                                           UI menus for example
                                         type: string
                                     type: object
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   commandType:
                                     description: Type of workspace command
                                     enum:
@@ -5063,6 +5117,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -5171,6 +5227,11 @@ spec:
                                 - required:
                                   - volume
                                 properties:
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   componentType:
                                     description: Type of component
                                     enum:
@@ -5202,6 +5263,10 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      cpuLimit:
+                                        type: string
+                                      cpuRequest:
+                                        type: string
                                       dedicatedPod:
                                         description: "Specify if a container should
                                           run in its own separated pod, instead of
@@ -5243,6 +5308,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5273,14 +5340,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -5306,6 +5377,8 @@ spec:
                                       image:
                                         type: string
                                       memoryLimit:
+                                        type: string
+                                      memoryRequest:
                                         type: string
                                       mountSources:
                                         description: "Toggles whether or not the project
@@ -5335,6 +5408,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -5394,6 +5469,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5424,14 +5501,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -5458,6 +5539,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -5506,6 +5589,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5536,14 +5621,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -5569,6 +5658,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -5609,6 +5703,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -5718,6 +5816,11 @@ spec:
                                     for example
                                   type: string
                               type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             commandType:
                               description: Type of workspace command
                               enum:
@@ -5841,6 +5944,8 @@ spec:
                               description: Mandatory identifier that allows referencing
                                 this command in composite commands, from a parent,
                                 or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             vscodeLaunch:
                               description: Command providing the definition of a VsCode
@@ -5947,6 +6052,11 @@ spec:
                           - required:
                             - plugin
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             componentType:
                               description: Type of component
                               enum:
@@ -5978,6 +6088,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
                                 dedicatedPod:
                                   description: "Specify if a container should run
                                     in its own separated pod, instead of running as
@@ -6016,6 +6130,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6043,14 +6159,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -6076,6 +6195,8 @@ spec:
                                 image:
                                   type: string
                                 memoryLimit:
+                                  type: string
+                                memoryRequest:
                                   type: string
                                 mountSources:
                                   description: "Toggles whether or not the project
@@ -6104,6 +6225,8 @@ spec:
                                           If several containers mount the same volume
                                           name then they will reuse the same volume
                                           and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -6159,6 +6282,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6186,14 +6311,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -6219,6 +6347,8 @@ spec:
                                 the component from other elements (such as commands)
                                 or from an external devfile that may reference this
                                 component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             openshift:
                               description: Allows importing into the workspace the
@@ -6263,6 +6393,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6290,14 +6422,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -6392,6 +6527,11 @@ spec:
                                               in Editor UI menus for example
                                             type: string
                                         type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
                                       commandType:
                                         description: Type of workspace command
                                         enum:
@@ -6522,6 +6662,8 @@ spec:
                                         description: Mandatory identifier that allows
                                           referencing this command in composite commands,
                                           from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       vscodeLaunch:
                                         description: Command providing the definition
@@ -6631,6 +6773,11 @@ spec:
                                     - required:
                                       - volume
                                     properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
                                       componentType:
                                         description: Type of component
                                         enum:
@@ -6663,6 +6810,10 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
                                           dedicatedPod:
                                             description: "Specify if a container should
                                               run in its own separated pod, instead
@@ -6706,6 +6857,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6740,7 +6893,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -6748,7 +6903,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -6775,6 +6931,8 @@ spec:
                                           image:
                                             type: string
                                           memoryLimit:
+                                            type: string
+                                          memoryRequest:
                                             type: string
                                           mountSources:
                                             description: "Toggles whether or not the
@@ -6807,6 +6965,8 @@ spec:
                                                     they will reuse the same volume
                                                     and will be able to access to
                                                     the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: The path in the component
@@ -6867,6 +7027,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6901,7 +7063,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -6909,7 +7073,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -6937,6 +7102,8 @@ spec:
                                           as commands) or from an external devfile
                                           that may reference this component through
                                           a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       openshift:
                                         description: Allows importing into the workspace
@@ -6986,6 +7153,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -7020,7 +7189,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -7028,7 +7199,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -7054,6 +7226,11 @@ spec:
                                         description: Allows specifying the definition
                                           of a volume shared by several other components
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           size:
                                             description: Size of the volume
                                             type: string
@@ -7093,6 +7270,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 size:
                                   description: Size of the volume
                                   type: string
@@ -7136,6 +7317,11 @@ spec:
                           - required:
                             - zip
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             clonePath:
                               description: Path relative to the root of the projects
                                 to which this project should be cloned into. This
@@ -7202,6 +7388,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7243,6 +7431,11 @@ spec:
                           - required:
                             - zip
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             description:
                               description: Description of a starter project
                               type: string
@@ -7304,6 +7497,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7432,6 +7627,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7554,6 +7751,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7620,6 +7819,10 @@ spec:
                 type: array
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
+                type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
                 type: string
               phase:
                 type: string

--- a/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -24,6 +24,8 @@ spec:
     kind: DevWorkspaceTemplate
     listKind: DevWorkspaceTemplateList
     plural: devworkspacetemplates
+    shortNames:
+    - dwt
     singular: devworkspacetemplate
   scope: Namespaced
   versions:
@@ -1595,6 +1597,10 @@ spec:
                                 description: Configuration overriding for a Volume
                                   component in a plugin
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   name:
                                     description: Mandatory name that allows referencing
                                       the Volume component in Container volume mounts
@@ -1645,6 +1651,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         name:
                           description: Mandatory name that allows referencing the
                             Volume component in Container volume mounts or inside
@@ -3299,6 +3309,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -3349,6 +3364,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -4125,6 +4144,8 @@ spec:
                     id:
                       description: Mandatory identifier that allows referencing this
                         command in composite commands, from a parent, or in events.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     vscodeLaunch:
                       description: Command providing the definition of a VsCode launch
@@ -4265,6 +4286,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        cpuLimit:
+                          type: string
+                        cpuRequest:
+                          type: string
                         dedicatedPod:
                           description: "Specify if a container should run in its own
                             separated pod, instead of running as part of the main
@@ -4300,6 +4325,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4324,14 +4351,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -4359,6 +4389,8 @@ spec:
                           type: string
                         memoryLimit:
                           type: string
+                        memoryRequest:
+                          type: string
                         mountSources:
                           description: "Toggles whether or not the project source
                             code should be mounted in the component. \n Defaults to
@@ -4385,6 +4417,8 @@ spec:
                                   mount the same volume name then they will reuse
                                   the same volume and will be able to access to the
                                   same files.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: The path in the component container where
@@ -4460,6 +4494,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4484,14 +4520,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -4518,6 +4557,8 @@ spec:
                         from other elements (such as commands) or from an external
                         devfile that may reference this component through a parent
                         or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     openshift:
                       description: Allows importing into the workspace the OpenShift
@@ -4560,6 +4601,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4584,14 +4627,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -4684,6 +4730,11 @@ spec:
                                       for example
                                     type: string
                                 type: object
+                              attributes:
+                                description: Map of implementation-dependant free-form
+                                  YAML attributes.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               commandType:
                                 description: Type of workspace command
                                 enum:
@@ -4808,6 +4859,8 @@ spec:
                                 description: Mandatory identifier that allows referencing
                                   this command in composite commands, from a parent,
                                   or in events.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               vscodeLaunch:
                                 description: Command providing the definition of a
@@ -4914,6 +4967,11 @@ spec:
                             - required:
                               - volume
                             properties:
+                              attributes:
+                                description: Map of implementation-dependant free-form
+                                  YAML attributes.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               componentType:
                                 description: Type of component
                                 enum:
@@ -4944,6 +5002,10 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  cpuLimit:
+                                    type: string
+                                  cpuRequest:
+                                    type: string
                                   dedicatedPod:
                                     description: "Specify if a container should run
                                       in its own separated pod, instead of running
@@ -4982,6 +5044,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5010,14 +5074,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -5043,6 +5110,8 @@ spec:
                                   image:
                                     type: string
                                   memoryLimit:
+                                    type: string
+                                  memoryRequest:
                                     type: string
                                   mountSources:
                                     description: "Toggles whether or not the project
@@ -5072,6 +5141,8 @@ spec:
                                             name then they will reuse the same volume
                                             and will be able to access to the same
                                             files.
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: The path in the component container
@@ -5127,6 +5198,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5155,14 +5228,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -5189,6 +5265,8 @@ spec:
                                   the component from other elements (such as commands)
                                   or from an external devfile that may reference this
                                   component through a parent or a plugin.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               openshift:
                                 description: Allows importing into the workspace the
@@ -5233,6 +5311,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5261,14 +5341,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -5294,6 +5377,10 @@ spec:
                                 description: Allows specifying the definition of a
                                   volume shared by several other components
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   size:
                                     description: Size of the volume
                                     type: string
@@ -5334,6 +5421,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         size:
                           description: Size of the volume
                           type: string
@@ -5439,6 +5530,11 @@ spec:
                                 this command to be used in Editor UI menus for example
                               type: string
                           type: object
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         commandType:
                           description: Type of workspace command
                           enum:
@@ -5557,6 +5653,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -5659,6 +5757,11 @@ spec:
                       - required:
                         - plugin
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         componentType:
                           description: Type of component
                           enum:
@@ -5690,6 +5793,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            cpuLimit:
+                              type: string
+                            cpuRequest:
+                              type: string
                             dedicatedPod:
                               description: "Specify if a container should run in its
                                 own separated pod, instead of running as part of the
@@ -5727,6 +5834,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5752,14 +5861,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -5786,6 +5898,8 @@ spec:
                               type: string
                             memoryLimit:
                               type: string
+                            memoryRequest:
+                              type: string
                             mountSources:
                               description: "Toggles whether or not the project source
                                 code should be mounted in the component. \n Defaults
@@ -5811,6 +5925,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -5864,6 +5980,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5889,14 +6007,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -5922,6 +6043,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -5965,6 +6088,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5990,14 +6115,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -6090,6 +6218,11 @@ spec:
                                           UI menus for example
                                         type: string
                                     type: object
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   commandType:
                                     description: Type of workspace command
                                     enum:
@@ -6216,6 +6349,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -6324,6 +6459,11 @@ spec:
                                 - required:
                                   - volume
                                 properties:
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   componentType:
                                     description: Type of component
                                     enum:
@@ -6355,6 +6495,10 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      cpuLimit:
+                                        type: string
+                                      cpuRequest:
+                                        type: string
                                       dedicatedPod:
                                         description: "Specify if a container should
                                           run in its own separated pod, instead of
@@ -6396,6 +6540,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6426,14 +6572,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -6459,6 +6609,8 @@ spec:
                                       image:
                                         type: string
                                       memoryLimit:
+                                        type: string
+                                      memoryRequest:
                                         type: string
                                       mountSources:
                                         description: "Toggles whether or not the project
@@ -6488,6 +6640,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -6547,6 +6701,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6577,14 +6733,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -6611,6 +6771,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -6659,6 +6821,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6689,14 +6853,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -6722,6 +6890,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -6760,6 +6933,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -6802,6 +6979,11 @@ spec:
                       - required:
                         - zip
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         clonePath:
                           description: Path relative to the root of the projects to
                             which this project should be cloned into. This is a unix-style
@@ -6866,6 +7048,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -6907,6 +7091,11 @@ spec:
                       - required:
                         - zip
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         description:
                           description: Description of a starter project
                           type: string
@@ -6966,6 +7155,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7087,6 +7278,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source
@@ -7202,6 +7395,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -7074,6 +7074,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -7124,6 +7129,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -8837,6 +8846,11 @@ spec:
                                         description: Configuration overriding for
                                           a Volume component in a plugin
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           name:
                                             description: Mandatory name that allows
                                               referencing the Volume component in
@@ -8890,6 +8904,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 name:
                                   description: Mandatory name that allows referencing
                                     the Volume component in Container volume mounts
@@ -9480,6 +9498,10 @@ spec:
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
                 type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
+                type: string
               phase:
                 type: string
               workspaceId:
@@ -9502,9 +9524,9 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: Url endpoint for accessing workspace
-      jsonPath: .status.ideUrl
-      name: URL
+    - description: Additional information about the workspace
+      jsonPath: .status.message
+      name: Info
       type: string
     name: v1alpha2
     schema:
@@ -9767,6 +9789,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -9911,6 +9935,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            cpuLimit:
+                              type: string
+                            cpuRequest:
+                              type: string
                             dedicatedPod:
                               description: "Specify if a container should run in its
                                 own separated pod, instead of running as part of the
@@ -9949,6 +9977,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -9975,14 +10005,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -10011,6 +10044,8 @@ spec:
                               type: string
                             memoryLimit:
                               type: string
+                            memoryRequest:
+                              type: string
                             mountSources:
                               description: "Toggles whether or not the project source
                                 code should be mounted in the component. \n Defaults
@@ -10037,6 +10072,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -10114,6 +10151,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -10140,14 +10179,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -10174,6 +10216,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -10218,6 +10262,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -10244,14 +10290,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -10345,6 +10394,11 @@ spec:
                                           UI menus for example
                                         type: string
                                     type: object
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   commandType:
                                     description: Type of workspace command
                                     enum:
@@ -10471,6 +10525,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -10579,6 +10635,11 @@ spec:
                                 - required:
                                   - volume
                                 properties:
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   componentType:
                                     description: Type of component
                                     enum:
@@ -10610,6 +10671,10 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      cpuLimit:
+                                        type: string
+                                      cpuRequest:
+                                        type: string
                                       dedicatedPod:
                                         description: "Specify if a container should
                                           run in its own separated pod, instead of
@@ -10651,6 +10716,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -10681,14 +10748,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -10714,6 +10785,8 @@ spec:
                                       image:
                                         type: string
                                       memoryLimit:
+                                        type: string
+                                      memoryRequest:
                                         type: string
                                       mountSources:
                                         description: "Toggles whether or not the project
@@ -10743,6 +10816,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -10802,6 +10877,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -10832,14 +10909,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -10866,6 +10947,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -10914,6 +10997,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -10944,14 +11029,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -10977,6 +11066,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -11017,6 +11111,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -11126,6 +11224,11 @@ spec:
                                     for example
                                   type: string
                               type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             commandType:
                               description: Type of workspace command
                               enum:
@@ -11249,6 +11352,8 @@ spec:
                               description: Mandatory identifier that allows referencing
                                 this command in composite commands, from a parent,
                                 or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             vscodeLaunch:
                               description: Command providing the definition of a VsCode
@@ -11355,6 +11460,11 @@ spec:
                           - required:
                             - plugin
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             componentType:
                               description: Type of component
                               enum:
@@ -11386,6 +11496,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
                                 dedicatedPod:
                                   description: "Specify if a container should run
                                     in its own separated pod, instead of running as
@@ -11424,6 +11538,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -11451,14 +11567,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -11484,6 +11603,8 @@ spec:
                                 image:
                                   type: string
                                 memoryLimit:
+                                  type: string
+                                memoryRequest:
                                   type: string
                                 mountSources:
                                   description: "Toggles whether or not the project
@@ -11512,6 +11633,8 @@ spec:
                                           If several containers mount the same volume
                                           name then they will reuse the same volume
                                           and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -11567,6 +11690,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -11594,14 +11719,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -11627,6 +11755,8 @@ spec:
                                 the component from other elements (such as commands)
                                 or from an external devfile that may reference this
                                 component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             openshift:
                               description: Allows importing into the workspace the
@@ -11671,6 +11801,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -11698,14 +11830,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -11800,6 +11935,11 @@ spec:
                                               in Editor UI menus for example
                                             type: string
                                         type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
                                       commandType:
                                         description: Type of workspace command
                                         enum:
@@ -11930,6 +12070,8 @@ spec:
                                         description: Mandatory identifier that allows
                                           referencing this command in composite commands,
                                           from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       vscodeLaunch:
                                         description: Command providing the definition
@@ -12039,6 +12181,11 @@ spec:
                                     - required:
                                       - volume
                                     properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
                                       componentType:
                                         description: Type of component
                                         enum:
@@ -12071,6 +12218,10 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
                                           dedicatedPod:
                                             description: "Specify if a container should
                                               run in its own separated pod, instead
@@ -12114,6 +12265,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -12148,7 +12301,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -12156,7 +12311,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -12183,6 +12339,8 @@ spec:
                                           image:
                                             type: string
                                           memoryLimit:
+                                            type: string
+                                          memoryRequest:
                                             type: string
                                           mountSources:
                                             description: "Toggles whether or not the
@@ -12215,6 +12373,8 @@ spec:
                                                     they will reuse the same volume
                                                     and will be able to access to
                                                     the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: The path in the component
@@ -12275,6 +12435,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -12309,7 +12471,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -12317,7 +12481,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -12345,6 +12510,8 @@ spec:
                                           as commands) or from an external devfile
                                           that may reference this component through
                                           a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       openshift:
                                         description: Allows importing into the workspace
@@ -12394,6 +12561,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -12428,7 +12597,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -12436,7 +12607,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -12462,6 +12634,11 @@ spec:
                                         description: Allows specifying the definition
                                           of a volume shared by several other components
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           size:
                                             description: Size of the volume
                                             type: string
@@ -12501,6 +12678,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 size:
                                   description: Size of the volume
                                   type: string
@@ -12544,6 +12725,11 @@ spec:
                           - required:
                             - zip
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             clonePath:
                               description: Path relative to the root of the projects
                                 to which this project should be cloned into. This
@@ -12610,6 +12796,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -12651,6 +12839,11 @@ spec:
                           - required:
                             - zip
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             description:
                               description: Description of a starter project
                               type: string
@@ -12712,6 +12905,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -12840,6 +13035,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -12962,6 +13159,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -13029,6 +13228,10 @@ spec:
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
                 type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
+                type: string
               phase:
                 type: string
               workspaceId:
@@ -13075,6 +13278,8 @@ spec:
     kind: DevWorkspaceTemplate
     listKind: DevWorkspaceTemplateList
     plural: devworkspacetemplates
+    shortNames:
+    - dwt
     singular: devworkspacetemplate
   scope: Namespaced
   versions:
@@ -14646,6 +14851,10 @@ spec:
                                 description: Configuration overriding for a Volume
                                   component in a plugin
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   name:
                                     description: Mandatory name that allows referencing
                                       the Volume component in Container volume mounts
@@ -14696,6 +14905,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         name:
                           description: Mandatory name that allows referencing the
                             Volume component in Container volume mounts or inside
@@ -16350,6 +16563,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -16400,6 +16618,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -17176,6 +17398,8 @@ spec:
                     id:
                       description: Mandatory identifier that allows referencing this
                         command in composite commands, from a parent, or in events.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     vscodeLaunch:
                       description: Command providing the definition of a VsCode launch
@@ -17316,6 +17540,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        cpuLimit:
+                          type: string
+                        cpuRequest:
+                          type: string
                         dedicatedPod:
                           description: "Specify if a container should run in its own
                             separated pod, instead of running as part of the main
@@ -17351,6 +17579,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -17375,14 +17605,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -17410,6 +17643,8 @@ spec:
                           type: string
                         memoryLimit:
                           type: string
+                        memoryRequest:
+                          type: string
                         mountSources:
                           description: "Toggles whether or not the project source
                             code should be mounted in the component. \n Defaults to
@@ -17436,6 +17671,8 @@ spec:
                                   mount the same volume name then they will reuse
                                   the same volume and will be able to access to the
                                   same files.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: The path in the component container where
@@ -17511,6 +17748,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -17535,14 +17774,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -17569,6 +17811,8 @@ spec:
                         from other elements (such as commands) or from an external
                         devfile that may reference this component through a parent
                         or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     openshift:
                       description: Allows importing into the workspace the OpenShift
@@ -17611,6 +17855,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -17635,14 +17881,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -17735,6 +17984,11 @@ spec:
                                       for example
                                     type: string
                                 type: object
+                              attributes:
+                                description: Map of implementation-dependant free-form
+                                  YAML attributes.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               commandType:
                                 description: Type of workspace command
                                 enum:
@@ -17859,6 +18113,8 @@ spec:
                                 description: Mandatory identifier that allows referencing
                                   this command in composite commands, from a parent,
                                   or in events.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               vscodeLaunch:
                                 description: Command providing the definition of a
@@ -17965,6 +18221,11 @@ spec:
                             - required:
                               - volume
                             properties:
+                              attributes:
+                                description: Map of implementation-dependant free-form
+                                  YAML attributes.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               componentType:
                                 description: Type of component
                                 enum:
@@ -17995,6 +18256,10 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  cpuLimit:
+                                    type: string
+                                  cpuRequest:
+                                    type: string
                                   dedicatedPod:
                                     description: "Specify if a container should run
                                       in its own separated pod, instead of running
@@ -18033,6 +18298,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -18061,14 +18328,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -18094,6 +18364,8 @@ spec:
                                   image:
                                     type: string
                                   memoryLimit:
+                                    type: string
+                                  memoryRequest:
                                     type: string
                                   mountSources:
                                     description: "Toggles whether or not the project
@@ -18123,6 +18395,8 @@ spec:
                                             name then they will reuse the same volume
                                             and will be able to access to the same
                                             files.
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: The path in the component container
@@ -18178,6 +18452,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -18206,14 +18482,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -18240,6 +18519,8 @@ spec:
                                   the component from other elements (such as commands)
                                   or from an external devfile that may reference this
                                   component through a parent or a plugin.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               openshift:
                                 description: Allows importing into the workspace the
@@ -18284,6 +18565,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -18312,14 +18595,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -18345,6 +18631,10 @@ spec:
                                 description: Allows specifying the definition of a
                                   volume shared by several other components
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   size:
                                     description: Size of the volume
                                     type: string
@@ -18385,6 +18675,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         size:
                           description: Size of the volume
                           type: string
@@ -18490,6 +18784,11 @@ spec:
                                 this command to be used in Editor UI menus for example
                               type: string
                           type: object
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         commandType:
                           description: Type of workspace command
                           enum:
@@ -18608,6 +18907,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -18710,6 +19011,11 @@ spec:
                       - required:
                         - plugin
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         componentType:
                           description: Type of component
                           enum:
@@ -18741,6 +19047,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            cpuLimit:
+                              type: string
+                            cpuRequest:
+                              type: string
                             dedicatedPod:
                               description: "Specify if a container should run in its
                                 own separated pod, instead of running as part of the
@@ -18778,6 +19088,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -18803,14 +19115,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -18837,6 +19152,8 @@ spec:
                               type: string
                             memoryLimit:
                               type: string
+                            memoryRequest:
+                              type: string
                             mountSources:
                               description: "Toggles whether or not the project source
                                 code should be mounted in the component. \n Defaults
@@ -18862,6 +19179,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -18915,6 +19234,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -18940,14 +19261,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -18973,6 +19297,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -19016,6 +19342,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -19041,14 +19369,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -19141,6 +19472,11 @@ spec:
                                           UI menus for example
                                         type: string
                                     type: object
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   commandType:
                                     description: Type of workspace command
                                     enum:
@@ -19267,6 +19603,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -19375,6 +19713,11 @@ spec:
                                 - required:
                                   - volume
                                 properties:
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   componentType:
                                     description: Type of component
                                     enum:
@@ -19406,6 +19749,10 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      cpuLimit:
+                                        type: string
+                                      cpuRequest:
+                                        type: string
                                       dedicatedPod:
                                         description: "Specify if a container should
                                           run in its own separated pod, instead of
@@ -19447,6 +19794,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -19477,14 +19826,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -19510,6 +19863,8 @@ spec:
                                       image:
                                         type: string
                                       memoryLimit:
+                                        type: string
+                                      memoryRequest:
                                         type: string
                                       mountSources:
                                         description: "Toggles whether or not the project
@@ -19539,6 +19894,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -19598,6 +19955,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -19628,14 +19987,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -19662,6 +20025,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -19710,6 +20075,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -19740,14 +20107,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -19773,6 +20144,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -19811,6 +20187,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -19853,6 +20233,11 @@ spec:
                       - required:
                         - zip
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         clonePath:
                           description: Path relative to the root of the projects to
                             which this project should be cloned into. This is a unix-style
@@ -19917,6 +20302,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -19958,6 +20345,11 @@ spec:
                       - required:
                         - zip
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         description:
                           description: Description of a starter project
                           type: string
@@ -20017,6 +20409,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -20138,6 +20532,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source
@@ -20253,6 +20649,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source

--- a/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -1666,6 +1666,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -1716,6 +1721,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -3429,6 +3438,11 @@ spec:
                                         description: Configuration overriding for
                                           a Volume component in a plugin
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           name:
                                             description: Mandatory name that allows
                                               referencing the Volume component in
@@ -3482,6 +3496,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 name:
                                   description: Mandatory name that allows referencing
                                     the Volume component in Container volume mounts
@@ -4072,6 +4090,10 @@ spec:
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
                 type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
+                type: string
               phase:
                 type: string
               workspaceId:
@@ -4094,9 +4116,9 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: Url endpoint for accessing workspace
-      jsonPath: .status.ideUrl
-      name: URL
+    - description: Additional information about the workspace
+      jsonPath: .status.message
+      name: Info
       type: string
     name: v1alpha2
     schema:
@@ -4359,6 +4381,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -4503,6 +4527,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            cpuLimit:
+                              type: string
+                            cpuRequest:
+                              type: string
                             dedicatedPod:
                               description: "Specify if a container should run in its
                                 own separated pod, instead of running as part of the
@@ -4541,6 +4569,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4567,14 +4597,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -4603,6 +4636,8 @@ spec:
                               type: string
                             memoryLimit:
                               type: string
+                            memoryRequest:
+                              type: string
                             mountSources:
                               description: "Toggles whether or not the project source
                                 code should be mounted in the component. \n Defaults
@@ -4629,6 +4664,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -4706,6 +4743,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4732,14 +4771,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -4766,6 +4808,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -4810,6 +4854,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4836,14 +4882,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -4937,6 +4986,11 @@ spec:
                                           UI menus for example
                                         type: string
                                     type: object
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   commandType:
                                     description: Type of workspace command
                                     enum:
@@ -5063,6 +5117,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -5171,6 +5227,11 @@ spec:
                                 - required:
                                   - volume
                                 properties:
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   componentType:
                                     description: Type of component
                                     enum:
@@ -5202,6 +5263,10 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      cpuLimit:
+                                        type: string
+                                      cpuRequest:
+                                        type: string
                                       dedicatedPod:
                                         description: "Specify if a container should
                                           run in its own separated pod, instead of
@@ -5243,6 +5308,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5273,14 +5340,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -5306,6 +5377,8 @@ spec:
                                       image:
                                         type: string
                                       memoryLimit:
+                                        type: string
+                                      memoryRequest:
                                         type: string
                                       mountSources:
                                         description: "Toggles whether or not the project
@@ -5335,6 +5408,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -5394,6 +5469,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5424,14 +5501,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -5458,6 +5539,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -5506,6 +5589,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5536,14 +5621,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -5569,6 +5658,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -5609,6 +5703,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -5718,6 +5816,11 @@ spec:
                                     for example
                                   type: string
                               type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             commandType:
                               description: Type of workspace command
                               enum:
@@ -5841,6 +5944,8 @@ spec:
                               description: Mandatory identifier that allows referencing
                                 this command in composite commands, from a parent,
                                 or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             vscodeLaunch:
                               description: Command providing the definition of a VsCode
@@ -5947,6 +6052,11 @@ spec:
                           - required:
                             - plugin
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             componentType:
                               description: Type of component
                               enum:
@@ -5978,6 +6088,10 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
                                 dedicatedPod:
                                   description: "Specify if a container should run
                                     in its own separated pod, instead of running as
@@ -6016,6 +6130,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6043,14 +6159,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -6076,6 +6195,8 @@ spec:
                                 image:
                                   type: string
                                 memoryLimit:
+                                  type: string
+                                memoryRequest:
                                   type: string
                                 mountSources:
                                   description: "Toggles whether or not the project
@@ -6104,6 +6225,8 @@ spec:
                                           If several containers mount the same volume
                                           name then they will reuse the same volume
                                           and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -6159,6 +6282,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6186,14 +6311,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -6219,6 +6347,8 @@ spec:
                                 the component from other elements (such as commands)
                                 or from an external devfile that may reference this
                                 component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             openshift:
                               description: Allows importing into the workspace the
@@ -6263,6 +6393,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6290,14 +6422,17 @@ spec:
                                           `http`"
                                         enum:
                                         - http
+                                        - https
                                         - ws
+                                        - wss
                                         - tcp
                                         - udp
                                         type: string
                                       secure:
                                         description: Describes whether the endpoint
                                           should be secured and protected by some
-                                          authentication process
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
                                         type: integer
@@ -6392,6 +6527,11 @@ spec:
                                               in Editor UI menus for example
                                             type: string
                                         type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
                                       commandType:
                                         description: Type of workspace command
                                         enum:
@@ -6522,6 +6662,8 @@ spec:
                                         description: Mandatory identifier that allows
                                           referencing this command in composite commands,
                                           from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       vscodeLaunch:
                                         description: Command providing the definition
@@ -6631,6 +6773,11 @@ spec:
                                     - required:
                                       - volume
                                     properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
                                       componentType:
                                         description: Type of component
                                         enum:
@@ -6663,6 +6810,10 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
                                           dedicatedPod:
                                             description: "Specify if a container should
                                               run in its own separated pod, instead
@@ -6706,6 +6857,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6740,7 +6893,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -6748,7 +6903,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -6775,6 +6931,8 @@ spec:
                                           image:
                                             type: string
                                           memoryLimit:
+                                            type: string
+                                          memoryRequest:
                                             type: string
                                           mountSources:
                                             description: "Toggles whether or not the
@@ -6807,6 +6965,8 @@ spec:
                                                     they will reuse the same volume
                                                     and will be able to access to
                                                     the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: The path in the component
@@ -6867,6 +7027,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6901,7 +7063,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -6909,7 +7073,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -6937,6 +7102,8 @@ spec:
                                           as commands) or from an external devfile
                                           that may reference this component through
                                           a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       openshift:
                                         description: Allows importing into the workspace
@@ -6986,6 +7153,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -7020,7 +7189,9 @@ spec:
                                                     `http`"
                                                   enum:
                                                   - http
+                                                  - https
                                                   - ws
+                                                  - wss
                                                   - tcp
                                                   - udp
                                                   type: string
@@ -7028,7 +7199,8 @@ spec:
                                                   description: Describes whether the
                                                     endpoint should be secured and
                                                     protected by some authentication
-                                                    process
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
                                                   type: integer
@@ -7054,6 +7226,11 @@ spec:
                                         description: Allows specifying the definition
                                           of a volume shared by several other components
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           size:
                                             description: Size of the volume
                                             type: string
@@ -7093,6 +7270,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 size:
                                   description: Size of the volume
                                   type: string
@@ -7136,6 +7317,11 @@ spec:
                           - required:
                             - zip
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             clonePath:
                               description: Path relative to the root of the projects
                                 to which this project should be cloned into. This
@@ -7202,6 +7388,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7243,6 +7431,11 @@ spec:
                           - required:
                             - zip
                           properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             description:
                               description: Description of a starter project
                               type: string
@@ -7304,6 +7497,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7432,6 +7627,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7554,6 +7751,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7620,6 +7819,10 @@ spec:
                 type: array
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
+                type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
                 type: string
               phase:
                 type: string

--- a/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -24,6 +24,8 @@ spec:
     kind: DevWorkspaceTemplate
     listKind: DevWorkspaceTemplateList
     plural: devworkspacetemplates
+    shortNames:
+    - dwt
     singular: devworkspacetemplate
   scope: Namespaced
   versions:
@@ -1595,6 +1597,10 @@ spec:
                                 description: Configuration overriding for a Volume
                                   component in a plugin
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   name:
                                     description: Mandatory name that allows referencing
                                       the Volume component in Container volume mounts
@@ -1645,6 +1651,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         name:
                           description: Mandatory name that allows referencing the
                             Volume component in Container volume mounts or inside
@@ -3299,6 +3309,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -3349,6 +3364,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -4125,6 +4144,8 @@ spec:
                     id:
                       description: Mandatory identifier that allows referencing this
                         command in composite commands, from a parent, or in events.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     vscodeLaunch:
                       description: Command providing the definition of a VsCode launch
@@ -4265,6 +4286,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        cpuLimit:
+                          type: string
+                        cpuRequest:
+                          type: string
                         dedicatedPod:
                           description: "Specify if a container should run in its own
                             separated pod, instead of running as part of the main
@@ -4300,6 +4325,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4324,14 +4351,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -4359,6 +4389,8 @@ spec:
                           type: string
                         memoryLimit:
                           type: string
+                        memoryRequest:
+                          type: string
                         mountSources:
                           description: "Toggles whether or not the project source
                             code should be mounted in the component. \n Defaults to
@@ -4385,6 +4417,8 @@ spec:
                                   mount the same volume name then they will reuse
                                   the same volume and will be able to access to the
                                   same files.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: The path in the component container where
@@ -4460,6 +4494,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4484,14 +4520,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -4518,6 +4557,8 @@ spec:
                         from other elements (such as commands) or from an external
                         devfile that may reference this component through a parent
                         or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     openshift:
                       description: Allows importing into the workspace the OpenShift
@@ -4560,6 +4601,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4584,14 +4627,17 @@ spec:
                                   an application protocol. \n Default value is `http`"
                                 enum:
                                 - http
+                                - https
                                 - ws
+                                - wss
                                 - tcp
                                 - udp
                                 type: string
                               secure:
                                 description: Describes whether the endpoint should
                                   be secured and protected by some authentication
-                                  process
+                                  process. This requires a protocol of `https` or
+                                  `wss`.
                                 type: boolean
                               targetPort:
                                 type: integer
@@ -4684,6 +4730,11 @@ spec:
                                       for example
                                     type: string
                                 type: object
+                              attributes:
+                                description: Map of implementation-dependant free-form
+                                  YAML attributes.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               commandType:
                                 description: Type of workspace command
                                 enum:
@@ -4808,6 +4859,8 @@ spec:
                                 description: Mandatory identifier that allows referencing
                                   this command in composite commands, from a parent,
                                   or in events.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               vscodeLaunch:
                                 description: Command providing the definition of a
@@ -4914,6 +4967,11 @@ spec:
                             - required:
                               - volume
                             properties:
+                              attributes:
+                                description: Map of implementation-dependant free-form
+                                  YAML attributes.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               componentType:
                                 description: Type of component
                                 enum:
@@ -4944,6 +5002,10 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  cpuLimit:
+                                    type: string
+                                  cpuRequest:
+                                    type: string
                                   dedicatedPod:
                                     description: "Specify if a container should run
                                       in its own separated pod, instead of running
@@ -4982,6 +5044,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5010,14 +5074,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -5043,6 +5110,8 @@ spec:
                                   image:
                                     type: string
                                   memoryLimit:
+                                    type: string
+                                  memoryRequest:
                                     type: string
                                   mountSources:
                                     description: "Toggles whether or not the project
@@ -5072,6 +5141,8 @@ spec:
                                             name then they will reuse the same volume
                                             and will be able to access to the same
                                             files.
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: The path in the component container
@@ -5127,6 +5198,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5155,14 +5228,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -5189,6 +5265,8 @@ spec:
                                   the component from other elements (such as commands)
                                   or from an external devfile that may reference this
                                   component through a parent or a plugin.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               openshift:
                                 description: Allows importing into the workspace the
@@ -5233,6 +5311,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5261,14 +5341,17 @@ spec:
                                             is `http`"
                                           enum:
                                           - http
+                                          - https
                                           - ws
+                                          - wss
                                           - tcp
                                           - udp
                                           type: string
                                         secure:
                                           description: Describes whether the endpoint
                                             should be secured and protected by some
-                                            authentication process
+                                            authentication process. This requires
+                                            a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
                                           type: integer
@@ -5294,6 +5377,10 @@ spec:
                                 description: Allows specifying the definition of a
                                   volume shared by several other components
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   size:
                                     description: Size of the volume
                                     type: string
@@ -5334,6 +5421,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         size:
                           description: Size of the volume
                           type: string
@@ -5439,6 +5530,11 @@ spec:
                                 this command to be used in Editor UI menus for example
                               type: string
                           type: object
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         commandType:
                           description: Type of workspace command
                           enum:
@@ -5557,6 +5653,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -5659,6 +5757,11 @@ spec:
                       - required:
                         - plugin
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         componentType:
                           description: Type of component
                           enum:
@@ -5690,6 +5793,10 @@ spec:
                               items:
                                 type: string
                               type: array
+                            cpuLimit:
+                              type: string
+                            cpuRequest:
+                              type: string
                             dedicatedPod:
                               description: "Specify if a container should run in its
                                 own separated pod, instead of running as part of the
@@ -5727,6 +5834,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5752,14 +5861,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -5786,6 +5898,8 @@ spec:
                               type: string
                             memoryLimit:
                               type: string
+                            memoryRequest:
+                              type: string
                             mountSources:
                               description: "Toggles whether or not the project source
                                 code should be mounted in the component. \n Defaults
@@ -5811,6 +5925,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -5864,6 +5980,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5889,14 +6007,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -5922,6 +6043,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -5965,6 +6088,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5990,14 +6115,17 @@ spec:
                                       value is `http`"
                                     enum:
                                     - http
+                                    - https
                                     - ws
+                                    - wss
                                     - tcp
                                     - udp
                                     type: string
                                   secure:
                                     description: Describes whether the endpoint should
                                       be secured and protected by some authentication
-                                      process
+                                      process. This requires a protocol of `https`
+                                      or `wss`.
                                     type: boolean
                                   targetPort:
                                     type: integer
@@ -6090,6 +6218,11 @@ spec:
                                           UI menus for example
                                         type: string
                                     type: object
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   commandType:
                                     description: Type of workspace command
                                     enum:
@@ -6216,6 +6349,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -6324,6 +6459,11 @@ spec:
                                 - required:
                                   - volume
                                 properties:
+                                  attributes:
+                                    description: Map of implementation-dependant free-form
+                                      YAML attributes.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
                                   componentType:
                                     description: Type of component
                                     enum:
@@ -6355,6 +6495,10 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      cpuLimit:
+                                        type: string
+                                      cpuRequest:
+                                        type: string
                                       dedicatedPod:
                                         description: "Specify if a container should
                                           run in its own separated pod, instead of
@@ -6396,6 +6540,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6426,14 +6572,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -6459,6 +6609,8 @@ spec:
                                       image:
                                         type: string
                                       memoryLimit:
+                                        type: string
+                                      memoryRequest:
                                         type: string
                                       mountSources:
                                         description: "Toggles whether or not the project
@@ -6488,6 +6640,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -6547,6 +6701,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6577,14 +6733,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -6611,6 +6771,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -6659,6 +6821,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6689,14 +6853,18 @@ spec:
                                                 is `http`"
                                               enum:
                                               - http
+                                              - https
                                               - ws
+                                              - wss
                                               - tcp
                                               - udp
                                               type: string
                                             secure:
                                               description: Describes whether the endpoint
                                                 should be secured and protected by
-                                                some authentication process
+                                                some authentication process. This
+                                                requires a protocol of `https` or
+                                                `wss`.
                                               type: boolean
                                             targetPort:
                                               type: integer
@@ -6722,6 +6890,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -6760,6 +6933,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -6802,6 +6979,11 @@ spec:
                       - required:
                         - zip
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         clonePath:
                           description: Path relative to the root of the projects to
                             which this project should be cloned into. This is a unix-style
@@ -6866,6 +7048,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -6907,6 +7091,11 @@ spec:
                       - required:
                         - zip
                       properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         description:
                           description: Description of a starter project
                           type: string
@@ -6966,6 +7155,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7087,6 +7278,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source
@@ -7202,6 +7395,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -84,7 +84,7 @@ if $USE_DEFAULT_ENV; then
   export DWO_IMG=${DEFAULT_IMAGE:-"quay.io/devfile/devworkspace-controller:next"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic
-  export DEVWORKSPACE_API_VERSION=aeda60d4361911da85103f224644bfa792498499
+  export DEVWORKSPACE_API_VERSION=283b0c54946e9fea9872c25e1e086c303688f0e8
   export ROUTING_SUFFIX=""
   export FORCE_DEVWORKSPACE_CRDS_UPDATE=true
 fi


### PR DESCRIPTION
### What does this PR do?
It's just a quick fix to update default deployment to the desired, but we would need to rework how we define devfile CRDs to avoid such desync in future.

### What issues does this PR fix or reference?
No issue is created but it fixes:

```
error: error validating "samples/plugins/theia-next.yaml": error validating data: ValidationError(DevWorkspaceTemplate.spec.components[1].volume): unknown field "ephemeral" in io.devfile.workspace.v1alpha2.DevWorkspaceTemplate.spec.components.volume; if you choose to ignore these errors, turn validation off with --validate=false
```
when you try to create devworkspace with ephemeral volume used on the default deployment.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
