### PR TITLE
Fixup default docker entrypoint to properly set username

### DIFF
--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -5,7 +5,7 @@
 
 if ! whoami &>/dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "${USER_NAME}:-devworkspace-controller:x:$(id -u):$(id -g):${USER_NAME}:-devworkspace-controller user:${HOME}:/sbin/nologin" >> /etc/passwd
+    echo "${USER_NAME:-devworkspace-controller}:x:$(id -u):$(id -g):${USER_NAME:-devworkspace-controller} user:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
 fi
 


### PR DESCRIPTION
### What does this PR do?
The entrypoint used for our containers had a typo that resulted in user name not being set.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
