### PR TITLE
Fixup edge cases in automounting git credentials

### DIFF
--- a/pkg/provision/workspace/automount/common.go
+++ b/pkg/provision/workspace/automount/common.go
@@ -23,6 +23,21 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+type FatalError struct {
+	Err error
+}
+
+func (e *FatalError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return ""
+}
+
+func (e *FatalError) Unwrap() error {
+	return e.Err
+}
+
 func GetAutoMountResources(devworkspace *dw.DevWorkspace, client k8sclient.Client, scheme *runtime.Scheme) ([]v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
 	namespace := devworkspace.GetNamespace()
 	gitCMPodAdditions, err := getDevWorkspaceGitConfig(devworkspace, client, scheme)

--- a/pkg/provision/workspace/automount/common.go
+++ b/pkg/provision/workspace/automount/common.go
@@ -27,7 +27,7 @@ func GetAutoMountResources(devworkspace *dw.DevWorkspace, client k8sclient.Clien
 	namespace := devworkspace.GetNamespace()
 	gitCMPodAdditions, err := getDevWorkspaceGitConfig(devworkspace, client, scheme)
 	if err != nil {
-		return nil, nil, nil
+		return nil, nil, err
 	}
 
 	cmPodAdditions, cmEnvAdditions, err := getDevWorkspaceConfigmaps(namespace, client)

--- a/pkg/provision/workspace/automount/git-credentials.go
+++ b/pkg/provision/workspace/automount/git-credentials.go
@@ -55,6 +55,9 @@ func getDevWorkspaceGitConfig(devworkspace *dw.DevWorkspace, client k8sclient.Cl
 	for _, secret := range secrets.Items {
 		credentials = append(credentials, string(secret.Data[gitCredentialsName]))
 		if val, ok := secret.Annotations[constants.DevWorkspaceMountPathAnnotation]; ok {
+			if mountpath != "" && val != mountpath {
+				return nil, &FatalError{fmt.Errorf("auto-mounted git credentials have conflicting mountPaths")}
+			}
 			mountpath = val
 		}
 	}

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -86,8 +86,15 @@ func SyncDeploymentToCluster(
 
 	automountPodAdditions, automountEnv, err := automount.GetAutoMountResources(workspace, clusterAPI.Client, clusterAPI.Scheme)
 	if err != nil {
-		return DeploymentProvisioningStatus{
-			ProvisioningStatus{Err: err},
+		var fatalErr *automount.FatalError
+		if errors.As(err, &fatalErr) {
+			return DeploymentProvisioningStatus{
+				ProvisioningStatus{Err: err, FailStartup: true},
+			}
+		} else {
+			return DeploymentProvisioningStatus{
+				ProvisioningStatus{Err: err},
+			}
 		}
 	}
 	if err := automount.CheckAutoMountVolumesForCollision(podAdditions, automountPodAdditions); err != nil {


### PR DESCRIPTION
### What does this PR do?
A couple of minor fixups to https://github.com/devfile/devworkspace-operator/pull/564 (I think):
* Don't drop error when getting git credentials
* Fail workspace startup if git credential secrets conflict in mountPath (not sure if this is needed...)

For now I just use an error type to return a fatal error in the automount function -- I'm considering refactoring our provision methods to signal via errors rather than a kinda complicated struct.

### What issues does this PR fix or reference?
n/a

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
