### PR TITLE
Check edge cases for automounted configmaps/secrets

### DIFF
--- a/controllers/workspace/provision/automount.go
+++ b/controllers/workspace/provision/automount.go
@@ -177,7 +177,7 @@ func checkAutoMountVolumesForCollision(base, automount []v1alpha1.PodAdditions) 
 	for _, podAddition := range base {
 		for _, volume := range podAddition.Volumes {
 			if conflict, exists := automountVolumeNames[volume.Name]; exists {
-				return fmt.Errorf("DevWorkspace volume %s conflicts with automounted volume from %s",
+				return fmt.Errorf("DevWorkspace volume '%s' conflicts with automounted volume from %s",
 					volume.Name, formatVolumeDescription(conflict))
 			}
 		}
@@ -223,14 +223,14 @@ func getVolumeDescriptionFromVolumeMount(vm corev1.VolumeMount, podAdditions []v
 	return vm.Name
 }
 
-// formatVolumeDescription formats a given volume as either "configmap <configmap-name>" or "secret <secret-name>",
+// formatVolumeDescription formats a given volume as either "configmap '<configmap-name>'" or "secret '<secret-name>'",
 // depending on whether the volume refers to a configmap or secret. If the volume is neither a secret nor configmap,
 // returns the name of the volume itself.
 func formatVolumeDescription(vol corev1.Volume) string {
 	if vol.Secret != nil {
-		return fmt.Sprintf("secret %s", vol.Secret.SecretName)
+		return fmt.Sprintf("secret '%s'", vol.Secret.SecretName)
 	} else if vol.ConfigMap != nil {
-		return fmt.Sprintf("configmap %s", vol.ConfigMap.Name)
+		return fmt.Sprintf("configmap '%s'", vol.ConfigMap.Name)
 	}
-	return vol.Name
+	return fmt.Sprintf("'%s'", vol.Name)
 }

--- a/controllers/workspace/provision/automount.go
+++ b/controllers/workspace/provision/automount.go
@@ -19,14 +19,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 )
 
-func getAutoMountResources(namespace string, client runtimeClient.Client) ([]v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
+func getAutoMountResources(namespace string, client k8sclient.Client) ([]v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
 	cmPodAdditions, cmEnvAdditions, err := getDevWorkspaceConfigmaps(namespace, client)
 	if err != nil {
 		return nil, nil, err
@@ -47,7 +46,7 @@ func getAutoMountResources(namespace string, client runtimeClient.Client) ([]v1a
 	return allPodAdditions, append(cmEnvAdditions, secretEnvAdditions...), nil
 }
 
-func getDevWorkspaceConfigmaps(namespace string, client runtimeClient.Client) (*v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
+func getDevWorkspaceConfigmaps(namespace string, client k8sclient.Client) (*v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
 	configmaps := &corev1.ConfigMapList{}
 	if err := client.List(context.TODO(), configmaps, k8sclient.InNamespace(namespace), k8sclient.MatchingLabels{
 		constants.DevWorkspaceMountLabel: "true",
@@ -72,7 +71,7 @@ func getDevWorkspaceConfigmaps(namespace string, client runtimeClient.Client) (*
 	return podAdditions, additionalEnvVars, nil
 }
 
-func getDevWorkspaceSecrets(namespace string, client runtimeClient.Client) (*v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
+func getDevWorkspaceSecrets(namespace string, client k8sclient.Client) (*v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
 	secrets := &corev1.SecretList{}
 	if err := client.List(context.TODO(), secrets, k8sclient.InNamespace(namespace), k8sclient.MatchingLabels{
 		constants.DevWorkspaceMountLabel: "true",

--- a/controllers/workspace/provision/automount.go
+++ b/controllers/workspace/provision/automount.go
@@ -1,0 +1,134 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package provision
+
+import (
+	"context"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+)
+
+func getDevWorkspaceConfigmaps(namespace string, client runtimeClient.Client) (*v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
+	configmaps := &corev1.ConfigMapList{}
+	if err := client.List(context.TODO(), configmaps, k8sclient.InNamespace(namespace), k8sclient.MatchingLabels{
+		constants.DevWorkspaceMountLabel: "true",
+	}); err != nil {
+		return nil, nil, err
+	}
+	podAdditions := &v1alpha1.PodAdditions{}
+	var additionalEnvVars []corev1.EnvFromSource
+	for _, configmap := range configmaps.Items {
+		mountAs := configmap.Annotations[constants.DevWorkspaceMountAsAnnotation]
+		if mountAs == "env" {
+			additionalEnvVars = append(additionalEnvVars, getConfigMapEnvFromSource(configmap.Name))
+		} else {
+			mountPath := configmap.Annotations[constants.DevWorkspaceMountPathAnnotation]
+			if mountPath == "" {
+				mountPath = path.Join("/etc/config/", configmap.Name)
+			}
+			podAdditions.Volumes = append(podAdditions.Volumes, getVolumeWithConfigMap(configmap.Name))
+			podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, getVolumeMounts(mountPath, configmap.Name))
+		}
+	}
+	return podAdditions, additionalEnvVars, nil
+}
+
+func getDevWorkspaceSecrets(namespace string, client runtimeClient.Client) (*v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
+	secrets := &corev1.SecretList{}
+	if err := client.List(context.TODO(), secrets, k8sclient.InNamespace(namespace), k8sclient.MatchingLabels{
+		constants.DevWorkspaceMountLabel: "true",
+	}); err != nil {
+		return nil, nil, err
+	}
+	podAdditions := &v1alpha1.PodAdditions{}
+	var additionalEnvVars []corev1.EnvFromSource
+	for _, secret := range secrets.Items {
+		mountAs := secret.Annotations[constants.DevWorkspaceMountAsAnnotation]
+		if mountAs == "env" {
+			additionalEnvVars = append(additionalEnvVars, getSecretEnvFromSource(secret.Name))
+		} else {
+			mountPath := secret.Annotations[constants.DevWorkspaceMountPathAnnotation]
+			if mountPath == "" {
+				mountPath = path.Join("/etc/", "secret/", secret.Name)
+			}
+			podAdditions.Volumes = append(podAdditions.Volumes, getVolumeWithSecret(secret.Name))
+			podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, getVolumeMounts(mountPath, secret.Name))
+		}
+	}
+	return podAdditions, additionalEnvVars, nil
+}
+
+func getVolumeWithConfigMap(name string) corev1.Volume {
+	modeReadOnly := int32(0640)
+	workspaceVolumeMount := corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: name,
+				},
+				DefaultMode: &modeReadOnly,
+			},
+		},
+	}
+	return workspaceVolumeMount
+}
+
+func getVolumeWithSecret(name string) corev1.Volume {
+	modeReadOnly := int32(0640)
+	workspaceVolumeMount := corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  name,
+				DefaultMode: &modeReadOnly,
+			},
+		},
+	}
+	return workspaceVolumeMount
+}
+
+func getVolumeMounts(mountPath, name string) corev1.VolumeMount {
+	workspaceVolumeMount := corev1.VolumeMount{
+		Name:      name,
+		ReadOnly:  true,
+		MountPath: mountPath,
+	}
+	return workspaceVolumeMount
+}
+
+func getConfigMapEnvFromSource(name string) corev1.EnvFromSource {
+	return corev1.EnvFromSource{
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+		},
+	}
+}
+
+func getSecretEnvFromSource(name string) corev1.EnvFromSource {
+	return corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+		},
+	}
+}

