### PR TITLE
chore(rev-parse) fix(bug) don't assume we have a .git folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,8 +205,7 @@ endif
 compile-devworkspace-controller:
 	$(eval GO_PACKAGE_PATH ?= $(shell head -n1 go.mod | cut -d " " -f 2))
 	$(eval BUILD_TIME = $(shell date -u '+%Y-%m-%dT%H:%M:%SZ'))
-	$(eval REF = $(shell cat .git/HEAD | sed 's|ref: ||'))
-	$(eval GIT_COMMIT_ID := $(shell cat .git/${REF}))
+	$(eval GIT_COMMIT_ID := $(shell git rev-parse --short=4 HEAD))
 	export ARCH="$(shell uname -m)";  \
 	if [[ "$(ARCH)" == "x86_64" ]]; then  \
 		export ARCH="amd64";  \
@@ -226,8 +225,7 @@ compile-devworkspace-controller:
 compile-webhook-server:
 	$(eval GO_PACKAGE_PATH ?= $(shell head -n1 go.mod | cut -d " " -f 2))
 	$(eval BUILD_TIME = $(shell date -u '+%Y-%m-%dT%H:%M:%SZ'))
-	$(eval REF = $(shell cat .git/HEAD | sed 's|ref: ||'))
-	$(eval GIT_COMMIT_ID := $(shell cat .git/${REF}))
+	$(eval GIT_COMMIT_ID := $(shell git rev-parse --short=4 HEAD))
 	export ARCH="$(shell uname -m)";  \
 	if [[ "$(ARCH)" == "x86_64" ]]; then  \
 		export ARCH="amd64";  \


### PR DESCRIPTION
### What does this PR do?

instead of assuming we have a local .git folder, just use `git rev-parse --short=4 HEAD`

This is because when we downstream this code, it breaks in https://github.com/redhat-developer/codeready-workspaces-images/tree/crw-2-rhel-8/codeready-workspaces-devworkspace-controller as the .git folder is a level up.

Added bonus is the SHA you get with `--short=4` could be shorter (minimum 4 chars if that allows for a unique commit SHA) than the default full-length SHA

Change-Id: Id46685217e3d8048bee6a33df92ef73cab5a7943
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1734

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.