### PR TITLE
DevWorkspace should be failed when its pod has CrashLoopBackOff status

### DIFF
--- a/controllers/workspace/condition.go
+++ b/controllers/workspace/condition.go
@@ -40,17 +40,42 @@ type workspaceConditions struct {
 }
 
 func (c *workspaceConditions) setConditionTrue(conditionType dw.DevWorkspaceConditionType, msg string) {
+	if c.conditions == nil {
+		c.conditions = map[dw.DevWorkspaceConditionType]dw.DevWorkspaceCondition{}
+	}
+
 	c.conditions[conditionType] = dw.DevWorkspaceCondition{
 		Status:  corev1.ConditionTrue,
 		Message: msg,
 	}
 }
 
+func (c *workspaceConditions) setCondition(conditionType dw.DevWorkspaceConditionType, dwCondition dw.DevWorkspaceCondition) {
+	if c.conditions == nil {
+		c.conditions = map[dw.DevWorkspaceConditionType]dw.DevWorkspaceCondition{}
+	}
+
+	c.conditions[conditionType] = dwCondition
+}
+
 func (c *workspaceConditions) setConditionFalse(conditionType dw.DevWorkspaceConditionType, msg string) {
+	if c.conditions == nil {
+		c.conditions = map[dw.DevWorkspaceConditionType]dw.DevWorkspaceCondition{}
+	}
+
 	c.conditions[conditionType] = dw.DevWorkspaceCondition{
 		Status:  corev1.ConditionFalse,
 		Message: msg,
 	}
+}
+
+func getConditionByType(conditions []dw.DevWorkspaceCondition, t dw.DevWorkspaceConditionType) *dw.DevWorkspaceCondition {
+	for _, condition := range conditions {
+		if condition.Type == t {
+			return &condition
+		}
+	}
+	return nil
 }
 
 // getFirstFalse checks current conditions in a set order (defined by conditionOrder) and returns the first

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -36,12 +36,15 @@ import (
 	coputil "github.com/redhat-cop/operator-utils/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
@@ -117,6 +120,18 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return reconcile.Result{Requeue: true}, err
 	}
 
