### PR TITLE
Use ubi minimal as the default pvc_clean_job image

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -304,7 +304,7 @@ spec:
                 - name: RELATED_IMAGE_web_terminal_tooling
                   value: quay.io/wto/web-terminal-tooling:latest
                 - name: RELATED_IMAGE_pvc_cleanup_job
-                  value: quay.io/libpod/busybox:1.30.1
+                  value: registry.access.redhat.com/ubi8-micro:8.4-81
                 - name: RELATED_IMAGE_async_storage_server
                   value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
                 - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -18547,7 +18547,7 @@ spec:
         - name: RELATED_IMAGE_web_terminal_tooling
           value: quay.io/wto/web-terminal-tooling:latest
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: quay.io/libpod/busybox:1.30.1
+          value: registry.access.redhat.com/ubi8-micro:8.4-81
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -59,7 +59,7 @@ spec:
         - name: RELATED_IMAGE_web_terminal_tooling
           value: quay.io/wto/web-terminal-tooling:latest
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: quay.io/libpod/busybox:1.30.1
+          value: registry.access.redhat.com/ubi8-micro:8.4-81
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -18549,7 +18549,7 @@ spec:
         - name: RELATED_IMAGE_web_terminal_tooling
           value: quay.io/wto/web-terminal-tooling:latest
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: quay.io/libpod/busybox:1.30.1
+          value: registry.access.redhat.com/ubi8-micro:8.4-81
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -59,7 +59,7 @@ spec:
         - name: RELATED_IMAGE_web_terminal_tooling
           value: quay.io/wto/web-terminal-tooling:latest
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: quay.io/libpod/busybox:1.30.1
+          value: registry.access.redhat.com/ubi8-micro:8.4-81
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -89,7 +89,7 @@ spec:
             - name: RELATED_IMAGE_devworkspace_webhook_server
               value: "quay.io/devfile/devworkspace-controller:next"
             - name: RELATED_IMAGE_pvc_cleanup_job
-              value: "quay.io/libpod/busybox:1.30.1"
+              value: "registry.access.redhat.com/ubi8-micro:8.4-81"
             - name: RELATED_IMAGE_async_storage_server
               value: "quay.io/eclipse/che-workspace-data-sync-storage:0.0.1"
             - name: RELATED_IMAGE_async_storage_sidecar


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR switches the default pvc cleanup job to be ubi8-minimal

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
```
oc apply -f samples/theia-next.yaml
# wait for it to come up
oc delete dw theia-next
# observe that the cleanup job works correctly
```


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
