### PR TITLE
Adapt make-release to a new DWO release cycle

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -11,147 +11,221 @@
 #
 
 set -e
-REPO=git@github.com:devfile/devworkspace-operator
+DWO_REPO="${DWO_REPO:-git@github.com:devfile/devworkspace-operator}"
+DWO_QUAY_REPO="${DWO_QUAY_REPO:-quay.io/devfile/devworkspace-controller}"
+PROJECT_CLONE_QUAY_REPO="${PROJECT_CLONE_QUAY_REPO:-quay.io/devfile/project-clone}"
 MAIN_BRANCH="main"
+VERBOSE=""
 TMP=""
 
-while [[ "$#" -gt 0 ]]; do
-  case $1 in
-    '-v'|'--version') VERSION="$2"; shift 1;;
-    '-tmp'|'--use-tmp-dir') TMP=$(mktemp -d); shift 0;;
-  esac
-  shift 1
-done
+usage () {
+cat << EOF
+This scripts handles upstream releasing stuff.
 
+Prerelease is supposed to happen first, that will create .x
+branch that will be used as a based for downstream DWO release.
+
+After DWO release candidate bits are built, tested and pushed to prod
+Release is supposed to happen, which will tag the DWO downstream release
+base revision.
+
+Arguments:
+  --version     : version to release, v0.8.0
+  --prerelease  : flag to perform prerelease. Is performed from main branch
+  --release     : flag to perform release. Is performed from v0.x.y branch
+  --revision    : GIT_SHA of the target brach to be used for releasing
+
+Development arguments to debug:
+  --dry-run     : do not push changes locally
+  --verbose     : enables verbose output
+  --tmp-dir     : perform operation in repo cloned into temporary folder. Repo can be mofidied with DWO_REPO env var
+
+Examples:
+$0 --prerelease --version v0.1.0
+$0 --release --version v0.1.0 --revision ${GIT_SHA}
+
+This script is intended to be triggered by GitHub Actions on the repo.
+EOF
+}
+
+dryrun() {
+    printf -v cmd_str '%q ' "$@"; echo "DRYRUN: Not executing $cmd_str" >&2
+}
+
+parse_args() {
+  while [[ "$#" -gt 0 ]]; do
+    case $1 in
+      '-v'|'--version') VERSION="$2"; shift 1;;
+      '--tmp-dir') TMP=$(mktemp -d); shift 0;;
+      '--release') DO_RELEASE=true; shift 0;;
+      '--prerelease') DO_PRERELEASE='true'; shift 0;;
+      '--dry-run') DRY_RUN='dryrun'; shift 0;;
+      '--verbose') VERBOSE='true'; shift 0;;
+      '--help') usage; exit 0;;
+      *) echo "Unknown parameter is used: $1."; usage; exit 1;;
+    esac
+    shift 1
+  done
+
+  if [ -z "${VERSION}" ]; then
+    echo "Required parameter --version is missing."
+    usage
+    exit 1
+  fi
+}
+
+# bumps the version in version/version.go
 bump_version () {
   CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
   NEXT_VERSION=$1
   BUMP_BRANCH=$2
 
+  echo "[INFO] Bumping version ${BUMP_BRANCH} to ${NEXT_VERSION}"
+
   git checkout "${BUMP_BRANCH}"
 
-  echo "Updating project version to ${NEXT_VERSION}"
   # change version/version.go file
-  sed -i version/version.go -r -e "s#(Version = \")(v?[0-9.]+)(\")#\1${NEXT_VERSION}\3#g"
+  sed -i version/version.go -r -e "s#(Version = \")(v?[0-9.]+).*(\")#\1v${NEXT_VERSION}+rc\3#g"
+  sed -i deploy/templates/components/csv/clusterserviceversion.yaml -r -e "s#(name: devworkspace-operator.)(v[0-9.]+)#\1v${NEXT_VERSION}#g"
+  sed -i deploy/templates/components/csv/clusterserviceversion.yaml -r -e "s#(version: )([0-9.]+)#\1${NEXT_VERSION}#g" 
   if [[ ! -z $(git status -s) ]]; then # dirty
-    git add version/version.go
     COMMIT_MSG="[release] Bump to ${NEXT_VERSION} in ${BUMP_BRANCH}"
     git commit -asm "${COMMIT_MSG}"
   fi
   git pull origin "${BUMP_BRANCH}"
 
-  set +e
-  PUSH_TRY="$(git push origin "${BUMP_BRANCH}")"
+  if [[ -z "$DRY_RUN" ]]; then
+    set +e
+    PUSH_TRY="$(git push origin "${BUMP_BRANCH}")"
+    PUSH_TRY_EXIT_CODE=$?
+    set -e
+  else
+    PUSH_TRY="protected branch hook declined"
+  fi
   # shellcheck disable=SC2181
-  if [[ $? -gt 0 ]] || [[ $PUSH_TRY == *"protected branch hook declined"* ]]; then
+  if [[ "${PUSH_TRY_EXIT_CODE}" -gt 0 ]] || [[ $PUSH_TRY == *"protected branch hook declined"* ]]; then
     PR_BRANCH=pr-${BUMP_BRANCH}-to-${NEXT_VERSION}
     # create pull request for the main branch branch, as branch is restricted
     git branch "${PR_BRANCH}"
     git checkout "${PR_BRANCH}"
-    git pull origin "${PR_BRANCH}"
-    git push origin "${PR_BRANCH}"
+    git pull origin "${PR_BRANCH}" || true
+    $DRY_RUN git push origin "${PR_BRANCH}"
     lastCommitComment="$(git log -1 --pretty=%B)"
-    hub pull-request -f -m "${lastCommitComment}" -b "${BUMP_BRANCH}" -h "${PR_BRANCH}"
+    $DRY_RUN hub pull-request -f -m "${lastCommitComment}" -b "${BUMP_BRANCH}" -h "${PR_BRANCH}"
   fi
-  set -e
   git checkout "${CURRENT_BRANCH}"
 }
 