--- a/controllers/workspace/provision/automount_test.go
+++ b/controllers/workspace/provision/automount_test.go
@@ -72,7 +72,7 @@ func TestCheckAutoMountVolumesForCollision(t *testing.T) {
 				{
 					name:       "baseVolume",
 					mountPath:  "basePath",
-					volumeType: configMapVolumeType,
+					volumeType: devWorkspaceVolume,
 				},
 			},
 			automountPodAdditions: []volumeDesc{
@@ -82,7 +82,7 @@ func TestCheckAutoMountVolumesForCollision(t *testing.T) {
 					volumeType: configMapVolumeType,
 				},
 			},
-			errRegexp: "DevWorkspace volume baseVolume conflicts with automounted volume from configmap baseVolume",
+			errRegexp: "DevWorkspace volume 'baseVolume' conflicts with automounted volume from configmap 'baseVolume'",
 		},
 		{
 			name: "Detects mountPath collision with DevWorkspace",
@@ -100,7 +100,7 @@ func TestCheckAutoMountVolumesForCollision(t *testing.T) {
 					volumeType: secretVolumeType,
 				},
 			},
-			errRegexp: fmt.Sprintf("DevWorkspace volume baseVolume in container %s has same mountpath as auto-mounted volume from secret testVolume", testContainerName),
+			errRegexp: fmt.Sprintf("DevWorkspace volume 'baseVolume' in container %s has same mountpath as auto-mounted volume from secret 'testVolume'", testContainerName),
 		},
 		{
 			name: "Detects mountPath collision in automounted volumes",
@@ -116,7 +116,7 @@ func TestCheckAutoMountVolumesForCollision(t *testing.T) {
 					volumeType: configMapVolumeType,
 				},
 			},
