### PR TITLE
feat: Automount git credentials if they exist

### DIFF
--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -26,6 +26,9 @@ const (
 	// DevWorkspaceMountLabel is the label key to store if a configmap or secret should be mounted to the devworkspace
 	DevWorkspaceMountLabel = "controller.devfile.io/mount-to-devworkspace"
 
+	// DevWorkspaceGitCredentialLabel is the label key to specify if the secret is a git credential
+	DevWorkspaceGitCredentialLabel = "controller.devfile.io/git-credential"
+
 	// DevWorkspaceMountPathAnnotation is the annotation key to store the mount path for the secret or configmap.
 	// If no mount path is provided, configmaps will be mounted at /etc/config/<configmap-name>, secrets will
 	// be mounted at /etc/secret/<secret-name>, and persistent volume claims will be mounted to /tmp/<claim-name>

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -26,7 +26,12 @@ const (
 	// DevWorkspaceMountLabel is the label key to store if a configmap or secret should be mounted to the devworkspace
 	DevWorkspaceMountLabel = "controller.devfile.io/mount-to-devworkspace"
 
-	// DevWorkspaceGitCredentialLabel is the label key to specify if the secret is a git credential
+	// DevWorkspaceGitCredentialLabel is the label key to specify if the secret is a git credential. All secrets who
+	// specify this label in a namespace will consolidate into one secret before mounting into a devworkspace.
+	// Only secret data with the credentials key will be used and credentials must be the base64 encoded version
+	//	of https://{USERNAME}:{PERSONAL_ACCESS_TOKEN}@{GIT_WEBSITE}
+	// E.g. echo -n "https://{USERNAME}:{PERSONAL_ACCESS_TOKEN}@{GIT_WEBSITE}" | base64
+	// see https://git-scm.com/docs/git-credential-store#_storage_format for more details
 	DevWorkspaceGitCredentialLabel = "controller.devfile.io/git-credential"
 
 	// DevWorkspaceMountPathAnnotation is the annotation key to store the mount path for the secret or configmap.

--- a/pkg/provision/workspace/automount/common.go
+++ b/pkg/provision/workspace/automount/common.go
@@ -14,6 +14,7 @@ package automount
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/provision/workspace/automount/configmaps.go
+++ b/pkg/provision/workspace/automount/configmaps.go
@@ -42,14 +42,14 @@ func getDevWorkspaceConfigmaps(namespace string, client k8sclient.Client) (*v1al
 			if mountPath == "" {
 				mountPath = path.Join("/etc/config/", configmap.Name)
 			}
-			podAdditions.Volumes = append(podAdditions.Volumes, getAutoMountVolumeWithConfigMap(configmap.Name))
-			podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, getAutoMountConfigMapVolumeMount(mountPath, configmap.Name))
+			podAdditions.Volumes = append(podAdditions.Volumes, GetAutoMountVolumeWithConfigMap(configmap.Name))
+			podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, GetAutoMountConfigMapVolumeMount(mountPath, configmap.Name))
 		}
 	}
 	return podAdditions, additionalEnvVars, nil
 }
 
