### PR TITLE
Fix panic in webhooks server when patching workspace with nil Labels

### DIFF
--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -66,6 +66,9 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha1OnUpdate(_ context.Context, req 
 
 	newCreator, found := newWksp.Labels[constants.DevWorkspaceCreatorLabel]
 	if !found {
+		if newWksp.Labels == nil {
+			newWksp.Labels = map[string]string{}
+		}
 		newWksp.Labels[constants.DevWorkspaceCreatorLabel] = oldCreator
 		return h.returnPatched(req, newWksp)
 	}
@@ -96,6 +99,9 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnUpdate(_ context.Context, req 
 
 	newCreator, found := newWksp.Labels[constants.DevWorkspaceCreatorLabel]
 	if !found {
+		if newWksp.Labels == nil {
+			newWksp.Labels = map[string]string{}
+		}
 		newWksp.Labels[constants.DevWorkspaceCreatorLabel] = oldCreator
 		return h.returnPatched(req, newWksp)
 	}


### PR DESCRIPTION
### What does this PR do?
Fix a panic that can occur if you try to update a DevWorkspace with nil labels

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
