### PR TITLE
Add DevWorkspace-specific metrics

### DIFF
--- a/controllers/workspace/condition.go
+++ b/controllers/workspace/condition.go
@@ -15,23 +15,18 @@ package controllers
 import (
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
-)
 
-const (
-	PullSecretsReady     dw.DevWorkspaceConditionType = "PullSecretsReady"
-	DevWorkspaceResolved dw.DevWorkspaceConditionType = "DevWorkspaceResolved"
-	StorageReady         dw.DevWorkspaceConditionType = "StorageReady"
-	DeploymentReady      dw.DevWorkspaceConditionType = "DeploymentReady"
-	DevWorkspaceWarning  dw.DevWorkspaceConditionType = "DevWorkspaceWarning"
+	"github.com/devfile/devworkspace-operator/pkg/conditions"
 )
 
 var conditionOrder = []dw.DevWorkspaceConditionType{
-	DevWorkspaceResolved,
-	StorageReady,
+	conditions.Started,
+	conditions.DevWorkspaceResolved,
+	conditions.StorageReady,
 	dw.DevWorkspaceRoutingReady,
 	dw.DevWorkspaceServiceAccountReady,
-	PullSecretsReady,
-	DeploymentReady,
+	conditions.PullSecretsReady,
+	conditions.DeploymentReady,
 	dw.DevWorkspaceReady,
 }
 
@@ -68,15 +63,6 @@ func (c *workspaceConditions) setConditionFalse(conditionType dw.DevWorkspaceCon
 		Status:  corev1.ConditionFalse,
 		Message: msg,
 	}
-}
-
-func getConditionByType(conditions []dw.DevWorkspaceCondition, t dw.DevWorkspaceConditionType) *dw.DevWorkspaceCondition {
-	for _, condition := range conditions {
-		if condition.Type == t {
-			return &condition
-		}
-	}
-	return nil
 }
 
 // getFirstFalse checks current conditions in a set order (defined by conditionOrder) and returns the first

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"
@@ -120,6 +121,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		workspace.Status.Phase = dw.DevWorkspaceStatusStarting
 		workspace.Status.Message = "Initializing DevWorkspace"
 		err = r.Status().Update(ctx, workspace)
+		metrics.WorkspaceStarted(workspace, reqLogger)
 		return reconcile.Result{Requeue: true}, err
 	}
 

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
 	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/conditions"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/library/annotate"
@@ -41,6 +42,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -120,6 +122,14 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		workspace.Status.DevWorkspaceId = workspaceId
 		workspace.Status.Phase = dw.DevWorkspaceStatusStarting
 		workspace.Status.Message = "Initializing DevWorkspace"
+		workspace.Status.Conditions = []dw.DevWorkspaceCondition{
+			{
+				Type:               conditions.Started,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Time{Time: clock.Now()},
+				Message:            "DevWorkspace is starting",
+			},
+		}
 		err = r.Status().Update(ctx, workspace)
 		metrics.WorkspaceStarted(workspace, reqLogger)
 		return reconcile.Result{Requeue: true}, err
@@ -152,6 +162,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 
 	// Prepare handling workspace status and condition
 	reconcileStatus := currentStatus{phase: dw.DevWorkspaceStatusStarting}
+	reconcileStatus.setConditionTrue(conditions.Started, "DevWorkspace is starting")
 	clusterWorkspace := workspace.DeepCopy()
 	timingInfo := map[string]string{}
 	timing.SetTime(timingInfo, timing.DevWorkspaceStarted)
@@ -187,12 +198,12 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), reqLogger, &reconcileStatus)
 	}
 	if warnings != nil {
-		reconcileStatus.setConditionTrue(DevWorkspaceWarning, flatten.FormatVariablesWarning(warnings))
+		reconcileStatus.setConditionTrue(conditions.DevWorkspaceWarning, flatten.FormatVariablesWarning(warnings))
 	} else {
-		reconcileStatus.setConditionFalse(DevWorkspaceWarning, "No warnings in processing DevWorkspace")
+		reconcileStatus.setConditionFalse(conditions.DevWorkspaceWarning, "No warnings in processing DevWorkspace")
 	}
 	workspace.Spec.Template = *flattenedWorkspace
