### PR TITLE
Fix starting a workspace once it enters the failed state

### DIFF
--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -30,9 +30,6 @@ import (
 
 const (
 	storageCleanupFinalizer = "storage.controller.devfile.io"
-	// devworkspacePhaseTerminating represents a DevWorkspace that has been deleted but is waiting on a finalizer.
-	// TODO: Should be moved to devfile/api side.
-	devworkspacePhaseTerminating dw.DevWorkspacePhase = "Terminating"
 )
 
 func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace) (reconcile.Result, error) {

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -68,7 +68,7 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {
 		log.Error(err, "Failed to clean up DevWorkspace storage")
-		failedStatus := currentStatus{phase: "Error"}
+		failedStatus := currentStatus{phase: dw.DevWorkspaceStatusError}
 		failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
 		return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
 	}
@@ -85,7 +85,7 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 			return reconcile.Result{RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
 			log.Error(storageErr, "Failed to clean up DevWorkspace storage")
-			failedStatus := currentStatus{phase: "Error"}
+			failedStatus := currentStatus{phase: dw.DevWorkspaceStatusError}
 			failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
 			return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
 		default:

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -31,6 +31,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	// devworkspacePhaseTerminating represents a DevWorkspace that has been deleted but is waiting on a finalizer.
+	// TODO: Should be moved to devfile/api side.
+	devworkspacePhaseTerminating dw.DevWorkspacePhase = "Terminating"
+
+	// devworkspacePhaseFailing represents a DevWorkspace that has encountered an unrecoverable error and is in
+	// the process of stopping.
+	devworkspacePhaseFailing dw.DevWorkspacePhase = "Failing"
+)
+
 type currentStatus struct {
 	workspaceConditions
 	// Current workspace phase


### PR DESCRIPTION
### What does this PR do?
Add a new `DevWorkspacePhase`, `"Failing"` to represent workspaces that have hit a fail condition but haven't yet been stopped. When the controller encounters a DevWorkspace with `phase: Failing` and `.spec.started: true`, it will stop that workspace and update the phase to `Failed`.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/413

### Is it tested? How?
```yaml
cat <<EOF | kubectl apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain
spec:
  started: true
  routingClass: 'basic'
  template:
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:latest
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "exit"
           - "1"
EOF
kubectl get dw -w
```

1. The workspace should enter phases `Failing` and `Failed` with message `Container web-terminal has state RunContainerError`
2. If you restart the workspace (`kubectl patch dw plain --type merge -p '{"spec": {"started": true}}'`), it should enter the starting phase and continue until it fails a second time.

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
