### PR TITLE
Fix usage of logger in finalize.go

### DIFF
--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -63,7 +63,7 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {
-		log.Info("Failed to clean up DevWorkspace storage for %s: %s", workspace.Name, err)
+		log.Error(err, "Failed to clean up DevWorkspace storage")
 		failedStatus := &currentStatus{
 			Conditions: map[devworkspace.WorkspaceConditionType]string{
 				"Error": err.Error(),
@@ -84,7 +84,7 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 			log.Info(storageErr.Message)
 			return reconcile.Result{RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
-			log.Info("Failed to clean up DevWorkspace storage for %s: %s", workspace.Name, storageErr)
+			log.Error(storageErr, "Failed to clean up DevWorkspace storage")
 			failedStatus := &currentStatus{
 				Conditions: map[devworkspace.WorkspaceConditionType]string{
 					"Error": storageErr.Message,


### PR DESCRIPTION
### What does this PR do?
Fixes a silly oversight in how we use `log` (treating it like `printf` instead of keys-and-values).

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
