### PR TITLE
Add support for devfile 2.0 global variables

### DIFF
--- a/controllers/workspace/condition.go
+++ b/controllers/workspace/condition.go
@@ -22,6 +22,7 @@ const (
 	DevWorkspaceResolved dw.DevWorkspaceConditionType = "DevWorkspaceResolved"
 	StorageReady         dw.DevWorkspaceConditionType = "StorageReady"
 	DeploymentReady      dw.DevWorkspaceConditionType = "DeploymentReady"
+	DevWorkspaceWarning  dw.DevWorkspaceConditionType = "DevWorkspaceWarning"
 )
 
 var conditionOrder = []dw.DevWorkspaceConditionType{

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -39,6 +39,9 @@ const (
 	// devworkspacePhaseFailing represents a DevWorkspace that has encountered an unrecoverable error and is in
 	// the process of stopping.
 	devworkspacePhaseFailing dw.DevWorkspacePhase = "Failing"
+
+	// warningPresentInfoMessage is the info message printed
+	warningPresentInfoMessage string = "[warnings present]"
 )
 
 type currentStatus struct {
@@ -67,6 +70,9 @@ func (r *DevWorkspaceReconciler) updateWorkspaceStatus(workspace *dw.DevWorkspac
 	syncConditions(&workspace.Status, status)
 
 	infoMessage := getInfoMessage(workspace, status)
+	if warn := getConditionByType(workspace.Status.Conditions, DevWorkspaceWarning); warn != nil && warn.Status == corev1.ConditionTrue {
+		infoMessage = fmt.Sprintf("%s %s", warningPresentInfoMessage, infoMessage)
+	}
 	if workspace.Status.Message != infoMessage {
 		workspace.Status.Message = infoMessage
 	}

--- a/pkg/library/flatten/flatten_test.go
+++ b/pkg/library/flatten/flatten_test.go
@@ -37,7 +37,7 @@ func TestResolveDevWorkspaceKubernetesReference(t *testing.T) {
 				WorkspaceNamespace: "test-ignored",
 				K8sClient:          testClient,
 			}
-			outputWorkspace, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -67,7 +67,7 @@ func TestResolveDevWorkspaceInternalRegistry(t *testing.T) {
 				Context:          context.Background(),
 				InternalRegistry: testRegistry,
 			}
-			outputWorkspace, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -98,7 +98,7 @@ func TestResolveDevWorkspacePluginRegistry(t *testing.T) {
 				Context:    context.Background(),
 				HttpClient: testHttpGetter,
 			}
-			outputWorkspace, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -129,7 +129,7 @@ func TestResolveDevWorkspacePluginURI(t *testing.T) {
 				Context:    context.Background(),
 				HttpClient: testHttpGetter,
 			}
-			outputWorkspace, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -165,7 +165,7 @@ func TestResolveDevWorkspaceParents(t *testing.T) {
 				K8sClient:          testK8sClient,
 				HttpClient:         testHttpGetter,
 			}
-			outputWorkspace, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -203,7 +203,7 @@ func TestResolveDevWorkspaceMissingDefaults(t *testing.T) {
 				K8sClient:  testK8sClient,
 				HttpClient: testHttpGetter,
 			}
-			outputWorkspace, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -239,7 +239,7 @@ func TestResolveDevWorkspaceAnnotations(t *testing.T) {
 				HttpClient:         testHttpGetter,
 				WorkspaceNamespace: "default-namespace",
 			}
-			outputWorkspace, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -275,7 +275,7 @@ func TestResolveDevWorkspaceTemplateNamespaceRestriction(t *testing.T) {
 				HttpClient:         testHttpGetter,
 				WorkspaceNamespace: "test-namespace",
 			}
-			outputWorkspace, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {


### PR DESCRIPTION
### What does this PR do?
Add support for [devfile 2.0 variables](https://docs.devfile.io/devfile/2.1.0/user-guide/api-reference.html). In most string fields in a DevWorkspace, DWO will attempt to replace the string `{{ some-variable }}` with the corresponding variable from `.spec.template.variables`.

If a replacement cannot be found, a new condition `DevWorkspaceWarning` is set on the DevWorkspace with a message like
> `Error processing variable replacements: invalid variables in component test-container: 'test-variable'"`

and the info message will be updated to include some warning text, e.g.
```
NAME         DEVWORKSPACE ID             PHASE      INFO
theia-next   workspace89e5bf5e04b34b6b   Starting   [warnings present] Waiting for workspace deployment
```

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/508

### Is it tested? How?
Apply the DevWorkspace below:
```yaml
cat <<EOF | kubectl apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next
spec:
  started: true
  template:
    attributes:
      controller.devfile.io/storage-type: "ephemeral"
    variables:
      test-variable: "testing_value"
    components:
      - name: test-container
        container:
          image: quay.io/libpod/busybox:latest
          command: ["tail"]
          args: ["-f", "/dev/null"]
          env:
          - name: TEST_ENV
            value: "{{test-variable}}"
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
EOF
```
The value in the env var should be replaced once the pod is created.

To test warnings, delete the variable from the devworkspace

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
