### PR TITLE
Fix location of fake DWO CSV

### DIFF
--- a/.ci/che-happy-path.sh
+++ b/.ci/che-happy-path.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+set -e
+
+export ARTIFACT_DIR=${ARTIFACT_DIR:-"/tmp/che-happy-path"}
+mkdir -p "${ARTIFACT_DIR}"
+
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+
+export CHE_NAMESPACE="eclipse-che"
+export HAPPY_PATH_POD_NAME=happy-path-che
+export HAPPY_PATH_TEST_PROJECT='https://github.com/che-samples/java-spring-petclinic/tree/devfilev2'
+
+# Create cluster-admin user inside of openshift cluster and login
+function provisionOpenShiftOAuthUser() {
+  if oc login -u che-user -p user --insecure-skip-tls-verify=false; then
+    echo "Che User already exists. Using it"
+    return 0
+  fi
+  echo "Che User does not exist. Setting up htpassw oauth for it."
+  SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+  oc delete secret che-htpass-secret -n openshift-config || true
+  oc create secret generic che-htpass-secret --from-file=htpasswd="$SCRIPT_DIR/resources/users.htpasswd" -n openshift-config
+
+# The idea was to patch oauth not to break existing ones but our selenium test is not adapted to it yet.
+# So, just override ATM
+#  oc patch oauth/cluster --type=json \
+#    -p '[{"op": "add", "path": "/spec/identityProviders/0", "value": {"name":"che-htpasswd","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"che-htpass-secret"}}}}]'
+  oc apply -f "$SCRIPT_DIR/resources/htpasswdProvider.yaml"
+
+  oc adm policy add-cluster-role-to-user cluster-admin che-user
+
+  echo -e "[INFO] Waiting for htpasswd auth to be working up to 5 minutes"
+  CURRENT_TIME=$(date +%s)
+  ENDTIME=$(($CURRENT_TIME + 300))
+  while [ $(date +%s) -lt $ENDTIME ]; do
+      if oc login -u che-user -p user --insecure-skip-tls-verify=false; then
+          break
+      fi
+      sleep 10
+  done
+}
+
+startHappyPathTest() {
+  # patch happy-path-che.yaml 
+  ECLIPSE_CHE_URL=http://$(oc get route -n "${CHE_NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
+  TS_SELENIUM_DEVWORKSPACE_URL="${ECLIPSE_CHE_URL}/#${HAPPY_PATH_TEST_PROJECT}"
+  HAPPY_PATH_POD_FILE=${SCRIPT_DIR}/resources/pod-che-happy-path.yaml
+  sed -i "s@CHE_URL@${ECLIPSE_CHE_URL}@g" ${HAPPY_PATH_POD_FILE}
+  sed -i "s@WORKSPACE_ROUTE@${TS_SELENIUM_DEVWORKSPACE_URL}@g" ${HAPPY_PATH_POD_FILE}
+  sed -i "s@CHE-NAMESPACE@${CHE_NAMESPACE}@g" ${HAPPY_PATH_POD_FILE}
+
+  echo "[INFO] Applying the following patched Che Happy Path Pod:"
+  cat ${HAPPY_PATH_POD_FILE}
+  echo "[INFO] --------------------------------------------------"
+  oc apply -f ${HAPPY_PATH_POD_FILE}
+  # wait for the pod to start
+  n=0
+  while [ $n -le 120 ]
+  do
+    PHASE=$(oc get pod -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} \
+        --template='{{ .status.phase }}')
+    if [[ ${PHASE} == "Running" ]]; then
+      echo "[INFO] Happy-path test started succesfully."
+      return
+    fi
+
+    sleep 5
+    n=$(( n+1 ))
+  done
+
+  echo "[ERROR] Failed to start happy-path test."
+  exit 1
+}
+
+provisionOpenShiftOAuthUser
+
+startHappyPathTest
+
+echo "1"
+# wait for the test to finish
+oc logs -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test -f
+echo "2"
+# just to sleep
+sleep 3
+
+echo "3"
+# download the test results
+mkdir -p /tmp/e2e
+oc rsync -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME}:/tmp/e2e/report/ /tmp/e2e -c download-reports
+oc exec -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c download-reports -- touch /tmp/done
+cp -r /tmp/e2e ${ARTIFACT_DIR}
+echo "4"
+EXIT_CODE=$(oc logs -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test | grep EXIT_CODE)
+if [[ ${EXIT_CODE} == "+ EXIT_CODE=1" ]]; then
+    echo "[ERROR] Happy-path test failed."
+    exit 1
+fi

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -36,25 +36,6 @@ function bumpPodsInfo() {
     oc get events -n $NS -o=yaml > $TARGET_DIR/events.log || true
 }
 
