### PR TITLE
Avoid unnecessary condition updates when status is 'Unknown'

### DIFF
--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -92,9 +92,11 @@ func syncConditions(workspaceStatus *dw.DevWorkspaceStatus, currentStatus *curre
 		currCondition, ok := currentStatus.conditions[workspaceCondition.Type]
 		if !ok {
 			// Didn't observe this condition this time; set status to unknown
-			workspaceStatus.Conditions[idx].LastTransitionTime = currTransitionTime
-			workspaceStatus.Conditions[idx].Status = corev1.ConditionUnknown
-			workspaceStatus.Conditions[idx].Message = ""
+			if workspaceCondition.Status != corev1.ConditionUnknown {
+				workspaceStatus.Conditions[idx].LastTransitionTime = currTransitionTime
+				workspaceStatus.Conditions[idx].Status = corev1.ConditionUnknown
+				workspaceStatus.Conditions[idx].Message = ""
+			}
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do?
Only update conditions with `Unknown` status when the existing condition is not `Unknown`. Basically, this avoids updating the last transition time on every reconcile loop if there are persistently 'unknown' conditions.

### What issues does this PR fix or reference?
This is a subtle issue since a sufficiently quick re-reconcile will result in no changes to the DevWorkspace (we update last transition time but it's within the accuracy of the timer), resulting in no additional reconciles. However, if the workqueue duration grows significantly, this can result in continually requeuing reconciles where all we're changing is `LastTransitionTime`.

### Is it tested? How?
The best way I've found to reproduce the issue:
1. Create 1000 stopped DevWorkspaces
2. Quickly update all of them to flood the reconcile queue

With these changes, the controller should work through the queue without enqueuing additional requests.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