-func getAutoMountVolumeWithConfigMap(name string) corev1.Volume {
+func GetAutoMountVolumeWithConfigMap(name string) corev1.Volume {
 	modeReadOnly := int32(0640)
 	workspaceVolumeMount := corev1.Volume{
 		Name: common.AutoMountConfigMapVolumeName(name),
@@ -65,7 +65,7 @@ func getAutoMountVolumeWithConfigMap(name string) corev1.Volume {
 	return workspaceVolumeMount
 }
 
-func getAutoMountConfigMapVolumeMount(mountPath, name string) corev1.VolumeMount {
+func GetAutoMountConfigMapVolumeMount(mountPath, name string) corev1.VolumeMount {
 	workspaceVolumeMount := corev1.VolumeMount{
 		Name:      common.AutoMountConfigMapVolumeName(name),
 		ReadOnly:  true,

--- a/pkg/provision/workspace/automount/git-credentials.go
+++ b/pkg/provision/workspace/automount/git-credentials.go
@@ -44,9 +44,10 @@ const credentialTemplate = "[credential]\n\thelper = store --file %s\n"
 func getDevWorkspaceGitConfig(devworkspace *dw.DevWorkspace, client k8sclient.Client, scheme *runtime.Scheme) (*v1alpha1.PodAdditions, error) {
 	namespace := devworkspace.GetNamespace()
 	secrets := &corev1.SecretList{}
-	if err := client.List(context.TODO(), secrets, k8sclient.InNamespace(namespace), k8sclient.MatchingLabels{
+	err := client.List(context.TODO(), secrets, k8sclient.InNamespace(namespace), k8sclient.MatchingLabels{
 		constants.DevWorkspaceGitCredentialLabel: "true",
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 	var credentials []string
@@ -78,7 +79,6 @@ func getDevWorkspaceGitConfig(devworkspace *dw.DevWorkspace, client k8sclient.Cl
 		}
 		podAdditions.Volumes = append(podAdditions.Volumes, secretAdditions.Volumes...)
 		podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, secretAdditions.VolumeMounts...)
-
 	}
 	return podAdditions, nil
 }

--- a/pkg/provision/workspace/automount/git-credentials.go
+++ b/pkg/provision/workspace/automount/git-credentials.go
@@ -18,7 +18,6 @@ import (
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
-	"github.com/prometheus/common/log"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -157,9 +156,6 @@ func createOrUpdateGitSecret(secretName string, namespace string, config string,
 		if err != nil {
 			return err
 		}
-		log.Info("Updated git secret")
-	} else {
-		log.Info("Created git secret")
 	}
 	return nil
 }
@@ -216,9 +212,7 @@ func createOrUpdateGitConfigMap(configMapName string, namespace string, config s
 		if err != nil {
 			return err
 		}
-		log.Info("Updated git config map")
-	} else {
-		log.Info("Created git config map")
+
 	}
 	return nil
 }

--- a/pkg/provision/workspace/automount/git-credentials.go
+++ b/pkg/provision/workspace/automount/git-credentials.go
@@ -1,0 +1,260 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package automount
+
+import (
+	"context"
+	"fmt"
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"github.com/prometheus/common/log"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"path/filepath"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"strings"
+)
+
+const gitCredentialsName = "credentials"
+const gitConfigName = "gitconfig"
+const gitConfigLocation = "/etc/" + gitConfigName
+const credentialTemplate = "[credential]\n\thelper = store --file %s\n"
+
+// getDevWorkspaceGitConfig takes care of mounting git credentials and a gitconfig into a devworkspace.
+//	It does so by:
+//		1. Finding all secrets labeled with "controller.devfile.io/git-credential": "true" and grabbing all their credentials
+//			and condensing them into one string
+//		2. Creating and mounting a gitconfig config map to /etc/gitconfig that points to where the credentials are stored
+//		3. Creating and mounting a credentials secret to mountpath/credentials that stores the users git credentials
+func getDevWorkspaceGitConfig(devworkspace *dw.DevWorkspace, client k8sclient.Client, scheme *runtime.Scheme) (*v1alpha1.PodAdditions, error) {
+	namespace := devworkspace.GetNamespace()
+	secrets := &corev1.SecretList{}
+	if err := client.List(context.TODO(), secrets, k8sclient.InNamespace(namespace), k8sclient.MatchingLabels{
+		constants.DevWorkspaceGitCredentialLabel: "true",
+	}); err != nil {
+		return nil, err
+	}
+	var credentials []string
+	var mountpath string
+	for _, secret := range secrets.Items {
+		credentials = append(credentials, string(secret.Data[gitCredentialsName]))
+		if val, ok := secret.Annotations[constants.DevWorkspaceMountPathAnnotation]; ok {
+			mountpath = val
+		}
+	}
+
+	podAdditions := &v1alpha1.PodAdditions{}
+	if len(credentials) > 0 {
+		gitCredsName := devworkspace.Status.DevWorkspaceId + "-" + gitConfigName
+
+		// mount the gitconfig
+		configMapAdditions, err := mountGitConfigMap(gitCredsName, mountpath, devworkspace, client, scheme)
+		if err != nil {
+			return podAdditions, err
+		}
+		podAdditions.Volumes = append(podAdditions.Volumes, configMapAdditions.Volumes...)
+		podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, configMapAdditions.VolumeMounts...)
+
+		// mount the users git credentials
+		joinedCredentials := strings.Join(credentials, "\n")
+		secretAdditions, err := mountGitCredentialsSecret(gitCredsName, mountpath, joinedCredentials, devworkspace, client, scheme)
+		if err != nil {
+			return podAdditions, err
+		}
+		podAdditions.Volumes = append(podAdditions.Volumes, secretAdditions.Volumes...)
+		podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, secretAdditions.VolumeMounts...)
+
+	}
+	return podAdditions, nil
+}
+
+// mountGitConfigMap mounts the gitconfig to /etc/gitconfig in all devworkspaces in the given namespace.
+//   It does so by:
+//		1. Creating the configmap that stores the gitconfig if it does not exist
+//		2. Setting the proper owner ref to the devworkspace
+//		3. Adding the new config map volume and volume mount to the pod additions
+func mountGitConfigMap(configMapName, mountPath string, devworkspace *dw.DevWorkspace, client k8sclient.Client, scheme *runtime.Scheme) (*v1alpha1.PodAdditions, error) {
+	podAdditions := &v1alpha1.PodAdditions{}
+
+	// Initialize the gitconfig template
+	credentialsGitConfig := fmt.Sprintf(credentialTemplate, filepath.Join(mountPath, gitCredentialsName))
+
+	// Create the configmap that stores the gitconfig
+	gitConfigMap, err := createOrUpdateGitConfigMap(configMapName, devworkspace.GetNamespace(), credentialsGitConfig, client)
+	if err != nil {
+		return nil, err
+	}
+
+	err = controllerutil.SetOwnerReference(devworkspace, gitConfigMap, scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the volume for the configmap
+	podAdditions.Volumes = append(podAdditions.Volumes, GetAutoMountVolumeWithConfigMap(configMapName))
+
+	// Create the gitconfig volume mount and set it's location as /etc/gitconfig so it's automatically picked up by git
+	gitConfigMapVolumeMount := GetAutoMountConfigMapVolumeMount(gitConfigLocation, configMapName)
+	gitConfigMapVolumeMount.SubPath = gitConfigName
+	gitConfigMapVolumeMount.ReadOnly = false
+	podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, gitConfigMapVolumeMount)
+
+	return podAdditions, nil
+}
+
+// mountGitCredentialsSecret mounts the users git credentials to mountpath/credentials
+//   It does so by:
+//		1. Creating the secret that stores the credentials if it does not exist
+//		2. Setting the proper owner ref to the devworkspace
+//		3. Adding the new secret volume and volume mount to the pod additions
+func mountGitCredentialsSecret(secretName, mountPath, credentials string, devworkspace *dw.DevWorkspace, client k8sclient.Client, scheme *runtime.Scheme) (*v1alpha1.PodAdditions, error) {
+	podAdditions := &v1alpha1.PodAdditions{}
+
+	// Create the configmap that stores all the users credentials
+	gitSecret, err := createOrUpdateGitSecret(secretName, devworkspace.GetNamespace(), credentials, client)
+	if err != nil {
+		return nil, err
+	}
+
+	err = controllerutil.SetOwnerReference(devworkspace, gitSecret, scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the volume for the secret
+	podAdditions.Volumes = append(podAdditions.Volumes, GetAutoMountVolumeWithSecret(secretName))
+
+	// Create the git credentials volume mount and set it's location as mountpath/credentials
+	gitSecretVolumeMount := GetAutoMountSecretVolumeMount(filepath.Join(mountPath, gitCredentialsName), secretName)
+	gitSecretVolumeMount.ReadOnly = true
+	gitSecretVolumeMount.SubPath = gitCredentialsName
+	podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, gitSecretVolumeMount)
+
+	return podAdditions, nil
+}
+
+func createOrUpdateGitSecret(secretName string, namespace string, config string, client k8sclient.Client) (*corev1.Secret, error) {
+	secret := getGitSecret(secretName, namespace, config)
+	if err := client.Create(context.TODO(), secret); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return secret, err
+		}
+		existingCfg, err := getClusterGitSecret(secretName, namespace, client)
+		if err != nil {
+			return secret, err
+		}
+		secret.ResourceVersion = existingCfg.ResourceVersion
+		err = client.Update(context.TODO(), secret)
+		if err != nil {
+			return secret, err
+		}
+		log.Info("Updated git secret")
+	} else {
+		log.Info("Created git secret")
+	}
+	return secret, nil
+}
+
+func getClusterGitSecret(secretName string, namespace string, client k8sclient.Client) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      secretName,
+	}
+	err := client.Get(context.TODO(), namespacedName, secret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return secret, nil
+}
+
+func getGitSecret(secretName string, namespace string, config string) *corev1.Secret {
+	gitConfigMap := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":    "git-config-secret",
+				"app.kubernetes.io/part-of": "devworkspace-operator",
+			},
+		},
+		Data: map[string][]byte{
+			gitCredentialsName: []byte(config),
+		},
+	}
+	return gitConfigMap
+}
+
+func createOrUpdateGitConfigMap(configMapName string, namespace string, config string, client k8sclient.Client) (*corev1.ConfigMap, error) {
+	configMap := getGitConfigMap(configMapName, namespace, config)
+	if err := client.Create(context.TODO(), configMap); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return configMap, err
+		}
+		existingCfg, err := getClusterGitConfigMap(configMapName, namespace, client)
+		if err != nil {
+			return configMap, err
+		}
+		configMap.ResourceVersion = existingCfg.ResourceVersion
+		err = client.Update(context.TODO(), configMap)
+		if err != nil {
+			return configMap, err
+		}
+		log.Info("Updated git config map")
+	} else {
+		log.Info("Created git config map")
+	}
+	return configMap, nil
+}
+
+func getClusterGitConfigMap(configMapName string, namespace string, client k8sclient.Client) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{}
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      configMapName,
+	}
+	err := client.Get(context.TODO(), namespacedName, configMap)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return configMap, nil
+}
+
+func getGitConfigMap(configMapName string, namespace string, config string) *corev1.ConfigMap {
+	gitConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":    "git-config-secret",
+				"app.kubernetes.io/part-of": "devworkspace-operator",
+			},
+		},
+		Data: map[string]string{
+			gitConfigName: config,
+		},
+	}
+
+	return gitConfigMap
+}

