### PR TITLE
Add messages to true conditions and propagate them to DW info

### DIFF
--- a/controllers/workspace/condition.go
+++ b/controllers/workspace/condition.go
@@ -63,3 +63,13 @@ func (c *workspaceConditions) getFirstFalse() *dw.DevWorkspaceCondition {
 	}
 	return nil
 }
+
+func (c *workspaceConditions) getLastTrue() *dw.DevWorkspaceCondition {
+	var latestCondition *dw.DevWorkspaceCondition
+	for _, cond := range conditionOrder {
+		if condition, present := c.conditions[cond]; present && condition.Status == corev1.ConditionTrue {
+			latestCondition = &condition
+		}
+	}
+	return latestCondition
+}

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -112,6 +112,8 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 			return reconcile.Result{}, err
 		}
 		workspace.Status.DevWorkspaceId = workspaceId
+		workspace.Status.Phase = dw.DevWorkspaceStatusStarting
+		workspace.Status.Message = "Initializing DevWorkspace"
 		err = r.Status().Update(ctx, workspace)
 		return reconcile.Result{Requeue: true}, err
 	}
@@ -160,7 +162,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), reqLogger, &reconcileStatus)
 	}
 	workspace.Spec.Template = *flattenedWorkspace
-	reconcileStatus.setConditionTrue(DevWorkspaceResolved, "")
+	reconcileStatus.setConditionTrue(DevWorkspaceResolved, "Resolved plugins and parents from DevWorkspace")
 
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {
@@ -194,7 +196,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 			return reconcile.Result{}, storageErr
 		}
 	}
-	reconcileStatus.setConditionTrue(StorageReady, "")
+	reconcileStatus.setConditionTrue(StorageReady, "Storage ready")
 
 	shimlib.FillDefaultEnvVars(devfilePodAdditions, *workspace)
 	timing.SetTime(timingInfo, timing.ComponentsReady)
@@ -216,7 +218,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		reconcileStatus.setConditionFalse(dw.DevWorkspaceRoutingReady, "Preparing networking")
 		return reconcile.Result{Requeue: routingStatus.Requeue}, routingStatus.Err
 	}
-	reconcileStatus.setConditionTrue(dw.DevWorkspaceRoutingReady, "")
+	reconcileStatus.setConditionTrue(dw.DevWorkspaceRoutingReady, "Networking ready")
 	timing.SetTime(timingInfo, timing.RoutingReady)
 
 	statusOk, err := syncWorkspaceIdeURL(clusterWorkspace, routingStatus.ExposedEndpoints, clusterAPI)
@@ -260,11 +262,11 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	if !serviceAcctStatus.Continue {
 		// FailStartup is not possible for generating the serviceaccount
 		reqLogger.Info("Waiting for workspace ServiceAccount")
-		reconcileStatus.setConditionFalse(dw.DevWorkspaceServiceAccountReady, "Waiting for devworkspace ServiceAccount")
+		reconcileStatus.setConditionFalse(dw.DevWorkspaceServiceAccountReady, "Waiting for DevWorkspace ServiceAccount")
 		return reconcile.Result{Requeue: serviceAcctStatus.Requeue}, serviceAcctStatus.Err
 	}
 	serviceAcctName := serviceAcctStatus.ServiceAccountName
-	reconcileStatus.setConditionTrue(dw.DevWorkspaceServiceAccountReady, "")
+	reconcileStatus.setConditionTrue(dw.DevWorkspaceServiceAccountReady, "DevWorkspace serviceaccount ready")
 
 	pullSecretStatus := provision.PullSecrets(clusterAPI)
 	if !pullSecretStatus.Continue {
@@ -272,7 +274,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return reconcile.Result{Requeue: pullSecretStatus.Requeue}, pullSecretStatus.Err
 	}
 	allPodAdditions = append(allPodAdditions, pullSecretStatus.PodAdditions)
-	reconcileStatus.setConditionTrue(PullSecretsReady, "")
+	reconcileStatus.setConditionTrue(PullSecretsReady, "DevWorkspace secrets ready")
 
 	// Step six: Create deployment and wait for it to be ready
 	timing.SetTime(timingInfo, timing.DeploymentCreated)
@@ -285,7 +287,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		reconcileStatus.setConditionFalse(DeploymentReady, "Waiting for workspace deployment")
 		return reconcile.Result{Requeue: deploymentStatus.Requeue}, deploymentStatus.Err
 	}
