### PR TITLE
Update controller resources and concurrency

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -288,7 +288,7 @@ spec:
                     fieldRef:
                       fieldPath: spec.serviceAccountName
                 - name: MAX_CONCURRENT_RECONCILES
-                  value: "1"
+                  value: "5"
                 - name: WEBHOOKS_SERVER_MEMORY_LIMIT
                   value: 300Mi
                 - name: WEBHOOKS_SERVER_MEMORY_REQUEST
@@ -338,11 +338,11 @@ spec:
                   timeoutSeconds: 5
                 resources:
                   limits:
-                    cpu: 200m
-                    memory: 300Mi
+                    cpu: "1"
+                    memory: 1Gi
                   requests:
-                    cpu: 100m
-                    memory: 20Mi
+                    cpu: 250m
+                    memory: 100Mi
               - args:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -18533,7 +18533,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: MAX_CONCURRENT_RECONCILES
-          value: "1"
+          value: "5"
         - name: WEBHOOKS_SERVER_MEMORY_LIMIT
           value: 300Mi
         - name: WEBHOOKS_SERVER_MEMORY_REQUEST
@@ -18583,11 +18583,11 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 200m
-            memory: 300Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 250m
+            memory: 100Mi
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -45,7 +45,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: MAX_CONCURRENT_RECONCILES
-          value: "1"
+          value: "5"
         - name: WEBHOOKS_SERVER_MEMORY_LIMIT
           value: 300Mi
         - name: WEBHOOKS_SERVER_MEMORY_REQUEST
@@ -95,11 +95,11 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 200m
-            memory: 300Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 250m
+            memory: 100Mi
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -18535,7 +18535,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: MAX_CONCURRENT_RECONCILES
-          value: "1"
+          value: "5"
         - name: WEBHOOKS_SERVER_MEMORY_LIMIT
           value: 300Mi
         - name: WEBHOOKS_SERVER_MEMORY_REQUEST
@@ -18585,11 +18585,11 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 200m
-            memory: 300Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 250m
+            memory: 100Mi
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -45,7 +45,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: MAX_CONCURRENT_RECONCILES
-          value: "1"
+          value: "5"
         - name: WEBHOOKS_SERVER_MEMORY_LIMIT
           value: 300Mi
         - name: WEBHOOKS_SERVER_MEMORY_REQUEST
@@ -95,11 +95,11 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 200m
-            memory: 300Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 250m
+            memory: 100Mi
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -54,11 +54,11 @@ spec:
             - "--metrics-addr=127.0.0.1:8080"
           resources:
             limits:
-              cpu: 200m
-              memory: 300Mi
+              cpu: 1000m
+              memory: 1Gi
             requests:
-              cpu: 100m
-              memory: 20Mi
+              cpu: 250m
+              memory: 100Mi
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -73,7 +73,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
             - name: MAX_CONCURRENT_RECONCILES
-              value: "1"
+              value: "5"
             - name: WEBHOOKS_SERVER_MEMORY_LIMIT
               value: 300Mi
             - name: WEBHOOKS_SERVER_MEMORY_REQUEST


### PR DESCRIPTION
### What does this PR do?
Update controller resources to
```yaml
resources:
  limits:
    cpu: 1000m
    memory: 1Gi
  requests:
    cpu: 250m
    memory: 100Mi
```
and concurrency to '5' to support heavier loads and non-development use cases.

In testing some stuff for metrics, I've noticed memory use creep above 600-700Mi when quite a few DevWorkspaces exist and are being created. Also, testing on `crc`, the DevWorkspace controller will enter a crashloop with the current memory limit when there are ~500 stopped workspaces on the cluster, as watched resources live in the controller-runtime's cache.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
