### PR TITLE
Remove icon from manifests

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -61,9 +61,6 @@ spec:
     [documentation](https://github.com/devfile/devworkspace-operator/blob/main/doc/uninstall.md)
     for details.
   displayName: DevWorkspace Operator
-  icon:
-  - base64data: ""
-    mediatype: ""
   install:
     spec:
       clusterPermissions:

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -62,9 +62,6 @@ spec:
     for details.
 
   displayName: DevWorkspace Operator
-  icon:
-  - base64data: ""
-    mediatype: ""
   install:
     spec:
       clusterPermissions: null


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR removes icon from the manifests so that OpenShift Console renders the default icon correctly

![Screenshot from 2021-07-27 11-44-04](https://user-images.githubusercontent.com/8839537/127184893-12511c9c-6270-404d-b3b8-9b070ec6dcdd.png)

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/507

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