-			errRegexp: "auto-mounted volumes from configmap testVolume2 and secret testVolume1 have the same mount path",
+			errRegexp: "auto-mounted volumes from configmap 'testVolume2' and secret 'testVolume1' have the same mount path",
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/workspace/provision/automount_test.go
+++ b/controllers/workspace/provision/automount_test.go
@@ -1,0 +1,190 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package provision
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+)
+
+type mountedVolumeType int
+
+const (
+	devWorkspaceVolume mountedVolumeType = iota
+	secretVolumeType
+	configMapVolumeType
+)
+
+const testContainerName = "testContainer"
+
+func TestCheckAutoMountVolumesForCollision(t *testing.T) {
+	type volumeDesc struct {
+		name       string
+		mountPath  string
+		volumeType mountedVolumeType
+	}
+	tests := []struct {
+		name                  string
+		basePodAdditions      []volumeDesc
+		automountPodAdditions []volumeDesc
+		errRegexp             string
+	}{
+		{
+			name: "Does not error when mounts are valid",
+			basePodAdditions: []volumeDesc{
+				{
+					name:       "baseVolume",
+					mountPath:  "basePath",
+					volumeType: configMapVolumeType,
+				},
+			},
+			automountPodAdditions: []volumeDesc{
+				{
+					name:       "automountConfigMap",
+					mountPath:  "/configmap/mount",
+					volumeType: configMapVolumeType,
+				},
+				{
+					name:       "automountSecret",
+					mountPath:  "/secret/mount",
+					volumeType: secretVolumeType,
+				},
+			},
+		},
+		{
+			name: "Detects volume name collision",
+			basePodAdditions: []volumeDesc{
+				{
+					name:       "baseVolume",
+					mountPath:  "basePath",
+					volumeType: configMapVolumeType,
+				},
+			},
+			automountPodAdditions: []volumeDesc{
+				{
+					name:       "baseVolume",
+					mountPath:  "/configmap/mount",
+					volumeType: configMapVolumeType,
+				},
+			},
+			errRegexp: "DevWorkspace volume baseVolume conflicts with automounted volume from configmap baseVolume",
+		},
+		{
+			name: "Detects mountPath collision with DevWorkspace",
+			basePodAdditions: []volumeDesc{
+				{
+					name:       "baseVolume",
+					mountPath:  "/collision/path",
+					volumeType: devWorkspaceVolume,
+				},
+			},
+			automountPodAdditions: []volumeDesc{
+				{
+					name:       "testVolume",
+					mountPath:  "/collision/path",
+					volumeType: secretVolumeType,
+				},
+			},
+			errRegexp: fmt.Sprintf("DevWorkspace volume baseVolume in container %s has same mountpath as auto-mounted volume from secret testVolume", testContainerName),
+		},
+		{
+			name: "Detects mountPath collision in automounted volumes",
+			automountPodAdditions: []volumeDesc{
+				{
+					name:       "testVolume1",
+					mountPath:  "/test/mount",
+					volumeType: secretVolumeType,
+				},
+				{
+					name:       "testVolume2",
+					mountPath:  "/test/mount",
+					volumeType: configMapVolumeType,
+				},
+			},
+			errRegexp: "auto-mounted volumes from configmap testVolume2 and secret testVolume1 have the same mount path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			convertToPodAddition := func(desc volumeDesc) v1alpha1.PodAdditions {
+				pa := v1alpha1.PodAdditions{}
+				switch desc.volumeType {
+				case secretVolumeType:
+					pa.Volumes = append(pa.Volumes, corev1.Volume{
+						Name: desc.name,
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: desc.name,
+							},
+						},
+					})
+				case configMapVolumeType:
+					pa.Volumes = append(pa.Volumes, corev1.Volume{
+						Name: desc.name,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: desc.name,
+								},
+							},
+						},
+					})
+				case devWorkspaceVolume:
+					pa.Volumes = append(pa.Volumes, corev1.Volume{
+						Name: desc.name,
+					})
+				}
+				switch desc.volumeType {
+				case devWorkspaceVolume:
+					container := corev1.Container{
+						Name: testContainerName,
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      desc.name,
+								MountPath: desc.mountPath,
+							},
+						},
+					}
+					pa.Containers = append(pa.Containers, container)
+				case secretVolumeType, configMapVolumeType:
+					pa.VolumeMounts = append(pa.VolumeMounts, corev1.VolumeMount{
+						Name:      desc.name,
+						MountPath: desc.mountPath,
+					})
+				}
+
+				return pa
+			}
+			var base []v1alpha1.PodAdditions
+			for _, desc := range tt.basePodAdditions {
+				base = append(base, convertToPodAddition(desc))
+			}
+			var automount []v1alpha1.PodAdditions
+			for _, desc := range tt.automountPodAdditions {
+				automount = append(automount, convertToPodAddition(desc))
+			}
+			outErr := checkAutoMountVolumesForCollision(base, automount)
+			if tt.errRegexp == "" {
+				assert.Nil(t, outErr, "Expected no error but got %s", outErr)
+			} else {
+				assert.NotNil(t, outErr, "Expected error but got nil")
+				assert.Regexp(t, tt.errRegexp, outErr, "Error message should match regexp %s", tt.errRegexp)
+			}
+		})
+	}
+}

