### PR TITLE
Update e2e test command hint in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@
 ### Is it tested? How?
 <!-- Please provide instructions here how reviewer can test your changes if applicable -->
 
-<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
+<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v7-devworkspaces-operator-e2e` -->


### PR DESCRIPTION
### What does this PR do?
Update the PR template to suggest the correct e2e trigger comment (v7 vs v5)

<!-- Before PR merging it's required to run e2e tests, to trigger them comment `/test v5-devworkspaces-operator-e2e` -->
