### PR TITLE
Upgrade the project to use go 1.14

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM quay.io/libpod/golang:1.13 as builder
+FROM quay.io/bitnami/golang:1.14 as builder
 RUN go env GOPROXY
 WORKDIR /devworkspace-operator
 # Copy the Go Modules manifests

--- a/build/rhel.Dockerfile
+++ b/build/rhel.Dockerfile
@@ -10,8 +10,8 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
-FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.13.15-4  as builder
-ENV PATH=/opt/rh/go-toolset-1.13/root/usr/bin:${PATH} \
+FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.14.12-4.1615820747  as builder
+ENV PATH=/opt/rh/go-toolset-1.14/root/usr/bin:${PATH} \
     GOPATH=/go/
 USER root
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/devworkspace-operator
 
-go 1.13
+go 1.14
 
 require (
 	github.com/devfile/api/v2 v2.0.0-20210420202853-ff3c01bf8292


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR updates the project to use go 1.14. The main reason for this change is for:
```
By default, if the go version in go.mod is 1.14 or higher and a vendor directory is present, the go command acts as if -mod=vendor were used. Otherwise, the go command acts as if -mod=readonly were used.
```
from https://golang.org/ref/mod#build-commands making productization a bit simpler


### What issues does this PR fix or reference?

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
