### PR TITLE
feat: add support for zip projects in project-clone init container

### DIFF
--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # This is documented here:
 # https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
@@ -9,4 +9,4 @@ if ! whoami &>/dev/null; then
   fi
 fi
 
-exec $@
+exec "$@"

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -36,7 +36,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM registry.access.redhat.com/ubi8-minimal:8.4-200.1622548483
-RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
+RUN microdnf -y update && microdnf install -y time git && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/project-clone
 

--- a/project-clone/internal/devfile.go
+++ b/project-clone/internal/devfile.go
@@ -24,6 +24,7 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/provision/metadata"
 )
 
+// GetClonePath gets the correct clonePath for a project, given the semantics in devfile/api
 func GetClonePath(project *dw.Project) string {
 	if project.ClonePath != "" {
 		return project.ClonePath
@@ -31,6 +32,8 @@ func GetClonePath(project *dw.Project) string {
 	return project.Name
 }
 
+// ReadFlattenedDevWorkspace reads the flattened DevWorkspaceTemplateSpec from disk. The location of the flattened
+// yaml is determined from the DevWorkspace Operator-provisioned environment variable.
 func ReadFlattenedDevWorkspace() (*dw.DevWorkspaceTemplateSpec, error) {
 	flattenedDevWorkspacePath := os.Getenv(metadata.FlattenedDevfileMountPathEnvVar)
 	if flattenedDevWorkspacePath == "" {

--- a/project-clone/internal/devfile.go
+++ b/project-clone/internal/devfile.go
@@ -42,7 +42,7 @@ func ReadFlattenedDevWorkspace() (*dw.DevWorkspaceTemplateSpec, error) {
 
 	fileBytes, err := ioutil.ReadFile(flattenedDevWorkspacePath)
 	if err != nil {
-		return nil, fmt.Errorf("error reading current DevWorkspace YAML: %s", err)
+		return nil, fmt.Errorf("error reading YAML file: %s", err)
 	}
 
 	dwts := &dw.DevWorkspaceTemplateSpec{}

--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -26,8 +26,7 @@ import (
 	"github.com/devfile/devworkspace-operator/project-clone/internal/shell"
 )
 
-// CloneProject clones the project specified to $PROJECTS_ROOT. Note: projects.Github is ignored as it will likely
-// be removed soon.
+// CloneProject clones the project specified to $PROJECTS_ROOT.
 func CloneProject(project *dw.Project) error {
 	clonePath := internal.GetClonePath(project)
 	log.Printf("Cloning project %s to %s", project.Name, clonePath)

--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -112,12 +112,12 @@ func CheckoutReference(repo *git.Repository, project *dw.Project) error {
 	}
 	remote, err := repo.Remote(defaultRemoteName)
 	if err != nil {
-		return fmt.Errorf("could not find remote %s: %s", checkoutFrom.Remote, err)
+		return fmt.Errorf("could not find remote %s: %s", defaultRemoteName, err)
 	}
 
 	refs, err := remote.List(&git.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to read remote %s: %s", checkoutFrom.Remote, err)
+		return fmt.Errorf("failed to read remote %s: %s", defaultRemoteName, err)
 	}
 
 	for _, ref := range refs {
@@ -125,13 +125,13 @@ func CheckoutReference(repo *git.Repository, project *dw.Project) error {
 			continue
 		}
 		if ref.Name().IsBranch() {
-			return checkoutRemoteBranch(repo, checkoutFrom.Remote, ref)
+			return checkoutRemoteBranch(repo, defaultRemoteName, ref)
 		} else if ref.Name().IsTag() {
-			return checkoutTag(repo, checkoutFrom.Remote, ref)
+			return checkoutTag(repo, defaultRemoteName, ref)
 		}
 	}
 
-	log.Printf("No tag or branch named %s found on remote %s; attempting to resolve commit", checkoutFrom.Revision, checkoutFrom.Remote)
+	log.Printf("No tag or branch named %s found on remote %s; attempting to resolve commit", checkoutFrom.Revision, defaultRemoteName)
 	hash, err := repo.ResolveRevision(plumbing.Revision(checkoutFrom.Revision))
 	if err != nil {
 		return fmt.Errorf("failed to resolve commit %s: %s", checkoutFrom.Revision, err)

--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -10,7 +10,7 @@
 //   Red Hat, Inc. - initial API and implementation
 //
 
-package internal
+package git
 
 import (
 	"fmt"
@@ -22,12 +22,14 @@ import (
 	"github.com/go-git/go-git/v5"
 	gitConfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+
+	"github.com/devfile/devworkspace-operator/project-clone/internal"
 )
 
 // CloneProject clones the project specified to $PROJECTS_ROOT. Note: projects.Github is ignored as it will likely
 // be removed soon.
 func CloneProject(project *dw.Project) (*git.Repository, error) {
-	clonePath := GetClonePath(project)
+	clonePath := internal.GetClonePath(project)
 	log.Printf("Cloning project %s to %s", project.Name, clonePath)
 
 	if len(project.Git.Remotes) == 0 {
@@ -62,7 +64,7 @@ func CloneProject(project *dw.Project) (*git.Repository, error) {
 		}
 	}
 
-	repo, err := git.PlainClone(path.Join(projectsRoot, clonePath), false, &git.CloneOptions{
+	repo, err := git.PlainClone(path.Join(internal.ProjectsRoot, clonePath), false, &git.CloneOptions{
 		URL:        defaultRemoteURL,
 		RemoteName: defaultRemoteName,
 		Progress:   os.Stdout,

--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package git
+
+import (
+	"log"
+	"os"
+
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+
+	"github.com/devfile/devworkspace-operator/project-clone/internal"
+)
+
+func SetupGitProject(project v1alpha2.Project) error {
+	needClone, needRemotes, err := internal.CheckProjectState(&project)
+	if err != nil {
+		log.Printf("Failed to process project %s: %s", project.Name, err)
+		os.Exit(1)
+	}
+	if needClone {
+		repo, err := CloneProject(&project)
+		if err != nil {
+			log.Printf("failed to clone project %s: %s", project.Name, err)
+			os.Exit(1)
+		}
+		if err := SetupRemotes(repo, &project); err != nil {
+			log.Printf("Failed to set up remotes for project %s: %s", project.Name, err)
+			os.Exit(1)
+		}
+		if err := CheckoutReference(repo, &project); err != nil {
+			log.Printf("Failed to checkout revision for project %s: %s", project.Name, err)
+			os.Exit(1)
+		}
+	} else if needRemotes {
+		repo, err := internal.OpenRepo(&project)
+		if err != nil {
+			log.Printf("Failed to open existing project %s: %s", project.Name, err)
+			os.Exit(1)
+		} else if repo == nil {
+			log.Printf("Unexpected error while setting up remotes for project %s: git repository not present", project.Name)
+			os.Exit(1)
+		}
+		if err := SetupRemotes(repo, &project); err != nil {
+			log.Printf("Failed to set up remotes for project %s: %s", project.Name, err)
+			os.Exit(1)
+		}
+	} else {
+		log.Printf("Project '%s' is already cloned and has all remotes configured", project.Name)
+	}
+	return nil
+}

--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -28,9 +28,17 @@ func SetupGitProject(project v1alpha2.Project) error {
 		os.Exit(1)
 	}
 	if needClone {
-		repo, err := CloneProject(&project)
+		err := CloneProject(&project)
 		if err != nil {
 			log.Printf("failed to clone project %s: %s", project.Name, err)
+			os.Exit(1)
+		}
+		repo, err := internal.OpenRepo(&project)
+		if err != nil {
+			log.Printf("Failed to open existing project %s: %s", project.Name, err)
+			os.Exit(1)
+		} else if repo == nil {
+			log.Printf("Unexpected error while setting up remotes for project %s: git repository not present", project.Name)
 			os.Exit(1)
 		}
 		if err := SetupRemotes(repo, &project); err != nil {

--- a/project-clone/internal/global.go
+++ b/project-clone/internal/global.go
@@ -20,12 +20,12 @@ import (
 )
 
 var (
-	projectsRoot string
+	ProjectsRoot string
 )
 
 func init() {
-	projectsRoot = os.Getenv(constants.ProjectsRootEnvVar)
-	if projectsRoot == "" {
+	ProjectsRoot = os.Getenv(constants.ProjectsRootEnvVar)
+	if ProjectsRoot == "" {
 		log.Printf("Required environment variable %s is unset", constants.ProjectsRootEnvVar)
 		os.Exit(1)
 	}

--- a/project-clone/internal/global.go
+++ b/project-clone/internal/global.go
@@ -23,6 +23,7 @@ var (
 	ProjectsRoot string
 )
 
+// Read and store ProjectsRoot env var for reuse throughout project-clone.
 func init() {
 	ProjectsRoot = os.Getenv(constants.ProjectsRootEnvVar)
 	if ProjectsRoot == "" {

--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -17,6 +17,8 @@ import (
 	"os/exec"
 )
 
+// GitCloneProject constructs a commandline string for cloning a git project, and deletgates execution
+// to the os/exec package.
 func GitCloneProject(repoUrl, defaultRemoteName, destPath string) error {
 	args := []string{
 		"clone",

--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -17,7 +17,7 @@ import (
 	"os/exec"
 )
 
-// GitCloneProject constructs a commandline string for cloning a git project, and deletgates execution
+// GitCloneProject constructs a command-line string for cloning a git project, and delegates execution
 // to the os/exec package.
 func GitCloneProject(repoUrl, defaultRemoteName, destPath string) error {
 	args := []string{

--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package shell
+
+import (
+	"os"
+	"os/exec"
+)
+
+func GitCloneProject(repoUrl, defaultRemoteName, destPath string) error {
+	args := []string{
+		"clone",
+		repoUrl,
+		"--origin", defaultRemoteName,
+		"--",
+		destPath,
+	}
+	return executeCommand("git", args...)
+}
+
+func executeCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
+}

--- a/project-clone/internal/utils.go
+++ b/project-clone/internal/utils.go
@@ -21,6 +21,13 @@ import (
 	"github.com/go-git/go-git/v5"
 )
 
+// CheckProjectState Checks that a project's configuration is reflected in an on-disk git repository.
+// - Returns needClone == true if the project has not yet been cloned
+// - Returns needRemotes == true if the remotes configured in the project are not available in the on-disk repo
+//
+// Remotes in provided project are checked against what is configured in the git repo, but only in one direction.
+// The git repo can have additional remotes -- they will be ignored here. If both the project and git repo have remote
+// A configured, but the corresponding remote URL is differnet, needRemotes will be true.
 func CheckProjectState(project *dw.Project) (needClone, needRemotes bool, err error) {
 	repo, err := OpenRepo(project)
 	if err != nil {
@@ -65,6 +72,8 @@ func OpenRepo(project *dw.Project) (*git.Repository, error) {
 	return repo, nil
 }
 
+// DirExists returns true if the path at dir exists and is a directory. Returns an error if the path
+// exists in the filesystem but does not refer to a directory.
 func DirExists(dir string) (bool, error) {
 	fileInfo, err := os.Stat(dir)
 	if err != nil {

--- a/project-clone/internal/utils.go
+++ b/project-clone/internal/utils.go
@@ -54,7 +54,7 @@ func CheckProjectState(project *dw.Project) (needClone, needRemotes bool, err er
 // currently exist, returns nil. Returns an error if an unexpected error occurs opening the git repo.
 func OpenRepo(project *dw.Project) (*git.Repository, error) {
 	clonePath := GetClonePath(project)
-	repo, err := git.PlainOpen(path.Join(projectsRoot, clonePath))
+	repo, err := git.PlainOpen(path.Join(ProjectsRoot, clonePath))
 	if err != nil {
 		if err != git.ErrRepositoryNotExists {
 			return nil, fmt.Errorf("encountered error reading git repo at %s: %s", clonePath, err)

--- a/project-clone/internal/utils.go
+++ b/project-clone/internal/utils.go
@@ -14,6 +14,7 @@ package internal
 
 import (
 	"fmt"
+	"os"
 	"path"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -62,4 +63,19 @@ func OpenRepo(project *dw.Project) (*git.Repository, error) {
 		return nil, nil
 	}
 	return repo, nil
+}
+
+func DirExists(dir string) (bool, error) {
+	fileInfo, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+	if fileInfo.IsDir() {
+		return true, nil
+	}
+	return false, fmt.Errorf("path %s already exists and is not a directory", dir)
 }

--- a/project-clone/internal/utils.go
+++ b/project-clone/internal/utils.go
@@ -27,7 +27,7 @@ import (
 //
 // Remotes in provided project are checked against what is configured in the git repo, but only in one direction.
 // The git repo can have additional remotes -- they will be ignored here. If both the project and git repo have remote
-// A configured, but the corresponding remote URL is differnet, needRemotes will be true.
+// A configured, but the corresponding remote URL is different, needRemotes will be true.
 func CheckProjectState(project *dw.Project) (needClone, needRemotes bool, err error) {
 	repo, err := OpenRepo(project)
 	if err != nil {

--- a/project-clone/internal/zip/setup.go
+++ b/project-clone/internal/zip/setup.go
@@ -34,6 +34,13 @@ const (
 func SetupZipProject(project v1alpha2.Project) error {
 	url := project.Zip.Location
 	clonePath := internal.GetClonePath(&project)
+	projectPath := path.Join(internal.ProjectsRoot, clonePath)
+	if exists, err := internal.DirExists(projectPath); exists {
+		// Assume project is already set up
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to check path %s: %s", projectPath, err)
+	}
 
 	zipFilePath := path.Join(tmpDir, fmt.Sprintf("%s.zip", clonePath))
 	log.Printf("Downloading project archive from %s", url)
@@ -41,8 +48,6 @@ func SetupZipProject(project v1alpha2.Project) error {
 	if err != nil {
 		return fmt.Errorf("failed to download archive: %s", err)
 	}
-
-	projectPath := path.Join(internal.ProjectsRoot, clonePath)
 
 	log.Printf("Extracting project archive to %s", zipFilePath)
 	err = unzip(zipFilePath, projectPath)

--- a/project-clone/internal/zip/setup.go
+++ b/project-clone/internal/zip/setup.go
@@ -1,0 +1,151 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package zip
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+
+	"github.com/devfile/devworkspace-operator/project-clone/internal"
+)
+
+const (
+	tmpDir = "/tmp/"
+)
+
+func SetupZipProject(project v1alpha2.Project) error {
+	url := project.Zip.Location
+	clonePath := internal.GetClonePath(&project)
+
+	zipFilePath := path.Join(tmpDir, fmt.Sprintf("%s.zip", clonePath))
+	log.Printf("Downloading project archive from %s", url)
+	err := downloadZip(url, zipFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to download archive: %s", err)
+	}
+
+	projectPath := path.Join(internal.ProjectsRoot, clonePath)
+
+	log.Printf("Extracting project archive to %s", zipFilePath)
+	err = unzip(zipFilePath, projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to extract project zip archive: %s", err)
+	}
+
+	return nil
+}
+
+func downloadZip(url, destPath string) error {
+	client := http.DefaultClient
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer closeSafe(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("request at %s returned status code %s", url, resp.StatusCode)
+	}
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer closeSafe(out)
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return out.Sync()
+}
+
+// unzip extracts an archive to a destination path.
+//
+// Adapted from the Che plugin broker:
+// https://github.com/eclipse/che-plugin-broker/blob/27e7c6953c92633cbe7e8ce746a16ca10d240ea2/utils/ioutil.go#L190
+func unzip(archivePath string, destPath string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer closeSafe(r)
+
+	if err := os.MkdirAll(destPath, 0755); err != nil {
+		return err
+	}
+
+	// Closure to address file descriptors issue with all the deferred .Close() methods
+	extractAndWriteFile := func(f *zip.File) error {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := rc.Close(); err != nil {
+				panic(err)
+			}
+		}()
+
+		extractPath := filepath.Join(destPath, f.Name)
+
+		if f.FileInfo().IsDir() {
+			return os.MkdirAll(extractPath, 0755)
+		} else {
+			if err := os.MkdirAll(filepath.Dir(extractPath), 0775); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(extractPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := f.Close(); err != nil {
+					panic(err)
+				}
+			}()
+
+			_, err = io.Copy(f, rc)
+			if err != nil {
+				return err
+			}
+
+			return f.Sync()
+		}
+	}
+
+	for _, f := range r.File {
+		err := extractAndWriteFile(f)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func closeSafe(c io.Closer) {
+	err := c.Close()
+	if err != nil {
+		log.Println(err)
+	}
+}

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -38,7 +38,7 @@ func main() {
 		case project.Zip != nil:
 			err = zip.SetupZipProject(project)
 		default:
-			log.Printf("Unsupported project type")
+			log.Printf("Project does not specify Git or Zip source")
 			os.Exit(1)
 		}
 		if err != nil {

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/devfile/devworkspace-operator/project-clone/internal"
 	"github.com/devfile/devworkspace-operator/project-clone/internal/git"
+	"github.com/devfile/devworkspace-operator/project-clone/internal/zip"
 )
 
-// TODO: Handle projects specifying a zip file instead of git
 // TODO: Handle sparse checkout
 // TODO: Add support for auth
 func main() {
@@ -30,10 +30,13 @@ func main() {
 		os.Exit(1)
 	}
 	for _, project := range workspace.Projects {
+		log.Printf("Processing project %s", project.Name)
 		var err error
 		switch {
 		case project.Git != nil:
 			err = git.SetupGitProject(project)
+		case project.Zip != nil:
+			err = zip.SetupZipProject(project)
 		default:
 			log.Printf("Unsupported project type")
 			os.Exit(1)

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -43,6 +43,7 @@ func main() {
 		}
 		if err != nil {
 			log.Printf("Encountered error while setting up project %s: %s", project.Name, err)
+			os.Exit(1)
 		}
 	}
 }

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/devfile/devworkspace-operator/pkg/provision/metadata"
-	"github.com/devfile/devworkspace-operator/project-clone/internal"
+	"github.com/devfile/devworkspace-operator/project-clone/internal/git"
 )
 
 // TODO: Handle projects specifying a zip file instead of git
@@ -38,27 +38,27 @@ func main() {
 		if project.Git == nil {
 			continue
 		}
-		needClone, needRemotes, err := internal.CheckProjectState(&project)
+		needClone, needRemotes, err := git.CheckProjectState(&project)
 		if err != nil {
 			log.Printf("Failed to process project %s: %s", project.Name, err)
 			os.Exit(1)
 		}
 		if needClone {
-			repo, err := internal.CloneProject(&project)
+			repo, err := git.CloneProject(&project)
 			if err != nil {
 				log.Printf("failed to clone project %s: %s", project.Name, err)
 				os.Exit(1)
 			}
-			if err := internal.SetupRemotes(repo, &project); err != nil {
+			if err := git.SetupRemotes(repo, &project); err != nil {
 				log.Printf("Failed to set up remotes for project %s: %s", project.Name, err)
 				os.Exit(1)
 			}
-			if err := internal.CheckoutReference(repo, &project); err != nil {
+			if err := git.CheckoutReference(repo, &project); err != nil {
 				log.Printf("Failed to checkout revision for project %s: %s", project.Name, err)
 				os.Exit(1)
 			}
 		} else if needRemotes {
-			repo, err := internal.OpenRepo(&project)
+			repo, err := git.OpenRepo(&project)
 			if err != nil {
 				log.Printf("Failed to open existing project %s: %s", project.Name, err)
 				os.Exit(1)
@@ -66,7 +66,7 @@ func main() {
 				log.Printf("Unexpected error while setting up remotes for project %s: git repository not present", project.Name)
 				os.Exit(1)
 			}
-			if err := internal.SetupRemotes(repo, &project); err != nil {
+			if err := git.SetupRemotes(repo, &project); err != nil {
 				log.Printf("Failed to set up remotes for project %s: %s", project.Name, err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
### What does this PR do?
* Add support for zip-type projects in devfiles. Zip files are downloaded and extracted as-is.
* Delegate git clone step to standard `git` binary rather than relying on the go-git library

Using git instead of go-git for cloning projects results in the project-clone image being ~180MB larger (due to requiring git). However, from some brief testing, it also reduces the memory requirement of project clone by around 5x for large projects.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/416
Closes https://github.com/devfile/devworkspace-operator/issues/454

### Is it tested? How?
Changes are built and pushed to `quay.io/amisevsk/project-clone:zip-support` and can be tested with the devfile below
```yaml
cat <<EOF | kubectl apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: projects-testing
spec:
  started: true
  template:
    projects:
      - name: dwo
        zip:
          location: https://github.com/devfile/devworkspace-operator/archive/refs/heads/0.6.x.zip
        clonePath: test-project-zip
      - name: dwo-2
        git:
          checkoutFrom:
            revision: 0.6.x
          remotes:
            origin: https://github.com/devfile/devworkspace-operator.git
        clonePath: "test-project-git"

    components:
      - name: tools
        container:
          image: quay.io/amisevsk/project-clone:debug
          command:
            - "tail"
            - "-f"
            - "/dev/null"
EOF
```

Alternatively, the project clone image can be tested directly:
```bash
TMPDIR=$(mktemp -d)
cat <<EOF > "$TMPDIR/dw.yaml"
projects:
  - name: dwo
    zip:
      location: https://github.com/devfile/devworkspace-operator/archive/refs/heads/0.6.x.zip
    clonePath: test-project-zip
  - name: dwo-2
    git:
      checkoutFrom:
        revision: 0.6.x
      remotes:
        origin: https://github.com/devfile/devworkspace-operator.git
    clonePath: "test-project-git"
EOF

podman run \
  -e DEVWORKSPACE_FLATTENED_DEVFILE=/tmp/dw.yaml \
  -e PROJECTS_ROOT=/projects \
  --mount type=bind,src=$TMPDIR/dw.yaml,dst=/tmp/dw.yaml,z \
  --mount type=tmpfs,tmpfs-size=500M,dst=/projects/ \
  quay.io/amisevsk/project-clone:zip-support -- /bin/bash -c "/usr/local/bin/project-clone; sleep 10d"
```
(once clone is completed, run `podman exec -it <the container> /bin/bash` and check `/projects` manually)

<!-- 
Before PR merging it's required to run e2e tests, to trigger them comment 
/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
-->
