### PR TITLE
Fix exporting info about failed e2e

### DIFF
--- a/.ci/openshift_e2e.sh
+++ b/.ci/openshift_e2e.sh
@@ -18,12 +18,38 @@ set -u
 # print each command before executing it
 set -x
 
-trap 'Catch_Finish $?' EXIT SIGINT
+function bumpPodsInfo() {
+    NS=$1
+    TARGET_DIR="${ARTIFACT_DIR}/${NS}-info"
+    mkdir -p $TARGET_DIR
 
+    for POD in $(oc get pods -o name -n ${NS}); do
+        for CONTAINER in $(oc get -n ${NS} ${POD} -o jsonpath="{.spec.containers[*].name}"); do
+            echo ""
+            echo "======== Getting logs from container $POD/$CONTAINER in $NS"
+            echo ""
+            # container name includes `pod/` prefix. remove it
+            LOGS_FILE=$TARGET_DIR/$(echo ${POD}-${CONTAINER}.log | sed 's|pod/||g')
+            oc logs ${POD} -c ${CONTAINER} -n ${NS} > $LOGS_FILE || true
+        done
+    done
+    echo "======== Bumping events -n ${NS} ========"
+    oc get events -n ${NS} -o=yaml > $TARGET_DIR/events.log || true
+}
+
+trap 'bumpLogs $?' EXIT SIGINT
+
+export BUMP_LOGS="true"
 # Catch the finish of the job and write logs in artifacts.
