### PR TITLE
Set resource limits/requests for the webhook server deployment

### DIFF
--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -18704,6 +18704,14 @@ spec:
               fieldPath: spec.serviceAccountName
         - name: MAX_CONCURRENT_RECONCILES
           value: "1"
+        - name: WEBHOOKS_SERVER_MEMORY_LIMIT
+          value: 300Mi
+        - name: WEBHOOKS_SERVER_MEMORY_REQUEST
+          value: 20Mi
+        - name: WEBHOOKS_SERVER_CPU_LIMIT
+          value: 200m
+        - name: WEBHOOKS_SERVER_CPU_REQUEST
+          value: 100m
         - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
           value: quay.io/eclipse/che-machine-exec:nightly
         - name: RELATED_IMAGE_web_terminal_tooling

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -45,6 +45,14 @@ spec:
               fieldPath: spec.serviceAccountName
         - name: MAX_CONCURRENT_RECONCILES
           value: "1"
+        - name: WEBHOOKS_SERVER_MEMORY_LIMIT
+          value: 300Mi
+        - name: WEBHOOKS_SERVER_MEMORY_REQUEST
+          value: 20Mi
+        - name: WEBHOOKS_SERVER_CPU_LIMIT
+          value: 200m
+        - name: WEBHOOKS_SERVER_CPU_REQUEST
+          value: 100m
         - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
           value: quay.io/eclipse/che-machine-exec:nightly
         - name: RELATED_IMAGE_web_terminal_tooling

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -18702,6 +18702,14 @@ spec:
               fieldPath: spec.serviceAccountName
         - name: MAX_CONCURRENT_RECONCILES
           value: "1"
+        - name: WEBHOOKS_SERVER_MEMORY_LIMIT
+          value: 300Mi
+        - name: WEBHOOKS_SERVER_MEMORY_REQUEST
+          value: 20Mi
+        - name: WEBHOOKS_SERVER_CPU_LIMIT
+          value: 200m
+        - name: WEBHOOKS_SERVER_CPU_REQUEST
+          value: 100m
         - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
           value: quay.io/eclipse/che-machine-exec:nightly
         - name: RELATED_IMAGE_web_terminal_tooling

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -43,6 +43,14 @@ spec:
               fieldPath: spec.serviceAccountName
         - name: MAX_CONCURRENT_RECONCILES
           value: "1"
+        - name: WEBHOOKS_SERVER_MEMORY_LIMIT
+          value: 300Mi
+        - name: WEBHOOKS_SERVER_MEMORY_REQUEST
+          value: 20Mi
+        - name: WEBHOOKS_SERVER_CPU_LIMIT
+          value: 200m
+        - name: WEBHOOKS_SERVER_CPU_REQUEST
+          value: 100m
         - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
           value: quay.io/eclipse/che-machine-exec:nightly
         - name: RELATED_IMAGE_web_terminal_tooling

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -60,6 +60,14 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: MAX_CONCURRENT_RECONCILES
               value: "1"
+            - name: WEBHOOKS_SERVER_MEMORY_LIMIT
+              value: 300Mi
+            - name: WEBHOOKS_SERVER_MEMORY_REQUEST
+              value: 20Mi
+            - name: WEBHOOKS_SERVER_CPU_LIMIT
+              value: 200m
+            - name: WEBHOOKS_SERVER_CPU_REQUEST
+              value: 100m
             - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
               value: "quay.io/eclipse/che-machine-exec:nightly"
             - name: RELATED_IMAGE_web_terminal_tooling

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type ControllerEnv struct{}
@@ -24,6 +26,11 @@ const (
 	webhooksSecretNameEnvVar = "WEBHOOK_SECRET_NAME"
 	developmentModeEnvVar    = "DEVELOPMENT_MODE"
 	maxConcurrentReconciles  = "MAX_CONCURRENT_RECONCILES"
+
+	WebhooksMemLimitEnvVar   = "WEBHOOKS_SERVER_MEMORY_LIMIT"
+	WebhooksMemRequestEnvVar = "WEBHOOKS_SERVER_MEMORY_REQUEST"
+	WebhooksCPULimitEnvVar   = "WEBHOOKS_SERVER_CPU_LIMIT"
+	WebhooksCPURequestEnvVar = "WEBHOOKS_SERVER_CPU_REQUEST"
 )
 
 func GetWebhooksSecretName() (string, error) {
@@ -48,4 +55,16 @@ func GetMaxConcurrentReconciles() (int, error) {
 		return 0, fmt.Errorf("could not parse environment variable %s: %s", maxConcurrentReconciles, err)
 	}
 	return val, nil
+}
+
+func GetResourceQuantityFromEnvVar(env string) (*resource.Quantity, error) {
+	val := os.Getenv(env)
+	if val == "" {
+		return nil, fmt.Errorf("environment variable %s is unset", env)
+	}
+	quantity, err := resource.ParseQuantity(val)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse environment variable %s: %s", env, err)
+	}
+	return &quantity, nil
 }


### PR DESCRIPTION
### What does this PR do?
Add environment variables to the controller deployment that govern memory/cpu limits/requests for the webhook server deployment.

I opted to just use the values we have for the DevWorkspace controller for now. Some testing should be done to see if these are appropriate or if other settings should be used.

### What issues does this PR fix or reference?
No resources specified for webhooks server

### Is it tested? How?
`make install` and check that resources are set on the `devworkspace-webhook-server` deployment.

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
