### PR TITLE
Introduce latest web terminal plugin version

### DIFF
--- a/internal-registry/redhat-developer/web-terminal-dev/latest/devworkspacetemplate.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/latest/devworkspacetemplate.yaml
@@ -1,0 +1,26 @@
+kind: DevWorkspaceTemplate
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: web-terminal-dev
+spec:
+  components:
+    - name: web-terminal
+      container:
+        image: "quay.io/eclipse/che-machine-exec:nightly"
+        command: ["/go/bin/che-machine-exec",
+                  "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+                  "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
+                  "--pod-selector", "controller.devfile.io/workspace_id=$(DEVWORKSPACE_ID)",
+                  "--use-bearer-token"]
+        endpoints:
+          - name: web-terminal
+            targetPort: 4444
+            secure: true
+            exposure: public
+            protocol: http
+            attributes:
+              type: ide
+        mountSources: false
+        env:
+          - name: USE_BEARER_TOKEN
+            value: "true"

--- a/internal-registry/redhat-developer/web-terminal/latest/devworkspacetemplate.yaml
+++ b/internal-registry/redhat-developer/web-terminal/latest/devworkspacetemplate.yaml
@@ -1,0 +1,27 @@
+kind: DevWorkspaceTemplate
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: web-terminal
+spec:
+  components:
+    - name: web-terminal
+      container:
+        image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0}"
+        command: ["/go/bin/che-machine-exec",
+                  "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+                  "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
+                  "--pod-selector", "controller.devfile.io/workspace_id=$(DEVWORKSPACE_ID)",
+                  "--use-bearer-token",
+                  "--use-tls"]
+        endpoints:
+          - name: web-terminal
+            targetPort: 4444
+            secure: true
+            exposure: internal
+            protocol: http
+            attributes:
+              type: ide
+        mountSources: false
+        env:
+          - name: USE_BEARER_TOKEN
+            value: "true"

--- a/samples/web-terminal-custom-tooling.yaml
+++ b/samples/web-terminal-custom-tooling.yaml
@@ -14,7 +14,7 @@ spec:
     components:
       - plugin:
           name: web-terminal
-          id: redhat-developer/web-terminal/4.5.0
+          id: redhat-developer/web-terminal/latest
       - container:
           memoryLimit: "256Mi"
           name: tooling

--- a/samples/web-terminal-dev.yaml
+++ b/samples/web-terminal-dev.yaml
@@ -14,4 +14,4 @@ spec:
     components:
       - plugin:
           name: web-terminal
-          id: redhat-developer/web-terminal-dev/4.5.0
+          id: redhat-developer/web-terminal-dev/latest

--- a/samples/web-terminal.yaml
+++ b/samples/web-terminal.yaml
@@ -14,4 +14,4 @@ spec:
     components:
       - plugin:
           name: web-terminal
-          id: redhat-developer/web-terminal/4.5.0
+          id: redhat-developer/web-terminal/latest


### PR DESCRIPTION
### What does this PR do?
It's possible way to fix https://issues.redhat.com/browse/WTO-65, I'm a bit tired to see 4.5.0 on the all  OpenShift versions. But we can't simply remove 4.5.0 versions not to break existing instances.

It will be needed to cherry-pick in to v1alphax branch if we decide it's a good idea.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/WTO-65

### Is it tested? How?
tested that web terminal started.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
