### PR TITLE
Add support for per-namespace configuration and add setting for workspace PVC request size

### DIFF
--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -77,4 +77,8 @@ const (
 	// Only secrets with 'true' value will be mount as pull secret
 	// Should be assigned to secrets with type docker config types (kubernetes.io/dockercfg and kubernetes.io/dockerconfigjson)
 	DevWorkspacePullSecretLabel = "controller.devfile.io/devworkspace_pullsecret"
+
+	// NamespacedConfigLabelKey is a label applied to configmaps to mark them as a configuration for all DevWorkspaces in
+	// the current namespace.
+	NamespacedConfigLabelKey = "controller.devfile.io/namespaced-config"
 )

--- a/pkg/provision/config/config.go
+++ b/pkg/provision/config/config.go
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+)
+
+const (
+	commonPVCSizeKey = "commonPVCSize"
+)
+
+type NamespacedConfig struct {
+	CommonPVCSize string
+}
+
+// ReadNamespacedConfig reads the per-namespace DevWorkspace configmap and returns it as a struct. If there are
+// no valid configmaps in the specified namespace, returns (nil, nil). If there are multiple configmaps with the
+// per-namespace configmap label, returns an error.
+func ReadNamespacedConfig(namespace string, api provision.ClusterAPI) (*NamespacedConfig, error) {
+	cmList := &corev1.ConfigMapList{}
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s=true", constants.NamespacedConfigLabelKey))
+	if err != nil {
+		return nil, err
+	}
+	selector := &client.ListOptions{
+		Namespace:     namespace,
+		LabelSelector: labelSelector,
+	}
+	err = api.Client.List(api.Ctx, cmList, selector)
+	if err != nil {
+		return nil, err
+	}
+	cms := cmList.Items
+	if len(cms) == 0 {
+		return nil, nil
+	} else if len(cms) > 1 {
+		var cmNames []string
+		for _, cm := range cms {
+			cmNames = append(cmNames, cm.Name)
+		}
+		return nil, fmt.Errorf("multiple per-namespace configs found: %s", strings.Join(cmNames, ", "))
+	}
+
+	cm := cms[0]
+	if cm.Data == nil {
+		return nil, nil
+	}
+
+	return &NamespacedConfig{
+		CommonPVCSize: cm.Data[commonPVCSizeKey],
+	}, nil
+}

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -101,7 +101,7 @@ func TestRewriteContainerVolumeMountsForCommonStorageClass(t *testing.T) {
 	tests := loadAllTestCasesOrPanic(t, "testdata/common-storage")
 	setupControllerCfg()
 	commonStorage := CommonStorageProvisioner{}
-	commonPVC, err := getCommonPVCSpec("test-namespace")
+	commonPVC, err := getCommonPVCSpec("test-namespace", "1Gi")
 	if err != nil {
 		t.Fatalf("Failure during setup: %s", err)
 	}


### PR DESCRIPTION
### What does this PR do?
* Add mechanism for defining namespace-level configuration for DevWorkspaces via configmap
    * A configmap is marked as relevant with the label `controller.devfile.io/namespaced-config`
* Add capability to define PVC size via configmap above.

TODOs: (either here or separate issues)
* Workspace PVCs are not updated once they are created, so the setting above only applies when the claim-devworkspace PVC does not exist. https://github.com/devfile/devworkspace-operator/issues/488
    * It's not straightforward to enable this, as *only* the PVC storage `request` can be changed after creation. The SyncObjects method won't work if it uses `Update()` and switching to `Patch()` fails for reasons I don't fully understand yet (likely due to dealing with runtime.Object)
* The configuration setting currently applies to the PVC's storage `request` and no limit is supplied. Should we allow the configmap to define both request and limit?

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/477

### Is it tested? How?
Create a configmap to set defaults for a specific namespace:
```yaml
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-nsconfig
  labels:
    controller.devfile.io/namespaced-config: "true"
data:
  commonPVCSize: 5Gi
EOF
```
and then create a DevWorkspace in that namespace.

If the namespace already has a claim-devworkspace, it will not be updated and so should be deleted before testing.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
