### PR TITLE
Improve condition handling to better represent workspace state

### DIFF
--- a/controllers/workspace/condition.go
+++ b/controllers/workspace/condition.go
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package controllers
+
+import (
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	PullSecretsReady     dw.WorkspaceConditionType = "PullSecretsReady"
+	DevWorkspaceResolved dw.WorkspaceConditionType = "DevWorkspaceResolved"
+	StorageReady         dw.WorkspaceConditionType = "StorageReady"
+	DeploymentReady      dw.WorkspaceConditionType = "DeploymentReady"
+)
+
+var conditionOrder = []dw.WorkspaceConditionType{
+	DevWorkspaceResolved,
+	StorageReady,
+	dw.WorkspaceRoutingReady,
+	dw.WorkspaceServiceAccountReady,
+	PullSecretsReady,
+	DeploymentReady,
+	dw.WorkspaceReady,
+}
+
+// workspaceConditions is a description of last-observed workspace conditions.
+type workspaceConditions struct {
+	conditions map[dw.WorkspaceConditionType]dw.WorkspaceCondition
+}
+
+func (c *workspaceConditions) setConditionTrue(conditionType dw.WorkspaceConditionType, msg string) {
+	c.conditions[conditionType] = dw.WorkspaceCondition{
+		Status:  corev1.ConditionTrue,
+		Message: msg,
+	}
+}
+
+func (c *workspaceConditions) setConditionFalse(conditionType dw.WorkspaceConditionType, msg string) {
+	c.conditions[conditionType] = dw.WorkspaceCondition{
+		Status:  corev1.ConditionFalse,
+		Message: msg,
+	}
+}
+
+// getFirstFalse checks current conditions in a set order (defined by conditionOrder) and returns the first
+// condition with a 'false' status. Returns nil if there is no currently observed false condition
+func (c *workspaceConditions) getFirstFalse() *dw.WorkspaceCondition {
+	for _, cond := range conditionOrder {
+		if condition, present := c.conditions[cond]; present && condition.Status == corev1.ConditionFalse {
+			return &condition
+		}
+	}
+	return nil
+}

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -47,14 +47,6 @@ import (
 	devworkspace "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
-type currentStatus struct {
-	// Map of condition types that are true for the current workspace. Key is valid condition, value is optional
-	// message to be filled into condition's 'Message' field.
-	Conditions map[devworkspace.WorkspaceConditionType]string
-	// Current workspace phase
-	Phase devworkspace.WorkspacePhase
-}
-
 // DevWorkspaceReconciler reconciles a DevWorkspace object
 type DevWorkspaceReconciler struct {
 	client.Client
@@ -132,10 +124,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	}
 
 	// Prepare handling workspace status and condition
-	reconcileStatus := currentStatus{
-		Conditions: map[devworkspace.WorkspaceConditionType]string{},
-		Phase:      devworkspace.WorkspaceStatusStarting,
-	}
+	reconcileStatus := initCurrentStatus()
 	clusterWorkspace := workspace.DeepCopy()
 	timingInfo := map[string]string{}
 	timing.SetTime(timingInfo, timing.WorkspaceStarted)
@@ -171,19 +160,13 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), reqLogger, &reconcileStatus)
 	}
 	workspace.Spec.Template = *flattenedWorkspace
+	reconcileStatus.setConditionTrue(DevWorkspaceResolved, "")
 
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {
-		reqLogger.Info("DevWorkspace start failed")
-		// Clean up cluster deployment
-		scaleErr := provision.ScaleDeploymentToZero(workspace, r.Client)
-		if scaleErr != nil {
-			return reconcile.Result{}, scaleErr
-		}
-		reconcileStatus.Phase = devworkspace.WorkspaceStatusFailed
-		reconcileStatus.Conditions[devworkspace.WorkspaceFailedStart] = fmt.Sprintf("Error provisioning storage: %s", err)
-		return reconcile.Result{}, nil
+		return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", err), reqLogger, &reconcileStatus)
 	}
