### PR TITLE
Improve error reporting in project clone

### DIFF
--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -13,6 +13,8 @@
 package shell
 
 import (
+	"fmt"
+	"log"
 	"os"
 	"os/exec"
 )
@@ -28,6 +30,25 @@ func GitCloneProject(repoUrl, defaultRemoteName, destPath string) error {
 		destPath,
 	}
 	return executeCommand("git", args...)
+}
+
+// GitResetProject runs `git reset --hard` in the project specified by projectPath
+func GitResetProject(projectPath string) error {
+	currDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %s", err)
+	}
+	defer func() {
+		if err := os.Chdir(currDir); err != nil {
+			log.Printf("failed to return to original working directory: %s", err)
+		}
+	}()
+
+	err = os.Chdir(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to move to project directory %s: %s", projectPath, err)
+	}
+	return executeCommand("git", "reset", "--hard")
 }
 
 func executeCommand(name string, args ...string) error {

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -13,17 +13,31 @@
 package main
 
 import (
+	"io"
 	"log"
 	"os"
+	"path"
 
 	"github.com/devfile/devworkspace-operator/project-clone/internal"
 	"github.com/devfile/devworkspace-operator/project-clone/internal/git"
 	"github.com/devfile/devworkspace-operator/project-clone/internal/zip"
 )
 
+const (
+	logFileName    = "project-clone-errors.log"
+	tmpLogFilePath = "/tmp/" + logFileName
+)
+
 // TODO: Handle sparse checkout
 // TODO: Add support for auth
 func main() {
+	f, err := os.Create(tmpLogFilePath)
+	if err != nil {
+		log.Printf("failed to open file %s for logging: %s", tmpLogFilePath, err)
+	}
+	mw := io.MultiWriter(os.Stdout, f)
+	log.SetOutput(mw)
+
 	workspace, err := internal.ReadFlattenedDevWorkspace()
 	if err != nil {
 		log.Printf("Failed to read current DevWorkspace: %s", err)
@@ -39,11 +53,34 @@ func main() {
 			err = zip.SetupZipProject(project)
 		default:
 			log.Printf("Project does not specify Git or Zip source")
-			os.Exit(1)
+			copyLogFileToProjectsRoot()
+			os.Exit(0)
 		}
 		if err != nil {
 			log.Printf("Encountered error while setting up project %s: %s", project.Name, err)
-			os.Exit(1)
+			copyLogFileToProjectsRoot()
+			os.Exit(0)
 		}
+	}
+}
+
+// copyLogFileToProjectsRoot copies the predefined log file into a persistent directory ($PROJECTS_ROOT)
+// so that issues in setting up a devfile's projects are persisted beyond workspace restarts. Note that
+// not all output from the project clone container is propagated to the log file. For example, the progress
+// in cloning a project using the `git` binary only appears in stdout/stderr.
+func copyLogFileToProjectsRoot() {
+	infile, err := os.Open(tmpLogFilePath)
+	if err != nil {
+		log.Printf("Failed to open log file: %s", err)
+	}
+	defer infile.Close()
+	outfile, err := os.Create(path.Join(internal.ProjectsRoot, logFileName))
+	if err != nil {
+		log.Printf("Failed to create log file: %s", err)
+	}
+	defer outfile.Close()
+
+	if _, err := io.Copy(outfile, infile); err != nil {
+		log.Printf("Failed to copy log file to $PROJECTS_ROOT: %s", err)
 	}
 }


### PR DESCRIPTION
### What does this PR do?
* Never restart the project-clone container since it's not re-entrant. Instead, log output to a file and copy it into `$PROJECTS_ROOT` if an error occurs.
* Run `git reset --hard` after checking out a branch to emulate git's behavior in (misconfigured?) git repos such as https://github.com/che-samples/java-spring-petclinic/tree/devfilev2 (`.vscode/extensions` is commited to the repo and `.gitignored`, which causes go-git to ignore it even for `git reset`)

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/457

### Is it tested? How?
* Update `RELATED_IMAGE_project_clone` in a DWO deployment to `quay.io/amisevsk/project-clone:error-reporting`
* Create a devworkspace to test error reporting:
  ```yaml
  cat <<EOF | kubectl apply -f -
  kind: DevWorkspace
  apiVersion: workspace.devfile.io/v1alpha2
  metadata:
    name: test-dw
  spec:
    started: true
    template:
      projects:
      - name: dwo
        git:
          checkoutFrom:
            remote: amisevsk
            revision: non-existent-branch
          remotes:
            amisevsk: https://github.com/amisevsk/devworkspace-operator.git
            origin: https://github.com/devfile/devworkspace-operator.git
            sleshchenko: https://github.com/sleshchenko/devworkspace-operator.git
      components:
        - name: theia
          plugin:
            uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
  EOF
  ```
    - `/projects` should contain a file named `project-clone-errors.log` after workspace is started
* Create a devworkspace to test reset behaviour:
  ```yaml
  cat <<EOF | kubectl apply -f -
  kind: DevWorkspace
  apiVersion: workspace.devfile.io/v1alpha2
  metadata:
    name: test-dw
  spec:
    started: true
    template:
      projects:
      - name: spring-petclinic
        git:
          checkoutFrom:
            revision: devfilev2
          remotes:
            origin: https://github.com/che-samples/spring-petclinic
      components:
        - name: theia
          plugin:
            uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
  EOF
  ```
    - Project's git state should be clean.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
