### PR TITLE
Update CSV description to remove TODO links

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -46,7 +46,7 @@ spec:
     will be available in all namespaces on the cluster. DevWorkspace creation is
     driven by the DevWorkspace custom resource, which can be created in any
     namespace to provision a full development environment. To get started, browse
-    the DevWorkspace [spec](TODO) or view preconfigured [samples](TODO).
+    the DevWorkspace [spec](https://docs.devfile.io/devfile/2.1.0/user-guide/api-reference.html).
 
     Once a DevWorkspace is started, it can be accessed via the URL in its
     `.status.mainUrl` field.
@@ -57,8 +57,9 @@ spec:
     ## Uninstalling the operator
     The DevWorkspace Operator utilizes finalizers on resources it creates and
     webhooks to restrict access to development resources. As a result, manual steps
-    are required in uninstalling the operator. See the [documentation](TODO) for
-    details.
+    are required in uninstalling the operator. See the
+    [documentation](https://github.com/devfile/devworkspace-operator/blob/main/doc/uninstall.md)
+    for details.
   displayName: DevWorkspace Operator
   icon:
   - base64data: ""

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -46,7 +46,7 @@ spec:
     will be available in all namespaces on the cluster. DevWorkspace creation is
     driven by the DevWorkspace custom resource, which can be created in any
     namespace to provision a full development environment. To get started, browse
-    the DevWorkspace [spec](TODO) or view preconfigured [samples](TODO).
+    the DevWorkspace [spec](https://docs.devfile.io/devfile/2.1.0/user-guide/api-reference.html).
 
     Once a DevWorkspace is started, it can be accessed via the URL in its
     `.status.mainUrl` field.
@@ -57,8 +57,9 @@ spec:
     ## Uninstalling the operator
     The DevWorkspace Operator utilizes finalizers on resources it creates and
     webhooks to restrict access to development resources. As a result, manual steps
-    are required in uninstalling the operator. See the [documentation](TODO) for
-    details.
+    are required in uninstalling the operator. See the
+    [documentation](https://github.com/devfile/devworkspace-operator/blob/main/doc/uninstall.md)
+    for details.
 
   displayName: DevWorkspace Operator
   icon:


### PR DESCRIPTION
### What does this PR do?  
Fill some TODO links in the CSV with the best-available current options:
* DevWorkspace spec: link to devfile 2.0 api reference. This isn't ideal since the docs are for devfile 2.0 and not DevWorkspace.
* Remove link to DevWorkspace samples, as we don't yet have a good repository of these.
* Link to GitHub for uninstall documentation for now.

### What issues does this PR fix or reference?
Semi-solution to https://github.com/devfile/devworkspace-operator/issues/473, but that issue should probably stay open until something more stable/official is in place.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