+
 	// Set finalizer on DevWorkspace if necessary
 	// Note: we need to check the flattened workspace to see if a finalizer is needed, as plugins could require storage
 	if isFinalizerNecessary(workspace, storageProvisioner) {
@@ -203,6 +186,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		switch storageErr := err.(type) {
 		case *storage.NotReadyError:
 			reqLogger.Info(storageErr.Message)
+			reconcileStatus.setConditionFalse(StorageReady, fmt.Sprintf("Provisioning storage: %s", storageErr.Message))
 			return reconcile.Result{Requeue: true, RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
 			return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", storageErr), reqLogger, &reconcileStatus)
@@ -210,10 +194,9 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 			return reconcile.Result{}, storageErr
 		}
 	}
+	reconcileStatus.setConditionTrue(StorageReady, "")
 
 	shimlib.FillDefaultEnvVars(devfilePodAdditions, *workspace)
-
-	reconcileStatus.Conditions[devworkspace.WorkspaceComponentsReady] = ""
 	timing.SetTime(timingInfo, timing.ComponentsReady)
 
 	rbacStatus := provision.SyncRBAC(workspace, r.Client, reqLogger)
@@ -230,9 +213,10 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 			return r.failWorkspace(workspace, "Failed to install network objects required for devworkspace", reqLogger, &reconcileStatus)
 		}
 		reqLogger.Info("Waiting on routing to be ready")
+		reconcileStatus.setConditionFalse(devworkspace.WorkspaceRoutingReady, "Preparing networking")
 		return reconcile.Result{Requeue: routingStatus.Requeue}, routingStatus.Err
 	}
-	reconcileStatus.Conditions[devworkspace.WorkspaceRoutingReady] = ""
+	reconcileStatus.setConditionTrue(devworkspace.WorkspaceRoutingReady, "")
 	timing.SetTime(timingInfo, timing.RoutingReady)
 
 	statusOk, err := syncWorkspaceIdeURL(clusterWorkspace, routingStatus.ExposedEndpoints, clusterAPI)
@@ -276,17 +260,19 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	if !serviceAcctStatus.Continue {
 		// FailStartup is not possible for generating the serviceaccount
 		reqLogger.Info("Waiting for workspace ServiceAccount")
+		reconcileStatus.setConditionFalse(devworkspace.WorkspaceServiceAccountReady, "Waiting for devworkspace ServiceAccount")
 		return reconcile.Result{Requeue: serviceAcctStatus.Requeue}, serviceAcctStatus.Err
 	}
 	serviceAcctName := serviceAcctStatus.ServiceAccountName
-	reconcileStatus.Conditions[devworkspace.WorkspaceServiceAccountReady] = ""
+	reconcileStatus.setConditionTrue(devworkspace.WorkspaceServiceAccountReady, "")
 
 	pullSecretStatus := provision.PullSecrets(clusterAPI)
 	if !pullSecretStatus.Continue {
+		reconcileStatus.setConditionFalse(PullSecretsReady, "Waiting for DevWorkspace pull secrets")
 		return reconcile.Result{Requeue: pullSecretStatus.Requeue}, pullSecretStatus.Err
 	}
 	allPodAdditions = append(allPodAdditions, pullSecretStatus.PodAdditions)
-	reconcileStatus.Conditions[PullSecretsReadyCondition] = ""
+	reconcileStatus.setConditionTrue(PullSecretsReady, "")
 
 	// Step six: Create deployment and wait for it to be ready
 	timing.SetTime(timingInfo, timing.DeploymentCreated)
@@ -296,9 +282,10 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 			return r.failWorkspace(workspace, fmt.Sprintf("DevWorkspace spec is invalid: %s", deploymentStatus.Err), reqLogger, &reconcileStatus)
 		}
 		reqLogger.Info("Waiting on deployment to be ready")
+		reconcileStatus.setConditionFalse(DeploymentReady, "Waiting for workspace deployment")
 		return reconcile.Result{Requeue: deploymentStatus.Requeue}, deploymentStatus.Err
 	}
-	reconcileStatus.Conditions[devworkspace.WorkspaceReady] = ""
+	reconcileStatus.setConditionTrue(DeploymentReady, "")
 	timing.SetTime(timingInfo, timing.DeploymentReady)
 
 	serverReady, err := checkServerStatus(clusterWorkspace)
