### PR TITLE
fix: finetune regex in the release script

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -112,7 +112,7 @@ set -e
 sed -i version/version.go -r -e "s#(Version = \")(v?[0-9.]+)(\")#\1${VERSION}\3#g"
 # change image tag in Makefile
 DWO_QUAY_IMG="quay.io/devfile/devworkspace-controller:${VERSION}"
-sed -i Makefile -r -e "s#quay.io/devfile/devworkspace-controller:.*[0-9a-zA-Z._-]#${DWO_QUAY_IMG}#g"
+sed -i Makefile -r -e "s#quay.io/devfile/devworkspace-controller:[0-9a-zA-Z._-]+#${DWO_QUAY_IMG}#g"
 docker build -t "${DWO_QUAY_IMG}" -f ./build/Dockerfile .
 docker push "${DWO_QUAY_IMG}"
 PROJECT_CLONE_QUAY_IMG="quay.io/devfile/project-clone:${VERSION}"

--- a/make-release.sh
+++ b/make-release.sh
@@ -112,11 +112,11 @@ set -e
 sed -i version/version.go -r -e "s#(Version = \")(v?[0-9.]+)(\")#\1${VERSION}\3#g"
 # change image tag in Makefile
 DWO_QUAY_IMG="quay.io/devfile/devworkspace-controller:${VERSION}"
-sed -i Makefile -r -e "s#quay.io/devfile/devworkspace-controller:.*#${DWO_QUAY_IMG}#g"
+sed -i Makefile -r -e "s#quay.io/devfile/devworkspace-controller:.*[0-9a-zA-Z._-]#${DWO_QUAY_IMG}#g"
 docker build -t "${DWO_QUAY_IMG}" -f ./build/Dockerfile .
 docker push "${DWO_QUAY_IMG}"
 PROJECT_CLONE_QUAY_IMG="quay.io/devfile/project-clone:${VERSION}"
-sed -i Makefile -r -e "s#quay.io/devfile/project-clone:.*#${PROJECT_CLONE_QUAY_IMG}#g"
+sed -i Makefile -r -e "s#quay.io/devfile/project-clone:.*[0-9a-zA-Z._-]#${PROJECT_CLONE_QUAY_IMG}#g"
 docker build -t "${PROJECT_CLONE_QUAY_IMG}" -f ./project-clone/Dockerfile .
 docker push "${PROJECT_CLONE_QUAY_IMG}"
 


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

### What does this PR do?
fix regex in the release script, to ensure that we replace only the image tag

### What issues does this PR fix or reference?
follow-up to previous PR https://github.com/devfile/devworkspace-operator/pull/480

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
only tested locally

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
