### PR TITLE
Add annotation for debugging workspace startup

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -125,6 +125,12 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 
 	// Stop failed workspaces
 	if workspace.Status.Phase == devworkspacePhaseFailing && workspace.Spec.Started {
+		// If debug annotation is present, leave the deployment in place to let users
+		// view logs.
+		if workspace.Annotations[constants.DevWorkspaceDebugStartAnnotation] == "true" {
+			return reconcile.Result{}, nil
+		}
+
 		patch := []byte(`{"spec":{"started": false}}`)
 		err := r.Client.Patch(context.Background(), workspace, client.RawPatch(types.MergePatchType, patch))
 		if err != nil {

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -47,6 +47,10 @@ const (
 	// this annotation will be cleared
 	DevWorkspaceStopReasonAnnotation = "controller.devfile.io/stopped-by"
 
+	// DevWorkspaceDebugStartAnnotation enables debugging workspace startup if set to "true". If a workspace with this annotation
+	// fails to start (i.e. enters the "Failed" phase), its deployment will not be scaled down in order to allow viewing logs, etc.
+	DevWorkspaceDebugStartAnnotation = "controller.devfile.io/debug-start"
+
 	// WebhookRestartedAtAnnotation holds the the time (unixnano) of when the webhook server was forced to restart by controller
 	WebhookRestartedAtAnnotation = "controller.devfile.io/restarted-at"
 


### PR DESCRIPTION
### What does this PR do?
Adds support for an annotation (`controller.devfile.io/debug-start: true`) on devworkspaces that disables scale-to-zero when a workspace fails. This leaves the workspace deployment/pod on the cluster, allowing for debugging issues with startup.

#### Notes
- **Annotation vs Attribute**: I opted to use annotations for this purpose since it's a DWO-specific feature and shouldn't be included in devfiles by default.
- **Annotation name**: Instead of something more specific like `disable-scale-to-zero` I named the annotation `controller.devfile.io/debug-start`. This annotation could be used for enabling additional debug information in the future.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/418

### Is it tested? How?
```yaml
cat <<EOF | kubectl apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain
  annotations:
    controller.devfile.io/debug-start: "true"
spec:
  started: true
  routingClass: 'basic'
  template:
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:latest
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "exit"
           - "1"
EOF
kubectl get dw -w
```
- Deployment and pod should be left on cluster once workspace fails

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
