### PR TITLE
Fix .gitattributes to correctly mark generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-deploy/deployment/*             linguist-generated
+deploy/deployment/**            linguist-generated
 deploy/templates/crd/bases/*    linguist-generated


### PR DESCRIPTION
### What does this PR do?
Fix `.gitattributes` to correctly mark all files in `deploy/deployment` as generated [(`*` matches anything except `/`)](https://www.git-scm.com/docs/gitignore#_pattern_format)

### What issues does this PR fix or reference?
Some files not marked as generated

### Is it tested? How?
Tested by modifying all files in `deploy/deployment` and looking at github comparison

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
