### PR TITLE
Check devworkspace pod events for "Unrecoverable" events

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -68,7 +68,7 @@ type DevWorkspaceReconciler struct {
 /////// Required permissions for controller
 // +kubebuilder:rbac:groups=apps;extensions,resources=deployments;replicasets,verbs=*
 // +kubebuilder:rbac:groups="",resources=pods;serviceaccounts;secrets;configmaps;persistentvolumeclaims,verbs=*
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=namespaces;events,verbs=get;list;watch
 // +kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;create;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -90,6 +90,7 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - events
           - namespaces
           verbs:
           - get

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -18507,6 +18507,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - namespaces
   verbs:
   - get

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -20,6 +20,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - namespaces
   verbs:
   - get

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -18507,6 +18507,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - namespaces
   verbs:
   - get

--- a/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -20,6 +20,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - namespaces
   verbs:
   - get

--- a/deploy/templates/components/rbac/role.yaml
+++ b/deploy/templates/components/rbac/role.yaml
@@ -19,6 +19,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - namespaces
   verbs:
   - get


### PR DESCRIPTION
### What does this PR do?
Checks events related to the DevWorkspace pod for what we would consider "unrecoverable" events (list stolen from [Che](https://github.com/eclipse-che/che-server/blob/72bfc85436022bc87aad109829411ef7f9b48663/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties#L358) :stuck_out_tongue:)

This requires adding an index to the manager, to allow us to list events with the appropriate fieldSelector.

Also adds `get/list/watch` Events RBAC to the controller.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/465

### Is it tested? How?
It's hard to reproduce these events manually; the easiest way I found was to patch `commonStorage.go` to read
```go
// Line 115
	podAdditions.Volumes = append(podAdditions.Volumes, corev1.Volume{
		Name: commonPVCName,
		VolumeSource: corev1.VolumeSource{
			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
				ClaimName: commonPVCName+"fake",
			},
		},
	})
```
and trying to start a non-ephemeral DevWorkspace.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
