### PR TITLE
[Selenium] Stabilize happy-path test, add  devworkspace-che logs to test report

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -20,6 +20,8 @@ function bumpPodsInfo() {
     TARGET_DIR="${ARTIFACT_DIR}/${NS}-info"
     mkdir -p "$TARGET_DIR"
 
+    oc get pods -n ${NS}
+
     for POD in $(oc get pods -o name -n ${NS}); do
         for CONTAINER in $(oc get -n ${NS} ${POD} -o jsonpath="{.spec.containers[*].name}"); do
             echo ""

--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -25,6 +25,7 @@ source "${SCRIPT_DIR}"/common.sh
 function Catch_Finish() {
     # grab devworkspace-controller namespace events after running e2e
     bumpPodsInfo "devworkspace-controller"
+    bumpPodsInfo "devworkspace-che"
     bumpPodsInfo "admin-che"
     oc get devworkspaces -n "admin-che" -o=yaml > $ARTIFACT_DIR/devworkspaces.yaml
     /tmp/chectl/bin/chectl server:logs --chenamespace=${NAMESPACE} --directory=${ARTIFACT_DIR} --telemetry=off
@@ -53,7 +54,15 @@ EOL
 
   echo "----------------------------------"
 
-  /tmp/chectl/bin/chectl server:deploy --che-operator-cr-patch-yaml=/tmp/che-cr-patch.yaml -p openshift --batch --telemetry=off --installer=operator
+  /tmp/chectl/bin/chectl server:deploy --che-operator-cr-patch-yaml=/tmp/che-cr-patch.yaml -p openshift --batch --telemetry=off --installer=operator --templates=/tmp/templates/
+}
+
+initLatestTemplates() {
+  curl -L https://api.github.com/repos/eclipse-che/che-operator/zipball/main  > /tmp/che-operator.zip &&
+  unzip /tmp/che-operator.zip -d /tmp && \
+  mkdir -p /tmp/templates/che-operator && \
+  mv /tmp/eclipse-che-che-operator-*/deploy /tmp/che-operator
+  cp -rf /tmp/che-operator/* /tmp/templates/che-operator
 }
 
 startHappyPathTest() {
@@ -114,5 +123,6 @@ runTest() {
 }
 
 installChectl
+initLatestTemplates
 provisionOpenShiftOAuthUser
 runTest

--- a/.ci/resources/pod-che-happy-path.yaml
+++ b/.ci/resources/pod-che-happy-path.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   volumes:
     - name: test-run-results
+    - name: dshm
+      emptyDir:
+        medium: Memory
   containers:
     # container containing the tests
     - name: happy-path-test
@@ -38,9 +41,15 @@ spec:
           value: "htpasswd"
         - name: DELETE_WORKSPACE_ON_FAILED_TEST
           value: "true"
+        - name: TS_SELENIUM_START_WORKSPACE_TIMEOUT
+          value: '540000'
+        - name: TS_IDE_LOAD_TIMEOUT
+          value: '40000'
       volumeMounts:
         - name: test-run-results
           mountPath: /tmp/e2e/report/
+        - mountPath: /dev/shm
+          name: dshm
       resources:
         requests:
           memory: "3Gi"


### PR DESCRIPTION
### What does this PR do?
Stabilize happy-path test, add `devworkspace-che` logs to test report, use latest `che-operator` templates.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19643

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
