### PR TITLE
Fix make run/debug locally in k8s

### DIFF
--- a/build/make/deploy.mk
+++ b/build/make/deploy.mk
@@ -43,8 +43,13 @@ _gen_configuration_env:
 
 _store_tls_cert:
 	mkdir -p /tmp/k8s-webhook-server/serving-certs/
+ifeq ($(PLATFORM),kubernetes)
+	$(K8S_CLI) get secret devworkspace-operator-webhook-cert -n $(NAMESPACE) -o json | jq -r '.data["tls.crt"]' | base64 -d > /tmp/k8s-webhook-server/serving-certs/tls.crt
+	$(K8S_CLI) get secret devworkspace-operator-webhook-cert -n $(NAMESPACE) -o json | jq -r '.data["tls.key"]' | base64 -d > /tmp/k8s-webhook-server/serving-certs/tls.key
+else
 	$(K8S_CLI) get secret devworkspace-webhooks-tls -n $(NAMESPACE) -o json | jq -r '.data["tls.crt"]' | base64 -d > /tmp/k8s-webhook-server/serving-certs/tls.crt
 	$(K8S_CLI) get secret devworkspace-webhooks-tls -n $(NAMESPACE) -o json | jq -r '.data["tls.key"]' | base64 -d > /tmp/k8s-webhook-server/serving-certs/tls.key
+endif
 
 ### install: Install controller in the configured Kubernetes cluster in ~/.kube/config
 install: _check_cert_manager _print_vars _init_devworkspace_crds _create_namespace generate_deployment


### PR DESCRIPTION
### What does this PR do?
On Kubernetes, the makefile was referencing the wrong secret for the
webhooks server, which resulted in it failing to start locally.

### What issues does this PR fix or reference?


### Is it tested? How?
`make run` or `make debug` on Kubernetes

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
