### PR TITLE
Routing errors propagation

### DIFF
--- a/apis/controller/v1alpha1/devworkspacerouting_types.go
+++ b/apis/controller/v1alpha1/devworkspacerouting_types.go
@@ -52,6 +52,8 @@ type DevWorkspaceRoutingStatus struct {
 	ExposedEndpoints map[string]ExposedEndpointList `json:"exposedEndpoints,omitempty"`
 	// Routing reconcile phase
 	Phase DevWorkspaceRoutingPhase `json:"phase,omitempty"`
+	// Message is a user-readable message explaining the current phase (e.g. reason for failure)
+	Message string `json:"message,omitempty"`
 }
 
 // Valid phases for devworkspacerouting
@@ -83,6 +85,9 @@ type ExposedEndpointList []ExposedEndpoint
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=devworkspaceroutings,scope=Namespaced,shortName=dwr
+// +kubebuilder:printcolumn:name="DevWorkspace ID",type="string",JSONPath=".spec.devworkspaceId",description="The owner DevWorkspace's unique id"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
+// +kubebuilder:printcolumn:name="Info",type="string",JSONPath=".status.message",description="Additional info about DevWorkspaceRouting state"
 type DevWorkspaceRouting struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -212,7 +212,11 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 			return r.failWorkspace(workspace, routingStatus.Message, reqLogger, &reconcileStatus)
 		}
 		reqLogger.Info("Waiting on routing to be ready")
