### PR TITLE
Use git binary for fetch to make ssh easier

### DIFF
--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -76,6 +76,7 @@ func CloneProject(project *dw.Project) error {
 // SetupRemotes sets up a git remote in repo for each remote in project.Git.Remotes
 func SetupRemotes(repo *git.Repository, project *dw.Project) error {
 	log.Printf("Setting up remotes for project %s", project.Name)
+	clonePath := internal.GetClonePath(project)
 	for remoteName, remoteUrl := range project.Git.Remotes {
 		_, err := repo.CreateRemote(&gitConfig.RemoteConfig{
 			Name: remoteName,
@@ -84,10 +85,8 @@ func SetupRemotes(repo *git.Repository, project *dw.Project) error {
 		if err != nil && err != git.ErrRemoteExists {
 			return fmt.Errorf("failed to add remote %s: %s", remoteName, err)
 		}
-		err = repo.Fetch(&git.FetchOptions{
-			RemoteName: remoteName,
-		})
-		if err != nil && err != git.NoErrAlreadyUpToDate {
+		err = shell.GitFetchRemote(path.Join(internal.ProjectsRoot, clonePath), remoteName)
+		if err != nil {
 			return fmt.Errorf("failed to fetch from remote %s: %s", remoteUrl, err)
 		}
 		log.Printf("Fetched remote %s at %s", remoteName, remoteUrl)

--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -51,6 +51,23 @@ func GitResetProject(projectPath string) error {
 	return executeCommand("git", "reset", "--hard")
 }
 
+func GitFetchRemote(projectPath, remote string) error {
+	currDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %s", err)
+	}
+	defer func() {
+		if err := os.Chdir(currDir); err != nil {
+			log.Printf("failed to return to original working directory: %s", err)
+		}
+	}()
+	err = os.Chdir(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to move to project directory %s: %s", projectPath, err)
+	}
+	return executeCommand("git", "fetch", remote)
+}
+
 func executeCommand(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
### What does this PR do?
Make changes necessary to make basic SSH support work in the project clone container (basically, just use `git` binary for all operations involving remote repos.

Currently, `project-clone` expects ssh keys to be stored in `/.ssh`, since no `$HOME` directory is configured for that container. To ensure compatibility with other editors, we should refine how users/homedirs are defined to make sure the same secret can be used for all workspace containers.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/400

### Is it tested? How?
Can be tested using the image `quay.io/amisevsk/project-clone:ssh` (change `RELATED_IMAGE_project_clone` on the controller deployment).

To manually test usage with a private repo, create a new ssh key (without passkey) and upload the pubkey to GitHub. Then, create a k8s secret in your namespace:
```bash
cat > /tmp/gitconfig <<EOF
host *
  IdentityFile /.ssh/id_rsa
  StrictHostKeyChecking = no
EOF

kubectl create secret generic git-ssh-key \
  --from-file=id_rsa=/path/to/private-key \
  --from-file=id_rsa.pub=/path/to/public-key \
  --from-file=config=/tmp/gitconfig

kubectl patch secret git-ssh-key --type merge -p \
  '{"metadata": {
     "labels": {
        "controller.devfile.io/mount-to-devworkspace": "true"
      }, 
      "annotations": {
        "controller.devfile.io/mount-path": "/.ssh/"
      }
    }
  }'
```
Once this is done, you should be able to create DevWorkspaces that use private repos.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
