### PR TITLE
Return back to v1beta1 CRD API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,8 +224,10 @@ endif
 ### manifests: Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=role webhook paths="./..." \
+			crd:crdVersions=v1beta1 \
 			output:crd:artifacts:config=deploy/templates/crd/bases \
 			output:rbac:artifacts:config=deploy/templates/components/rbac
+	rm -rf ./config
 	patch/patch_crds.sh
 
 ### fmt: Run go fmt against code

--- a/update_devworkspace_crds.sh
+++ b/update_devworkspace_crds.sh
@@ -56,8 +56,9 @@ else
 	echo "DevWorkspace API is specified from branch ${DEVWORKSPACE_API_VERSION}"
 	git checkout --quiet "${DEVWORKSPACE_API_VERSION}"
 fi
-cp crds/workspace.devfile.io_devworkspaces.yaml \
-   crds/workspace.devfile.io_devworkspacetemplates.yaml \
-   $SCRIPT_DIR/deploy/templates/crd/bases/
+cp crds/workspace.devfile.io_devworkspaces.v1beta1.yaml \
+  $SCRIPT_DIR/deploy/templates/crd/bases/workspace.devfile.io_devworkspaces.yaml
+cp crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml \
+  $SCRIPT_DIR/deploy/templates/crd/bases/workspace.devfile.io_devworkspacetemplates.yaml
 
 cd $SCRIPT_DIR


### PR DESCRIPTION
### What does this PR do?
Return back to v1beta1 CRD API.
It's draft since probably we need to workaround:
> Warning: default unsupported in CRD version v1beta1, v1 required. Removing defaults.
+ currently kustomize fails with:
```
Error: no matches for IdId apiextensions.k8s.io_v1_CustomResourceDefinition|~X|devworkspaces.workspace.devfile.io; failed to find unique target for patch apiextensions.k8s.io_v1_CustomResourceDefinition|devworkspaces.workspace.devfile.io
```
Changing https://github.com/devfile/devworkspace-operator/blob/main/deploy/templates/service-ca/crd_webhooks_patch.yaml to v1beta1 does not help.

### What issues does this PR fix or reference?
It's DWO part for https://github.com/eclipse/che/issues/19472

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