--- a/controllers/workspace/provision/deployment.go
+++ b/controllers/workspace/provision/deployment.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
@@ -367,56 +366,6 @@ func getPods(workspace *dw.DevWorkspace, client runtimeClient.Client) (*corev1.P
 	return pods, nil
 }
 
-func getDevWorkspaceConfigmaps(namespace string, client runtimeClient.Client) (*v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
-	configmaps := &corev1.ConfigMapList{}
-	if err := client.List(context.TODO(), configmaps, k8sclient.InNamespace(namespace), k8sclient.MatchingLabels{
-		constants.DevWorkspaceMountLabel: "true",
-	}); err != nil {
-		return nil, nil, err
-	}
-	podAdditions := &v1alpha1.PodAdditions{}
-	var additionalEnvVars []corev1.EnvFromSource
-	for _, configmap := range configmaps.Items {
-		mountAs := configmap.Annotations[constants.DevWorkspaceMountAsAnnotation]
-		if mountAs == "env" {
-			additionalEnvVars = append(additionalEnvVars, getConfigMapEnvFromSource(configmap.Name))
-		} else {
-			mountPath := configmap.Annotations[constants.DevWorkspaceMountPathAnnotation]
-			if mountPath == "" {
-				mountPath = path.Join("/etc/", "config/", configmap.Name)
-			}
-			podAdditions.Volumes = append(podAdditions.Volumes, getVolumeWithConfigMap(configmap.Name))
-			podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, getVolumeMounts(mountPath, configmap.Name))
-		}
-	}
-	return podAdditions, additionalEnvVars, nil
-}
-
-func getDevWorkspaceSecrets(namespace string, client runtimeClient.Client) (*v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
-	secrets := &corev1.SecretList{}
-	if err := client.List(context.TODO(), secrets, k8sclient.InNamespace(namespace), k8sclient.MatchingLabels{
-		constants.DevWorkspaceMountLabel: "true",
-	}); err != nil {
-		return nil, nil, err
-	}
-	podAdditions := &v1alpha1.PodAdditions{}
-	var additionalEnvVars []corev1.EnvFromSource
-	for _, secret := range secrets.Items {
-		mountAs := secret.Annotations[constants.DevWorkspaceMountAsAnnotation]
-		if mountAs == "env" {
-			additionalEnvVars = append(additionalEnvVars, getSecretEnvFromSource(secret.Name))
-		} else {
-			mountPath := secret.Annotations[constants.DevWorkspaceMountPathAnnotation]
-			if mountPath == "" {
-				mountPath = path.Join("/etc/", "secret/", secret.Name)
-			}
-			podAdditions.Volumes = append(podAdditions.Volumes, getVolumeWithSecret(secret.Name))
-			podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, getVolumeMounts(mountPath, secret.Name))
-		}
-	}
-	return podAdditions, additionalEnvVars, nil
-}
-
 // checkFailedPods check if related pods has unrecoverable states: CrashLoopBackOffReason, ImagePullErr
 // Returns optional message with detected unrecoverable state details
 //         error is any happens during check
