### PR TITLE
fixup(project-clone): Fix issue resolving remote name in git projects

### DIFF
--- a/project-clone/internal/git_operations.go
+++ b/project-clone/internal/git_operations.go
@@ -36,7 +36,7 @@ func CloneProject(project *dw.Project) (*git.Repository, error) {
 
 	var defaultRemoteName, defaultRemoteURL string
 	if project.Git.CheckoutFrom != nil {
-		defaultRemoteName := project.Git.CheckoutFrom.Remote
+		defaultRemoteName = project.Git.CheckoutFrom.Remote
 		if defaultRemoteName == "" {
 			// omitting remote attribute is possible if there is a single remote
 			if len(project.Git.Remotes) == 1 {


### PR DESCRIPTION
### What does this PR do?
Fix a minor typo in figuring out the default remote name when checkoutFrom is not specified and there is only one remote. Redeclaring the variable means that outside of the `if` condition, the value remains `""`.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
