### PR TITLE
devworkspace controller should not be in charge of routing suffix for DWR CRs

### DIFF
--- a/apis/controller/v1alpha1/devworkspacerouting_types.go
+++ b/apis/controller/v1alpha1/devworkspacerouting_types.go
@@ -25,8 +25,6 @@ type DevWorkspaceRoutingSpec struct {
 	DevWorkspaceId string `json:"devworkspaceId"`
 	// Class of the routing: this drives which DevWorkspaceRouting controller will manage this routing
 	RoutingClass DevWorkspaceRoutingClass `json:"routingClass,omitempty"`
-	// Routing suffix for cluster
-	RoutingSuffix string `json:"routingSuffix"`
 	// Machines to endpoints map
 	Endpoints map[string]EndpointList `json:"endpoints"`
 	// Selector that should be used by created services to point to the devworkspace Pod

--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
@@ -116,7 +116,6 @@ func (r *DevWorkspaceRoutingReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 		DevWorkspaceId: instance.Spec.DevWorkspaceId,
 		Namespace:      instance.Namespace,
 		PodSelector:    instance.Spec.PodSelector,
-		RoutingSuffix:  instance.Spec.RoutingSuffix,
 	}
 
 	restrictedAccess, setRestrictedAccess := instance.Annotations[constants.DevWorkspaceRestrictedAccessAnnotation]

--- a/controllers/controller/devworkspacerouting/solvers/common.go
+++ b/controllers/controller/devworkspacerouting/solvers/common.go
@@ -30,7 +30,6 @@ type DevWorkspaceMetadata struct {
 	DevWorkspaceId string
 	Namespace      string
 	PodSelector    map[string]string
-	RoutingSuffix  string
 }
 
 // GetDiscoverableServicesForEndpoints converts the endpoint list into a set of services, each corresponding to a single discoverable
@@ -192,7 +191,7 @@ func getRouteForEndpoint(endpoint dw.Endpoint, meta DevWorkspaceMetadata) routeV
 			Annotations: routeAnnotations(endpointName),
 		},
 		Spec: routeV1.RouteSpec{
-			Host: common.WorkspaceHostname(meta.DevWorkspaceId, meta.RoutingSuffix),
+			Host: common.WorkspaceHostname(meta.DevWorkspaceId),
 			Path: common.EndpointPath(endpointName),
 			TLS: &routeV1.TLSConfig{
 				InsecureEdgeTerminationPolicy: routeV1.InsecureEdgeTerminationPolicyRedirect,
@@ -212,7 +211,7 @@ func getRouteForEndpoint(endpoint dw.Endpoint, meta DevWorkspaceMetadata) routeV
 func getIngressForEndpoint(endpoint dw.Endpoint, meta DevWorkspaceMetadata) v1beta1.Ingress {
 	targetEndpoint := intstr.FromInt(endpoint.TargetPort)
 	endpointName := common.EndpointName(endpoint.Name)
-	hostname := common.EndpointHostname(meta.DevWorkspaceId, endpointName, endpoint.TargetPort, meta.RoutingSuffix)
+	hostname := common.EndpointHostname(meta.DevWorkspaceId, endpointName, endpoint.TargetPort)
 	ingressPathType := v1beta1.PathTypeImplementationSpecific
 	return v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/controller/devworkspacerouting/solvers/common.go
+++ b/controllers/controller/devworkspacerouting/solvers/common.go
@@ -152,33 +152,33 @@ func getServicesForEndpoints(endpoints map[string]controllerv1alpha1.EndpointLis
 	}
 }
 
-func getRoutesForSpec(endpoints map[string]controllerv1alpha1.EndpointList, meta DevWorkspaceMetadata) []routeV1.Route {
+func getRoutesForSpec(routingSuffix string, endpoints map[string]controllerv1alpha1.EndpointList, meta DevWorkspaceMetadata) []routeV1.Route {
 	var routes []routeV1.Route
 	for _, machineEndpoints := range endpoints {
 		for _, endpoint := range machineEndpoints {
 			if endpoint.Exposure != dw.PublicEndpointExposure {
 				continue
 			}
-			routes = append(routes, getRouteForEndpoint(endpoint, meta))
+			routes = append(routes, getRouteForEndpoint(routingSuffix, endpoint, meta))
 		}
 	}
 	return routes
 }
 
-func getIngressesForSpec(endpoints map[string]controllerv1alpha1.EndpointList, meta DevWorkspaceMetadata) []v1beta1.Ingress {
+func getIngressesForSpec(routingSuffix string, endpoints map[string]controllerv1alpha1.EndpointList, meta DevWorkspaceMetadata) []v1beta1.Ingress {
 	var ingresses []v1beta1.Ingress
 	for _, machineEndpoints := range endpoints {
 		for _, endpoint := range machineEndpoints {
 			if endpoint.Exposure != dw.PublicEndpointExposure {
 				continue
 			}
-			ingresses = append(ingresses, getIngressForEndpoint(endpoint, meta))
+			ingresses = append(ingresses, getIngressForEndpoint(routingSuffix, endpoint, meta))
 		}
 	}
 	return ingresses
 }
 
-func getRouteForEndpoint(endpoint dw.Endpoint, meta DevWorkspaceMetadata) routeV1.Route {
+func getRouteForEndpoint(routingSuffix string, endpoint dw.Endpoint, meta DevWorkspaceMetadata) routeV1.Route {
 	targetEndpoint := intstr.FromInt(endpoint.TargetPort)
 	endpointName := common.EndpointName(endpoint.Name)
 	return routeV1.Route{
@@ -191,7 +191,7 @@ func getRouteForEndpoint(endpoint dw.Endpoint, meta DevWorkspaceMetadata) routeV
 			Annotations: routeAnnotations(endpointName),
 		},
 		Spec: routeV1.RouteSpec{
-			Host: common.WorkspaceHostname(meta.DevWorkspaceId),
+			Host: common.WorkspaceHostname(routingSuffix, meta.DevWorkspaceId),
 			Path: common.EndpointPath(endpointName),
 			TLS: &routeV1.TLSConfig{
 				InsecureEdgeTerminationPolicy: routeV1.InsecureEdgeTerminationPolicyRedirect,
@@ -208,10 +208,10 @@ func getRouteForEndpoint(endpoint dw.Endpoint, meta DevWorkspaceMetadata) routeV
 	}
 }
 
-func getIngressForEndpoint(endpoint dw.Endpoint, meta DevWorkspaceMetadata) v1beta1.Ingress {
+func getIngressForEndpoint(routingSuffix string, endpoint dw.Endpoint, meta DevWorkspaceMetadata) v1beta1.Ingress {
 	targetEndpoint := intstr.FromInt(endpoint.TargetPort)
 	endpointName := common.EndpointName(endpoint.Name)
-	hostname := common.EndpointHostname(meta.DevWorkspaceId, endpointName, endpoint.TargetPort)
+	hostname := common.EndpointHostname(routingSuffix, meta.DevWorkspaceId, endpointName, endpoint.TargetPort)
 	ingressPathType := v1beta1.PathTypeImplementationSpecific
 	return v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/workspace/provision/routing.go
+++ b/controllers/workspace/provision/routing.go
@@ -175,7 +175,6 @@ func getSpecRouting(
 		Spec: v1alpha1.DevWorkspaceRoutingSpec{
 			DevWorkspaceId: workspace.Status.DevWorkspaceId,
 			RoutingClass:   v1alpha1.DevWorkspaceRoutingClass(routingClass),
-			RoutingSuffix:  config.ControllerCfg.GetRoutingSuffix(),
 			Endpoints:      endpoints,
 			PodSelector: map[string]string{
 				constants.DevWorkspaceIDLabel: workspace.Status.DevWorkspaceId,

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -142,14 +142,10 @@ spec:
                 description: 'Class of the routing: this drives which DevWorkspaceRouting
                   controller will manage this routing'
                 type: string
-              routingSuffix:
-                description: Routing suffix for cluster
-                type: string
             required:
             - devworkspaceId
             - endpoints
             - podSelector
-            - routingSuffix
             type: object
           status:
             description: DevWorkspaceRoutingStatus defines the observed state of DevWorkspaceRouting

--- a/deploy/deployment/kubernetes/objects/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
@@ -142,14 +142,10 @@ spec:
                 description: 'Class of the routing: this drives which DevWorkspaceRouting
                   controller will manage this routing'
                 type: string
-              routingSuffix:
-                description: Routing suffix for cluster
-                type: string
             required:
             - devworkspaceId
             - endpoints
             - podSelector
-            - routingSuffix
             type: object
           status:
             description: DevWorkspaceRoutingStatus defines the observed state of DevWorkspaceRouting

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -142,14 +142,10 @@ spec:
                 description: 'Class of the routing: this drives which DevWorkspaceRouting
                   controller will manage this routing'
                 type: string
-              routingSuffix:
-                description: Routing suffix for cluster
-                type: string
             required:
             - devworkspaceId
             - endpoints
             - podSelector
-            - routingSuffix
             type: object
           status:
             description: DevWorkspaceRoutingStatus defines the observed state of DevWorkspaceRouting

--- a/deploy/deployment/openshift/objects/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml
@@ -142,14 +142,10 @@ spec:
                 description: 'Class of the routing: this drives which DevWorkspaceRouting
                   controller will manage this routing'
                 type: string
-              routingSuffix:
-                description: Routing suffix for cluster
-                type: string
             required:
             - devworkspaceId
             - endpoints
             - podSelector
-            - routingSuffix
             type: object
           status:
             description: DevWorkspaceRoutingStatus defines the observed state of DevWorkspaceRouting

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceroutings.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceroutings.yaml
@@ -141,14 +141,10 @@ spec:
                   description: 'Class of the routing: this drives which DevWorkspaceRouting
                     controller will manage this routing'
                   type: string
-                routingSuffix:
-                  description: Routing suffix for cluster
-                  type: string
               required:
                 - devworkspaceId
                 - endpoints
                 - podSelector
-                - routingSuffix
               type: object
             status:
               description: DevWorkspaceRoutingStatus defines the observed state of

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -35,22 +35,22 @@ func ServiceAccountName(workspaceId string) string {
 	return fmt.Sprintf("%s-%s", workspaceId, "sa")
 }
 
-func EndpointHostname(workspaceId, endpointName string, endpointPort int) string {
+func EndpointHostname(routingSuffix, workspaceId, endpointName string, endpointPort int) string {
 	hostname := fmt.Sprintf("%s-%s-%d", workspaceId, endpointName, endpointPort)
 	if len(hostname) > 63 {
 		hostname = strings.TrimSuffix(hostname[:63], "-")
 	}
-	return fmt.Sprintf("%s", hostname)
+	return fmt.Sprintf("%s.%s", hostname, routingSuffix)
 }
 
 // WorkspaceHostname evaluates a single hostname for a workspace, and should be used for routing
 // when endpoints are distinguished by path rules
-func WorkspaceHostname(workspaceId string) string {
+func WorkspaceHostname(routingSuffix, workspaceId string) string {
 	hostname := workspaceId
 	if len(hostname) > 63 {
 		hostname = strings.TrimSuffix(hostname[:63], "-")
 	}
-	return fmt.Sprintf("%s", hostname)
+	return fmt.Sprintf("%s.%s", hostname, routingSuffix)
 }
 
 func EndpointPath(endpointName string) string {

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -35,22 +35,22 @@ func ServiceAccountName(workspaceId string) string {
 	return fmt.Sprintf("%s-%s", workspaceId, "sa")
 }
 
-func EndpointHostname(workspaceId, endpointName string, endpointPort int, routingSuffix string) string {
+func EndpointHostname(workspaceId, endpointName string, endpointPort int) string {
 	hostname := fmt.Sprintf("%s-%s-%d", workspaceId, endpointName, endpointPort)
 	if len(hostname) > 63 {
 		hostname = strings.TrimSuffix(hostname[:63], "-")
 	}
-	return fmt.Sprintf("%s.%s", hostname, routingSuffix)
+	return fmt.Sprintf("%s", hostname)
 }
 
 // WorkspaceHostname evaluates a single hostname for a workspace, and should be used for routing
 // when endpoints are distinguished by path rules
-func WorkspaceHostname(workspaceId, routingSuffix string) string {
+func WorkspaceHostname(workspaceId string) string {
 	hostname := workspaceId
 	if len(hostname) > 63 {
 		hostname = strings.TrimSuffix(hostname[:63], "-")
 	}
-	return fmt.Sprintf("%s.%s", hostname, routingSuffix)
+	return fmt.Sprintf("%s", hostname)
 }
 
 func EndpointPath(endpointName string) string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,10 +69,6 @@ func (wc *ControllerConfig) GetExperimentalFeaturesEnabled() bool {
 	return wc.GetPropertyOrDefault(experimentalFeaturesEnabled, defaultExperimentalFeaturesEnabled) == "true"
 }
 
-func (wc *ControllerConfig) GetRoutingSuffix() string {
-	return wc.GetPropertyOrDefault(routingSuffix, defaultRoutingSuffix)
-}
-
 func (wc *ControllerConfig) GetPVCStorageClassName() *string {
 	return wc.GetProperty(workspacePVCStorageClassName)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -251,7 +251,7 @@ func fillOpenShiftRouteSuffixIfNecessary(nonCachedClient client.Client, configMa
 	host := testRoute.Spec.Host
 	if host != "" {
 		prefixToRemove := "devworkspace-controller-test-route-" + configMap.Namespace + "."
-		configMap.Data[routingSuffix] = strings.TrimPrefix(host, prefixToRemove)
+		configMap.Data[RoutingSuffix] = strings.TrimPrefix(host, prefixToRemove)
 	}
 
 	err = nonCachedClient.Update(context.TODO(), configMap)

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -27,10 +27,10 @@ const (
 	routingClass        = "devworkspace.default_routing_class"
 	defaultRoutingClass = "basic"
 
-	// routingSuffix is the default domain for routes/ingresses created on the cluster. All
-	// routes/ingresses will be created with URL http(s)://<unique-to-workspace-part>.<routingSuffix>
-	routingSuffix        = "devworkspace.routing.cluster_host_suffix"
-	defaultRoutingSuffix = ""
+	// RoutingSuffix is the base domain for routes/ingresses created on the cluster. All
+	// routes/ingresses will be created with URL http(s)://<unique-to-workspace-part>.<RoutingSuffix>
+	// is supposed to be used by embedded routing solvers only
+	RoutingSuffix = "devworkspace.routing.cluster_host_suffix"
 
 	experimentalFeaturesEnabled        = "devworkspace.experimental_features_enabled"
 	defaultExperimentalFeaturesEnabled = "false"


### PR DESCRIPTION
### What does this PR do?
Removes the routingSuffix. It should be assigned by the DWR controller.

It should be merged in sync with https://github.com/che-incubator/devworkspace-che-operator/pull/45

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/373

### Is it tested? How?
Ran unit tests.
