### PR TITLE
Change tag image on next for getting last changes in the test codebase

### DIFF
--- a/.ci/resources/pod-che-happy-path.yaml
+++ b/.ci/resources/pod-che-happy-path.yaml
@@ -12,7 +12,7 @@ spec:
   containers:
     # container containing the tests
     - name: happy-path-test
-      image: quay.io/eclipse/che-e2e:nightly
+      image: quay.io/eclipse/che-e2e:next
       imagePullPolicy: Always
       env:
         - name: TEST_SUITE


### PR DESCRIPTION
### What does this PR do?
Changes the **nightly** tag for the test image on the **next**

### What issues does this PR fix or reference?
eclipse/che#20406 

### Is it tested? How?


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspaces-operator-e2e, v8-devworkspace-happy-path` to trigger)
    - [ ] `v8-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-devworkspace-happy-path`: DevWorkspace e2e test
