### PR TITLE
chore: Remove dependabot for dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  # Enable version updates for Docker
-  - package-ecosystem: "docker"
-    # Look for a `Dockerfile` in the `build` directory
-    directory: "/build"
-    # Check for updates once a week
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

### What does this PR do?
Remove Dependabot for dockerfiles, which will be replaced by `update-base-images.yml` workflow in eclipse-che/che-release project (to manage all updates from one place)
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18831

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