+	// Stop failed workspaces
+	if workspace.Status.Phase == dw.DevWorkspaceStatusFailed && workspace.Spec.Started {
+		patch := []byte(`{"spec":{"started": false}}`)
+		err := r.Client.Patch(context.Background(), workspace, client.RawPatch(types.MergePatchType, patch))
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Requeue reconcile to stop workspace
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	// Handle stopped workspaces
 	if !workspace.Spec.Started {
 		timing.ClearAnnotations(workspace)
@@ -125,7 +140,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	}
 
 	// Prepare handling workspace status and condition
-	reconcileStatus := initCurrentStatus()
+	reconcileStatus := currentStatus{phase: dw.DevWorkspaceStatusStarting}
 	clusterWorkspace := workspace.DeepCopy()
 	timingInfo := map[string]string{}
 	timing.SetTime(timingInfo, timing.DevWorkspaceStarted)
@@ -282,7 +297,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	deploymentStatus := provision.SyncDeploymentToCluster(workspace, allPodAdditions, serviceAcctName, clusterAPI)
 	if !deploymentStatus.Continue {
 		if deploymentStatus.FailStartup {
-			return r.failWorkspace(workspace, fmt.Sprintf("DevWorkspace spec is invalid: %s", deploymentStatus.Err), reqLogger, &reconcileStatus)
+			return r.failWorkspace(workspace, deploymentStatus.Info(), reqLogger, &reconcileStatus)
 		}
 		reqLogger.Info("Waiting on deployment to be ready")
 		reconcileStatus.setConditionFalse(DeploymentReady, "Waiting for workspace deployment")
@@ -307,55 +322,68 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 }
 
 func (r *DevWorkspaceReconciler) stopWorkspace(workspace *dw.DevWorkspace, logger logr.Logger) (reconcile.Result, error) {
+	status := currentStatus{phase: dw.DevWorkspaceStatusStopping}
+	if workspace.Status.Phase == dw.DevWorkspaceStatusFailed {
+		status.phase = dw.DevWorkspaceStatusFailed
+		failedCondition := getConditionByType(workspace.Status.Conditions, dw.DevWorkspaceFailedStart)
+		if failedCondition != nil {
+			status.setCondition(dw.DevWorkspaceFailedStart, *failedCondition)
+		}
+	}
+
+	stopped, err := r.doStop(workspace, logger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if stopped {
+		if status.phase != dw.DevWorkspaceStatusFailed {
+			status.phase = dw.DevWorkspaceStatusStopped
+		}
+	}
+	return r.updateWorkspaceStatus(workspace, logger, &status, reconcile.Result{}, nil)
+}
+
+func (r *DevWorkspaceReconciler) doStop(workspace *dw.DevWorkspace, logger logr.Logger) (stopped bool, err error) {
 	workspaceDeployment := &appsv1.Deployment{}
 	namespaceName := types.NamespacedName{
 		Name:      common.DeploymentName(workspace.Status.DevWorkspaceId),
 		Namespace: workspace.Namespace,
 	}
-	status := &currentStatus{}
-	err := r.Get(context.TODO(), namespaceName, workspaceDeployment)
+	err = r.Get(context.TODO(), namespaceName, workspaceDeployment)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
-			status.phase = dw.DevWorkspaceStatusStopped
-			return r.updateWorkspaceStatus(workspace, logger, status, reconcile.Result{}, nil)
+			return true, nil
 		}
-		return reconcile.Result{}, err
+		return false, err
 	}
 
-	status.phase = dw.DevWorkspaceStatusStopping
 	replicas := workspaceDeployment.Spec.Replicas
 	if replicas == nil || *replicas > 0 {
 		logger.Info("Stopping workspace")
-		patch := client.MergeFrom(workspaceDeployment.DeepCopy())
-		var replicasZero int32 = 0
-		workspaceDeployment.Spec.Replicas = &replicasZero
-		err = r.Patch(context.TODO(), workspaceDeployment, patch)
+		err = provision.ScaleDeploymentToZero(workspace, r.Client)
 		if err != nil && !k8sErrors.IsConflict(err) {
-			return reconcile.Result{}, err
+			return false, err
 		}
-		return r.updateWorkspaceStatus(workspace, logger, status, reconcile.Result{}, nil)
+		return false, nil
 	}
 
 	if workspaceDeployment.Status.Replicas == 0 {
-		logger.Info("Workspace stopped")
-		status.phase = dw.DevWorkspaceStatusStopped
+		return true, nil
 	}
-	return r.updateWorkspaceStatus(workspace, logger, status, reconcile.Result{}, nil)
+	return false, nil
 }
 
 // failWorkspace marks a workspace as failed by setting relevant fields in the status struct.
 // These changes are not synced to cluster immediately, and are intended to be synced to the cluster via a deferred function
 // in the main reconcile loop. If needed, changes can be flushed to the cluster immediately via `updateWorkspaceStatus()`
 func (r *DevWorkspaceReconciler) failWorkspace(workspace *dw.DevWorkspace, msg string, logger logr.Logger, status *currentStatus) (reconcile.Result, error) {
-	logger.Info("Workspace start failed")
-	// Clean up cluster deployment
-	err := provision.ScaleDeploymentToZero(workspace, r.Client)
-	if err != nil {
-		// Return error here without setting phase to failed in order to retry cleaning the deployment
-		return reconcile.Result{}, err
-	}
+	logger.Info("DevWorkspace failed to start: " + msg)
 	status.phase = dw.DevWorkspaceStatusFailed
 	status.setConditionTrue(dw.DevWorkspaceFailedStart, msg)
+	if workspace.Spec.Started {
+		return reconcile.Result{Requeue: true}, nil
+	}
 	return reconcile.Result{}, nil
 }
 
