### PR TITLE
Restrict reading DWTs in other namespaces

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -174,11 +174,11 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 	timing.SetTime(timingInfo, timing.ComponentsCreated)
 	// TODO#185 : Temporarily do devfile flattening in main reconcile loop; this should be moved to a subcontroller.
 	flattenHelpers := flatten.ResolverTools{
-		DefaultNamespace: workspace.Namespace,
-		Context:          ctx,
-		K8sClient:        r.Client,
-		InternalRegistry: &registry.InternalRegistryImpl{},
-		HttpClient:       http.DefaultClient,
+		WorkspaceNamespace: workspace.Namespace,
+		Context:            ctx,
+		K8sClient:          r.Client,
+		InternalRegistry:   &registry.InternalRegistryImpl{},
+		HttpClient:         http.DefaultClient,
 	}
 	flattenedWorkspace, err := flatten.ResolveDevWorkspace(&workspace.Spec.Template, flattenHelpers)
 	if err != nil {

--- a/pkg/library/flatten/testdata/annotate/annotate-devfile-with-importing-source.yaml
+++ b/pkg/library/flatten/testdata/annotate/annotate-devfile-with-importing-source.yaml
@@ -15,6 +15,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: parent-devworkspacetemplate
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         projects:
           - name: parent-project

--- a/pkg/library/flatten/testdata/k8s-ref/error_bad-plugin-merge.yaml
+++ b/pkg/library/flatten/testdata/k8s-ref/error_bad-plugin-merge.yaml
@@ -13,6 +13,10 @@ input:
                 memoryLimit: 512Mi
   devworkspaceResources:
     override:
+      metadata:
+        name: override
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: my-component

--- a/pkg/library/flatten/testdata/k8s-ref/error_conflicting-merge.yaml
+++ b/pkg/library/flatten/testdata/k8s-ref/error_conflicting-merge.yaml
@@ -12,6 +12,10 @@ input:
           image: test-image
   devworkspaceResources:
     test-plugin:
+      metadata:
+        name: test-plugin
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: my-component

--- a/pkg/library/flatten/testdata/k8s-ref/error_plugins-have-cycle.yml
+++ b/pkg/library/flatten/testdata/k8s-ref/error_plugins-have-cycle.yml
@@ -13,6 +13,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: plugin-a
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: plugin-b
@@ -25,6 +27,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: plugin-b
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: plugin-a

--- a/pkg/library/flatten/testdata/k8s-ref/nested-plugins-annotation.yaml
+++ b/pkg/library/flatten/testdata/k8s-ref/nested-plugins-annotation.yaml
@@ -14,6 +14,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: plugin-a
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: plugin-b
@@ -26,6 +28,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: plugin-b
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: plugin-b-container

--- a/pkg/library/flatten/testdata/k8s-ref/nodejs-workspace.yaml
+++ b/pkg/library/flatten/testdata/k8s-ref/nodejs-workspace.yaml
@@ -82,8 +82,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: theia-next
-        labels:
-          "devworkspace.devfile.io/editor-name": "che-theia"
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: plugins
@@ -211,6 +211,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: machine-exec
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
         labels:
           "devworkspace.devfile.io/editor-compatibility": "che-theia"
       spec:
@@ -242,6 +244,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: vscode-typescript
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
         labels:
           "devworkspace.devfile.io/editor-compatibility": "che-theia"
       spec:

--- a/pkg/library/flatten/testdata/k8s-ref/web-terminal-with-plugin.yaml
+++ b/pkg/library/flatten/testdata/k8s-ref/web-terminal-with-plugin.yaml
@@ -22,6 +22,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: web-terminal
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
         labels:
           "devworkspace.devfile.io/editor-name": "web-terminal"
       spec:

--- a/pkg/library/flatten/testdata/namespace-restriction/error_read-dwt-from-non-approved-namespace.yaml
+++ b/pkg/library/flatten/testdata/namespace-restriction/error_read-dwt-from-non-approved-namespace.yaml
@@ -1,0 +1,27 @@
+name: "Try to read a DWT from another namespace and no annotation exists"
+
+input:
+  devworkspace:
+    components:
+      - name: "plugin-a"
+        plugin:
+          kubernetes:
+            name: plugin-a
+  devworkspaceResources:
+    plugin-a:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-a
+        namespace: not-test-namespace
+        annotations:
+          controller.devfile.io/allow-import-from: "namespace1,namespace2"
+      spec:
+        components:
+          - name: plugin-a-container
+            container:
+              name: test-container
+              image: test-img
+
+output:
+  errRegexp: "could not find DevWorkspaceTemplate"

--- a/pkg/library/flatten/testdata/namespace-restriction/error_read-plain-dwt-from-another-namespace copy.yaml
+++ b/pkg/library/flatten/testdata/namespace-restriction/error_read-plain-dwt-from-another-namespace copy.yaml
@@ -1,4 +1,4 @@
-name: "Plugin references self"
+name: "Try to read a DWT from another namespace with empty annotation"
 
 input:
   devworkspace:
@@ -13,15 +13,15 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: plugin-a
+        namespace: not-test-namespace
         annotations:
-          "controller.devfile.io/allow-import-from": "*"
+          controller.devfile.io/allow-import-from: ""
       spec:
         components:
-          - name: plugin-a
-            plugin:
-              kubernetes:
-                name: plugin-a
-                namespace: devworkspace-plugins
+          - name: plugin-a-container
+            container:
+              name: test-container
+              image: test-img
 
 output:
-  errRegexp: "DevWorkspace has an cycle in references.*"
+  errRegexp: "could not find DevWorkspaceTemplate"

--- a/pkg/library/flatten/testdata/namespace-restriction/error_read-plain-dwt-from-another-namespace.yaml
+++ b/pkg/library/flatten/testdata/namespace-restriction/error_read-plain-dwt-from-another-namespace.yaml
@@ -1,4 +1,4 @@
-name: "Plugin references self"
+name: "Try to read a DWT from another namespace and no annotation exists"
 
 input:
   devworkspace:
@@ -13,15 +13,13 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: plugin-a
-        annotations:
-          "controller.devfile.io/allow-import-from": "*"
+        namespace: not-test-namespace
       spec:
         components:
-          - name: plugin-a
-            plugin:
-              kubernetes:
-                name: plugin-a
-                namespace: devworkspace-plugins
+          - name: plugin-a-container
+            container:
+              name: test-container
+              image: test-img
 
 output:
-  errRegexp: "DevWorkspace has an cycle in references.*"
+  errRegexp: "could not find DevWorkspaceTemplate"

--- a/pkg/library/flatten/testdata/namespace-restriction/read-dwt-in-permitted-namespace.yaml.yaml
+++ b/pkg/library/flatten/testdata/namespace-restriction/read-dwt-in-permitted-namespace.yaml.yaml
@@ -1,0 +1,34 @@
+name: "Can read DevWorkspaceTemplate in permitted namespace"
+
+input:
+  devworkspace:
+    components:
+      - name: "plugin-a"
+        plugin:
+          kubernetes:
+            name: plugin-a
+  devworkspaceResources:
+    plugin-a:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-a
+        namespace: not-test-namespace
+        annotations:
+          controller.devfile.io/allow-import-from: "namespace1,namespace2,test-namespace"
+      spec:
+        components:
+          - name: plugin-a-container
+            container:
+              name: test-container
+              image: test-img
+
+output:
+  devworkspace:
+    components:
+      - name: plugin-a-container
+        attributes:
+          controller.devfile.io/imported-by: "plugin-a"
+        container:
+          name: test-container
+          image: test-img

--- a/pkg/library/flatten/testdata/namespace-restriction/read-dwt-in-same-namespace.yaml
+++ b/pkg/library/flatten/testdata/namespace-restriction/read-dwt-in-same-namespace.yaml
@@ -1,0 +1,32 @@
+name: "Can read DevWorkspaceTemplate in same namespace as DevWorkspace"
+
+input:
+  devworkspace:
+    components:
+      - name: "plugin-a"
+        plugin:
+          kubernetes:
+            name: plugin-a
+  devworkspaceResources:
+    plugin-a:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-a
+        namespace: test-namespace
+      spec:
+        components:
+          - name: plugin-a-container
+            container:
+              name: test-container
+              image: test-img
+
+output:
+  devworkspace:
+    components:
+      - name: plugin-a-container
+        attributes:
+          controller.devfile.io/imported-by: "plugin-a"
+        container:
+          name: test-container
+          image: test-img

--- a/pkg/library/flatten/testdata/namespace-restriction/read-dwt-with-any-namespace-annotation.yaml
+++ b/pkg/library/flatten/testdata/namespace-restriction/read-dwt-with-any-namespace-annotation.yaml
@@ -1,0 +1,34 @@
+name: "Can read DevWorkspaceTemplate when DWT is allowed for all namespaces"
+
+input:
+  devworkspace:
+    components:
+      - name: "plugin-a"
+        plugin:
+          kubernetes:
+            name: plugin-a
+  devworkspaceResources:
+    plugin-a:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-a
+        namespace: not-test-namespace
+        annotations:
+          controller.devfile.io/allow-import-from: "*"
+      spec:
+        components:
+          - name: plugin-a-container
+            container:
+              name: test-container
+              image: test-img
+
+output:
+  devworkspace:
+    components:
+      - name: plugin-a-container
+        attributes:
+          controller.devfile.io/imported-by: "plugin-a"
+        container:
+          name: test-container
+          image: test-img

--- a/pkg/library/flatten/testdata/parent/error_parent-has-parent.yaml
+++ b/pkg/library/flatten/testdata/parent/error_parent-has-parent.yaml
@@ -16,6 +16,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: parent-devworkspacetemplate
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         parent:
           id: another-parent

--- a/pkg/library/flatten/testdata/parent/error_parent-has-plugins.yaml
+++ b/pkg/library/flatten/testdata/parent/error_parent-has-plugins.yaml
@@ -16,6 +16,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: parent-devworkspacetemplate
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: parent-component

--- a/pkg/library/flatten/testdata/parent/resolve-parent-and-plugins.yaml
+++ b/pkg/library/flatten/testdata/parent/resolve-parent-and-plugins.yaml
@@ -25,6 +25,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: parent-devworkspacetemplate
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: parent-component

--- a/pkg/library/flatten/testdata/parent/resolve-parent-by-k8s-reference.yaml
+++ b/pkg/library/flatten/testdata/parent/resolve-parent-by-k8s-reference.yaml
@@ -22,6 +22,8 @@ input:
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:
         name: parent-devworkspacetemplate
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
       spec:
         components:
           - name: parent-component

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -32,8 +32,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
   -asmflags all=-trimpath=/ \
   project-clone/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM registry.access.redhat.com/ubi8-minimal:8.4-200.1622548483
 RUN microdnf -y update && microdnf install -y time git && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"

--- a/samples/plugins/machine-exec.yaml
+++ b/samples/plugins/machine-exec.yaml
@@ -2,6 +2,8 @@ kind: DevWorkspaceTemplate
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
   name: machine-exec
+  annotations:
+    controller.devfile.io/allow-import-from: '*'
 spec:
   components:
     - name: che-machine-exec

--- a/samples/plugins/remote-runtime-injector.yaml
+++ b/samples/plugins/remote-runtime-injector.yaml
@@ -2,6 +2,8 @@ kind: DevWorkspaceTemplate
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
   name: remote-runtime-injector
+  annotations:
+    controller.devfile.io/allow-import-from: '*'
 spec:
   components:
     - name: remote-runtime-injector

--- a/samples/plugins/theia-next.yaml
+++ b/samples/plugins/theia-next.yaml
@@ -2,6 +2,8 @@ kind: DevWorkspaceTemplate
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
   name: theia-next
+  annotations:
+    controller.devfile.io/allow-import-from: '*'
 spec:
   components:
     - name: plugins

--- a/samples/plugins/web-terminal-dev.yaml
+++ b/samples/plugins/web-terminal-dev.yaml
@@ -2,6 +2,8 @@ kind: DevWorkspaceTemplate
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
   name: web-terminal-dev
+  annotations:
+    controller.devfile.io/allow-import-from: '*'
 spec:
   components:
     - name: web-terminal

--- a/samples/plugins/web-terminal.yaml
+++ b/samples/plugins/web-terminal.yaml
@@ -2,6 +2,8 @@ kind: DevWorkspaceTemplate
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
   name: web-terminal
+  annotations:
+    controller.devfile.io/allow-import-from: '*'
 spec:
   components:
     - name: web-terminal


### PR DESCRIPTION
### What does this PR do?
Removes the ability for DevWorkspaces to read dwts across the cluster, defaulting to only being able to read dwts from the current namespace. Adds an annotation (on dwts) to allow them to be readable in either all namespaces or a specific set of namespaces.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/403

### Is it tested? How?
Test cases added. 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