-usage ()
-{
-  echo "Usage: $0 --version [VERSION TO RELEASE]"
-  echo "Example: $0 --version v0.1.0"; echo
+prerelease() {
+  echo "[INFO] Starting prerelease procedure"
+  # derive bugfix branch from version
+  BRANCH=${VERSION#v}
+  BRANCH=${BRANCH%.*}.x
+
+  echo "[INFO] Creating ${BRANCH} from ${MAIN_BRANCH}"
+  git checkout ${MAIN_BRANCH}
+  git branch "${BRANCH}" || git checkout "${BRANCH}"
+  sed -i version/version.go -r -e "s#(Version = \")(v?[0-9.]+-rc)(\")#\1${VERSION}\3#g"
+  if [[ ! -z $(git status -s) ]]; then # dirty
+    COMMIT_MSG="[prerelease] Remove rc from version"
+    git commit -asm "${COMMIT_MSG}"
+  fi
+  $DRY_RUN git push origin "${BRANCH}"
+  git fetch origin "${BRANCH}:${BRANCH}" || true
+  git checkout "${BRANCH}"
+
+  # change VERSION file + commit change into ${BASEBRANCH} branch
+  # bump the y digit, if it is a major release
+  [[ $BRANCH =~ ^([0-9]+)\.([0-9]+)\.x ]] && BASE=${BASH_REMATCH[1]}; NEXT=${BASH_REMATCH[2]}; (( NEXT=NEXT+1 )) # for BRANCH=0.1.x, get BASE=0, NEXT=2
+  NEXT_VERSION_Y="${BASE}.${NEXT}.0"
+  bump_version "${NEXT_VERSION_Y}" "${MAIN_BRANCH}"
+  echo "Prerelease is done"
 }
 
-if [[ ! ${VERSION} ]]; then
-  usage
-  exit 1
-fi
+release() {
+  echo "[INFO] Starting Release procedure"
+  # derive bugfix branch from version
+  BRANCH=${VERSION#v}
+  BRANCH=${BRANCH%.*}.x
 
-
-# derive bugfix branch from version
-BRANCH=${VERSION#v}
-BRANCH=${BRANCH%.*}.x
-
-# if doing a .0 release, use main branch; if doing a .z release, use $BRANCH
-if [[ ${VERSION} == *".0" ]]; then
-  BASEBRANCH="${MAIN_BRANCH}"
-else
   BASEBRANCH="${BRANCH}"
-fi
+
+  git remote show origin
+
+  # get sources from ${BASEBRANCH} branch
+  git fetch origin "${BASEBRANCH}":"${BASEBRANCH}" || true
+  git checkout "${BASEBRANCH}"
+
+  # create new branch off ${BASEBRANCH} (or check out latest commits if branch already exists), then push to origin
+  if [[ "${BASEBRANCH}" != "${BRANCH}" ]]; then
+    git branch "${BRANCH}" || git checkout "${BRANCH}"
+    $DRY_RUN git push origin "${BRANCH}"
+    git fetch origin "${BRANCH}:${BRANCH}" || true
+    git checkout "${BRANCH}"
+  else
+    git fetch origin "${BRANCH}:${BRANCH}" || true
+    git checkout "${BRANCH}"
+  fi
+
+  # change version/version.go file
+  sed -i version/version.go -r -e "s#(Version = \")(v?[0-9.]+)(\")#\1${VERSION}\3#g"
+  # change image tag in Makefile
+  DWO_QUAY_IMG="${DWO_QUAY_REPO}:${VERSION}"
+  sed -i Makefile -r -e "s#quay.io/devfile/devworkspace-controller:[0-9a-zA-Z._-]+#${DWO_QUAY_IMG}#g"
+  docker build -t "${DWO_QUAY_IMG}" -f ./build/Dockerfile .
+  $DRY_RUN docker push "${DWO_QUAY_IMG}"
+
+  PROJECT_CLONE_QUAY_IMG="${PROJECT_CLONE_QUAY_REPO}:${VERSION}"
+  sed -i Makefile -r -e "s#quay.io/devfile/project-clone:.*[0-9a-zA-Z._-]#${PROJECT_CLONE_QUAY_IMG}#g"
+  docker build -t "${PROJECT_CLONE_QUAY_IMG}" -f ./project-clone/Dockerfile .
+  $DRY_RUN docker push "${PROJECT_CLONE_QUAY_IMG}"
+
+  bash -x ./deploy/generate-deployment.sh \
+    --use-defaults \
+    --default-image "${DWO_QUAY_IMG}" \
+    --project-clone-image "${PROJECT_CLONE_QUAY_IMG}"
+
+  # tag the release if the version/version.go file has changed
+  if [[ ! -z $(git status -s) ]]; then # dirty
+    COMMIT_MSG="[release] Release ${VERSION}"
+    git add version/version.go
+    git commit -asm "${COMMIT_MSG}"
+  fi
+  git tag "${VERSION}"
+  $DRY_RUN git push origin "${VERSION}"
+
+  # now update ${BASEBRANCH} to the new rc version
+  git checkout "${BASEBRANCH}"
+
+  # bump the z digit
+  [[ ${VERSION#v} =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]] \
+    && BASE="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}";  \
+    NEXT="${BASH_REMATCH[3]}"; (( NEXT=NEXT+1 )) # for VERSION=0.1.2, get BASE=0.1, NEXT=3
+  NEXT_VERSION_Z="${BASE}.${NEXT}"
+  bump_version "${NEXT_VERSION_Z}" "${BRANCH}"
+  echo "[INFO] Release is done"
+}
+
+parse_args "$@"
+
+[[ ! -z $VERBOSE ]] && echo "[INFO] Enabling verbose output" && set -x
 
 # work in tmp dir
 if [[ $TMP ]] && [[ -d $TMP ]]; then
   pushd "$TMP" > /dev/null || exit 1
   # get sources from ${BASEBRANCH} branch
-  echo "Check out ${REPO} to ${TMP}/${REPO##*/}"
-  git clone "${REPO}" -q
-  cd "${REPO##*/}" || exit 1
+  echo "[INFO] Check out ${DWO_REPO} to ${TMP}/${DWO_REPO##*/}"
+  git clone "${DWO_REPO}" -q
+  cd "${DWO_REPO##*/}" || exit 1
 fi
 
-git remote show origin
+[[ ! -z "$DO_PRERELEASE" ]] && prerelease
 
-# get sources from ${BASEBRANCH} branch
-git fetch origin "${BASEBRANCH}":"${BASEBRANCH}" || true
-git checkout "${BASEBRANCH}"
-
-# create new branch off ${BASEBRANCH} (or check out latest commits if branch already exists), then push to origin
-if [[ "${BASEBRANCH}" != "${BRANCH}" ]]; then
-  git branch "${BRANCH}" || git checkout "${BRANCH}"
-  git push origin "${BRANCH}"
-  git fetch origin "${BRANCH}:${BRANCH}" || true
-  git checkout "${BRANCH}"
-else
-  git fetch origin "${BRANCH}:${BRANCH}" || true
-  git checkout "${BRANCH}"
-fi
-set -e
-
-# change version/version.go file
-sed -i version/version.go -r -e "s#(Version = \")(v?[0-9.]+)(\")#\1${VERSION}\3#g"
-# change image tag in Makefile
-DWO_QUAY_IMG="quay.io/devfile/devworkspace-controller:${VERSION}"
-sed -i Makefile -r -e "s#quay.io/devfile/devworkspace-controller:[0-9a-zA-Z._-]+#${DWO_QUAY_IMG}#g"
-docker build -t "${DWO_QUAY_IMG}" -f ./build/Dockerfile .
-docker push "${DWO_QUAY_IMG}"
-PROJECT_CLONE_QUAY_IMG="quay.io/devfile/project-clone:${VERSION}"
-sed -i Makefile -r -e "s#quay.io/devfile/project-clone:.*[0-9a-zA-Z._-]#${PROJECT_CLONE_QUAY_IMG}#g"
-docker build -t "${PROJECT_CLONE_QUAY_IMG}" -f ./project-clone/Dockerfile .
-docker push "${PROJECT_CLONE_QUAY_IMG}"
-
-set -x
-bash -x ./deploy/generate-deployment.sh \
-  --use-defaults \
-  --default-image ${DWO_QUAY_IMG} \
-  --project-clone-image ${PROJECT_CLONE_QUAY_IMG}
-
-# tag the release if the version/version.go file has changed
-if [[ ! -z $(git status -s) ]]; then # dirty
-  COMMIT_MSG="[release] Release ${VERSION}"
-  git add version/version.go
-  git commit -asm "${COMMIT_MSG}"
-  git tag "${VERSION}"
-  git push origin "${VERSION}"
-fi
-
-# now update ${BASEBRANCH} to the new snapshot version
-git checkout "${BASEBRANCH}"
-
-# change VERSION file + commit change into ${BASEBRANCH} branch
-if [[ "${BASEBRANCH}" != "${BRANCH}" ]]; then
-  # bump the y digit, if it is a major release
-  [[ $BRANCH =~ ^([0-9]+)\.([0-9]+)\.x ]] && BASE=${BASH_REMATCH[1]}; NEXT=${BASH_REMATCH[2]}; (( NEXT=NEXT+1 )) # for BRANCH=0.1.x, get BASE=0, NEXT=2
-  NEXT_VERSION_Y="${BASE}.${NEXT}.0-SNAPSHOT"
-  bump_version "${NEXT_VERSION_Y}" "${BASEBRANCH}"
-fi
-# bump the z digit
-[[ ${VERSION#v} =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]] && BASE="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"; NEXT="${BASH_REMATCH[3]}"; (( NEXT=NEXT+1 )) # for VERSION=0.1.2, get BASE=0.1, NEXT=3
-NEXT_VERSION_Z="${BASE}.${NEXT}-SNAPSHOT"
-bump_version "${NEXT_VERSION_Z}" "${BRANCH}"
+[[ ! -z "$DO_RELEASE" ]] && release
 
 # cleanup tmp dir
 if [[ $TMP ]] && [[ -d $TMP ]]; then
   popd > /dev/null || exit
-  rm -fr "$TMP"
+  $DRY_RUN rm -fr "$TMP"
 fi


### PR DESCRIPTION
### What does this PR do?
Adapt make-release to a new DWO release cycle.

It's not well tested yet but the idea is to do releases like the following:
1. trigger prerelease, which will:
  - create a new .x branch like `v0.8.x`
  - bump version in main branch to `v0.9.0-dev`
2. do downstreaming from v0.8.x branch
3. after DWO is released and pushed to prod we proceed the next step.
4. Trigger release, which will:
  - patch resources with the right tagged values for deployment templates and Makefile;
    :question: need to decide if the right tagged values should be from redhat catalog or quay.io;
  - create a tag
  - bump version in .x branch for next bugfix release, like `v0.8.1` if it will happen;

### What issues does this PR fix or reference?
it's for https://github.com/devfile/devworkspace-operator/issues/520

### Is it tested? How?
I've tested `./make-release.sh --prerelease --version v0.9.0 --tmp-dir`, the result is https://github.com/devfile/devworkspace-operator/pull/533

Also, I've tested it with
```
export DWO_REPO=git@github.com:sleshchenko/devworkspace-operator
export DWO_QUAY_REPO=quay.io/sleshche/devworkspace-controller
export PROJECT_CLONE_QUAY_REPO=quay.io/sleshche/project-clone
./make-release.sh --prerelease --version v0.9.0 --tmp-dir
./make-release.sh --release --version v0.9.0 --tmp-dir
./make-release.sh --release --version v0.9.1 --tmp-dir
```
So, you can check 
https://github.com/sleshchenko/devworkspace-operator/tree/main
https://github.com/sleshchenko/devworkspace-operator/tree/0.9.x
https://github.com/sleshchenko/devworkspace-operator/releases/tag/v0.9.0
https://github.com/sleshchenko/devworkspace-operator/releases/tag/v0.9.1

https://quay.io/sleshche/devworkspace-controller
https://quay.io/sleshche/project-clone

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
