### PR TITLE
Disable 'experimental features' in default builds

### DIFF
--- a/deploy/bundle/manifests/devworkspace-controller-configmap_v1_configmap.yaml
+++ b/deploy/bundle/manifests/devworkspace-controller-configmap_v1_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   devworkspace.default_routing_class: basic
-  devworkspace.experimental_features_enabled: "true"
+  devworkspace.experimental_features_enabled: "false"
   devworkspace.routing.cluster_host_suffix: ""
   devworkspace.sidecar.image_pull_policy: Always
 kind: ConfigMap

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -18454,7 +18454,7 @@ subjects:
 apiVersion: v1
 data:
   devworkspace.default_routing_class: basic
-  devworkspace.experimental_features_enabled: "true"
+  devworkspace.experimental_features_enabled: "false"
   devworkspace.routing.cluster_host_suffix: ""
   devworkspace.sidecar.image_pull_policy: Always
 kind: ConfigMap

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-configmap.ConfigMap.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-configmap.ConfigMap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   devworkspace.default_routing_class: basic
-  devworkspace.experimental_features_enabled: "true"
+  devworkspace.experimental_features_enabled: "false"
   devworkspace.routing.cluster_host_suffix: ""
   devworkspace.sidecar.image_pull_policy: Always
 kind: ConfigMap

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -18454,7 +18454,7 @@ subjects:
 apiVersion: v1
 data:
   devworkspace.default_routing_class: basic
-  devworkspace.experimental_features_enabled: "true"
+  devworkspace.experimental_features_enabled: "false"
   devworkspace.routing.cluster_host_suffix: ""
   devworkspace.sidecar.image_pull_policy: Always
 kind: ConfigMap

--- a/deploy/deployment/openshift/objects/devworkspace-controller-configmap.ConfigMap.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-configmap.ConfigMap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   devworkspace.default_routing_class: basic
-  devworkspace.experimental_features_enabled: "true"
+  devworkspace.experimental_features_enabled: "false"
   devworkspace.routing.cluster_host_suffix: ""
   devworkspace.sidecar.image_pull_policy: Always
 kind: ConfigMap

--- a/deploy/templates/base/config.properties
+++ b/deploy/templates/base/config.properties
@@ -3,4 +3,4 @@ devworkspace.default_routing_class=${DEFAULT_ROUTING}
 # image pull policy that is applied to all devworkspace's containers
 devworkspace.sidecar.image_pull_policy=${PULL_POLICY}
 # Do not enable it in production!!!
-devworkspace.experimental_features_enabled=true
+devworkspace.experimental_features_enabled=false


### PR DESCRIPTION
### What does this PR do?
Disables the experimental features flag in the generated configmap. Features can still be enabled manually by updating the devworkspace controller's configmap

### What issues does this PR fix or reference?
If we don't do this, we'll be ignoring the comment in the config.properties file :)
> Do not enable it in production!!!

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
