### PR TITLE
Fix error in volumes processing

### DIFF
--- a/pkg/provision/storage/shared.go
+++ b/pkg/provision/storage/shared.go
@@ -153,12 +153,12 @@ func addEphemeralVolumesToPodAdditions(podAdditions *v1alpha1.PodAdditions, work
 // volumes, and the projects volume, which must be handled specially. If the workspace does not define a projects volume,
 // the returned value is nil.
 func getWorkspaceVolumes(workspace *dw.DevWorkspace) (persistent, ephemeral []dw.Component, projects *dw.Component) {
-	for _, component := range workspace.Spec.Template.Components {
+	for idx, component := range workspace.Spec.Template.Components {
 		if component.Volume == nil {
 			continue
 		}
 		if component.Name == devfileConstants.ProjectsVolumeName {
-			projects = &component
+			projects = &workspace.Spec.Template.Components[idx]
 			continue
 		}
 		if component.Volume.Ephemeral {

--- a/pkg/provision/storage/testdata/handles-projects-volume-ordering.yaml
+++ b/pkg/provision/storage/testdata/handles-projects-volume-ordering.yaml
@@ -1,0 +1,56 @@
+name: "Does not depend on component order in detecting projects volume"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image-1
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+      - name: testing-container-2
+        image: testing-image-2
+        volumeMounts:
+          - name: "projects"
+      - name: testing-container-3
+        image: testing-image-3
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true
+      - name: projects
+        volume:
+          ephemeral: true
+      - name: testing-container-2
+        container:
+          image: testing-image-2
+          mountSources: true
+      - name: testing-container-3
+        container:
+          image: testing-image-3
+          sourceMapping: "/plugins-mountpath"
+          mountSources: false
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image-1
+        volumeMounts:
+          - name: projects
+            mountPath: "/projects-mountpath"
+      - name: testing-container-2
+        image: testing-image-2
+        volumeMounts:
+          - name: "projects"
+      - name: testing-container-3
+        image: testing-image-3
+
+    volumes:
+      - name: projects
+        emptyDir: {}


### PR DESCRIPTION
### What does this PR do?
Fix error in how the projects volume is detected in storage provisioner, which could result in a panic if additional components appear after the projects volume.

By assigning `projects = &component` in `getWorkspaceVolumes`, the `projects` var would be updated on each loop after it's set, which will result in projects pointing at the wrong component unless projects is last in the list.

### What issues does this PR fix or reference?
Panic with e.g. 
```yaml
cat <<EOF | kubectl apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
      - name: projects
        volume:
          ephemeral: true
EOF
```

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
