### PR TITLE
Add terminating phase for workspaces waiting on finalizers

### DIFF
--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -30,6 +30,9 @@ import (
 
 const (
 	storageCleanupFinalizer = "storage.controller.devfile.io"
+	// devworkspacePhaseTerminating represents a DevWorkspace that has been deleted but is waiting on a finalizer.
+	// TODO: Should be moved to devfile/api side.
+	devworkspacePhaseTerminating devworkspace.WorkspacePhase = "Terminating"
 )
 
 func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, workspace *devworkspace.DevWorkspace) (reconcile.Result, error) {
@@ -37,6 +40,7 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 		return reconcile.Result{}, nil
 	}
 	workspace.Status.Message = "Cleaning up resources for deletion"
+	workspace.Status.Phase = devworkspacePhaseTerminating
 	err := r.Client.Status().Update(ctx, workspace)
 	if err != nil && !k8sErrors.IsConflict(err) {
 		return reconcile.Result{}, err


### PR DESCRIPTION
### What does this PR do?
Adds `Terminating` phase to DevWorkspaces, to show deleted workspaces that are waiting on a finalizer:
```
theia   workspacea79dbc5374564e5f   Terminating   Cleaning up resources for deletion
```

This PR adds the new Phase to code in this repo. Once we settle on naming, it should be moved into `devfile/api` with the other phases.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/333

### Is it tested? How?
1. `kubectl apply -f samples/with-k8s-ref/theia-next.yaml`
2. `kubectl get dw -w`
3. (new window) `kubectl delete dw theia`
4. The watch from step 2 should show workspace in `Terminating` phase.

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
