### PR TITLE
Label metrics by routingClass in addition to source

### DIFF
--- a/controllers/workspace/metrics/metrics.go
+++ b/controllers/workspace/metrics/metrics.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	workspaceSourceLabel = "controller.devfile.io/devworkspace-source"
-	metricSourceLabel    = "source"
+	workspaceSourceLabel     = "controller.devfile.io/devworkspace-source"
+	metricSourceLabel        = "source"
+	metricsRoutingClassLabel = "routingclass"
 )
 
 var (
@@ -31,6 +32,7 @@ var (
 		},
 		[]string{
 			metricSourceLabel,
+			metricsRoutingClassLabel,
 		},
 	)
 	workspaceStarts = prometheus.NewCounterVec(
@@ -41,6 +43,7 @@ var (
 		},
 		[]string{
 			metricSourceLabel,
+			metricsRoutingClassLabel,
 		},
 	)
 	workspaceFailures = prometheus.NewCounterVec(
@@ -51,6 +54,7 @@ var (
 		},
 		[]string{
 			metricSourceLabel,
+			metricsRoutingClassLabel,
 		},
 	)
 	workspaceStartupTimesHist = prometheus.NewHistogramVec(
@@ -62,6 +66,7 @@ var (
 		},
 		[]string{
 			metricSourceLabel,
+			metricsRoutingClassLabel,
 		},
 	)
 )

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/devfile/devworkspace-operator/pkg/conditions"
+	"github.com/devfile/devworkspace-operator/pkg/config"
 )
 
 // WorkspaceStarted updates metrics for workspaces entering the 'Starting' phase, given a workspace. If an error is
@@ -42,7 +43,11 @@ func WorkspaceFailed(wksp *dw.DevWorkspace, log logr.Logger) {
 
 func incrementMetricForWorkspace(metric *prometheus.CounterVec, wksp *dw.DevWorkspace, log logr.Logger) {
 	sourceLabel := wksp.Labels[workspaceSourceLabel]
-	ctr, err := metric.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel})
+	routingClass := wksp.Spec.RoutingClass
+	if routingClass == "" {
+		routingClass = config.ControllerCfg.GetDefaultRoutingClass()
+	}
+	ctr, err := metric.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel, metricsRoutingClassLabel: routingClass})
 	if err != nil {
 		log.Error(err, "Failed to increment metric")
 	}
@@ -51,7 +56,11 @@ func incrementMetricForWorkspace(metric *prometheus.CounterVec, wksp *dw.DevWork
 
 func incrementStartTimeBucketForWorkspace(wksp *dw.DevWorkspace, log logr.Logger) {
 	sourceLabel := wksp.Labels[workspaceSourceLabel]
-	hist, err := workspaceStartupTimesHist.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel})
+	routingClass := wksp.Spec.RoutingClass
+	if routingClass == "" {
+		routingClass = config.ControllerCfg.GetDefaultRoutingClass()
+	}
+	hist, err := workspaceStartupTimesHist.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel, metricsRoutingClassLabel: routingClass})
 	if err != nil {
 		log.Error(err, "Failed to update metric")
 	}

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -43,6 +43,9 @@ func WorkspaceFailed(wksp *dw.DevWorkspace, log logr.Logger) {
 
 func incrementMetricForWorkspace(metric *prometheus.CounterVec, wksp *dw.DevWorkspace, log logr.Logger) {
 	sourceLabel := wksp.Labels[workspaceSourceLabel]
+	if sourceLabel == "" {
+		sourceLabel = "unknown"
+	}
 	routingClass := wksp.Spec.RoutingClass
 	if routingClass == "" {
 		routingClass = config.ControllerCfg.GetDefaultRoutingClass()
@@ -56,6 +59,9 @@ func incrementMetricForWorkspace(metric *prometheus.CounterVec, wksp *dw.DevWork
 
 func incrementStartTimeBucketForWorkspace(wksp *dw.DevWorkspace, log logr.Logger) {
 	sourceLabel := wksp.Labels[workspaceSourceLabel]
+	if sourceLabel == "" {
+		sourceLabel = "unknown"
+	}
 	routingClass := wksp.Spec.RoutingClass
 	if routingClass == "" {
 		routingClass = config.ControllerCfg.GetDefaultRoutingClass()


### PR DESCRIPTION
### What does this PR do?
Add a label to devworkspace specific metrics based on routingClass, e.g. 
```
devworkspace_started_total{routingclass="basic",source="Che"}
```
This allows a roundabout way of filtering metrics based on tooling, since routingClasses are associated with specific tools (e.g. `web-terminal` for WTO, `che` for DWCO).

It also replaces the empty `source` label with `"unknown"` if the annotation is not applied.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Easiest way: 
1. `make run`
2. start a devworkspace or two
3. `curl -s localhost:8080/metrics | grep '^dev'`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
