### PR TITLE
Use space for default image parameter during release

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -112,7 +112,7 @@ docker build -t "${QUAY_REPO}" -f ./build/Dockerfile .
 docker push "${QUAY_REPO}"
 
 set -x
-bash -x ./deploy/generate-deployment.sh --use-defaults --default-image="quay.io/devfile/devworkspace-controller:${VERSION}"
+bash -x ./deploy/generate-deployment.sh --use-defaults --default-image quay.io/devfile/devworkspace-controller:${VERSION}"
 # tag the release
 git tag "${VERSION}"
 git push origin "${VERSION}"

--- a/make-release.sh
+++ b/make-release.sh
@@ -112,7 +112,7 @@ docker build -t "${QUAY_REPO}" -f ./build/Dockerfile .
 docker push "${QUAY_REPO}"
 
 set -x
-bash -x ./deploy/generate-deployment.sh --use-defaults --default-image quay.io/devfile/devworkspace-controller:${VERSION}"
+bash -x ./deploy/generate-deployment.sh --use-defaults --default-image quay.io/devfile/devworkspace-controller:${VERSION}
 # tag the release
 git tag "${VERSION}"
 git push origin "${VERSION}"


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

### What does this PR do?
Fix parameter for generate-deployment.sh usage during release

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