-	reconcileStatus.setConditionTrue(DevWorkspaceResolved, "Resolved plugins and parents from DevWorkspace")
+	reconcileStatus.setConditionTrue(conditions.DevWorkspaceResolved, "Resolved plugins and parents from DevWorkspace")
 
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {
@@ -221,7 +232,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 		switch storageErr := err.(type) {
 		case *storage.NotReadyError:
 			reqLogger.Info(storageErr.Message)
-			reconcileStatus.setConditionFalse(StorageReady, fmt.Sprintf("Provisioning storage: %s", storageErr.Message))
+			reconcileStatus.setConditionFalse(conditions.StorageReady, fmt.Sprintf("Provisioning storage: %s", storageErr.Message))
 			return reconcile.Result{Requeue: true, RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
 			return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", storageErr), reqLogger, &reconcileStatus)
@@ -229,7 +240,7 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 			return reconcile.Result{}, storageErr
 		}
 	}
-	reconcileStatus.setConditionTrue(StorageReady, "Storage ready")
+	reconcileStatus.setConditionTrue(conditions.StorageReady, "Storage ready")
 
 	timing.SetTime(timingInfo, timing.ComponentsReady)
 
@@ -305,11 +316,11 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 
 	pullSecretStatus := provision.PullSecrets(clusterAPI)
 	if !pullSecretStatus.Continue {
-		reconcileStatus.setConditionFalse(PullSecretsReady, "Waiting for DevWorkspace pull secrets")
+		reconcileStatus.setConditionFalse(conditions.PullSecretsReady, "Waiting for DevWorkspace pull secrets")
 		return reconcile.Result{Requeue: pullSecretStatus.Requeue}, pullSecretStatus.Err
 	}
 	allPodAdditions = append(allPodAdditions, pullSecretStatus.PodAdditions)
-	reconcileStatus.setConditionTrue(PullSecretsReady, "DevWorkspace secrets ready")
+	reconcileStatus.setConditionTrue(conditions.PullSecretsReady, "DevWorkspace secrets ready")
 
 	// Step six: Create deployment and wait for it to be ready
 	timing.SetTime(timingInfo, timing.DeploymentCreated)
@@ -319,10 +330,10 @@ func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ct
 			return r.failWorkspace(workspace, deploymentStatus.Info(), reqLogger, &reconcileStatus)
 		}
 		reqLogger.Info("Waiting on deployment to be ready")
-		reconcileStatus.setConditionFalse(DeploymentReady, "Waiting for workspace deployment")
+		reconcileStatus.setConditionFalse(conditions.DeploymentReady, "Waiting for workspace deployment")
 		return reconcile.Result{Requeue: deploymentStatus.Requeue}, deploymentStatus.Err
 	}
-	reconcileStatus.setConditionTrue(DeploymentReady, "DevWorkspace deployment ready")
+	reconcileStatus.setConditionTrue(conditions.DeploymentReady, "DevWorkspace deployment ready")
 	timing.SetTime(timingInfo, timing.DeploymentReady)
 
 	serverReady, err := checkServerStatus(clusterWorkspace)
@@ -344,7 +355,7 @@ func (r *DevWorkspaceReconciler) stopWorkspace(workspace *dw.DevWorkspace, logge
 	status := currentStatus{phase: dw.DevWorkspaceStatusStopping}
 	if workspace.Status.Phase == devworkspacePhaseFailing || workspace.Status.Phase == dw.DevWorkspaceStatusFailed {
 		status.phase = workspace.Status.Phase
-		failedCondition := getConditionByType(workspace.Status.Conditions, dw.DevWorkspaceFailedStart)
+		failedCondition := conditions.GetConditionByType(workspace.Status.Conditions, dw.DevWorkspaceFailedStart)
 		if failedCondition != nil {
 			status.setCondition(dw.DevWorkspaceFailedStart, *failedCondition)
 		}

--- a/controllers/workspace/metrics/metrics.go
+++ b/controllers/workspace/metrics/metrics.go
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	workspaceSourceLabel = "controller.devfile.io/devworkspace-source"
+	metricSourceLabel    = "source"
+)
+
+var (
+	workspaceTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "devworkspace",
+			Name:      "started_total",
+			Help:      "Number of devworkspace starting events",
+		},
+		[]string{
+			metricSourceLabel,
+		},
+	)
+	workspaceStarts = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "devworkspace",
+			Name:      "started_success_total",
+			Help:      "Number of devworkspaces successfully entering the 'Running' phase",
+		},
+		[]string{
+			metricSourceLabel,
+		},
+	)
+	workspaceFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "devworkspace",
+			Name:      "fail_total",
+			Help:      "Number of failed DevWorkspaces",
+		},
+		[]string{
+			metricSourceLabel,
+		},
+	)
+)
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(workspaceTotal, workspaceStarts, workspaceFailures)
+}

