### PR TITLE
Enable concurrent reconciles

### DIFF
--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting/solvers"
 	maputils "github.com/devfile/devworkspace-operator/internal/map"
+	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 
@@ -32,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -301,7 +303,13 @@ func remove(list []string, s string) []string {
 }
 
 func (r *DevWorkspaceRoutingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	maxConcurrentReconciles, err := config.GetMaxConcurrentReconciles()
+	if err != nil {
+		return err
+	}
+
 	bld := ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&controllerv1alpha1.DevWorkspaceRouting{}).
 		Owns(&corev1.Service{}).
 		Owns(&v1beta1.Ingress{})

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -22,6 +22,7 @@ import (
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
 	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/library/annotate"
 	containerlib "github.com/devfile/devworkspace-operator/pkg/library/container"
@@ -42,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -443,8 +445,14 @@ func dwRelatedPodsHandler() handler.EventHandler {
 }
 
 func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	maxConcurrentReconciles, err := config.GetMaxConcurrentReconciles()
+	if err != nil {
+		return err
+	}
+
 	// TODO: Set up indexing https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html#setup
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&dw.DevWorkspace{}).
 		// List DevWorkspaceTemplates as owned to enable updating workspaces when templates
 		// are changed; this should be moved to whichever controller is responsible for flattening

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -18700,6 +18700,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "1"
         - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
           value: quay.io/eclipse/che-machine-exec:nightly
         - name: RELATED_IMAGE_web_terminal_tooling

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -41,6 +41,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "1"
         - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
           value: quay.io/eclipse/che-machine-exec:nightly
         - name: RELATED_IMAGE_web_terminal_tooling

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -18698,6 +18698,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "1"
         - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
           value: quay.io/eclipse/che-machine-exec:nightly
         - name: RELATED_IMAGE_web_terminal_tooling

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -39,6 +39,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: MAX_CONCURRENT_RECONCILES
+          value: "1"
         - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
           value: quay.io/eclipse/che-machine-exec:nightly
         - name: RELATED_IMAGE_web_terminal_tooling

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -58,6 +58,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
+            - name: MAX_CONCURRENT_RECONCILES
+              value: "1"
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_web_terminal_tooling

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -15,6 +15,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
 
 type ControllerEnv struct{}
@@ -22,6 +23,7 @@ type ControllerEnv struct{}
 const (
 	webhooksSecretNameEnvVar = "WEBHOOK_SECRET_NAME"
 	developmentModeEnvVar    = "DEVELOPMENT_MODE"
+	maxConcurrentReconciles  = "MAX_CONCURRENT_RECONCILES"
 )
 
 func GetWebhooksSecretName() (string, error) {
@@ -34,4 +36,16 @@ func GetWebhooksSecretName() (string, error) {
 
 func GetDevModeEnabled() bool {
 	return os.Getenv(developmentModeEnvVar) == "true"
+}
+
+func GetMaxConcurrentReconciles() (int, error) {
+	env := os.Getenv(maxConcurrentReconciles)
+	if env == "" {
+		return 0, fmt.Errorf("environment variable %s is unset", maxConcurrentReconciles)
+	}
+	val, err := strconv.Atoi(env)
+	if err != nil {
+		return 0, fmt.Errorf("could not parse environment variable %s: %s", maxConcurrentReconciles, err)
+	}
+	return val, nil
 }


### PR DESCRIPTION
### What does this PR do?
Enable concurrent reconciles by setting an env var. Default value is 1 since I can't really tell if increasing concurrence helps.

### Is it tested? How?
Should be no difference.

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
