### PR TITLE
fix: Increase project-clone CPU/memory limits to 1000m/1Gi to make clone faster

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -56,8 +56,8 @@ const (
 	// Resource limits/requests for project cloner init container
 	ProjectCloneMemoryLimit   = "300Mi"
 	ProjectCloneMemoryRequest = "64Mi"
-	ProjectCloneCPULimit      = "50m"
-	ProjectCloneCPURequest    = "5m"
+	ProjectCloneCPULimit      = "500m"
+	ProjectCloneCPURequest    = "100m"
 
 	// Constants describing storage classes supported by the controller
 	// CommonStorageClassType defines the 'common' storage policy -- one PVC is provisioned per namespace and all devworkspace storage

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -54,9 +54,9 @@ const (
 	PVCCleanupPodCPURequest = "5m"
 
 	// Resource limits/requests for project cloner init container
-	ProjectCloneMemoryLimit   = "300Mi"
-	ProjectCloneMemoryRequest = "64Mi"
-	ProjectCloneCPULimit      = "500m"
+	ProjectCloneMemoryLimit   = "1Gi"
+	ProjectCloneMemoryRequest = "128Mi"
+	ProjectCloneCPULimit      = "1000m"
 	ProjectCloneCPURequest    = "100m"
 
 	// Constants describing storage classes supported by the controller


### PR DESCRIPTION
### What does this PR do?
Increases the CPU limit for the project clone container from 50m to 500m to make cloning faster. In my brief testing, with 50m, project clone for https://github.com/che-samples/spring-petclinic takes ~15 seconds (as timed by the "started" and "completed" fields on cluster), whereas with 500m the same operation takes ~2 seconds.

Also increases memory limit to `1Gi`, to avoid OOMKilled when cloning large repos.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/446
Fixes https://github.com/devfile/devworkspace-operator/issues/447

### Is it tested? How?
```yaml
cat <<EOF | kubectl apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: checkoutfrom
  annotations:
    controller.devfile.io/debug-start: "true"
spec:
  started: true
  template:
    projects:
      - name: spring-petclinic
        git:
          checkoutFrom:
            revision: devfilev2
          remotes:
            origin: "https://github.com/che-samples/spring-petclinic"

    components:
      - name: tools
        container:
          image: quay.io/eclipse/che-java11-maven:nightly
EOF
```

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
