### PR TITLE
fix(project-clone): Handle case of checkoutFrom with only one remote

### DIFF
--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -53,7 +53,7 @@ func main() {
 				log.Printf("Failed to set up remotes for project %s: %s", project.Name, err)
 				os.Exit(1)
 			}
-			if err := internal.CheckoutReference(repo, project.Git.CheckoutFrom); err != nil {
+			if err := internal.CheckoutReference(repo, &project); err != nil {
 				log.Printf("Failed to checkout revision for project %s: %s", project.Name, err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
### What does this PR do?
if we provide `checkoutFrom.revision` and there is only one remote, we don't need to specify again `checkoutFrom.remote`

### What issues does this PR fix or reference?
fixes https://github.com/devfile/devworkspace-operator/issues/443


### Is it tested? How?
use this project-clone image and use as devWorkspace:

FYI I've pushed `quay.io/fbenoit/project-clone:checkoutfrom`


```bash
$ kubectl apply -f https://gist.githubusercontent.com/benoitf/08bffac9b6e5dbbddacf7f462750c07e/raw/61dffd9df0980f4a8535ff5a44c77eab18f32a8b/devworkspace.yaml
```
you should then see in logs


```bash
$ kubectl logs -f -n florent -c project-clone pod/workspace272a90274b1942b3-6f9c97bb59-4l97q                                                                                              
2021/06/04 13:15:22 Read DevWorkspace at /devworkspace-metadata/flattened.devworkspace.yaml
2021/06/04 13:15:22 Cloning project spring-petclinic to spring-petclinic
Enumerating objects: 8606, done.
Counting objects: 100% (5/5), done.
Compressing objects: 100% (4/4), done.
Total 8606 (delta 0), reused 4 (delta 0), pack-reused 8601
2021/06/04 13:15:47 Cloned project spring-petclinic to spring-petclinic
2021/06/04 13:15:47 Setting up remotes for project spring-petclinic
2021/06/04 13:15:47 Fetched remote origin at https://github.com/che-samples/spring-petclinic
2021/06/04 13:15:47 Creating branch devfilev2 to track remote branch devfilev2 from
```

instead of
```
 failed to clone project spring-petclinic: project checkoutFrom refers to non-existing remote
```