### PR TITLE
Add volume into custom web terminal sample

### DIFF
--- a/internal-registry/redhat-developer/web-terminal-dev/latest/devworkspacetemplate.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/latest/devworkspacetemplate.yaml
@@ -10,7 +10,7 @@ spec:
         command: ["/go/bin/che-machine-exec",
                   "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
                   "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
-                  "--pod-selector", "controller.devfile.io/workspace_id=$(DEVWORKSPACE_ID)",
+                  "--pod-selector", "controller.devfile.io/devworkspace_id=$(DEVWORKSPACE_ID)",
                   "--use-bearer-token"]
         endpoints:
           - name: web-terminal

--- a/internal-registry/redhat-developer/web-terminal/latest/devworkspacetemplate.yaml
+++ b/internal-registry/redhat-developer/web-terminal/latest/devworkspacetemplate.yaml
@@ -10,7 +10,7 @@ spec:
         command: ["/go/bin/che-machine-exec",
                   "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
                   "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
-                  "--pod-selector", "controller.devfile.io/workspace_id=$(DEVWORKSPACE_ID)",
+                  "--pod-selector", "controller.devfile.io/devworkspace_id=$(DEVWORKSPACE_ID)",
                   "--use-bearer-token",
                   "--use-tls"]
         endpoints:

--- a/samples/web-terminal-custom-tooling.yaml
+++ b/samples/web-terminal-custom-tooling.yaml
@@ -24,3 +24,8 @@ spec:
           env:
             - name: PS1
               value: \[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]
+          volumeMounts:
+            - name: home-storage
+              path: "/home/user"
+      - volume:
+          name: home-storage


### PR DESCRIPTION
### What does this PR do?
Add volume into custom web terminal sample.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Made sure that the sample work fine with the latest tooling image after https://github.com/redhat-developer/web-terminal-tooling/pull/26 is merged.

It did not work for me with default latest WTO, so a dedicated issue is created https://issues.redhat.com/browse/WTO-89
<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
