### PR TITLE
fix: propogate container components cpu/memory limit/request

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -25,12 +25,15 @@ var ControllerAppLabels = func() map[string]string {
 const (
 	DefaultProjectsSourcesRoot = "/projects"
 
-	AuthEnabled = "false"
-
 	ServiceAccount = "devworkspace"
 
-	SidecarDefaultMemoryLimit = "128M"
-	PVCStorageSize            = "1Gi"
+	SidecarDefaultMemoryLimit   = "128M"
+	SidecarDefaultMemoryRequest = "64M"
+
+	SidecarDefaultCpuLimit   = "-1"
+	SidecarDefaultCpuRequest = "-1"
+
+	PVCStorageSize = "1Gi"
 
 	// DevWorkspaceIDLoggerKey is the key used to log workspace ID in the reconcile
 	DevWorkspaceIDLoggerKey = "devworkspace_id"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -30,8 +30,8 @@ const (
 	SidecarDefaultMemoryLimit   = "128M"
 	SidecarDefaultMemoryRequest = "64M"
 
-	SidecarDefaultCpuLimit   = "-1"
-	SidecarDefaultCpuRequest = "-1"
+	SidecarDefaultCpuLimit   = "" // do not provide any value
+	SidecarDefaultCpuRequest = "" // do not provide any value
 
 	PVCStorageSize = "1Gi"
 

--- a/pkg/library/container/conversion.go
+++ b/pkg/library/container/conversion.go
@@ -70,7 +70,6 @@ func devfileEndpointsToContainerPorts(endpoints []dw.Endpoint) []v1.ContainerPor
 }
 
 func devfileResourcesToContainerResources(devfileContainer *dw.ContainerComponent) (*v1.ResourceRequirements, error) {
-	// TODO: Handle memory request and CPU when implemented in devfile API
 	memLimit := devfileContainer.MemoryLimit
 	if memLimit == "" {
 		memLimit = constants.SidecarDefaultMemoryLimit
@@ -79,9 +78,42 @@ func devfileResourcesToContainerResources(devfileContainer *dw.ContainerComponen
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse memory limit %q: %w", memLimit, err)
 	}
+
+	memReq := devfileContainer.MemoryRequest
+	if memReq == "" {
+		memReq = constants.SidecarDefaultMemoryRequest
+	}
+	memReqQuantity, err := resource.ParseQuantity(memReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse memory request %q: %w", memReq, err)
+	}
+
+	cpuLimit := devfileContainer.CpuLimit
+	if cpuLimit == "" {
+		cpuLimit = constants.SidecarDefaultCpuLimit
+	}
+	cpuLimitQuantity, err := resource.ParseQuantity(cpuLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cpu limit %q: %w", cpuLimit, err)
+	}
+
+	cpuReq := devfileContainer.CpuRequest
+	if cpuReq == "" {
+		cpuReq = constants.SidecarDefaultCpuRequest
+	}
+	cpuReqQuantity, err := resource.ParseQuantity(cpuReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cpu request %q: %w", cpuReq, err)
+	}
+
 	return &v1.ResourceRequirements{
 		Limits: v1.ResourceList{
 			v1.ResourceMemory: memLimitQuantity,
+			v1.ResourceCPU:    cpuLimitQuantity,
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: memReqQuantity,
+			v1.ResourceCPU:    cpuReqQuantity,
 		},
 	}, nil
 }

--- a/pkg/library/container/conversion.go
+++ b/pkg/library/container/conversion.go
@@ -70,6 +70,9 @@ func devfileEndpointsToContainerPorts(endpoints []dw.Endpoint) []v1.ContainerPor
 }
 
 func devfileResourcesToContainerResources(devfileContainer *dw.ContainerComponent) (*v1.ResourceRequirements, error) {
+	limits := v1.ResourceList{}
+	requests := v1.ResourceList{}
+
 	memLimit := devfileContainer.MemoryLimit
 	if memLimit == "" {
 		memLimit = constants.SidecarDefaultMemoryLimit
@@ -78,6 +81,7 @@ func devfileResourcesToContainerResources(devfileContainer *dw.ContainerComponen
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse memory limit %q: %w", memLimit, err)
 	}
+	limits[v1.ResourceMemory] = memLimitQuantity
 
 	memReq := devfileContainer.MemoryRequest
 	if memReq == "" {
@@ -87,34 +91,35 @@ func devfileResourcesToContainerResources(devfileContainer *dw.ContainerComponen
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse memory request %q: %w", memReq, err)
 	}
+	requests[v1.ResourceMemory] = memReqQuantity
 
 	cpuLimit := devfileContainer.CpuLimit
 	if cpuLimit == "" {
 		cpuLimit = constants.SidecarDefaultCpuLimit
 	}
-	cpuLimitQuantity, err := resource.ParseQuantity(cpuLimit)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cpu limit %q: %w", cpuLimit, err)
+	if cpuLimit != "" {
+		cpuLimitQuantity, err := resource.ParseQuantity(cpuLimit)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cpu limit %q: %w", cpuLimit, err)
+		}
+		limits[v1.ResourceCPU] = cpuLimitQuantity
 	}
 
 	cpuReq := devfileContainer.CpuRequest
 	if cpuReq == "" {
 		cpuReq = constants.SidecarDefaultCpuRequest
 	}
-	cpuReqQuantity, err := resource.ParseQuantity(cpuReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cpu request %q: %w", cpuReq, err)
+	if cpuReq != "" {
+		cpuReqQuantity, err := resource.ParseQuantity(cpuReq)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse cpu request %q: %w", cpuReq, err)
+		}
+		requests[v1.ResourceCPU] = cpuReqQuantity
 	}
 
 	return &v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceMemory: memLimitQuantity,
-			v1.ResourceCPU:    cpuLimitQuantity,
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceMemory: memReqQuantity,
-			v1.ResourceCPU:    cpuReqQuantity,
-		},
+		Limits:   limits,
+		Requests: requests,
 	}, nil
 }
 

--- a/pkg/library/container/testdata/converts-all-fields.yaml
+++ b/pkg/library/container/testdata/converts-all-fields.yaml
@@ -5,7 +5,10 @@ input:
     - name: testing-container-1
       container:
         image: testing-image-1
-        memoryLimit: 999Mi  # isolate test to not include memoryLimit
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
         sourceMapping: "/source-mapping"
         command: ["test", "command"]
         args: ["test", "args"]
@@ -41,8 +44,12 @@ output:
         image: testing-image-1
         imagePullPolicy: Always
         resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
           limits:
-            memory: "999Mi"
+            memory: "-1"
+            cpu: "-1"
         env:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-1"

--- a/pkg/library/container/testdata/detects-init-containers.yaml
+++ b/pkg/library/container/testdata/detects-init-containers.yaml
@@ -6,12 +6,18 @@ input:
       container:
         image: testing-image-1
         mountSources: false # isolate test to not include volumes
-        memoryLimit: "999Mi"  # isolate test to not include memoryLimit
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
     - name: testing-container-2
       container:
         image: testing-image-2
         mountSources: false # isolate test to not include volumes
-        memoryLimit: "999Mi"  # isolate test to not include memoryLimit
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
   commands:
     - id: test_preStart_command
       apply:
@@ -29,8 +35,12 @@ output:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-1"
         resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
           limits:
-            memory: "999Mi"
+            memory: "-1"
+            cpu: "-1"
     initContainers:
       - name: testing-container-2
         image: testing-image-2
@@ -39,5 +49,9 @@ output:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-2"
         resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
           limits:
-            memory: "999Mi"
+            memory: "-1"
+            cpu: "-1"

--- a/pkg/library/container/testdata/handles-container-that-mounts-projects-directly.yaml
+++ b/pkg/library/container/testdata/handles-container-that-mounts-projects-directly.yaml
@@ -8,7 +8,10 @@ input:
     - name: testing-container-1
       container:
         image: testing-image-1
-        memoryLimit: 999Mi  # isolate test to not include memoryLimit
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
         sourceMapping: "/testdir1"
         mountSources: true
         volumeMounts:
@@ -22,8 +25,12 @@ output:
         image: testing-image-1
         imagePullPolicy: Always
         resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
           limits:
-            memory: "999Mi"
+            memory: "-1"
+            cpu: "-1"
         volumeMounts:
           - name: "projects"
             mountPath: "/not-source-mapping"

--- a/pkg/library/container/testdata/handles-endpoints-with-common-port.yaml
+++ b/pkg/library/container/testdata/handles-endpoints-with-common-port.yaml
@@ -5,7 +5,10 @@ input:
     - name: testing-container-1
       container:
         image: testing-image-1
-        memoryLimit: 999Mi  # isolate test to not include memoryLimit
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
         mountSources: false
         endpoints:
           - name: "test-endpoint-1"
@@ -22,8 +25,12 @@ output:
         image: testing-image-1
         imagePullPolicy: Always
         resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
           limits:
-            memory: "999Mi"
+            memory: "-1"
+            cpu: "-1"
         env:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-1"

--- a/pkg/library/container/testdata/handles-mountSources.yaml
+++ b/pkg/library/container/testdata/handles-mountSources.yaml
@@ -5,19 +5,28 @@ input:
     - name: testing-container-1
       container:
         image: testing-image-1
-        memoryLimit: 999Mi  # isolate test to not include memoryLimit
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
         sourceMapping: "/testdir1"
         # no mountSources defined -> should mount sources
     - name: testing-container-2
       container:
         image: testing-image-2
-        memoryLimit: 999Mi  # isolate test to not include memoryLimit
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
         # No sourceMapping -> defaults to "/projects"
         mountSources: true # mountSources: true -> should mount sources
     - name: testing-container-3
       container:
         image: testing-image-3
-        memoryLimit: 999Mi  # isolate test to not include memoryLimit
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
         sourceMapping: "/projects"
         mountSources: false # mountSources: false -> should not mount sources
 output:
@@ -27,8 +36,12 @@ output:
         image: testing-image-1
         imagePullPolicy: Always
         resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
           limits:
-            memory: "999Mi"
+            memory: "-1"
+            cpu: "-1"
         volumeMounts:
           - name: "projects"
             mountPath: "/testdir1"
@@ -43,8 +56,12 @@ output:
         image: testing-image-2
         imagePullPolicy: Always
         resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
           limits:
-            memory: "999Mi"
+            memory: "-1"
+            cpu: "-1"
         volumeMounts:
           - name: "projects"
             mountPath: "/projects"
@@ -63,5 +80,9 @@ output:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-3"
         resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
           limits:
-            memory: "999Mi"
+            memory: "-1"
+            cpu: "-1"

--- a/pkg/library/container/testdata/handles-resources.yaml
+++ b/pkg/library/container/testdata/handles-resources.yaml
@@ -1,16 +1,19 @@
-name: "Processes memoryLimit correctly"
+name: "Processes resources settings correctly"
 
 input:
   components:
     - name: testing-container-1
       container:
         image: testing-image-1
+        memoryRequest: 512Mi
         memoryLimit: 999Mi
+        cpuRequest: "0.01"
+        cpuLimit: 10m
         mountSources: false
     - name: testing-container-2
       container:
         image: testing-image-2
-        # Omitted memory limit - should use default
+        # Omitted resources - should use default
         mountSources: false
 
 output:
@@ -23,8 +26,12 @@ output:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-1"
         resources:
+          requests:
+            memory: "512Mi"
+            cpu: "0.01"
           limits:
             memory: "999Mi"
+            cpu: "10m"
       - name: testing-container-2
         image: testing-image-2
         imagePullPolicy: Always
@@ -32,5 +39,9 @@ output:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-2"
         resources:
+          requests:
+            memory: "64M"
+            cpu: "-1"
           limits:
             memory: "128M"
+            cpu: "-1"

--- a/pkg/library/container/testdata/handles-resources.yaml
+++ b/pkg/library/container/testdata/handles-resources.yaml
@@ -41,7 +41,7 @@ output:
         resources:
           requests:
             memory: "64M"
-            cpu: "-1"
+            # cpu: "" default behaviour - do not provide any value
           limits:
             memory: "128M"
-            cpu: "-1"
+            # cpu: "" default behaviour - do not provide any value

--- a/pkg/library/container/testdata/ignores-non-container-components.yaml
+++ b/pkg/library/container/testdata/ignores-non-container-components.yaml
@@ -6,7 +6,10 @@ input:
       container:
         image: testing-image-1
         mountSources: false # isolate test to not include volumes
-        memoryLimit: "999Mi"  # isolate test to not include memoryLimit
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
     - name: test-volume
       volume: {}
 output:
@@ -19,5 +22,9 @@ output:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-1"
         resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
           limits:
-            memory: "999Mi"
+            memory: "-1"
+            cpu: "-1"


### PR DESCRIPTION
### What does this PR do?
This PR propagates Propogate container components cpu/memory limit/request.

:notebook: Probably default values should be configurable(as well as default PVC size, which is 1Gi now, which is not enough for sure for development normal project), but since we want to get rid of configmap, I'm not sure it worths adding it now. So, I'll create a dedicated issue, or find if it suites anywhere in existing one.

### What issues does this PR fix or reference?
fixes https://github.com/devfile/devworkspace-operator/issues/429

### Is it tested? How?
I haven't retested it yet after the newer changes but before:
1. Run devworkspace with theia.
2. Check that the right values are used in deployment, like `cpuLimit: 1500m` https://github.com/eclipse-che/che-plugin-registry/blob/master/che-editors.yaml#L42
3. make sure it's loaded in browser and plugins are loaded withing 5 seconds (before is was 30 seconds).

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
