### PR TITLE
Support workspace env

### DIFF
--- a/pkg/library/flatten/flatten.go
+++ b/pkg/library/flatten/flatten.go
@@ -68,6 +68,11 @@ func ResolveDevWorkspace(workspace *dw.DevWorkspaceTemplateSpec, tooling Resolve
 		return resolvedDW, &warnings, nil
 	}
 
+	err = resolveWorkspaceEnvVar(resolvedDW)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to process workspaceEnv: %w", err)
+	}
+
 	return resolvedDW, nil, nil
 }
 

--- a/pkg/library/flatten/flatten_test.go
+++ b/pkg/library/flatten/flatten_test.go
@@ -212,6 +212,29 @@ func TestResolveDevWorkspaceTemplateNamespaceRestriction(t *testing.T) {
 	}
 }
 
+func TestResolveDevWorkspaceWorkspaceEnv(t *testing.T) {
+	tests := testutil.LoadAllTestsOrPanic(t, "testdata/workspace-env")
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			// sanity check: input defines components
+			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines devworkspace with no components")
+			testResolverTools := getTestingTools(tt.Input, "test-ignored")
+
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
+				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
+			} else {
+				if !assert.NoError(t, err, "Should not return error") {
+					return
+				}
+				assert.Truef(t, cmp.Equal(tt.Output.DevWorkspace, outputWorkspace, testutil.WorkspaceTemplateDiffOpts),
+					"DevWorkspace should match expected output:\n%s",
+					cmp.Diff(tt.Output.DevWorkspace, outputWorkspace, testutil.WorkspaceTemplateDiffOpts))
+			}
+		})
+	}
+}
+
 func getTestingTools(input testutil.TestInput, testNamespace string) ResolverTools {
 	testHttpGetter := &testutil.FakeHTTPGetter{
 		DevfileResources:      input.DevfileResources,

--- a/pkg/library/flatten/flatten_test.go
+++ b/pkg/library/flatten/flatten_test.go
@@ -28,15 +28,7 @@ func TestResolveDevWorkspaceKubernetesReference(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
-			testClient := &testutil.FakeK8sClient{
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testResolverTools := ResolverTools{
-				Context:            context.Background(),
-				WorkspaceNamespace: "test-ignored",
-				K8sClient:          testClient,
-			}
+			testResolverTools := getTestingTools(tt.Input, "test-ignored")
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
@@ -59,14 +51,8 @@ func TestResolveDevWorkspaceInternalRegistry(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
-			testRegistry := &testutil.FakeInternalRegistry{
-				Plugins: tt.Input.DevWorkspaceResources,
-				Errors:  tt.Input.Errors,
-			}
-			testResolverTools := ResolverTools{
-				Context:          context.Background(),
-				InternalRegistry: testRegistry,
-			}
+			testResolverTools := getTestingTools(tt.Input, "test-ignored")
+
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
@@ -89,15 +75,8 @@ func TestResolveDevWorkspacePluginRegistry(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
-			testHttpGetter := &testutil.FakeHTTPGetter{
-				DevfileResources:      tt.Input.DevfileResources,
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testResolverTools := ResolverTools{
-				Context:    context.Background(),
-				HttpClient: testHttpGetter,
-			}
+			testResolverTools := getTestingTools(tt.Input, "test-ignored")
+
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
@@ -120,15 +99,8 @@ func TestResolveDevWorkspacePluginURI(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
-			testHttpGetter := &testutil.FakeHTTPGetter{
-				DevfileResources:      tt.Input.DevfileResources,
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testResolverTools := ResolverTools{
-				Context:    context.Background(),
-				HttpClient: testHttpGetter,
-			}
+			testResolverTools := getTestingTools(tt.Input, "test-ignored")
+
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
@@ -150,21 +122,8 @@ func TestResolveDevWorkspaceParents(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
-			testHttpGetter := &testutil.FakeHTTPGetter{
-				DevfileResources:      tt.Input.DevfileResources,
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testK8sClient := &testutil.FakeK8sClient{
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testResolverTools := ResolverTools{
-				Context:            context.Background(),
-				WorkspaceNamespace: "test-ignored",
-				K8sClient:          testK8sClient,
-				HttpClient:         testHttpGetter,
-			}
+			testResolverTools := getTestingTools(tt.Input, "test-ignored")
+
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
@@ -189,20 +148,9 @@ func TestResolveDevWorkspaceMissingDefaults(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
-			testHttpGetter := &testutil.FakeHTTPGetter{
-				DevfileResources:      tt.Input.DevfileResources,
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testK8sClient := &testutil.FakeK8sClient{
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testResolverTools := ResolverTools{
-				Context:    context.Background(),
-				K8sClient:  testK8sClient,
-				HttpClient: testHttpGetter,
-			}
+			testResolverTools := getTestingTools(tt.Input, "")
+			testResolverTools.InternalRegistry = nil
+
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
@@ -224,21 +172,8 @@ func TestResolveDevWorkspaceAnnotations(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines devworkspace with no components")
-			testHttpGetter := &testutil.FakeHTTPGetter{
-				DevfileResources:      tt.Input.DevfileResources,
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testK8sClient := &testutil.FakeK8sClient{
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testResolverTools := ResolverTools{
-				Context:            context.Background(),
-				K8sClient:          testK8sClient,
-				HttpClient:         testHttpGetter,
-				WorkspaceNamespace: "default-namespace",
-			}
+			testResolverTools := getTestingTools(tt.Input, "test-ignored")
+
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
@@ -260,21 +195,8 @@ func TestResolveDevWorkspaceTemplateNamespaceRestriction(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines devworkspace with no components")
-			testHttpGetter := &testutil.FakeHTTPGetter{
-				DevfileResources:      tt.Input.DevfileResources,
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testK8sClient := &testutil.FakeK8sClient{
-				DevWorkspaceResources: tt.Input.DevWorkspaceResources,
-				Errors:                tt.Input.Errors,
-			}
-			testResolverTools := ResolverTools{
-				Context:            context.Background(),
-				K8sClient:          testK8sClient,
-				HttpClient:         testHttpGetter,
-				WorkspaceNamespace: "test-namespace",
-			}
+			testResolverTools := getTestingTools(tt.Input, "test-namespace")
+
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
@@ -287,5 +209,29 @@ func TestResolveDevWorkspaceTemplateNamespaceRestriction(t *testing.T) {
 					cmp.Diff(tt.Output.DevWorkspace, outputWorkspace, testutil.WorkspaceTemplateDiffOpts))
 			}
 		})
+	}
+}
+
+func getTestingTools(input testutil.TestInput, testNamespace string) ResolverTools {
+	testHttpGetter := &testutil.FakeHTTPGetter{
+		DevfileResources:      input.DevfileResources,
+		DevWorkspaceResources: input.DevWorkspaceResources,
+		Errors:                input.Errors,
+	}
+	testK8sClient := &testutil.FakeK8sClient{
+		DevWorkspaceResources: input.DevWorkspaceResources,
+		Errors:                input.Errors,
+	}
+	testRegistry := &testutil.FakeInternalRegistry{
+		Plugins: input.DevWorkspaceResources,
+
+		Errors: input.Errors,
+	}
+	return ResolverTools{
+		Context:            context.Background(),
+		InternalRegistry:   testRegistry,
+		K8sClient:          testK8sClient,
+		HttpClient:         testHttpGetter,
+		WorkspaceNamespace: testNamespace,
 	}
 }

--- a/pkg/library/flatten/helper.go
+++ b/pkg/library/flatten/helper.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
 )
 
 // resolutionContextTree is a recursive structure representing information about the devworkspace that is
@@ -63,4 +64,16 @@ func formatImportCycle(end *resolutionContextTree) string {
 		cycle = fmt.Sprintf("%s -> %s", end.componentName, cycle)
 	}
 	return cycle
+}
+
+func getOriginalNameForComponent(component dw.Component) string {
+	if component.Attributes.Exists(constants.PluginSourceAttribute) {
+		var err error
+		componentName := component.Attributes.GetString(constants.PluginSourceAttribute, &err)
+		if err != nil {
+			return component.Name
+		}
+		return componentName
+	}
+	return component.Name
 }

--- a/pkg/library/flatten/internal/testutil/common.go
+++ b/pkg/library/flatten/internal/testutil/common.go
@@ -34,6 +34,9 @@ var WorkspaceTemplateDiffOpts = cmp.Options{
 	cmpopts.SortSlices(func(a, b string) bool {
 		return strings.Compare(a, b) > 0
 	}),
+	cmpopts.SortSlices(func(a, b dw.EnvVar) bool {
+		return strings.Compare(a.Name, b.Name) > 0
+	}),
 	// TODO: Devworkspace overriding results in empty []string instead of nil
 	cmpopts.IgnoreFields(dw.DevWorkspaceEvents{}, "PostStart", "PreStop", "PostStop"),
 }

--- a/pkg/library/flatten/testdata/workspace-env/adds-workspace-env-to-all-containers.yaml
+++ b/pkg/library/flatten/testdata/workspace-env/adds-workspace-env-to-all-containers.yaml
@@ -33,10 +33,8 @@ input:
         - name: plugin-a
           attributes:
             workspaceEnv:
-              - name: TEST_ENV_1
-                value: TEST_VAL_1
-              - name: TEST_ENV_2
-                value: TEST_VAL_2
+              TEST_ENV_1: TEST_VAL_1
+              TEST_ENV_2: TEST_VAL_2
           container:
             name: test-container
             image: test-image
@@ -48,10 +46,8 @@ output:
         attributes:
           controller.devfile.io/imported-by: test-plugin
           workspaceEnv:
-            - name: TEST_ENV_1
-              value: TEST_VAL_1
-            - name: TEST_ENV_2
-              value: TEST_VAL_2
+            TEST_ENV_1: TEST_VAL_1
+            TEST_ENV_2: TEST_VAL_2
         container:
           name: test-container
           image: test-image

--- a/pkg/library/flatten/testdata/workspace-env/adds-workspace-env-to-all-containers.yaml
+++ b/pkg/library/flatten/testdata/workspace-env/adds-workspace-env-to-all-containers.yaml
@@ -1,0 +1,84 @@
+name: "Adds workspace environment variables from plugin"
+
+input:
+  devworkspace:
+    components:
+
+      - name: test-plugin
+        plugin:
+          uri: "https://my-plugin.io/test"
+
+      - name: regular-container
+        container:
+          image: test-image-regular
+
+      - name: init-container
+        container:
+          image: test-image-init
+
+    commands:
+      - id: make-init
+        apply:
+          component: init-container
+
+    events:
+      prestart: [make-init]
+
+  devfileResources:
+    "https://my-plugin.io/test":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-a"
+      components:
+        - name: plugin-a
+          attributes:
+            workspaceEnv:
+              - name: TEST_ENV_1
+                value: TEST_VAL_1
+              - name: TEST_ENV_2
+                value: TEST_VAL_2
+          container:
+            name: test-container
+            image: test-image
+
+output:
+  devworkspace:
+    components:
+      - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: test-plugin
+          workspaceEnv:
+            - name: TEST_ENV_1
+              value: TEST_VAL_1
+            - name: TEST_ENV_2
+              value: TEST_VAL_2
+        container:
+          name: test-container
+          image: test-image
+          env:
+            - name: TEST_ENV_1
+              value: TEST_VAL_1
+            - name: TEST_ENV_2
+              value: TEST_VAL_2
+      - name: regular-container
+        container:
+          image: test-image-regular
+          env:
+          - name: TEST_ENV_1
+            value: TEST_VAL_1
+          - name: TEST_ENV_2
+            value: TEST_VAL_2
+      - name: init-container
+        container:
+          image: test-image-init
+          env:
+          - name: TEST_ENV_1
+            value: TEST_VAL_1
+          - name: TEST_ENV_2
+            value: TEST_VAL_2
+    commands:
+      - id: make-init
+        apply:
+          component: init-container
+    events:
+      prestart: [make-init]

--- a/pkg/library/flatten/testdata/workspace-env/adds-workspace-env-written-as-json.yaml
+++ b/pkg/library/flatten/testdata/workspace-env/adds-workspace-env-written-as-json.yaml
@@ -1,0 +1,84 @@
+name: "Adds JSON workspace environment variables from plugin "
+
+input:
+  devworkspace:
+    components:
+
+      - name: test-plugin
+        plugin:
+          uri: "https://my-plugin.io/test"
+
+      - name: regular-container
+        container:
+          image: test-image-regular
+
+      - name: init-container
+        container:
+          image: test-image-init
+
+    commands:
+      - id: make-init
+        apply:
+          component: init-container
+
+    events:
+      prestart: [make-init]
+
+  devfileResources:
+    "https://my-plugin.io/test":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-a"
+      components:
+        - name: plugin-a
+          attributes:
+            workspaceEnv:
+              [{"name": "TEST_ENV_1",
+               "value": "TEST_VAL_1"},
+              {"name": "TEST_ENV_2",
+               "value": "TEST_VAL_2"}]
+          container:
+            name: test-container
+            image: test-image
+
+output:
+  devworkspace:
+    components:
+      - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: test-plugin
+          workspaceEnv:
+            [{"name": "TEST_ENV_1",
+              "value": "TEST_VAL_1"},
+            {"name": "TEST_ENV_2",
+              "value": "TEST_VAL_2"}]
+        container:
+          name: test-container
+          image: test-image
+          env:
+            - name: TEST_ENV_1
+              value: TEST_VAL_1
+            - name: TEST_ENV_2
+              value: TEST_VAL_2
+      - name: regular-container
+        container:
+          image: test-image-regular
+          env:
+          - name: TEST_ENV_1
+            value: TEST_VAL_1
+          - name: TEST_ENV_2
+            value: TEST_VAL_2
+      - name: init-container
+        container:
+          image: test-image-init
+          env:
+          - name: TEST_ENV_1
+            value: TEST_VAL_1
+          - name: TEST_ENV_2
+            value: TEST_VAL_2
+    commands:
+      - id: make-init
+        apply:
+          component: init-container
+    events:
+      prestart: [make-init]

--- a/pkg/library/flatten/testdata/workspace-env/adds-workspace-env-written-as-json.yaml
+++ b/pkg/library/flatten/testdata/workspace-env/adds-workspace-env-written-as-json.yaml
@@ -33,10 +33,10 @@ input:
         - name: plugin-a
           attributes:
             workspaceEnv:
-              [{"name": "TEST_ENV_1",
-               "value": "TEST_VAL_1"},
-              {"name": "TEST_ENV_2",
-               "value": "TEST_VAL_2"}]
+              {
+                "TEST_ENV_1": "TEST_VAL_1",
+                "TEST_ENV_2": "TEST_VAL_2",
+              }
           container:
             name: test-container
             image: test-image
@@ -48,10 +48,10 @@ output:
         attributes:
           controller.devfile.io/imported-by: test-plugin
           workspaceEnv:
-            [{"name": "TEST_ENV_1",
-              "value": "TEST_VAL_1"},
-            {"name": "TEST_ENV_2",
-              "value": "TEST_VAL_2"}]
+            {
+              "TEST_ENV_1": "TEST_VAL_1",
+              "TEST_ENV_2": "TEST_VAL_2",
+            }
         container:
           name: test-container
           image: test-image

--- a/pkg/library/flatten/testdata/workspace-env/error_duplicated-env-var-with-different-value.yaml
+++ b/pkg/library/flatten/testdata/workspace-env/error_duplicated-env-var-with-different-value.yaml
@@ -1,0 +1,34 @@
+name: "Returns an error when there are conflicting definitions of workspace env var"
+
+input:
+  devworkspace:
+    components:
+      - name: test-container
+        attributes:
+          workspaceEnv:
+            - name: TEST_ENV_2
+              value: NOT_TEST_VAL_2
+        container:
+          image: test-image
+      - name: test-plugin
+        plugin:
+          uri: "https://my-plugin.io/test"
+  devfileResources:
+    "https://my-plugin.io/test":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-a"
+      components:
+        - name: plugin-a
+          attributes:
+            workspaceEnv:
+            - name: TEST_ENV_1
+              value: TEST_VAL_1
+            - name: TEST_ENV_2
+              value: TEST_VAL_2
+          container:
+            name: test-container
+            image: test-image
+
+output:
+  errRegexp: "failed to process workspaceEnv: conflicting definition of environment variable TEST_ENV_2 in components 'test-plugin' and 'test-container'"

--- a/pkg/library/flatten/testdata/workspace-env/error_duplicated-env-var-with-different-value.yaml
+++ b/pkg/library/flatten/testdata/workspace-env/error_duplicated-env-var-with-different-value.yaml
@@ -6,8 +6,7 @@ input:
       - name: test-container
         attributes:
           workspaceEnv:
-            - name: TEST_ENV_2
-              value: NOT_TEST_VAL_2
+            TEST_ENV_2: NOT_TEST_VAL_2
         container:
           image: test-image
       - name: test-plugin
@@ -22,10 +21,8 @@ input:
         - name: plugin-a
           attributes:
             workspaceEnv:
-            - name: TEST_ENV_1
-              value: TEST_VAL_1
-            - name: TEST_ENV_2
-              value: TEST_VAL_2
+              TEST_ENV_1: TEST_VAL_1
+              TEST_ENV_2: TEST_VAL_2
           container:
             name: test-container
             image: test-image

--- a/pkg/library/flatten/testdata/workspace-env/error_workspaceEnv-formatted-wrong.yaml
+++ b/pkg/library/flatten/testdata/workspace-env/error_workspaceEnv-formatted-wrong.yaml
@@ -1,0 +1,29 @@
+name: "Returns an error when workspaceEnv cannot be read as []EnvVar"
+
+input:
+  devworkspace:
+    components:
+      - name: test-plugin
+        plugin:
+          uri: "https://my-plugin.io/test"
+  devfileResources:
+    "https://my-plugin.io/test":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-a"
+      components:
+        - name: plugin-a
+          attributes:
+            # Note this fails to deserialize because it's just a yaml string, not a list.
+            # JSON can be used here if you remove the pipe
+            workspaceEnv: |
+              [{"name": "TEST_ENV_1",
+               "value": "TEST_VAL_1"},
+              {"name": "TEST_ENV_2",
+               "value": "TEST_VAL_2"}]
+          container:
+            name: test-container
+            image: test-image
+
+output:
+  errRegexp: "failed to read attribute workspaceEnv on component test-plugin"

--- a/pkg/library/flatten/testdata/workspace-env/error_workspaceEnv-formatted-wrong.yaml
+++ b/pkg/library/flatten/testdata/workspace-env/error_workspaceEnv-formatted-wrong.yaml
@@ -17,10 +17,10 @@ input:
             # Note this fails to deserialize because it's just a yaml string, not a list.
             # JSON can be used here if you remove the pipe
             workspaceEnv: |
-              [{"name": "TEST_ENV_1",
-               "value": "TEST_VAL_1"},
-              {"name": "TEST_ENV_2",
-               "value": "TEST_VAL_2"}]
+              {
+                "TEST_ENV_1": "TEST_ENV_1",
+                "TEST_ENV_2": "TEST_ENV_2",
+              }
           container:
             name: test-container
             image: test-image

--- a/pkg/library/flatten/workspaceEnv.go
+++ b/pkg/library/flatten/workspaceEnv.go
@@ -1,0 +1,81 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package flatten
+
+import (
+	"fmt"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+)
+
+const (
+	// WorkspaceEnvAttribute is an attribute that specifies a set of environment variables provided by a component
+	// that should be added to all workspace containers. The structure of the attribute value should be a map of strings
+	// to strings, e.g.
+	//
+	//   attributes:
+	//     workspaceEnv:
+	//       - name: ENV_1
+	//         value: VAL_1
+	//       - name: ENV_2
+	//         value: VAL_2
+	WorkspaceEnvAttribute = "workspaceEnv"
+)
+
+func resolveWorkspaceEnvVar(flattenedDW *dw.DevWorkspaceTemplateSpec) error {
+	workspaceEnv, err := collectWorkspaceEnv(flattenedDW)
+	if err != nil {
+		return err
+	}
+
+	for idx, component := range flattenedDW.Components {
+		if component.Container != nil {
+			flattenedDW.Components[idx].Container.Env = append(component.Container.Env, workspaceEnv...)
+		}
+	}
+
+	return nil
+}
+
+func collectWorkspaceEnv(flattenedDW *dw.DevWorkspaceTemplateSpec) ([]dw.EnvVar, error) {
+	var workspaceEnv []dw.EnvVar
+
+	// Keep track of used workspace env vars to detect conflicts
+	usedEnvVar := map[string]string{}
+	// Bookkeeping map so that we can format error messages in case of conflict
+	envVarToComponent := map[string]string{}
+
+	for _, component := range flattenedDW.Components {
+		if !component.Attributes.Exists(WorkspaceEnvAttribute) {
+			continue
+		}
+
+		var componentEnv []dw.EnvVar
+		err := component.Attributes.GetInto(WorkspaceEnvAttribute, &componentEnv)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read attribute %s on component %s: %w", WorkspaceEnvAttribute, getOriginalNameForComponent(component), err)
+		}
+
+		for _, envVar := range componentEnv {
+			if existingVal, exists := usedEnvVar[envVar.Name]; exists && existingVal != envVar.Value {
+				return nil, fmt.Errorf("conflicting definition of environment variable %s in components '%s' and '%s'",
+					envVar.Name, envVarToComponent[envVar.Name], component.Name)
+			}
+			usedEnvVar[envVar.Name] = envVar.Value
+			envVarToComponent[envVar.Name] = getOriginalNameForComponent(component)
+		}
+
+		workspaceEnv = append(workspaceEnv, componentEnv...)
+	}
+	return workspaceEnv, nil
+}


### PR DESCRIPTION
### What does this PR do?
Adds support for workspaceEnv as in devfile 1.0 via the attribute `workspaceEnv` on components. Environment variables can be added to all containers in a DevWorkspace by specifying e.g.

```yaml
components:
  - name: my-component
    attributes:
      workspaceEnv: 
        TEST_ENV_1: TEST_VAL_1
        TEST_ENV_2: TEST_VAL_2
```

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/530

### Is it tested? How?
Test cases are added. Can be tested directly using the DevWorkspace 
```yaml
cat <<EOF | kubectl apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next
spec:
  started: true
  template:
    attributes:
      controller.devfile.io/storage-type: "ephemeral"
    components:
      - name: tooling
        attributes:
          workspaceEnv: 
            TEST_ENV_1: TEST_VAL_1
            TEST_ENV_2: TEST_VAL_2
        container:
          image: quay.io/wto/web-terminal-tooling
          args: ["tail", "-f", "/dev/null"]
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml

```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