@@ -513,45 +462,6 @@ func getWorkspaceSubpathVolumeMount(workspaceId string) corev1.VolumeMount {
 	return workspaceVolumeMount
 }
 
-func getVolumeWithConfigMap(name string) corev1.Volume {
-	modeReadOnly := int32(0640)
-	workspaceVolumeMount := corev1.Volume{
-		Name: name,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: name,
-				},
-				DefaultMode: &modeReadOnly,
-			},
-		},
-	}
-	return workspaceVolumeMount
-}
-
-func getVolumeWithSecret(name string) corev1.Volume {
-	modeReadOnly := int32(0640)
-	workspaceVolumeMount := corev1.Volume{
-		Name: name,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName:  name,
-				DefaultMode: &modeReadOnly,
-			},
-		},
-	}
-	return workspaceVolumeMount
-}
-
-func getVolumeMounts(mountPath, name string) corev1.VolumeMount {
-	workspaceVolumeMount := corev1.VolumeMount{
-		Name:      name,
-		ReadOnly:  true,
-		MountPath: mountPath,
-	}
-	return workspaceVolumeMount
-}
-
 func needsPVCWorkaround(podAdditions *v1alpha1.PodAdditions) bool {
 	commonPVCName := config.ControllerCfg.GetWorkspacePVCName()
 	for _, vol := range podAdditions.Volumes {
@@ -571,24 +481,4 @@ func checkContainerStatusForFailure(containerStatus *corev1.ContainerStatus) (ok
 		}
 	}
 	return true
-}
-
-func getConfigMapEnvFromSource(name string) corev1.EnvFromSource {
-	return corev1.EnvFromSource{
-		ConfigMapRef: &corev1.ConfigMapEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: name,
-			},
-		},
-	}
-}
-
-func getSecretEnvFromSource(name string) corev1.EnvFromSource {
-	return corev1.EnvFromSource{
-		SecretRef: &corev1.SecretEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: name,
-			},
-		},
-	}
 }