-	reconcileStatus.setConditionTrue(DeploymentReady, "")
+	reconcileStatus.setConditionTrue(DeploymentReady, "DevWorkspace deployment ready")
 	timing.SetTime(timingInfo, timing.DeploymentReady)
 
 	serverReady, err := checkServerStatus(clusterWorkspace)

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -182,6 +182,11 @@ func getInfoMessage(workspace *dw.DevWorkspace, status *currentStatus) string {
 		return latestCondition.Message
 	}
 
-	// No condition is false but workspace is not running; unclear what value should be set.
+	latestTrueCondition := status.getLastTrue()
+	if latestTrueCondition != nil {
+		return latestTrueCondition.Message
+	}
+
+	// No conditions are set but workspace is not running; unclear what value should be set.
 	return ""
 }


### PR DESCRIPTION
### What does this PR do?
Add useful message when setting a condition to `true` and propagate that condition to the status.message field when there is a false condition cannot be found. This fills any gaps during startup where the message field is left blank (e.g. between provisioning networking and setting up a serviceaccount)

Also adds the starting phase and a message when setting DevWorkspace ID to ensure there's some info in message and phase immediately.

This also has the benefit of adding some context to conditions that may otherwise be unclear, e.g. `DevWorkspaceResolved`:
```
❯ kc get dw theia-next -o yaml | yq -y '.status.conditions[] | {type, message}'
type: StorageReady
message: Storage ready
---
type: ServiceAccountReady
message: DevWorkspace serviceaccount ready
---
type: RoutingReady
message: Networking ready
---
type: Ready
message: null
---
type: PullSecretsReady
message: DevWorkspace secrets ready
---
type: DevWorkspaceResolved
message: Resolved plugins and parents from DevWorkspace
---
type: DeploymentReady
message: DevWorkspace deployment ready
```

### What issues does this PR fix or reference?
By default, watching a devworkspace startup process prints something like
```
NAME         DEVWORKSPACE ID             PHASE      INFO
theia-next   workspace0c45b5f0f73d461d   Starting   
theia-next   workspace0c45b5f0f73d461d   Starting   
theia-next   workspace0c45b5f0f73d461d   Starting   
theia-next   workspace0c45b5f0f73d461d   Starting   Preparing networking
theia-next   workspace0c45b5f0f73d461d   Starting   Preparing networking
theia-next   workspace0c45b5f0f73d461d   Starting   Preparing networking
theia-next   workspace0c45b5f0f73d461d   Starting   
theia-next   workspace0c45b5f0f73d461d   Starting   
theia-next   workspace0c45b5f0f73d461d   Starting   Waiting for DevWorkspace ServiceAccount
theia-next   workspace0c45b5f0f73d461d   Starting   Waiting for DevWorkspace ServiceAccount
theia-next   workspace0c45b5f0f73d461d   Starting   Waiting for workspace deployment
theia-next   workspace0c45b5f0f73d461d   Starting   Waiting for workspace deployment
theia-next   workspace0c45b5f0f73d461d   Starting   Waiting for editor to start
theia-next   workspace0c45b5f0f73d461d   Starting   Waiting for editor to start
theia-next   workspace0c45b5f0f73d461d   Running    https://workspace0c45b5f0f73d461d-theia-3100.192.168.49.2.nip.io
```
In the middle, it's not clear what's going on for the DevWorkspace

### Is it tested? How?
Test by applying any DevWorkspace, e.g.
```bash
kubectl apply -f samples/theia-next.yaml && kubectl get dw -w
```
Output should be something like (note: duplicate lines removed):
```
❯ kc apply -f samples/theia-next.yaml && kc get dw -w
devworkspace.workspace.devfile.io/theia-next created
NAME         DEVWORKSPACE ID             PHASE      INFO
theia-next   workspace0c45b5f0f73d461d   Starting   Initializing DevWorkspace
theia-next   workspace0c45b5f0f73d461d   Starting   Preparing networking
theia-next   workspace0c45b5f0f73d461d   Starting   Networking ready
theia-next   workspace0c45b5f0f73d461d   Starting   Waiting for DevWorkspace ServiceAccount
theia-next   workspace0c45b5f0f73d461d   Starting   Waiting for workspace deployment
theia-next   workspace0c45b5f0f73d461d   Starting   Waiting for editor to start
theia-next   workspace0c45b5f0f73d461d   Running    https://workspace0c45b5f0f73d461d-theia-3100.192.168.49.2.nip.io
```

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
