### PR TITLE
Ignore VolumeMount order in containers when checking deployment sync

### DIFF
--- a/controllers/workspace/provision/deployment.go
+++ b/controllers/workspace/provision/deployment.go
@@ -64,6 +64,9 @@ var deploymentDiffOpts = cmp.Options{
 	cmpopts.SortSlices(func(a, b corev1.Volume) bool {
 		return strings.Compare(a.Name, b.Name) > 0
 	}),
+	cmpopts.SortSlices(func(a, b corev1.VolumeMount) bool {
+		return strings.Compare(a.Name, b.Name) > 0
+	}),
 }
 
 func SyncDeploymentToCluster(


### PR DESCRIPTION
### What does this PR do?
Changes the diff opts used for deployments to ignore volume mount order.

### What issues does this PR fix or reference?
I ran into an issue while testing https://github.com/devfile/devworkspace-operator/issues/455 where the order of volumeMounts different between what we generate in the controller and what's on the cluster, resulting in a reconcile loop.

### Is it tested? How?
I don't have a great reproducer.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
