### PR TITLE
Enable github action to build v1alphax image

### DIFF
--- a/.github/workflows/dockerimage-next.yml
+++ b/.github/workflows/dockerimage-next.yml
@@ -10,7 +10,7 @@ name: Next Dockerimage
 
 on:
   push:
-    branches: [ master ]
+    branches: [ v1alphax ]
 
 jobs:
 
@@ -27,5 +27,5 @@ jobs:
         registry: quay.io
         repository: devfile/devworkspace-controller
         dockerfile: ./build/Dockerfile
-        tags: next
+        tags: v1alphax
         tag_with_sha: true

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := bash
 
 OPERATOR_SDK_VERSION = v0.17.0
 NAMESPACE ?= devworkspace-controller
-IMG ?= quay.io/devfile/devworkspace-controller:next
+IMG ?= quay.io/devfile/devworkspace-controller:v1alphax
 TOOL ?= oc
 ROUTING_SUFFIX ?= 192.168.99.100.nip.io
 PULL_POLICY ?= Always

--- a/internal-registry/redhat-developer/web-terminal-dev/latest/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal-dev/latest/meta.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+publisher: redhat-developer
+name: web-terminal-dev
+version: latest
+type: Che Editor
+displayName: Web Terminal
+title: Web Terminal
+description: Web provides the ability to start a terminal inside
+  the OpenShift Console. The development version does not run with TLS enabled and
+  is intended for development purposes only.
+icon: null
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2020-06-01"
+category: Other
+spec:
+  endpoints:
+    - name: web-terminal
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: http
+        type: ide
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+    - name: web-terminal
+      image: "quay.io/eclipse/che-machine-exec:nightly"
+      command: ["/go/bin/che-machine-exec",
+                "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+                "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
+                "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)"]
+      ports:
+        - exposedPort: 4444
+      env:
+        - name: USE_BEARER_TOKEN
+          value: true

--- a/internal-registry/redhat-developer/web-terminal/latest/meta.yaml
+++ b/internal-registry/redhat-developer/web-terminal/latest/meta.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+publisher: redhat-developer
+name: web-terminal
+version: latest
+type: Che Editor
+displayName: Web Terminal
+title: Web Terminal
+description: Web Terminal provides the ability to start a terminal inside the OpenShift Console.
+icon: null
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2020-05-13"
+category: Other
+spec:
+  endpoints:
+   -  name: web-terminal
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: http
+        type: ide
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+   - name: web-terminal
+     image: "${RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0}"
+     command: ["/go/bin/che-machine-exec",
+               "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+               "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
+               "--pod-selector", "controller.devfile.io/workspace_id=$(CHE_WORKSPACE_ID)",
+               "--use-tls"]
+     ports:
+       - exposedPort: 4444
+     env:
+       - name: USE_BEARER_TOKEN
+         value: true

--- a/samples/web-terminal-custom-tooling.yaml
+++ b/samples/web-terminal-custom-tooling.yaml
@@ -16,7 +16,7 @@ spec:
     components:
       - plugin:
           name: web-terminal
-          id: redhat-developer/web-terminal/4.5.0
+          id: redhat-developer/web-terminal/latest
       - container:
           memoryLimit: "256Mi"
           name: tooling

--- a/samples/web-terminal-dev.yaml
+++ b/samples/web-terminal-dev.yaml
@@ -16,4 +16,4 @@ spec:
     components:
       - plugin:
           name: web-terminal
-          id: redhat-developer/web-terminal-dev/4.5.0
+          id: redhat-developer/web-terminal-dev/latest

--- a/samples/web-terminal.yaml
+++ b/samples/web-terminal.yaml
@@ -16,4 +16,4 @@ spec:
     components:
       - plugin:
           name: web-terminal
-          id: redhat-developer/web-terminal/4.5.0
+          id: redhat-developer/web-terminal/latest


### PR DESCRIPTION
### What does this PR do?
It's back-porting for https://github.com/devfile/devworkspace-operator/pull/329
So, the main purpose of this PR is introduce the latest web terminal plugin.

In addition it enables building v1alphax container image, which previously we built manually after merge.

### What issues does this PR fix or reference?
back-ports https://github.com/devfile/devworkspace-operator/pull/329

### Is it tested? How?
Not yet. but I'm going to test that samples/web-terminal.yaml works as expected.