--- a/controllers/workspace/provision/deployment.go
+++ b/controllers/workspace/provision/deployment.go
@@ -71,28 +71,22 @@ func SyncDeploymentToCluster(
 	saName string,
 	clusterAPI ClusterAPI) DeploymentProvisioningStatus {
 
-	cmPodAdditions, configmapEnvFromSourceAdditions, err := getDevWorkspaceConfigmaps(workspace.Namespace, clusterAPI.Client)
+	automountPodAdditions, automountEnv, err := getAutoMountResources(workspace.Namespace, clusterAPI.Client)
 	if err != nil {
 		return DeploymentProvisioningStatus{
-			ProvisioningStatus: ProvisioningStatus{Err: err},
+			ProvisioningStatus{Err: err},
 		}
 	}
-	podAdditions = append(podAdditions, *cmPodAdditions)
-
-	sPodAdditions, secretEnvFromSourceAdditions, err := getDevWorkspaceSecrets(workspace.Namespace, clusterAPI.Client)
-	if err != nil {
+	if err := checkAutoMountVolumesForCollision(podAdditions, automountPodAdditions); err != nil {
 		return DeploymentProvisioningStatus{
-			ProvisioningStatus: ProvisioningStatus{Err: err},
+			ProvisioningStatus{Err: err, FailStartup: true},
 		}
 	}
-	podAdditions = append(podAdditions, *sPodAdditions)
+	podAdditions = append(podAdditions, automountPodAdditions...)
 
 	var envFromSourceAdditions []corev1.EnvFromSource
-	if configmapEnvFromSourceAdditions != nil {
-		envFromSourceAdditions = append(envFromSourceAdditions, configmapEnvFromSourceAdditions...)
-	}
-	if secretEnvFromSourceAdditions != nil {
-		envFromSourceAdditions = append(envFromSourceAdditions, secretEnvFromSourceAdditions...)
+	if automountEnv != nil {
+		envFromSourceAdditions = append(envFromSourceAdditions, automountEnv...)
 	}
 
 	// [design] we have to pass components and routing pod additions separately because we need mountsources from each

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -76,3 +76,11 @@ func PVCCleanupJobName(workspaceId string) string {
 func MetadataConfigMapName(workspaceId string) string {
 	return fmt.Sprintf("%s-metadata", workspaceId)
 }
+
+func AutoMountConfigMapVolumeName(volumeName string) string {
+	return fmt.Sprintf("automount-configmap-%s", volumeName)
+}
+
+func AutoMountSecretVolumeName(volumeName string) string {
+	return fmt.Sprintf("automount-secret-%s", volumeName)
+}


### PR DESCRIPTION
### What does this PR do?
Checks some edge cases in automounted secrets and volumes that can cause workspace startup to hang
1. Fail startup if the deployment we're creating is invalid
2. Check for collision in automounted volumes:
    * automounted volume collides with DevWorkspace volume on name
    * automounted volume collides with DevWorkspace volume on mountPath
    * automounted volumes collide on mountPath

Also prefixes automounted volumes with `automount-[secret|configmap]` to avoid collisions with each other and with DevWorkspace volumes (e.g. you can't automount a configmap named "project" currently).

**Note**: prefixing volume names as above can lead to issues, so it may be worth it to drop the last commit in this PR. If a secret/configmap's name is very long and the prefix pushes it over 63 chars, workspace start will fail.

### What issues does this PR fix or reference?
Minor issue I happened to run into while checking https://github.com/devfile/devworkspace-operator/issues/455 where my secrets shared a mountPath and no error was shown (except in logs)

### Is it tested? How?
Here comes a long testing doc:
1. Store the DevWorkspace we'll use for testing in /tmp/
    ```yaml
    cat > /tmp/test-dw.yaml <<EOF
    kind: DevWorkspace
    apiVersion: workspace.devfile.io/v1alpha2
    metadata:
      name: theia-next
    spec:
      started: true
      template:
        components:
          - name: test-container
            container:
              image: quay.io/libpod/busybox:latest
              volumeMounts:
                - name: testing-volume
                  path: /test-path
          - name: theia
            plugin:
              uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
          - name: testing-volume
            volume: {}
    EOF
    ```
2. Create secrets and configmaps for testing
    ```bash
    kubectl create secret generic test
    kubectl create configmap test
    kubectl patch secret test --type merge -p \
      '{
        "metadata": {
          "labels": {
            "controller.devfile.io/mount-to-devworkspace": "true"
          }
        }
      }'
    kubectl patch cm test --type merge -p \
      '{
        "metadata": {
          "labels": {
            "controller.devfile.io/mount-to-devworkspace": "true"
          }
        }
      }'
    ```
3. Case 1: automounted volumes collide on mountPath
    ```bash
    kubectl patch secret test --type merge -p \
      '{
        "metadata": {
          "annotations": {
            "controller.devfile.io/mount-path": "/collision"
          }
        }
      }'
    kubectl patch cm test --type merge -p \
      '{
        "metadata": {
          "annotations": {
            "controller.devfile.io/mount-path": "/collision"
          }
        }
      }'
    kubectl apply -f /tmp/test-dw.yaml
    kubectl get dw -w
    ```
    (should fail with meaningful error message)
4. Case 2: automounted volume and DevWorkspace volume collide on mountPath
    ```bash
    kubectl delete dw theia-next
    kubectl patch cm test --type merge -p \
      '{
        "metadata": {
          "annotations": {
            "controller.devfile.io/mount-path": "/test-path"
          }
        }
      }'
    kubectl apply -f /tmp/test-dw.yaml
    kubectl get dw -w
    ```
    (should fail with meaningful error message)


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
