### PR TITLE
Bump version in main branch to v0.9.0+dev

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/internal-objects: '["devworkspaceroutings.controller.devfile.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-  name: devworkspace-operator.v0.8.0
+  name: devworkspace-operator.v0.9.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -414,7 +414,7 @@ spec:
   provider:
     name: Devfile
     url: https://devfile.io
-  version: 0.8.0
+  version: 0.9.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     operators.operatorframework.io/internal-objects: '["devworkspaceroutings.controller.devfile.io"]'
-  name: devworkspace-operator.v0.8.0
+  name: devworkspace-operator.v0.9.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -95,4 +95,6 @@ spec:
   provider:
     name: Devfile
     url: https://devfile.io
-  version: 0.8.0
+  # uncomment the below when devworkspace-operator.v0.8.0 is availble
+  # replaces: devworkspace-operator.v0.8.0
+  version: 0.9.0

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ package version
 
 var (
 	// Version is the operator version
-	Version = "v0.8.0"
+	Version = "v0.9.0+dev"
 	// Commit is the commit hash corresponding to the code that was built. Can be suffixed with `-dirty`
 	Commit string = "unknown"
 	// BuildTime is the time of build of the binary


### PR DESCRIPTION
### What does this PR do?
Bump version in main branch to v0.9.0+dev

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Nothing to test

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
