### PR TITLE
Update GitHub Action for PRs to use go 1.15.13 and old version of addlicense

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: 1.15.13
     -
       name: Set up Python 3.8
       uses: actions/setup-python@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,7 +72,9 @@ jobs:
     -
       name: Check format
       run: |
-        go get -u github.com/google/addlicense
+        # Have to use older version of addlicense as newer versions *require* Go 1.16. This
+        # requirement can be removed once this project moves to Go 1.16
+        go get -u github.com/google/addlicense@99ebc9c9db7bceb8623073e894533b978d7b7c8a
         go get -u golang.org/x/tools/cmd/goimports
         git reset HEAD --hard
 


### PR DESCRIPTION
### What does this PR do?
This PR separates out the change described in https://github.com/devfile/devworkspace-operator/pull/540#issuecomment-892747218 by updating the GH action to use go 1.15.13 and avoid issue https://github.com/golang/go/issues/44557

It also pins the version of addlicense used in github actions to https://github.com/google/addlicense/commit/99ebc9c9db7bceb8623073e894533b978d7b7c8a, as the following commits make addlicense require Go 1.16

### What issues does this PR fix or reference?
I noticed that the automated check for https://github.com/devfile/devworkspace-operator/pull/544 is failing due to 
```
build github.com/google/addlicense: cannot load io/fs: malformed module path "io/fs": missing dot in first path element
```

### Is it tested? How?
Hopefully all actions pass :)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
