### PR TITLE
Add home directory to project clone container

### DIFF
--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -39,7 +39,8 @@ WORKDIR /
 COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/project-clone
 
 ENV USER_UID=1001 \
-    USER_NAME=project-clone
+    USER_NAME=project-clone \
+    HOME=/home/user
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup


### PR DESCRIPTION
### What does this PR do?
Add a home directory (/home/user) to the project clone container to support tools that expect to have a home directory available.

### What issues does this PR fix or reference?
E.g. while testing private repo access, ssh-agent expects keys to be mounted to `/.ssh`.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
