### PR TITLE
Fix happy path test by adaption to Che Operator changes

### DIFF
--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -54,15 +54,7 @@ EOL
 
   echo "----------------------------------"
 
-  /tmp/chectl/bin/chectl server:deploy --che-operator-cr-patch-yaml=/tmp/che-cr-patch.yaml -p openshift --batch --telemetry=off --installer=operator --templates=/tmp/templates/
-}
-
-initLatestTemplates() {
-  curl -L https://api.github.com/repos/eclipse-che/che-operator/zipball/main  > /tmp/che-operator.zip &&
-  unzip /tmp/che-operator.zip -d /tmp && \
-  mkdir -p /tmp/templates/che-operator && \
-  mv /tmp/eclipse-che-che-operator-*/deploy /tmp/che-operator
-  cp -rf /tmp/che-operator/* /tmp/templates/che-operator
+  /tmp/chectl/bin/chectl server:deploy --che-operator-cr-patch-yaml=/tmp/che-cr-patch.yaml -p openshift --batch --telemetry=off --installer=operator
 }
 
 startHappyPathTest() {
@@ -123,6 +115,5 @@ runTest() {
 }
 
 installChectl
-initLatestTemplates
 provisionOpenShiftOAuthUser
 runTest


### PR DESCRIPTION
### What does this PR do?
Fix happy path test by adaption to Che Operator changes
Che Operator stops providing ready to use templates
after upgrading to Operator SDK 1.x
So, we just stop providing templates for chectl which does not make
sense since we use next chectl which should have the latest changes

### What issues does this PR fix or reference?
It fixes https://github.com/devfile/devworkspace-operator/issues/502


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