-
-# Create cluster-admin user inside of openshift cluster and login
-function provisionOpenShiftOAuthUser() {
-  SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-  oc create secret generic htpass-secret --from-file=htpasswd="$SCRIPT_DIR/resources/users.htpasswd" -n openshift-config
-  oc apply -f "$SCRIPT_DIR/resources/htpasswdProvider.yaml"
-  oc adm policy add-cluster-role-to-user cluster-admin user
-
-  echo -e "[INFO] Waiting for htpasswd auth to be working up to 5 minutes"
-  CURRENT_TIME=$(date +%s)
-  ENDTIME=$(($CURRENT_TIME + 300))
-  while [ $(date +%s) -lt $ENDTIME ]; do
-      if oc login -u user -p user --insecure-skip-tls-verify=false; then
-          break
-      fi
-      sleep 10
-  done
-}
-
 installChectl() {
   wget $(curl https://che-incubator.github.io/chectl/download-link/next-linux-x64)
   tar -xzf chectl-linux-x64.tar.gz

--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -23,12 +23,15 @@ source "${SCRIPT_DIR}"/common.sh
 
 # Catch the finish of the job and write logs in artifacts.
 function Catch_Finish() {
-    # grab devworkspace-controller namespace events after running e2e
     bumpPodsInfo "devworkspace-controller"
-    bumpPodsInfo "devworkspace-che"
-    bumpPodsInfo "admin-che"
-    oc get devworkspaces -n "admin-che" -o=yaml > $ARTIFACT_DIR/devworkspaces.yaml
-    /tmp/chectl/bin/chectl server:logs --chenamespace=${NAMESPACE} --directory=${ARTIFACT_DIR} --telemetry=off
+    bumpPodsInfo "eclipse-che"
+    USERS_CHE_NS="che-user-che"
+    bumpPodsInfo $USERS_CHE_NS
+    # Fetch DW related CRs but do not fail when CRDs are not installed yet
+    oc get devworkspace -n $USERS_CHE_NS -o=yaml > ${ARTIFACT_DIR}/devworkspaces.yaml || true
+    oc get devworkspacetemplate -n $USERS_CHE_NS -o=yaml > ${ARTIFACT_DIR}/devworkspace-templates.yaml || true
+    oc get devworkspacerouting -n $USERS_CHE_NS -o=yaml > ${ARTIFACT_DIR}/devworkspace-routings.yaml || true
+    /tmp/chectl/bin/chectl server:logs --chenamespace=eclipse-che --directory=${ARTIFACT_DIR}/chectl-server-logs --telemetry=off
 }
 trap 'Catch_Finish $?' EXIT SIGINT
 

--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -49,7 +49,8 @@ deployDWO() {
 deployChe() {
   # create fake DWO CSV to prevent Che Operator getting
   # ownerships of DWO resources
-  kubectl apply -f ./resources/fake-dwo-csv.yaml
+  oc new-project eclipse-che || true
+  kubectl apply -f ${SCRIPT_DIR}/resources/fake-dwo-csv.yaml
 
   /tmp/chectl/bin/chectl server:deploy \
     -p openshift \

--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -37,7 +37,7 @@ trap 'Catch_Finish $?' EXIT SIGINT
 
 # ENV used by PROW ci
 export CI="openshift"
-export NAMESPACE="eclipse-che"
+export CHE_NAMESPACE="eclipse-che"
 export HAPPY_PATH_POD_NAME=happy-path-che
 export HAPPY_PATH_TEST_PROJECT='https://github.com/che-samples/java-spring-petclinic/tree/devfilev2'
 # Pod created by openshift ci don't have user. Using this envs should avoid errors with git user.
@@ -45,6 +45,7 @@ export GIT_COMMITTER_NAME="CI BOT"
 export GIT_COMMITTER_EMAIL="ci_bot@notused.com"
 
 deployDWO() {
+  export NAMESPACE="devworkspace-controller"
   export DWO_IMG='${DEVWORKSPACE_OPERATOR}'
   make install
 }
@@ -65,12 +66,12 @@ deployChe() {
 
 startHappyPathTest() {
   # patch happy-path-che.yaml 
-  ECLIPSE_CHE_URL=http://$(oc get route -n "${NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
+  ECLIPSE_CHE_URL=http://$(oc get route -n "${CHE_NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
   TS_SELENIUM_DEVWORKSPACE_URL="${ECLIPSE_CHE_URL}/#${HAPPY_PATH_TEST_PROJECT}"
   HAPPY_PATH_POD_FILE=${SCRIPT_DIR}/resources/pod-che-happy-path.yaml
   sed -i "s@CHE_URL@${ECLIPSE_CHE_URL}@g" ${HAPPY_PATH_POD_FILE}
   sed -i "s@WORKSPACE_ROUTE@${TS_SELENIUM_DEVWORKSPACE_URL}@g" ${HAPPY_PATH_POD_FILE}
-  sed -i "s@CHE-NAMESPACE@${NAMESPACE}@g" ${HAPPY_PATH_POD_FILE}
+  sed -i "s@CHE-NAMESPACE@${CHE_NAMESPACE}@g" ${HAPPY_PATH_POD_FILE}
 
   echo "[INFO] Applying the following patched Che Happy Path Pod:"
   cat ${HAPPY_PATH_POD_FILE}
@@ -80,7 +81,7 @@ startHappyPathTest() {
   n=0
   while [ $n -le 120 ]
   do
-    PHASE=$(oc get pod -n ${NAMESPACE} ${HAPPY_PATH_POD_NAME} \
+    PHASE=$(oc get pod -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} \
         --template='{{ .status.phase }}')
     if [[ ${PHASE} == "Running" ]]; then
       echo "[INFO] Happy-path test started succesfully."
@@ -99,18 +100,18 @@ runTest() {
   startHappyPathTest
 
   # wait for the test to finish
-  oc logs -n ${NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test -f
+  oc logs -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test -f
 
   # just to sleep
   sleep 3
 
   # download the test results
   mkdir -p /tmp/e2e
-  oc rsync -n ${NAMESPACE} ${HAPPY_PATH_POD_NAME}:/tmp/e2e/report/ /tmp/e2e -c download-reports
-  oc exec -n ${NAMESPACE} ${HAPPY_PATH_POD_NAME} -c download-reports -- touch /tmp/done
+  oc rsync -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME}:/tmp/e2e/report/ /tmp/e2e -c download-reports
+  oc exec -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c download-reports -- touch /tmp/done
   cp -r /tmp/e2e ${ARTIFACT_DIR}
 
-  EXIT_CODE=$(oc logs -n ${NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test | grep EXIT_CODE)
+  EXIT_CODE=$(oc logs -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test | grep EXIT_CODE)
 
   if [[ ${EXIT_CODE} == "+ EXIT_CODE=1" ]]; then
     echo "[ERROR] Happy-path test failed."

--- a/.ci/resources/htpasswdProvider.yaml
+++ b/.ci/resources/htpasswdProvider.yaml
@@ -9,4 +9,4 @@ spec:
     type: HTPasswd
     htpasswd:
       fileData:
-        name: htpass-secret
+        name: che-htpass-secret

--- a/.ci/resources/pod-che-happy-path.yaml
+++ b/.ci/resources/pod-che-happy-path.yaml
@@ -28,7 +28,7 @@ spec:
         - name: TS_SELENIUM_LOG_LEVEL
           value: TRACE
         - name: TS_SELENIUM_OCP_USERNAME
-          value: 'user'
+          value: 'che-user'
         - name: TS_SELENIUM_OCP_PASSWORD
           value: "user"
         - name: TS_SELENIUM_VALUE_OPENSHIFT_OAUTH

--- a/.ci/resources/users.htpasswd
+++ b/.ci/resources/users.htpasswd
@@ -1,1 +1,1 @@
-user:{SHA}Et6pb+wgWTVmq3VpLJlJWWgzrck=
+che-user:{SHA}Et6pb+wgWTVmq3VpLJlJWWgzrck=

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,6 @@
 
 ### PR Checklist
 
-- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspaces-operator-e2e, v8-devworkspace-happy-path` to trigger)
-    - [ ] `v8-devworkspaces-operator-e2e`: DevWorkspace e2e test
-    - [ ] `v8-devworkspace-happy-path`: DevWorkspace e2e test
+- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
+    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
+    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


### PR DESCRIPTION
### What does this PR do?
It has the following fixes and improvements for happy path test:
- Fix location of fake DWO CSV
- Fixed and Improved logs fetching;
- Adapt happy path test to be runnable locally against any OpenShift Cluster with Che and DWO deployed.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspaces-operator-e2e, v8-devworkspace-happy-path` to trigger)
    - [ ] `v8-devworkspaces-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-devworkspace-happy-path`: DevWorkspace e2e test