--- a/controllers/workspace/metrics/metrics.go
+++ b/controllers/workspace/metrics/metrics.go
@@ -53,9 +53,20 @@ var (
 			metricSourceLabel,
 		},
 	)
+	workspaceStartupTimesHist = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "devworkspace",
+			Name:      "startup_time",
+			Help:      "Total time taken to start a DevWorkspace, in seconds",
+			Buckets:   []float64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180},
+		},
+		[]string{
+			metricSourceLabel,
+		},
+	)
 )
 
 func init() {
 	// Register custom metrics with the global prometheus registry
-	metrics.Registry.MustRegister(workspaceTotal, workspaceStarts, workspaceFailures)
+	metrics.Registry.MustRegister(workspaceTotal, workspaceStarts, workspaceFailures, workspaceStartupTimesHist)
 }

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package metrics
+
+import (
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func WorkspaceStarted(wksp *dw.DevWorkspace, log logr.Logger) {
+	incrementMetricForWorkspace(workspaceTotal, wksp, log)
+}
+
+func WorkspaceRunning(wksp *dw.DevWorkspace, log logr.Logger) {
+	incrementMetricForWorkspace(workspaceStarts, wksp, log)
+}
+
+func WorkspaceFailed(wksp *dw.DevWorkspace, log logr.Logger) {
+	incrementMetricForWorkspace(workspaceFailures, wksp, log)
+}
+
+func incrementMetricForWorkspace(metric *prometheus.CounterVec, wksp *dw.DevWorkspace, log logr.Logger) {
+	sourceLabel := wksp.Labels[workspaceSourceLabel]
+	ctr, err := metric.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel})
+	if err != nil {
+		log.Info("Failed to increment metric: %s", err)
+	}
+	ctr.Inc()
+}

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -16,16 +16,26 @@ import (
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/devfile/devworkspace-operator/pkg/conditions"
 )
 
+// WorkspaceStarted updates metrics for workspaces entering the 'Starting' phase, given a workspace. If an error is
+// encountered, the provided logger is used to log the error.
 func WorkspaceStarted(wksp *dw.DevWorkspace, log logr.Logger) {
 	incrementMetricForWorkspace(workspaceTotal, wksp, log)
 }
 
+// WorkspaceRunning updates metrics for workspaces entering the 'Running' phase, given a workspace. If an error is
+// encountered, the provided logger is used to log the error. This function assumes the provided workspace has
+// fully-synced conditions (i.e. the WorkspaceReady condition is present).
 func WorkspaceRunning(wksp *dw.DevWorkspace, log logr.Logger) {
 	incrementMetricForWorkspace(workspaceStarts, wksp, log)
+	incrementStartTimeBucketForWorkspace(wksp, log)
 }
 
+// WorkspaceFailed updates metrics for workspace entering the 'Failed' phase. If an error is encountered, the provided
+// logger is used to log the error.
 func WorkspaceFailed(wksp *dw.DevWorkspace, log logr.Logger) {
 	incrementMetricForWorkspace(workspaceFailures, wksp, log)
 }
@@ -34,7 +44,27 @@ func incrementMetricForWorkspace(metric *prometheus.CounterVec, wksp *dw.DevWork
 	sourceLabel := wksp.Labels[workspaceSourceLabel]
 	ctr, err := metric.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel})
 	if err != nil {
-		log.Info("Failed to increment metric: %s", err)
+		log.Error(err, "Failed to increment metric")
 	}
 	ctr.Inc()