-function Catch_Finish() {
+function bumpLogs() {
     # grab devworkspace-controller namespace events after running e2e
-    getDevWorkspaceOperatorLogs
+    if [ $BUMP_LOGS == "true" ]; then
+        bumpPodsInfo $NAMESPACE
+        bumpPodsInfo test-terminal-namespace
+        oc get devworkspaces -n test-terminal-namespace -o=yaml > $ARTIFACTS_DIR/devworkspaces.yaml
+        # export logs once, on failure or after tests are finished
+        export BUMP_LOGS="false"
+    fi
 }
 
 # ENV used by PROW ci
@@ -41,21 +67,6 @@ export DWO_IMG=${DEVWORKSPACE_OPERATOR}
 export GIT_COMMITTER_NAME="CI BOT"
 export GIT_COMMITTER_EMAIL="ci_bot@notused.com"
 
-function getDevWorkspaceOperatorLogs() {
-    mkdir -p ${ARTIFACTS_DIR}/devworkspace-operator
-    cd ${ARTIFACTS_DIR}/devworkspace-operator
-    for POD in $(oc get pods -o name -n ${NAMESPACE}); do
-       for CONTAINER in $(oc get -n ${NAMESPACE} ${POD} -o jsonpath="{.spec.containers[*].name}"); do
-            echo ""
-            echo "<=========================Getting logs from container $CONTAINER in $POD==================================>"
-            echo ""
-            oc logs ${POD} -c ${CONTAINER} -n ${NAMESPACE} | tee $(echo ${POD}-${CONTAINER}.log | sed 's|pod/||g')
-        done
-    done
-    echo "======== oc get events ========"
-    oc get events -n ${NAMESPACE}| tee get_events.log
-}
-
 # For some reason go on PROW force usage vendor folder
 # This workaround is here until we don't figure out cause
 go mod tidy
@@ -66,4 +77,5 @@ make install
 # and we might need to grab data from there
 export CLEAN_UP_AFTER_SUITE="false"
 make test_e2e
+bumpLogs
 make uninstall

--- a/.ci/openshift_e2e.sh
+++ b/.ci/openshift_e2e.sh
@@ -46,7 +46,7 @@ function bumpLogs() {
     if [ $BUMP_LOGS == "true" ]; then
         bumpPodsInfo $NAMESPACE
         bumpPodsInfo test-terminal-namespace
-        oc get devworkspaces -n test-terminal-namespace -o=yaml > $ARTIFACTS_DIR/devworkspaces.yaml
+        oc get devworkspaces -n test-terminal-namespace -o=yaml > $ARTIFACT_DIR/devworkspaces.yaml
         # export logs once, on failure or after tests are finished
         export BUMP_LOGS="false"
     fi
@@ -54,7 +54,9 @@ function bumpLogs() {
 
 # ENV used by PROW ci
 export CI="openshift"
-export ARTIFACTS_DIR="/tmp/artifacts"
+# Use ARTIFACT_DIR from https://docs.ci.openshift.org/docs/architecture/step-registry/#available-environment-variables
+# or assign default for local testing
+export ARTIFACT_DIR="${ARTIFACT_DIR:-/tmp/artifacts}"
 export NAMESPACE="devworkspace-controller"
 # Component is defined in Openshift CI job configuration. See: https://github.com/openshift/release/blob/master/ci-operator/config/devfile/devworkspace-operator/devfile-devworkspace-operator-master__v4.yaml#L8
 export CI_COMPONENT="devworkspace-operator"

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ docker-build:
 docker-push:
 ifneq ($(INITIATOR),CI)
 ifeq ($(DWO_IMG),quay.io/devfile/devworkspace-controller:next)
-	@echo -n "Are you sure we want to push $(DWO_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
+	@echo -n "Are you sure you want to push $(DWO_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
 endif
 endif
 	docker push ${DWO_IMG}

--- a/test/e2e/pkg/client/devws.go
+++ b/test/e2e/pkg/client/devws.go
@@ -23,7 +23,7 @@ import (
 )
 
 //get workspace current dev workspace status from the Custom Resource object
-func (w *K8sClient) GetDevWsStatus(name, namespace string) (*dw.DevWorkspacePhase, error) {
+func (w *K8sClient) GetDevWsStatus(name, namespace string) (*dw.DevWorkspaceStatus, error) {
 	namespacedName := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -35,7 +35,7 @@ func (w *K8sClient) GetDevWsStatus(name, namespace string) (*dw.DevWorkspacePhas
 	if err != nil {
 		return nil, err
 	}
-	return &workspace.Status.Phase, nil
+	return &workspace.Status, nil
 }
 
 func (w *K8sClient) WaitDevWsStatus(name, namespace string, expectedStatus dw.DevWorkspacePhase) (bool, error) {
@@ -51,11 +51,11 @@ func (w *K8sClient) WaitDevWsStatus(name, namespace string, expectedStatus dw.De
 			if err != nil {
 				return false, err
 			}
-			log.Printf("Now current status of developer workspace is: %s", *currentStatus)
-			if *currentStatus == dw.DevWorkspaceStatusFailed {
-				return false, errors.New("workspace has been failed unexpectedly")
+			log.Printf("Now current status of developer workspace is: %s. Message: %s", currentStatus.Phase, currentStatus.Message)
+			if currentStatus.Phase == dw.DevWorkspaceStatusFailed {
+				return false, errors.New("workspace has been failed unexpectedly. Message: " + currentStatus.Message)
 			}
-			if *currentStatus == expectedStatus {
+			if currentStatus.Phase == expectedStatus {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
### What issues does this PR fix or reference?

Previously, logs were saved after make uninstall is done. So nothing is saved
This PR fixes exporting info about failed e2e and logs are saved after script is interupted/exited or before `make uninstall`.
Also, now we export DevWorkspaces.

In addition, e2e tests better report failed DevWorkspaces. Now we the the following output:
```
------------------------------
• Failure [4.005 seconds]
[Create OpenShift Web Terminal Workspace]
/home/sleshche/projects/devworkspace-operator/test/e2e/pkg/tests/devworkspaces_tests.go:25
  Add OpenShift web terminal to cluster and wait running status [It]
  /home/sleshche/projects/devworkspace-operator/test/e2e/pkg/tests/devworkspaces_tests.go:42

  OpenShift Web terminal workspace didn't start properly. Error: workspace has been failed unexpectedly. Message: Error processing devfile: failed to read plugin for component web-terminal from internal registry: environment variable RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0 is unset              
```

### Is it tested? How?
I tested it locally and got 
```
/tmp/artifacts > tree .                                                                                              12:30:43
.
├── devworkspace-controller-info
│   ├── devworkspace-controller-manager-5fc9cbbc54-5xztv-devworkspace-controller.log
│   ├── devworkspace-controller-manager-6f6d74f498-6bxl6-devworkspace-controller.log
│   ├── devworkspace-webhook-server-774d8767cb-rxj76-webhook-server.log
│   └── events.log
├── devworkspaces.yaml
├── junit-workspaces-operator.xml
└── test-terminal-namespace-info
    └── events.log

```

It works on Prow and can be checked on https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/devfile_devworkspace-operator/383/pull-ci-devfile-devworkspace-operator-main-v7-devworkspaces-operator-e2e/1382234097992077312/artifacts/devworkspaces-operator-e2e/devworkspaces-operator-e2e/artifacts/


<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