--- a/pkg/provision/workspace/automount/git-credentials.go
+++ b/pkg/provision/workspace/automount/git-credentials.go
@@ -15,6 +15,9 @@ package automount
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
+
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
@@ -23,10 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"path/filepath"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
 )
 
 const gitCredentialsName = "credentials"

--- a/pkg/provision/workspace/automount/secret.go
+++ b/pkg/provision/workspace/automount/secret.go
@@ -42,14 +42,14 @@ func getDevWorkspaceSecrets(namespace string, client k8sclient.Client) (*v1alpha
 			if mountPath == "" {
 				mountPath = path.Join("/etc/", "secret/", secret.Name)
 			}
-			podAdditions.Volumes = append(podAdditions.Volumes, getAutoMountVolumeWithSecret(secret.Name))
-			podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, getAutoMountSecretVolumeMount(mountPath, secret.Name))
+			podAdditions.Volumes = append(podAdditions.Volumes, GetAutoMountVolumeWithSecret(secret.Name))
+			podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, GetAutoMountSecretVolumeMount(mountPath, secret.Name))
 		}
 	}
 	return podAdditions, additionalEnvVars, nil
 }
 
-func getAutoMountVolumeWithSecret(name string) v1.Volume {
+func GetAutoMountVolumeWithSecret(name string) v1.Volume {
 	modeReadOnly := int32(0640)
 	workspaceVolumeMount := v1.Volume{
 		Name: common.AutoMountSecretVolumeName(name),
@@ -63,7 +63,7 @@ func getAutoMountVolumeWithSecret(name string) v1.Volume {
 	return workspaceVolumeMount
 }
 
-func getAutoMountSecretVolumeMount(mountPath, name string) v1.VolumeMount {
+func GetAutoMountSecretVolumeMount(mountPath, name string) v1.VolumeMount {
 	workspaceVolumeMount := v1.VolumeMount{
 		Name:      common.AutoMountSecretVolumeName(name),
 		ReadOnly:  true,

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -84,7 +84,7 @@ func SyncDeploymentToCluster(
 	saName string,
 	clusterAPI ClusterAPI) DeploymentProvisioningStatus {
 
-	automountPodAdditions, automountEnv, err := automount.GetAutoMountResources(workspace.Namespace, clusterAPI.Client)
+	automountPodAdditions, automountEnv, err := automount.GetAutoMountResources(workspace, clusterAPI.Client, clusterAPI.Scheme)
 	if err != nil {
 		return DeploymentProvisioningStatus{
 			ProvisioningStatus{Err: err},


### PR DESCRIPTION
### What does this PR do?
This PR enables the ability to automount git credentials if they exist. The way it works is fundamentally the same as [Che](https://www.eclipse.org/che/docs/che-7/end-user-guide/mounting-a-secret-as-a-file-or-an-environment-variable-into-a-workspace-container/#mounting-a-git-credential-store-into-a-workspace-container_che).
1. Users provide a secret containing their credentials with a label of `"controller.devfile.io/git-credential": "true"`
2. When a devworkspace is created the devworkspace controller looks for all secrets with that label, combines them into a new secret (so that you can have multiple credentials referenced in one credential file. See https://github.com/eclipse/che/issues/18721) and then mounts both that new combined secret and a system wide gitconfig that points to the secret so that user credentials are already picked up when cloning
3. Devworkspace now has access to those credentials and can use them for cloning inside of project clone

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/506

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Create a secret on the cluster containing:
```
kind: Secret
apiVersion: v1
metadata:
  name: git-credentials-secret
  namespace: devworkspace-controller
  annotations:
    controller.devfile.io/mount-path: /home/theia/.git-credentials/
  labels:
    controller.devfile.io/git-credential: 'true'
data:
  credentials: >- ${your base64 credentials here}
type: Opaque
```
${your base64 credentials here} should be base64 encoded in the format of "https://{USERNAME}:{PERSONAL_ACCESS_TOKEN}@github.com". E.g. `echo -n "https://{USERNAME}:{PERSONAL_ACCESS_TOKEN}@github.com" | base64` 
2. Create a private repo on github
3. Create a devworkspace that uses your private repo in the same namespace as your secret
4. See that project cloned correctly


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v7-devworkspaces-operator-e2e, v7-devworkspace-happy-path` to trigger)
    - [ ] `v7-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v7-devworkspace-happy-path`: DevWorkspace e2e test
