### PR TITLE
Fix accidentally applying flattened DW to cluster in reconcile

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -177,8 +177,8 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	// Set finalizer on DevWorkspace if necessary
 	// Note: we need to check the flattened workspace to see if a finalizer is needed, as plugins could require storage
 	if isFinalizerNecessary(workspace) {
-		coputil.AddFinalizer(workspace, pvcCleanupFinalizer)
-		if err := r.Update(ctx, workspace); err != nil {
+		coputil.AddFinalizer(clusterWorkspace, pvcCleanupFinalizer)
+		if err := r.Update(ctx, clusterWorkspace); err != nil {
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
### What does this PR do?
We're accidentally applying the flattened DevWorkspace content to the cluster, overwriting the original file. This PR is a minor fixup to avoid that issue, but we should improve this in the future to better delineate the 'working copy' flattened DevWorkspace from the DevWorkspace that exists on the cluster.

### What issues does this PR fix or reference?


### Is it tested? How?
1. `kubectl apply -f samples/with-k8s-ref/theia-next.yaml`
2. Wait for workspace to be waiting for deployment and check that resource on cluster is unchanged (e.g. `kubectl apply -f samples/with-k8s-ref/theia-next.yaml` a second time should report `devworkspace.workspace.devfile.io/theia unchanged`

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
