### PR TITLE
feat: expose a command to trigger e2e tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,8 @@
 ### Is it tested? How?
 <!-- Please provide instructions here how reviewer can test your changes if applicable -->
 
-<!-- 
-Before PR merging it's required to run e2e tests, to trigger them comment 
-/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path
--->
+### PR Checklist
+
+- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
+    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
+    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test


### PR DESCRIPTION
### What does this PR do?
When I need to trigger test, I know that I'm able to find a command in the comment for PR template, but it's not visible enough and not convenient to use. So, instead I introduce PR checklink where this command can be easily copied from.

Let me know if you have a better idea of how to trigger PR checks or expose info.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Just check this PR description.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace + Che Happy Path test