@@ -306,11 +293,13 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return reconcile.Result{}, err
 	}
 	if !serverReady {
+		reconcileStatus.setConditionFalse(devworkspace.WorkspaceReady, "Waiting for editor to start")
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 	timing.SetTime(timingInfo, timing.WorkspaceReady)
 	timing.SummarizeStartup(clusterWorkspace)
-	reconcileStatus.Phase = devworkspace.WorkspaceStatusRunning
+	reconcileStatus.setConditionTrue(devworkspace.WorkspaceReady, "")
+	reconcileStatus.phase = devworkspace.WorkspaceStatusRunning
 	return reconcile.Result{}, nil
 }
 
@@ -324,13 +313,13 @@ func (r *DevWorkspaceReconciler) stopWorkspace(workspace *devworkspace.DevWorksp
 	err := r.Get(context.TODO(), namespaceName, workspaceDeployment)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
-			status.Phase = devworkspace.WorkspaceStatusStopped
+			status.phase = devworkspace.WorkspaceStatusStopped
 			return r.updateWorkspaceStatus(workspace, logger, status, reconcile.Result{}, nil)
 		}
 		return reconcile.Result{}, err
 	}
 
-	status.Phase = devworkspace.WorkspaceStatusStopping
+	status.phase = devworkspace.WorkspaceStatusStopping
 	replicas := workspaceDeployment.Spec.Replicas
 	if replicas == nil || *replicas > 0 {
 		logger.Info("Stopping workspace")
@@ -346,7 +335,7 @@ func (r *DevWorkspaceReconciler) stopWorkspace(workspace *devworkspace.DevWorksp
 
 	if workspaceDeployment.Status.Replicas == 0 {
 		logger.Info("Workspace stopped")
-		status.Phase = devworkspace.WorkspaceStatusStopped
+		status.phase = devworkspace.WorkspaceStatusStopped
 	}
 	return r.updateWorkspaceStatus(workspace, logger, status, reconcile.Result{}, nil)
 }
@@ -362,8 +351,8 @@ func (r *DevWorkspaceReconciler) failWorkspace(workspace *devworkspace.DevWorksp
 		// Return error here without setting phase to failed in order to retry cleaning the deployment
 		return reconcile.Result{}, err
 	}
-	status.Phase = devworkspace.WorkspaceStatusFailed
-	status.Conditions[devworkspace.WorkspaceFailedStart] = msg
+	status.phase = devworkspace.WorkspaceStatusFailed
+	status.setConditionTrue(devworkspace.WorkspaceFailedStart, msg)
 	return reconcile.Result{}, nil
 }
 

--- a/samples/with-k8s-ref/async-theia-next.yaml
+++ b/samples/with-k8s-ref/async-theia-next.yaml
@@ -8,7 +8,7 @@ spec:
   started: true
   template:
     projects:
-      - name: project
+      - name: web-nodejs-sample
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"

--- a/samples/with-k8s-ref/theia-next.yaml
+++ b/samples/with-k8s-ref/theia-next.yaml
@@ -6,7 +6,7 @@ spec:
   started: true
   template:
     projects:
-      - name: project
+      - name: web-nodejs-sample
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"

--- a/samples/with-k8s-ref/theia-nodejs.yaml
+++ b/samples/with-k8s-ref/theia-nodejs.yaml
@@ -6,7 +6,7 @@ spec:
   started: true
   template:
     projects:
-      - name: project
+      - name: web-nodejs-sample
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"


### PR DESCRIPTION
### What does this PR do?
Improves how we handle conditions to allow multiple "waiting" messages to be defined, and explicitly set conditions to be false when we know they're not true (e.g. if we're waiting for routing, it makes sense to set the RoutingReady condition to false).

Since we already have a condition for `PullSecretsReady`, I figured I'd add a few more for big steps in workspace startup. Semantically, the only changed usage is `WorkspaceReady` is now true when the workspace is in the running phase (whereas previously we still had to wait for the editor).

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/337

### Is it tested? How?
1. Deploy operator as normal
2. `kubectl apply -f samples/with-k8s-ref/theia-next.yaml && kubectl get dw -w`
3. Observe status conditions progressing as workspace starts up.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
