### PR TITLE
Move storage type setting to devfile attributes

### DIFF
--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -39,13 +39,13 @@ const (
 	// The full annotation name is supposed to be "<routingClass>.routing.controller.devfile.io/<anything>"
 	RoutingAnnotationInfix = ".routing.controller.devfile.io/"
 
-	// DevWorkspaceStorageTypeLabel defines the strategy used for provisioning storage for the workspace.
+	// DevWorkspaceStorageTypeAtrr defines the strategy used for provisioning storage for the workspace.
 	// If empty, the common PVC strategy is used.
 	// Supported options:
 	// - "common": Create one PVC per namespace, and store data for all workspaces in that namespace in that PVC
 	// - "async" : Create one PVC per namespace, and create a remote server that syncs data from workspaces to the PVC.
 	//             All volumeMounts used for devworkspaces are emptyDir
-	DevWorkspaceStorageTypeLabel = "controller.devfile.io/storage-type"
+	DevWorkspaceStorageTypeAtrr = "controller.devfile.io/storage-type"
 
 	// WorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
 	DevWorkspaceEndpointNameAnnotation = "controller.devfile.io/endpoint_name"

--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -246,7 +246,8 @@ func (*AsyncStorageProvisioner) getAsyncWorkspaceCount(api provision.ClusterAPI)
 		return 0, 0, err
 	}
 	for _, workspace := range workspaces.Items {
-		if workspace.Labels[constants.DevWorkspaceStorageTypeLabel] == constants.AsyncStorageClassType {
+		storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAtrr, nil)
+		if storageClass == constants.AsyncStorageClassType {
 			total++
 			if workspace.Spec.Started {
 				started++

--- a/pkg/provision/storage/provisioner.go
+++ b/pkg/provision/storage/provisioner.go
@@ -40,7 +40,7 @@ func GetProvisioner(workspace *dw.DevWorkspace) (Provisioner, error) {
 	// TODO: Figure out what to do if a workspace changes the storage type after its been created
 	// e.g. common -> async so as to not leave files on PVCs after removal. Maybe block changes to
 	// this label via webhook?
-	storageClass := workspace.Labels[constants.DevWorkspaceStorageTypeLabel]
+	storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAtrr, nil)
 	if storageClass == "" {
 		return &CommonStorageProvisioner{}, nil
 	}

--- a/samples/plugins/theia-next.yaml
+++ b/samples/plugins/theia-next.yaml
@@ -9,11 +9,6 @@ spec:
     - name: remote-endpoint
       volume:
         ephemeral: true
-    - name: vsx-installer
-      plugin:
-        kubernetes:
-          name: vsx-installer
-          namespace: devworkspace-plugins
     - name: remote-runtime-injector
       plugin:
         kubernetes:

--- a/samples/with-k8s-ref/async-theia-next.yaml
+++ b/samples/with-k8s-ref/async-theia-next.yaml
@@ -2,11 +2,11 @@ kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
   name: theia
-  labels:
-    controller.devfile.io/storage-type: async
 spec:
   started: true
   template:
+    attributes:
+      controller.devfile.io/storage-type: async
     projects:
       - name: web-nodejs-sample
         git:


### PR DESCRIPTION
### What does this PR do?
Moves the storage type setting from using lables to devfile attributes. 

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/392

### Is it tested? How?
tested to see if the storage type gets set properly when specifying it through devfile attributes using samples/with-k8s-ref/async-theia-next.yaml  
