### PR TITLE
Don't remove openshift-operators namespace on make uninstall

### DIFF
--- a/build/make/deploy.mk
+++ b/build/make/deploy.mk
@@ -76,7 +76,9 @@ endif
 	$(K8S_CLI) delete all -l "app.kubernetes.io/part-of=devworkspace-operator" --all-namespaces
 	$(K8S_CLI) delete mutatingwebhookconfigurations.admissionregistration.k8s.io controller.devfile.io --ignore-not-found
 	$(K8S_CLI) delete validatingwebhookconfigurations.admissionregistration.k8s.io controller.devfile.io --ignore-not-found
+ifneq ($(NAMESPACE),openshift-operators)
 	$(K8S_CLI) delete namespace $(NAMESPACE) --ignore-not-found
+endif
 
 _check_cert_manager:
 ifeq ($(PLATFORM),kubernetes)


### PR DESCRIPTION
### What does this PR do?
Make it so that `make uninstall` doesn't remove `openshift-operators` accidentally (a problem I keep running into when trying to uninstall the operator :wink:)

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