@@ -388,6 +416,32 @@ func getWorkspaceId(instance *dw.DevWorkspace) (string, error) {
 	return "workspace" + strings.Join(strings.Split(uid.String(), "-")[0:3], ""), nil
 }
 
+// Mapping the pod to the devworkspace
+func dwRelatedPodsHandler() handler.EventHandler {
+	podToDW := func(mapObj handler.MapObject) []reconcile.Request {
+		meta := mapObj.Meta
+		labels := meta.GetLabels()
+		if _, ok := labels[constants.DevWorkspaceNameLabel]; !ok {
+			return nil
+		}
+
+		//If the dewworkspace label does not exist, do no reconcile
+		if _, ok := labels[constants.DevWorkspaceIDLabel]; !ok {
+			return nil
+		}
+
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Name:      labels[constants.DevWorkspaceNameLabel],
+					Namespace: meta.GetNamespace(),
+				},
+			},
+		}
+	}
+	return &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(podToDW)}
+}
+
 func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// TODO: Set up indexing https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html#setup
 	return ctrl.NewControllerManagedBy(mgr).
@@ -399,6 +453,8 @@ func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&batchv1.Job{}).
 		Owns(&controllerv1alpha1.DevWorkspaceRouting{}).
+		Watches(&source.Kind{Type: &corev1.Pod{}}, dwRelatedPodsHandler()).
 		WithEventFilter(predicates).
+		WithEventFilter(podPredicates).
 		Complete(r)
 }

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -68,8 +68,7 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {
 		log.Error(err, "Failed to clean up DevWorkspace storage")
-		failedStatus := initCurrentStatus()
-		failedStatus.phase = "Error"
+		failedStatus := currentStatus{phase: "Error"}
 		failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
 		return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
 	}
@@ -86,8 +85,7 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 			return reconcile.Result{RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
 			log.Error(storageErr, "Failed to clean up DevWorkspace storage")
-			failedStatus := initCurrentStatus()
-			failedStatus.phase = "Error"
+			failedStatus := currentStatus{phase: "Error"}
 			failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
 			return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
 		default:

--- a/controllers/workspace/provision/data_types.go
+++ b/controllers/workspace/provision/data_types.go
@@ -29,6 +29,20 @@ type ProvisioningStatus struct {
 	Message     string
 }
 
+// Info returns the the user-friendly info about provisioning status
+// It includes message or error or both if present
+func (s *ProvisioningStatus) Info() string {
+	var message = s.Message
+	if s.Err != nil {
+		if message != "" {
+			message = message + ": " + s.Err.Error()
+		} else {
+			message = s.Err.Error()
+		}
+	}
+	return message
+}
+
 type ClusterAPI struct {
 	Client client.Client
 	Scheme *runtime.Scheme

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -21,11 +21,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-logr/logr"
-
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
+
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclock "k8s.io/apimachinery/pkg/util/clock"
@@ -36,15 +36,6 @@ type currentStatus struct {
 	workspaceConditions
 	// Current workspace phase
 	phase dw.DevWorkspacePhase
-}
-
-func initCurrentStatus() currentStatus {
-	return currentStatus{
-		workspaceConditions: workspaceConditions{
-			conditions: map[dw.DevWorkspaceConditionType]dw.DevWorkspaceCondition{},
-		},
-		phase: dw.DevWorkspaceStatusStarting,
-	}
 }
 
 // clock is used to set status condition timestamps.


### PR DESCRIPTION
### What does this PR do?
This PR fetches the pod and checks the the status to see if the pod has the of CrashLoopBackOff status. If so the devworkspace is updated to have the Failed phase.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/353

### Is it tested? How?
Updated web-terminal-custom-tooling.yaml to force CrashLoopBackOff

![image](https://user-images.githubusercontent.com/40298444/113777869-aa1d4480-96f9-11eb-9910-e99b24f9d6e0.png)


