### PR TITLE
Create a separate service to support controller metrics

### DIFF
--- a/deploy/bundle/manifests/devworkspace-controller-manager-service_v1_service.yaml
+++ b/deploy/bundle/manifests/devworkspace-controller-manager-service_v1_service.yaml
@@ -12,9 +12,6 @@ spec:
     port: 443
     protocol: TCP
     targetPort: conversion
-  - name: metrics
-    port: 8443
-    targetPort: metrics
   selector:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator

--- a/deploy/bundle/manifests/devworkspace-controller-metrics_v1_service.yaml
+++ b/deploy/bundle/manifests/devworkspace-controller-metrics_v1_service.yaml
@@ -1,17 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
+  creationTimestamp: null
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
-  name: devworkspace-controller-manager-service
-  namespace: devworkspace-controller
+  name: devworkspace-controller-metrics
 spec:
   ports:
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: conversion
+  - name: metrics
+    port: 8443
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
+status:
+  loadBalancer: {}

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -18767,6 +18767,20 @@ spec:
     port: 443
     protocol: TCP
     targetPort: conversion
+  selector:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator
+  name: devworkspace-controller-metrics
+  namespace: devworkspace-controller
+spec:
+  ports:
   - name: metrics
     port: 8443
     targetPort: metrics

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-metrics.Service.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-metrics.Service.yaml
@@ -4,14 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
-  name: devworkspace-controller-manager-service
+  name: devworkspace-controller-metrics
   namespace: devworkspace-controller
 spec:
   ports:
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: conversion
+  - name: metrics
+    port: 8443
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -18769,6 +18769,20 @@ spec:
     port: 443
     protocol: TCP
     targetPort: conversion
+  selector:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator
+  name: devworkspace-controller-metrics
+  namespace: devworkspace-controller
+spec:
+  ports:
   - name: metrics
     port: 8443
     targetPort: metrics

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager-service.Service.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager-service.Service.yaml
@@ -14,9 +14,6 @@ spec:
     port: 443
     protocol: TCP
     targetPort: conversion
-  - name: metrics
-    port: 8443
-    targetPort: metrics
   selector:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator

--- a/deploy/deployment/openshift/objects/devworkspace-controller-metrics.Service.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-metrics.Service.yaml
@@ -4,14 +4,13 @@ metadata:
   labels:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator
-  name: devworkspace-controller-manager-service
+  name: devworkspace-controller-metrics
   namespace: devworkspace-controller
 spec:
   ports:
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: conversion
+  - name: metrics
+    port: 8443
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator

--- a/deploy/templates/components/manager/kustomization.yaml
+++ b/deploy/templates/components/manager/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - manager.yaml
 - serviceaccount.yaml
 - service.yaml
+- service-metrics.yaml
 
 vars:
 - name: CONTROLLER_SERVICE_ACCOUNT

--- a/deploy/templates/components/manager/service-metrics.yaml
+++ b/deploy/templates/components/manager/service-metrics.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics
+  namespace: system
+spec:
+  ports:
+  - name: metrics
+    port: 8443
+    targetPort: metrics
+  selector:
+    app.kubernetes.io/name: devworkspace-controller
+    app.kubernetes.io/part-of: devworkspace-operator

--- a/deploy/templates/components/manager/service.yaml
+++ b/deploy/templates/components/manager/service.yaml
@@ -1,3 +1,10 @@
+# This service cannot be modified; added ports will be removed in an OLM install,
+# and changing the name defined below will result in duplicate services being created
+# when installed via OLM. This service is also necessary for conversion webhooks to
+# be created successfully in OLM.
+# In other words, take great care in modifying the object below.
+# See issue https://github.com/operator-framework/operator-lifecycle-manager/issues/2233
+# for details.
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,9 +16,6 @@ spec:
     port: 443
     targetPort: conversion
     protocol: TCP
-  - name: metrics
-    port: 8443
-    targetPort: metrics
   selector:
     app.kubernetes.io/name: devworkspace-controller
     app.kubernetes.io/part-of: devworkspace-operator


### PR DESCRIPTION
### What does this PR do?
Due to an issue with OLM, it's necessary to specially define the controller's service, meaning that any additional ports we want to use need to exist in a separate service.

* The deployment manifests need to contain a service that points at the conversion webhooks port in the controller deployment in order to satisfy OLM requirements for conversion webhooks in the CSV.
* This service must be named '<deploymentName>-manager-service', otherwise OLM will create a service with that name (even if it duplicates an existing service)
* OLM will always create the service `<deploymentName>-manager-service' based on its computed spec, overwriting the ports defined in that service (i.e. no additional ports can be included).

See issue https://github.com/operator-framework/operator-lifecycle-manager/issues/2233 for details

### What issues does this PR fix or reference?
When installed via OLM, the service endpoint for metrics does not exist, making metrics access require a workaround.

### Is it tested? How?
Should be no functional changes (if you have a script to port-forward metrics or similar, it will need updating)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
