### PR TITLE
Fix outdated test name for memoryLimit/Request handling

### DIFF
--- a/pkg/library/container/testdata/fixes-memory-limit-less-than-default-request.yaml
+++ b/pkg/library/container/testdata/fixes-memory-limit-less-than-default-request.yaml
@@ -1,4 +1,4 @@
-name: "Gives useful error when memory limit is less than default request"
+name: "Reduces default memory request when limit is lower than the default"
 
 input:
   components:
@@ -6,6 +6,7 @@ input:
       container:
         image: testing-image
         memoryLimit: 1Mi
+        # memoryRequest: 64Mi default (something greater than 1Mi)
         mountSources: false
 
 output:


### PR DESCRIPTION
### What does this PR do?
Fixup bad test name for memory request handling.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/pull/464/files/5952763effb1e63fcd8cc768e4db0fe6f053dc93#r657780981

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