-		reconcileStatus.setConditionFalse(dw.DevWorkspaceRoutingReady, "Preparing networking")
+		message := "Preparing networking"
+		if routingStatus.Message != "" {
+			message = routingStatus.Message
+		}
+		reconcileStatus.setConditionFalse(dw.DevWorkspaceRoutingReady, message)
 		return reconcile.Result{Requeue: routingStatus.Requeue}, routingStatus.Err
 	}
 	reconcileStatus.setConditionTrue(dw.DevWorkspaceRoutingReady, "")

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -209,8 +209,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	routingStatus := provision.SyncRoutingToCluster(workspace, clusterAPI)
 	if !routingStatus.Continue {
 		if routingStatus.FailStartup {
-			// TODO: Propagate failure reason from devWorkspaceRouting
-			return r.failWorkspace(workspace, "Failed to install network objects required for devworkspace", reqLogger, &reconcileStatus)
+			return r.failWorkspace(workspace, routingStatus.Message, reqLogger, &reconcileStatus)
 		}
 		reqLogger.Info("Waiting on routing to be ready")
 		reconcileStatus.setConditionFalse(dw.DevWorkspaceRoutingReady, "Preparing networking")

--- a/controllers/workspace/provision/routing.go
+++ b/controllers/workspace/provision/routing.go
@@ -98,10 +98,7 @@ func SyncRoutingToCluster(
 		clusterRouting.Annotations = specRouting.Annotations
 		clusterRouting.Spec = specRouting.Spec
 		err := clusterAPI.Client.Update(context.TODO(), clusterRouting)
-		if err != nil {
-			if errors.IsConflict(err) {
-				return RoutingProvisioningStatus{ProvisioningStatus: ProvisioningStatus{Requeue: true}}
-			}
+		if err != nil && !errors.IsConflict(err) {
 			return RoutingProvisioningStatus{ProvisioningStatus: ProvisioningStatus{Err: err}}
 		}
 		return RoutingProvisioningStatus{
@@ -119,6 +116,7 @@ func SyncRoutingToCluster(
 			ProvisioningStatus: ProvisioningStatus{
 				Continue: false,
 				Requeue:  false,
+				Message:  clusterRouting.Status.Message,
 			},
 		}
 	}

--- a/controllers/workspace/provision/routing.go
+++ b/controllers/workspace/provision/routing.go
@@ -111,7 +111,7 @@ func SyncRoutingToCluster(
 
 	if clusterRouting.Status.Phase == v1alpha1.RoutingFailed {
 		return RoutingProvisioningStatus{
-			ProvisioningStatus: ProvisioningStatus{FailStartup: true},
+			ProvisioningStatus: ProvisioningStatus{FailStartup: true, Message: clusterRouting.Status.Message},
 		}
 	}
 	if clusterRouting.Status.Phase != v1alpha1.RoutingReady {

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -19,7 +19,20 @@ spec:
     singular: devworkspacerouting
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The owner DevWorkspace's unique id
+      jsonPath: .spec.devworkspaceId
+      name: DevWorkspace ID
+      type: string
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Additional info about DevWorkspaceRouting state
+      jsonPath: .status.message
+      name: Info
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DevWorkspaceRouting is the Schema for the devworkspaceroutings
@@ -164,6 +177,10 @@ spec:
                   type: array
                 description: Machine name to exposed endpoint map
                 type: object
+              message:
+                description: Message is a user-readable message explaining the current
+                  phase (e.g. reason for failure)
+                type: string
               phase:
                 description: Routing reconcile phase
                 type: string

--- a/deploy/deployment/kubernetes/objects/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
@@ -19,7 +19,20 @@ spec:
     singular: devworkspacerouting
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The owner DevWorkspace's unique id
+      jsonPath: .spec.devworkspaceId
+      name: DevWorkspace ID
+      type: string
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Additional info about DevWorkspaceRouting state
+      jsonPath: .status.message
+      name: Info
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DevWorkspaceRouting is the Schema for the devworkspaceroutings
@@ -164,6 +177,10 @@ spec:
                   type: array
                 description: Machine name to exposed endpoint map
                 type: object
+              message:
+                description: Message is a user-readable message explaining the current
+                  phase (e.g. reason for failure)
+                type: string
               phase:
                 description: Routing reconcile phase
                 type: string

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -19,7 +19,20 @@ spec:
     singular: devworkspacerouting
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The owner DevWorkspace's unique id
+      jsonPath: .spec.devworkspaceId
+      name: DevWorkspace ID
+      type: string
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Additional info about DevWorkspaceRouting state
+      jsonPath: .status.message
+      name: Info
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DevWorkspaceRouting is the Schema for the devworkspaceroutings
@@ -164,6 +177,10 @@ spec:
                   type: array
                 description: Machine name to exposed endpoint map
                 type: object
+              message:
+                description: Message is a user-readable message explaining the current
+                  phase (e.g. reason for failure)
+                type: string
               phase:
                 description: Routing reconcile phase
                 type: string

--- a/deploy/deployment/openshift/objects/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
@@ -19,7 +19,20 @@ spec:
     singular: devworkspacerouting
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The owner DevWorkspace's unique id
+      jsonPath: .spec.devworkspaceId
+      name: DevWorkspace ID
+      type: string
+    - description: The current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Additional info about DevWorkspaceRouting state
+      jsonPath: .status.message
+      name: Info
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DevWorkspaceRouting is the Schema for the devworkspaceroutings
@@ -164,6 +177,10 @@ spec:
                   type: array
                 description: Machine name to exposed endpoint map
                 type: object
+              message:
+                description: Message is a user-readable message explaining the current
+                  phase (e.g. reason for failure)
+                type: string
               phase:
                 description: Routing reconcile phase
                 type: string

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceroutings.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceroutings.yaml
@@ -16,7 +16,20 @@ spec:
     singular: devworkspacerouting
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - description: The owner DevWorkspace's unique id
+          jsonPath: .spec.devworkspaceId
+          name: DevWorkspace ID
+          type: string
+        - description: The current phase
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - description: Additional info about DevWorkspaceRouting state
+          jsonPath: .status.message
+          name: Info
+          type: string
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: DevWorkspaceRouting is the Schema for the devworkspaceroutings
@@ -164,6 +177,10 @@ spec:
                     type: array
                   description: Machine name to exposed endpoint map
                   type: object
+                message:
+                  description: Message is a user-readable message explaining the current
+                    phase (e.g. reason for failure)
+                  type: string
                 phase:
                   description: Routing reconcile phase
                   type: string


### PR DESCRIPTION
### What does this PR do?
Adds a string field `.status.message` to DevWorkspaceRoutings, and uses this value in place of `"preparing networking"` in DevWorkspaces that are waiting for routing to be ready. This means that user-readable failure reasons can be set in DevWorkspaceRoutings and are automatically propagated to the DevWorkspace status.

Also adds printColumns to DevWorkspaceRoutings to improve readability for short output:
```
❯ kc get dwr
NAME                                DEVWORKSPACE ID             PHASE   INFO
routing-workspaceda77c562abd649a1   workspaceda77c562abd649a1   Ready   DevWorkspaceRouting prepared
```

Commit messages should be clear for what each commit adds. Note that I've also added propagating messages from dwr to dw status even when the dwr is not failed, but since a the dwr is ready so quickly in normal usage the message never reaches the DevWorkspace's status, so we never see `Preparing [services|routes|ingresses]`. This might still be useful if e.g. there is an issue applying resources, but might also make tracking progress harder (since the messages may or may not appear)

### What issues does this PR fix or reference?
Closes https://github.com/eclipse/che/issues/17455

### Is it tested? How?
Easiest to test on Kubernetes as otherwise all routingClasses are valid and the default `dwr` reconciler cannot fail:
```bash
{ cat <<EOF | kubectl apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next
spec:
  started: true
  routingClass: cluster-tls
  template:
    components:
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
EOF
} && kubectl get dw -w
```

Output: 
```
❯ kc apply -f samples/theia-next.yaml && kc get dw -w
devworkspace.workspace.devfile.io/theia-next created
NAME         DEVWORKSPACE ID             PHASE      INFO
theia-next   workspaceba44c7e060774cb3           
theia-next   workspaceba44c7e060774cb3   Starting   Preparing networking
theia-next   workspaceba44c7e060774cb3   Failed     Invalid routingClass for DevWorkspace: routing class cluster-tls only supported on OpenShift
```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
