### PR TITLE
fix hanging terminal

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -79,6 +79,9 @@ const (
 	// this annotation will be cleared
 	WorkspaceStopReasonAnnotation = "controller.devfile.io/stopped-by"
 
+	// WebhookRestartedAtAnnotation holds the the time (unixnano) of when the webhook server was forced to restart by controller
+	WebhookRestartedAtAnnotation = "controller.devfile.io/restarted-at"
+
 	// PVCCleanupPodMemoryLimit is the memory limit used for PVC clean up pods
 	PVCCleanupPodMemoryLimit = "100Mi"
 

--- a/pkg/webhook/deployment.go
+++ b/pkg/webhook/deployment.go
@@ -92,9 +92,10 @@ func getSpecDeployment(webhooksSecretName, namespace string) (*appsv1.Deployment
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      server.WebhookServerDeploymentName,
-					Namespace: namespace,
-					Labels:    server.WebhookServerAppLabels(),
+					Name:        server.WebhookServerDeploymentName,
+					Namespace:   namespace,
+					Labels:      server.WebhookServerAppLabels(),
+					Annotations: server.WebhookServerAppAnnotations(),
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -14,7 +14,10 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"strconv"
+	"time"
 
+	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -51,6 +54,17 @@ var WebhookServerAppLabels = func() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":    WebhookServerAppName,
 		"app.kubernetes.io/part-of": "devworkspace-operator",
+	}
+}
+
+var WebhookServerAppAnnotations = func() map[string]string {
+	//Add restart timestamp which will update the webhook server
+	//deployment to force restart. This is done so that the
+	//serviceaccount uid is updated to use the latest and the
+	//web-terminal does not hang.
+	now := time.Now()
+	return map[string]string{
+		constants.WebhookRestartedAtAnnotation: strconv.FormatInt(now.UnixNano(), 10),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR forces the webhook-server to restart by updating the webhook-server deployment with an arbitrary annotation that contains the time at which the pod was restarted.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/WTO-77

### Is it tested? How?
Tested via PR on alphax: https://github.com/devfile/devworkspace-operator/pull/335