### PR TITLE
Upgrade replaces since DWO 0.9.0 is alive & fix build of olm next pieces

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -99,7 +99,12 @@ jobs:
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin quay.io
 
       - name: "Build Bundle & Index images"
-        run: make build_bundle_image build_index_image
+        run: |
+          # next OLM images is just for quick testing and don't have all versions.
+          # so, drop it from there
+          sed -i '/replaces: devworkspace-operator.v*/d' deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+
+          make build_bundle_image build_index_image
 
       - name: "Docker Logout"
         run: docker logout

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -433,7 +433,7 @@ spec:
   provider:
     name: Devfile
     url: https://devfile.io
-  replaces: devworkspace-operator.v0.8.0
+  replaces: devworkspace-operator.v0.9.0
   version: 0.10.0
   webhookdefinitions:
   - admissionReviewVersions:

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -95,5 +95,5 @@ spec:
   provider:
     name: Devfile
     url: https://devfile.io
-  replaces: devworkspace-operator.v0.8.0
+  replaces: devworkspace-operator.v0.9.0
   version: 0.10.0


### PR DESCRIPTION
### What does this PR do?
Upgrade replaces since DWO 0.9.0 is alive & fix build of olm next pieces

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
it tested by https://github.com/devfile/devworkspace-operator/runs/3506439015

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspaces-operator-e2e, v8-devworkspace-happy-path` to trigger)
    - [ ] `v8-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-devworkspace-happy-path`: DevWorkspace e2e test
