### PR TITLE
fix hanging terminal

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -60,6 +60,9 @@ const (
 	// Stopped by Annotation holds the information as to why a workspace has stopped
 	StoppedByAnnotation = "controller.devfile.io/stopped-by"
 
+	// WebhookRestartAtAnnotation holds the the time (unixnano) of when the webhook server was forced to restart by controller
+	WebhookRestartedAtAnnotation = "controller.devfile.io/restarted-at"
+
 	// ControllerServiceAccountNameEnvVar stores the name of the serviceaccount used in the controller.
 	ControllerServiceAccountNameEnvVar = "CONTROLLER_SERVICE_ACCOUNT_NAME"
 )

--- a/pkg/webhook/deployment.go
+++ b/pkg/webhook/deployment.go
@@ -14,12 +14,10 @@ package webhook
 
 import (
 	"context"
-
+	"github.com/devfile/devworkspace-operator/internal/images"
+	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/webhook/server"
 
-	"github.com/devfile/devworkspace-operator/internal/images"
-
-	"github.com/devfile/devworkspace-operator/pkg/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -89,9 +87,10 @@ func getSpecDeployment(namespace string) (*appsv1.Deployment, error) {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      server.WebhookServerDeploymentName,
-					Namespace: namespace,
-					Labels:    server.WebhookServerAppLabels(),
+					Name:        server.WebhookServerDeploymentName,
+					Namespace:   namespace,
+					Labels:      server.WebhookServerAppLabels(),
+					Annotations: server.WebhookServerAppAnnotations(),
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -14,8 +14,12 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/devfile/devworkspace-operator/internal/cluster"
+	"github.com/devfile/devworkspace-operator/pkg/config"
+
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -49,6 +53,17 @@ var WebhookServerAppLabels = func() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":    WebhookServerAppName,
 		"app.kubernetes.io/part-of": "devworkspace-operator",
+	}
+}
+
+var WebhookServerAppAnnotations = func() map[string]string {
+	//Add restart timestamp which will update the webhook server
+	//deployment to force restart. This is done so that the
+	//serviceaccount uid is updated to use the latest and the
+	//web-terminal does not hang.
+	now := time.Now()
+	return map[string]string{
+		config.WebhookRestartedAtAnnotation: strconv.FormatInt(now.UnixNano(), 10),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR forces the webhook-server to restart by updating the webhook-server deployment with an arbitrary annotation that contains the time at which the pod was restarted.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/WTO-77

### Is it tested? How?
Reproduced the issue by installing, uninstalling and re-installing the web-terminal. The following are the screenshots of each stage and the terminal starting: 

Shows the pod restarting
![image (3)](https://user-images.githubusercontent.com/40298444/111677399-8f8c3580-87f5-11eb-93c2-5d0ea7ad16ab.png)

Pod has restarted
![image (4)](https://user-images.githubusercontent.com/40298444/111677409-931fbc80-87f5-11eb-8691-350baaebac65.png)

Timestamp in webhook deployment
![image (5)](https://user-images.githubusercontent.com/40298444/111677426-974bda00-87f5-11eb-9657-43d2b0f81054.png)

Terminal starting after re-install
![image (6)](https://user-images.githubusercontent.com/40298444/111677435-9a46ca80-87f5-11eb-920b-98496591a498.png)

