### PR TITLE
Update workspace role to allow get/list/create/delete secrets

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -79,7 +79,7 @@ type DevWorkspaceReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups=apps;extensions,resources=replicasets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps;extensions,resources=deployments,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;create;delete
+// +kubebuilder:rbac:groups="",resources=secrets,resourceNames=workspace-credentials-secret,verbs=get;create;delete
 
 func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ctrl.Result, err error) {
 	ctx := context.Background()

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -79,6 +79,7 @@ type DevWorkspaceReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups=apps;extensions,resources=replicasets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps;extensions,resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;create;delete
 
 func (r *DevWorkspaceReconciler) Reconcile(req ctrl.Request) (reconcileResult ctrl.Result, err error) {
 	ctx := context.Background()

--- a/controllers/workspace/provision/rbac.go
+++ b/controllers/workspace/provision/rbac.go
@@ -57,6 +57,11 @@ func generateRBAC(namespace string) []runtime.Object {
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
+					Resources: []string{"secrets"},
+					APIGroups: []string{""},
+					Verbs:     []string{"get", "list", "create", "delete"},
+				},
+				{
 					Resources: []string{"devworkspaces"},
 					APIGroups: []string{"workspace.devfile.io"},
 					Verbs:     []string{"get", "watch", "list", "patch", "update"},

--- a/controllers/workspace/provision/rbac.go
+++ b/controllers/workspace/provision/rbac.go
@@ -57,9 +57,10 @@ func generateRBAC(namespace string) []runtime.Object {
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
-					Resources: []string{"secrets"},
-					APIGroups: []string{""},
-					Verbs:     []string{"get", "list", "create", "delete"},
+					Resources:     []string{"secrets"},
+					APIGroups:     []string{""},
+					Verbs:         []string{"get", "create", "delete"},
+					ResourceNames: []string{"workspace-credentials-secret"},
 				},
 				{
 					Resources: []string{"devworkspaces"},

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -103,6 +103,16 @@ spec:
           - create
         - apiGroups:
           - ""
+          resourceNames:
+          - workspace-credentials-secret
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+        - apiGroups:
+          - ""
           resources:
           - services
           verbs:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -18520,6 +18520,16 @@ rules:
   - create
 - apiGroups:
   - ""
+  resourceNames:
+  - workspace-credentials-secret
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - ""
   resources:
   - services
   verbs:

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -33,6 +33,16 @@ rules:
   - create
 - apiGroups:
   - ""
+  resourceNames:
+  - workspace-credentials-secret
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - ""
   resources:
   - services
   verbs:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -18520,6 +18520,16 @@ rules:
   - create
 - apiGroups:
   - ""
+  resourceNames:
+  - workspace-credentials-secret
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - ""
   resources:
   - services
   verbs:

--- a/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -33,6 +33,16 @@ rules:
   - create
 - apiGroups:
   - ""
+  resourceNames:
+  - workspace-credentials-secret
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - ""
   resources:
   - services
   verbs:

--- a/deploy/templates/components/rbac/role.yaml
+++ b/deploy/templates/components/rbac/role.yaml
@@ -32,6 +32,16 @@ rules:
   - create
 - apiGroups:
   - ""
+  resourceNames:
+  - workspace-credentials-secret
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - ""
   resources:
   - services
   verbs:


### PR DESCRIPTION
### What does this PR do?
This PR is an update to https://github.com/devfile/devworkspace-operator/pull/489. Instead of granting access to all secrets in the namespace, we scope the permission down to single secret named `workspace-credentials-secret`.

### What issues does this PR fix or reference?
Closes #483

### Is it tested? How?
Test that workspace SA can create/update/delete secret named `workspace-credentials-secret`. I haven't tested how the `list` permission interacts with a restricted role in this way (will do later)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
