### PR TITLE
Fail devworkspace start if devfile is invalid

### DIFF
--- a/pkg/provision/storage/commonStorage.go
+++ b/pkg/provision/storage/commonStorage.go
@@ -48,8 +48,12 @@ func (p *CommonStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAd
 	}
 
 	if err := p.rewriteContainerVolumeMounts(workspace.Status.DevWorkspaceId, podAdditions, &workspace.Spec.Template); err != nil {
-		return err
+		return &ProvisioningError{
+			Err:     err,
+			Message: "Could not rewrite container volume mounts",
+		}
 	}
+
 	if _, err := syncCommonPVC(workspace.Namespace, clusterAPI); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?
Fails devworkspace when there is an error in rewriteContainerVolumeMounts.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/356

However, we should probably write a utility function that validates a devfile to catch all issues up front.

### Is it tested? How?
Applied yaml and watched to see if the devworkspace would fail
![image](https://user-images.githubusercontent.com/40298444/114218997-1eddc200-9938-11eb-8bba-387d93b7b7cf.png)