+}
+
+func incrementStartTimeBucketForWorkspace(wksp *dw.DevWorkspace, log logr.Logger) {
+	sourceLabel := wksp.Labels[workspaceSourceLabel]
+	hist, err := workspaceStartupTimesHist.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel})
+	if err != nil {
+		log.Error(err, "Failed to update metric")
+	}
+	readyCondition := conditions.GetConditionByType(wksp.Status.Conditions, dw.DevWorkspaceReady)
+	if readyCondition == nil {
+		return
+	}
+	startedCondition := conditions.GetConditionByType(wksp.Status.Conditions, conditions.Started)
+	if startedCondition == nil {
+		return
+	}
+	readyTime := readyCondition.LastTransitionTime
+	startTime := startedCondition.LastTransitionTime
+	startDuration := readyTime.Sub(startTime.Time)
+	hist.Observe(startDuration.Seconds())
 }

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -24,6 +24,7 @@ import (
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/provision"
+	"github.com/devfile/devworkspace-operator/pkg/conditions"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -72,7 +73,7 @@ func (r *DevWorkspaceReconciler) updateWorkspaceStatus(workspace *dw.DevWorkspac
 	syncConditions(&workspace.Status, status)
 
 	infoMessage := getInfoMessage(workspace, status)
-	if warn := getConditionByType(workspace.Status.Conditions, DevWorkspaceWarning); warn != nil && warn.Status == corev1.ConditionTrue {
+	if warn := conditions.GetConditionByType(workspace.Status.Conditions, conditions.DevWorkspaceWarning); warn != nil && warn.Status == corev1.ConditionTrue {
 		infoMessage = fmt.Sprintf("%s %s", warningPresentInfoMessage, infoMessage)
 	}
 	if workspace.Status.Message != infoMessage {

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -67,10 +67,9 @@ var healthHttpClient = &http.Client{
 // Parameters for result and error are returned unmodified, unless error is nil and another error is encountered while
 // updating the status.
 func (r *DevWorkspaceReconciler) updateWorkspaceStatus(workspace *dw.DevWorkspace, logger logr.Logger, status *currentStatus, reconcileResult reconcile.Result, reconcileError error) (reconcile.Result, error) {
+	syncConditions(&workspace.Status, status)
 	updateMetricsForPhase(workspace, status.phase, logger)
 	workspace.Status.Phase = status.phase
-
-	syncConditions(&workspace.Status, status)
 
 	infoMessage := getInfoMessage(workspace, status)
 	if warn := conditions.GetConditionByType(workspace.Status.Conditions, conditions.DevWorkspaceWarning); warn != nil && warn.Status == corev1.ConditionTrue {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87
+	github.com/prometheus/client_golang v1.7.1
 	github.com/redhat-cop/operator-utils v0.1.0
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.16.0 // indirect

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package conditions
+
+import dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+
+const (
+	Started              dw.DevWorkspaceConditionType = "Started"
+	PullSecretsReady     dw.DevWorkspaceConditionType = "PullSecretsReady"
+	DevWorkspaceResolved dw.DevWorkspaceConditionType = "DevWorkspaceResolved"
+	StorageReady         dw.DevWorkspaceConditionType = "StorageReady"
+	DeploymentReady      dw.DevWorkspaceConditionType = "DeploymentReady"
+	DevWorkspaceWarning  dw.DevWorkspaceConditionType = "DevWorkspaceWarning"
+)
+
+func GetConditionByType(conditions []dw.DevWorkspaceCondition, t dw.DevWorkspaceConditionType) *dw.DevWorkspaceCondition {
+	for _, condition := range conditions {
+		if condition.Type == t {
+			return &condition
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?
Adds DevWorkspace-specific metrics to the metrics server, tracking
1. Number of workspace starts
2. Number of successfully started workspaces (i.e. workspaces entering 'Running' phase)
3. Number of devworkspaces that enter the Failed state
4. A histogram of workspace startup time, bucketed in 10-second intervals

Currently, the metrics come with a `source` label. The value of this label is derived from the value of the `controller.devfile.io/devworkspace-source` label on the DevWorkspace (optional). If set, this allows metrics to be partitioned based on the tool creating the DevWorkspace (e.g. Web Terminal Operator, Eclipse Che, etc.)

Metrics are updated on phase changes in the DevWorkspace (i.e. going from phase 'Started' -> 'Running') to avoid double counting DevWorkspaces.

### What issues does this PR fix or reference?
Additional nice-to-haves for https://github.com/devfile/devworkspace-operator/issues/241

### Is it tested? How?
Changes can be tested in same way as https://github.com/devfile/devworkspace-operator/pull/405 (note metrics won't appear until they're updated at least once)

A simpler way to test these changes directly is by running the controller locally:
1. `make run` the controller in one window
2. `kubectl apply -f samples/theia-next.yaml`
3. curl -s http://localhost:8080/metrics | grep '^dev'

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
