### PR TITLE
Set the project clone RELATED_IMAGE env var on releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ endif
 
 export NAMESPACE ?= devworkspace-controller
 export DWO_IMG ?= quay.io/devfile/devworkspace-controller:next
+export PROJECT_CLONE_IMG ?= quay.io/devfile/project-clone:next
 export ROUTING_SUFFIX ?= 192.168.99.100.nip.io
 export PULL_POLICY ?= Always
 export DEFAULT_ROUTING ?= basic
@@ -87,6 +88,7 @@ _print_vars:
 	@echo "Current env vars:"
 	@echo "    NAMESPACE=$(NAMESPACE)"
 	@echo "    DWO_IMG=$(DWO_IMG)"
+	@echo "    PROJECT_CLONE_IMG=$(PROJECT_CLONE_IMG)"
 	@echo "    PULL_POLICY=$(PULL_POLICY)"
 	@echo "    ROUTING_SUFFIX=$(ROUTING_SUFFIX)"
 	@echo "    DEFAULT_ROUTING=$(DEFAULT_ROUTING)"
@@ -343,6 +345,7 @@ help: Makefile
 	@echo ''
 	@echo 'Supported environment variables:'
 	@echo '    DWO_IMG                    - Image used for controller'
+	@echo '    PROJECT_CLONE_IMG          - Image used for project-clone init container'
 	@echo '    NAMESPACE                  - Namespace to use for deploying controller'
 	@echo '    KUBECONFIG                 - Kubeconfig which should be used for accessing to the cluster. Currently is: $(KUBECONFIG)'
 	@echo '    ROUTING_SUFFIX             - Cluster routing suffix (e.g. $$(minikube ip).nip.io, apps-crc.testing)'

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -18688,6 +18688,8 @@ spec:
           value: "true"
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
+        - name: RELATED_IMAGE_project_clone
+          value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME
@@ -18712,8 +18714,6 @@ spec:
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar
           value: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
-        - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
         image: quay.io/devfile/devworkspace-controller:next
         imagePullPolicy: Always
         livenessProbe:

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -29,6 +29,8 @@ spec:
           value: "true"
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
+        - name: RELATED_IMAGE_project_clone
+          value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME
@@ -53,8 +55,6 @@ spec:
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar
           value: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
-        - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
         image: quay.io/devfile/devworkspace-controller:next
         imagePullPolicy: Always
         livenessProbe:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -18686,6 +18686,8 @@ spec:
           value: "true"
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
+        - name: RELATED_IMAGE_project_clone
+          value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME
@@ -18710,8 +18712,6 @@ spec:
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar
           value: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
-        - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
         image: quay.io/devfile/devworkspace-controller:next
         imagePullPolicy: Always
         livenessProbe:

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -27,6 +27,8 @@ spec:
           value: "true"
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
+        - name: RELATED_IMAGE_project_clone
+          value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME
@@ -51,8 +53,6 @@ spec:
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar
           value: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
-        - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
         image: quay.io/devfile/devworkspace-controller:next
         imagePullPolicy: Always
         livenessProbe:

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -37,8 +37,13 @@ Arguments:
   --default-image
       Controller (and webhook) image to use for the default deployment.
       Used only when '--use-defaults' is passed; otherwise, the value of
-      the IMG environment variable is used. If unspecified, the default
+      the DWO_IMG environment variable is used. If unspecified, the default
       value of 'quay.io/devfile/devworkspace-controller:next' is used
+  --project-clone-image
+      Image to use for the project clone init container. Used only when
+      '--use-defaults' is passed; otherwise, the value of the PROJECT_CLONE_IMG
+      environment variable is used. If unspecifed, the default value of
+      'quay.io/devfile/project-clone:next' is used.
   --split-yaml
       Parse output file combined.yaml into a yaml file for each record
       in combined yaml. Files are output to the 'objects' subdirectory
@@ -62,6 +67,10 @@ while [[ "$#" -gt 0 ]]; do
       DEFAULT_IMAGE=$2
       shift
       ;;
+      --project-clone-image)
+      PROJECT_CLONE_IMG=$2
+      shift
+      ;;
       --split-yamls)
       SPLIT_YAMLS=true
       ;;
@@ -82,6 +91,7 @@ if $USE_DEFAULT_ENV; then
   echo "Using defaults for environment variables"
   export NAMESPACE=devworkspace-controller
   export DWO_IMG=${DEFAULT_IMAGE:-"quay.io/devfile/devworkspace-controller:next"}
+  export PROJECT_CLONE_IMG=${PROJECT_CLONE_IMG:-"quay.io/devfile/project-clone:next"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic
   export DEVWORKSPACE_API_VERSION=1f335562c475972132851c68227dd36558317bb3

--- a/deploy/templates/base/manager_image_patch.yaml
+++ b/deploy/templates/base/manager_image_patch.yaml
@@ -14,3 +14,5 @@ spec:
         env:
           - name: RELATED_IMAGE_devworkspace_webhook_server
             value: ${DWO_IMG}
+          - name: RELATED_IMAGE_project_clone
+            value: ${PROJECT_CLONE_IMG}

--- a/make-release.sh
+++ b/make-release.sh
@@ -120,7 +120,10 @@ docker build -t "${PROJECT_CLONE_QUAY_REPO}" -f ./project-clone/Dockerfile .
 docker push "${PROJECT_CLONE_QUAY_REPO}"
 
 set -x
-bash -x ./deploy/generate-deployment.sh --use-defaults --default-image ${QUAY_REPO}
+bash -x ./deploy/generate-deployment.sh \
+  --use-defaults \
+  --default-image ${QUAY_REPO} \
+  --project-clone-image ${PROJECT_CLONE_QUAY_REPO}
 
 # tag the release if the version/version.go file has changed
 if [[ ! -z $(git status -s) ]]; then # dirty


### PR DESCRIPTION
### What does this PR do?
Set the value of `RELATED_IMAGE_project_clone` used by the DevWorkspace operator to match the released version of DWO. I had mixed up how DWO_IMG is used in `generate-deployment.sh` so it's actually easier to do this than I thought.

### What issues does this PR fix or reference?
Follow up on PR review for https://github.com/devfile/devworkspace-operator/pull/371

### Is it tested? How?
`./deploy/generate-deployment.sh --use-defaults --project-clone-image test:test` should modify templates as expected.

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
