### PR TITLE
Automount configmaps/secrets into devworkspaces

### DIFF
--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -14,14 +14,29 @@ package constants
 
 // Constants that are used in labels and annotation on DevWorkspace-related resources.
 const (
-	// DevWorkspaceIDLabel is label key to store workspace identifier
+	// DevWorkspaceIDLabel is the label key to store workspace identifier
 	DevWorkspaceIDLabel = "controller.devfile.io/devworkspace_id"
 
 	// DevWorkspaceCreatorLabel is the label key for storing the UID of the user who created the workspace
 	DevWorkspaceCreatorLabel = "controller.devfile.io/creator"
 
-	// DevWorkspaceNameLabel is label key to store workspace name
+	// DevWorkspaceNameLabel is the label key to store workspace name
 	DevWorkspaceNameLabel = "controller.devfile.io/devworkspace_name"
+
+	// DevWorkspaceMountLabel is the label key to store if a configmap or secret should be mounted to the devworkspace
+	DevWorkspaceMountLabel = "controller.devfile.io/mount-to-devworkspace"
+
+	// DevWorkspaceMountPathAnnotation is the annotation key to store the mount path for the secret or configmap.
+	// If no mount path is provided, configmaps will be mounted at /etc/config/<configmap-name> and secrets will
+	// be mounted at /etc/secret/<secret-name>
+	DevWorkspaceMountPathAnnotation = "controller.devfile.io/mount-path"
+
+	// DevWorkspaceMountAsAnnotation is the annotation key to configure the way how configmaps or secrets should be mounted.
+	// Supported options:
+	// - "env" - mount as environment variables
+	// - "file" - mount as a file
+	// If mountAs is not provided, the default behaviour will be to mount as a file.
+	DevWorkspaceMountAsAnnotation = "controller.devfile.io/mount-as"
 
 	// DevWorkspaceRestrictedAccessAnnotation marks the intention that devworkspace access is restricted to only the creator; setting this
 	// annotation will cause devworkspace start to fail if webhooks are disabled.


### PR DESCRIPTION
### What does this PR do?
Automounts configmaps/secrets to **all** devworkspace if the automount label is present. 

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/384

### Is it tested? How?
1. make install
2. 
```
cat << EOF | oc apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: file-configmap
  namespace: devworkspace-controller
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
#  annotations:
#    controller.devfile.io/mount-as: file # default behavior
type: Opaque
data:
  important-cfg: "test"
EOF
```
3.
```
cat << EOF | oc apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: file-configmap-custom-path
  namespace: devworkspace-controller
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
  annotations:
#    controller.devfile.io/mount-as: file # default behavior
    controller.devfile.io/mount-path: /etc/config/custom-mount-path/here
type: Opaque
data:
  important-cfg: "test"
EOF
```
4.
```
cat << EOF | oc apply -f -
apiVersion: v1
kind: Secret
metadata:
  name: env-var-secret
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
  annotations:
    controller.devfile.io/mount-as: env
stringData:
  secret_username: admin
  secret_password: t0p-Secret
EOF
```
4. oc apply -f samples/web-terminal-custom-tooling.yaml
5. kubectl exec -it <pod> -c tooling -- bash
6. ls /etc/config
7. env | grep secret_

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
