### PR TITLE
Ignore IPFamilies and IPFamilyPolicy while syncing services

### DIFF
--- a/controllers/controller/devworkspacerouting/sync_services.go
+++ b/controllers/controller/devworkspacerouting/sync_services.go
@@ -31,7 +31,7 @@ import (
 
 var serviceDiffOpts = cmp.Options{
 	cmpopts.IgnoreFields(corev1.Service{}, "TypeMeta", "ObjectMeta", "Status"),
-	cmpopts.IgnoreFields(corev1.ServiceSpec{}, "ClusterIP", "ClusterIPs", "SessionAffinity"),
+	cmpopts.IgnoreFields(corev1.ServiceSpec{}, "ClusterIP", "ClusterIPs", "IPFamilies", "IPFamilyPolicy", "SessionAffinity"),
 	cmpopts.IgnoreFields(corev1.ServicePort{}, "TargetPort"),
 	cmpopts.SortSlices(func(a, b corev1.ServicePort) bool {
 		return strings.Compare(a.Name, b.Name) > 0


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR fixes an issue on OpenShift 4.8 where devworkspace routing gets stuck in a loop while trying to sync services

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/532

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [x] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [x] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [x] `v7-devworkspace-happy-path`: DevWorkspace e2e test
