### PR TITLE
Fixups to async storage

### DIFF
--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -101,13 +101,8 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 	return reconcile.Result{}, r.Update(ctx, workspace)
 }
 
-func isFinalizerNecessary(workspace *devworkspace.DevWorkspace) bool {
-	storageProvisioner, err := storage.GetProvisioner(workspace)
-	if err != nil {
-		// Return false here since storage isn't needed for invalid workspaces
-		return false
-	}
-	return storageProvisioner.NeedsStorage(&workspace.Spec.Template)
+func isFinalizerNecessary(workspace *devworkspace.DevWorkspace, provisioner storage.Provisioner) bool {
+	return provisioner.NeedsStorage(&workspace.Spec.Template)
 }
 
 func (r *DevWorkspaceReconciler) namespaceIsTerminating(ctx context.Context, namespace string) (bool, error) {

--- a/controllers/workspace/provision/rbac.go
+++ b/controllers/workspace/provision/rbac.go
@@ -28,8 +28,8 @@ import (
 func SyncRBAC(workspace *devworkspace.DevWorkspace, client client.Client, reqLogger logr.Logger) ProvisioningStatus {
 	rbac := generateRBAC(workspace.Namespace)
 
-	didChange, err := SyncMutableObjects(rbac, client, reqLogger)
-	return ProvisioningStatus{Continue: !didChange, Err: err}
+	requeue, err := SyncMutableObjects(rbac, client, reqLogger)
+	return ProvisioningStatus{Continue: !requeue, Err: err}
 }
 
 func generateRBAC(namespace string) []runtime.Object {

--- a/pkg/provision/storage/doc.go
+++ b/pkg/provision/storage/doc.go
@@ -14,7 +14,8 @@
 // volume components in a devfile. These functions also handle mounting project sources to containers that require it.
 //
 // TODO:
-// - Add functionality for generating PVCs with the appropriate size based on size requests in the devfile
+// - Figure out how to handle 'size' parameter on volumes, given that we can't meaningfully use it for
+//   common PVC-type storage
 // - Devfile API spec is unclear on how mountSources should be handled -- mountPath is assumed to be /projects
 //   and volume name is assumed to be "projects"
 //   see issues:

--- a/pkg/provision/storage/shared.go
+++ b/pkg/provision/storage/shared.go
@@ -83,11 +83,11 @@ func syncCommonPVC(namespace string, clusterAPI provision.ClusterAPI) (*corev1.P
 	if err != nil {
 		return nil, err
 	}
-	currObject, didChange, err := provision.SyncObject(pvc, clusterAPI.Client, clusterAPI.Logger, false)
+	currObject, requeue, err := provision.SyncObject(pvc, clusterAPI.Client, clusterAPI.Logger, false)
 	if err != nil {
 		return nil, err
 	}
-	if didChange {
+	if requeue {
 		return nil, &NotReadyError{
 			Message: "Updated common PVC on cluster",
 		}


### PR DESCRIPTION
### What does this PR do?
This PR addresses some non-single-line fixes from review on https://github.com/devfile/devworkspace-operator/pull/296:
- https://github.com/devfile/devworkspace-operator/pull/296#discussion_r596653750
- https://github.com/devfile/devworkspace-operator/pull/296#discussion_r596681476
- https://github.com/devfile/devworkspace-operator/pull/296#discussion_r596722914

It does not address one open question from review:
- https://github.com/devfile/devworkspace-operator/pull/296#discussion_r596714302
as I'm not sure it makes sense to go in this direction.

Let me know if there's any comments I missed here and I'll add them to the PR.

### What issues does this PR fix or reference?
Follow up to https://github.com/devfile/devworkspace-operator/pull/296

### Is it tested? How?
Should functionally be no changes. For testing async workspaces, there is the process from the original PR:
> This PR adds a yaml file: `samples/with-k8s-ref/async-theia-next.yaml`, which is the usual theia-next sample with async storage enabled. This can be used to test basic use cases (create workspace, change a file, stop workspace, restart workspace -- note it takes a second for the files to repopulate after startup). 
> 
> To test cleanup, it's necessary to ssh into either a dedicated pod or the async storage server and check the contents of `/async-storage`. A flow that does this is
> ```bash
> kubectl apply -f samples/with-k8s-ref/async-theia-next.yaml
> # wait started; change file; stop workspace; wait till workspace pods terminated
> kubectl exec -it async-storage-xxxxx -- /bin/sh
> # ls -al /async-storage, look at files
> yq -y '.metadata.name = "alt-theia-next"' samples/with-k8s-ref/async-theia-next.yaml | kubectl apply -f -
> # note: this image won't be able to sync due to issue described above
> kubectl patch dw alt-theia-next --type merge -p '{"spec": {"started": false}}'
> kubectl delete dw theia # Delete initial workspace
> kubectl exec -it async-storage-xxxxx -- ls -al /async-storage # should be empty
> kubectl delete dw alt-theia-next
> # should be no async-storage deployment left on cluster after all workspaces deleted.
> ```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
