### PR TITLE
feat: Enable config to log diff on objects when updating

### DIFF
--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
@@ -53,6 +53,8 @@ type DevWorkspaceRoutingReconciler struct {
 	Scheme *runtime.Scheme
 	// SolverGetter will be used to get solvers for a particular devWorkspaceRouting
 	SolverGetter solvers.RoutingSolverGetter
+	// Enable additional debug logging
+	DebugLogging bool
 }
 
 // +kubebuilder:rbac:groups=controller.devfile.io,resources=devworkspaceroutings,verbs=*

--- a/controllers/controller/devworkspacerouting/sync_ingresses.go
+++ b/controllers/controller/devworkspacerouting/sync_ingresses.go
@@ -54,7 +54,7 @@ func (r *DevWorkspaceRoutingReconciler) syncIngresses(routing *controllerv1alpha
 		if contains, idx := listContainsIngressByName(specIngress, clusterIngresses); contains {
 			clusterIngress := clusterIngresses[idx]
 			if !cmp.Equal(specIngress, clusterIngress, ingressDiffOpts) {
-				r.Log.Info("Updating ingress")
+				r.Log.Info(fmt.Sprintf("Updating ingress: %s", clusterIngress.Name))
 				if r.DebugLogging {
 					r.Log.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specIngress, clusterIngress, ingressDiffOpts)))
 				}

--- a/controllers/controller/devworkspacerouting/sync_ingresses.go
+++ b/controllers/controller/devworkspacerouting/sync_ingresses.go
@@ -54,6 +54,10 @@ func (r *DevWorkspaceRoutingReconciler) syncIngresses(routing *controllerv1alpha
 		if contains, idx := listContainsIngressByName(specIngress, clusterIngresses); contains {
 			clusterIngress := clusterIngresses[idx]
 			if !cmp.Equal(specIngress, clusterIngress, ingressDiffOpts) {
+				r.Log.Info("Updating ingress")
+				if r.DebugLogging {
+					r.Log.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specIngress, clusterIngress, ingressDiffOpts)))
+				}
 				// Update ingress's spec
 				clusterIngress.Spec = specIngress.Spec
 				err := r.Update(context.TODO(), &clusterIngress)

--- a/controllers/controller/devworkspacerouting/sync_routes.go
+++ b/controllers/controller/devworkspacerouting/sync_routes.go
@@ -55,6 +55,10 @@ func (r *DevWorkspaceRoutingReconciler) syncRoutes(routing *controllerv1alpha1.D
 		if contains, idx := listContainsRouteByName(specRoute, clusterRoutes); contains {
 			clusterRoute := clusterRoutes[idx]
 			if !cmp.Equal(specRoute, clusterRoute, routeDiffOpts) {
+				r.Log.Info("Updating route")
+				if r.DebugLogging {
+					r.Log.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specRoute, clusterRoute, routeDiffOpts)))
+				}
 				// Update route's spec
 				clusterRoute.Spec = specRoute.Spec
 				err := r.Update(context.TODO(), &clusterRoute)

--- a/controllers/controller/devworkspacerouting/sync_routes.go
+++ b/controllers/controller/devworkspacerouting/sync_routes.go
@@ -55,7 +55,7 @@ func (r *DevWorkspaceRoutingReconciler) syncRoutes(routing *controllerv1alpha1.D
 		if contains, idx := listContainsRouteByName(specRoute, clusterRoutes); contains {
 			clusterRoute := clusterRoutes[idx]
 			if !cmp.Equal(specRoute, clusterRoute, routeDiffOpts) {
-				r.Log.Info("Updating route")
+				r.Log.Info(fmt.Sprintf("Updating route: %s", clusterRoute.Name))
 				if r.DebugLogging {
 					r.Log.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specRoute, clusterRoute, routeDiffOpts)))
 				}

--- a/controllers/controller/devworkspacerouting/sync_services.go
+++ b/controllers/controller/devworkspacerouting/sync_services.go
@@ -59,6 +59,10 @@ func (r *DevWorkspaceRoutingReconciler) syncServices(routing *controllerv1alpha1
 		if contains, idx := listContainsByName(specService, clusterServices); contains {
 			clusterService := clusterServices[idx]
 			if !cmp.Equal(specService, clusterService, serviceDiffOpts) {
+				r.Log.Info("Updating service")
+				if r.DebugLogging {
+					r.Log.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specService, clusterService, serviceDiffOpts)))
+				}
 				// Cannot naively copy spec, as clusterIP is unmodifiable
 				clusterIP := clusterService.Spec.ClusterIP
 				clusterService.Spec = specService.Spec

--- a/controllers/controller/devworkspacerouting/sync_services.go
+++ b/controllers/controller/devworkspacerouting/sync_services.go
@@ -59,7 +59,7 @@ func (r *DevWorkspaceRoutingReconciler) syncServices(routing *controllerv1alpha1
 		if contains, idx := listContainsByName(specService, clusterServices); contains {
 			clusterService := clusterServices[idx]
 			if !cmp.Equal(specService, clusterService, serviceDiffOpts) {
-				r.Log.Info("Updating service")
+				r.Log.Info(fmt.Sprintf("Updating service: %s", clusterService.Name))
 				if r.DebugLogging {
 					r.Log.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specService, clusterService, serviceDiffOpts)))
 				}

--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ func main() {
 		Log:          ctrl.Log.WithName("controllers").WithName("DevWorkspaceRouting"),
 		Scheme:       mgr.GetScheme(),
 		SolverGetter: &solvers.SolverGetter{},
+		DebugLogging: config.ControllerCfg.GetExperimentalFeaturesEnabled(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DevWorkspaceRouting")
 		os.Exit(1)

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -121,7 +121,7 @@ func SyncDeploymentToCluster(
 	}
 
 	if clusterDeployment == nil {
-		clusterAPI.Logger.Info("Creating deployment...")
+		clusterAPI.Logger.Info("Creating deployment")
 		if err := clusterAPI.Client.Create(context.TODO(), specDeployment); err != nil {
 			return DeploymentProvisioningStatus{
 				ProvisioningStatus{
@@ -136,7 +136,7 @@ func SyncDeploymentToCluster(
 	}
 
 	if !cmp.Equal(specDeployment.Spec.Selector, clusterDeployment.Spec.Selector) {
-		clusterAPI.Logger.Info("Deployment selector is different. Recreating deployment...")
+		clusterAPI.Logger.Info("Deployment selector is different. Recreating deployment")
 		clusterDeployment.Spec = specDeployment.Spec
 		err := clusterAPI.Client.Delete(context.TODO(), clusterDeployment)
 		if err != nil {
@@ -148,7 +148,10 @@ func SyncDeploymentToCluster(
 	}
 
 	if !cmp.Equal(specDeployment, clusterDeployment, deploymentDiffOpts) {
-		clusterAPI.Logger.Info("Updating deployment...")
+		clusterAPI.Logger.Info("Updating deployment")
+		if config.ControllerCfg.GetExperimentalFeaturesEnabled() {
+			clusterAPI.Logger.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specDeployment, clusterDeployment, deploymentDiffOpts)))
+		}
 		clusterDeployment.Spec = specDeployment.Spec
 		err := clusterAPI.Client.Update(context.TODO(), clusterDeployment)
 		if err != nil {

--- a/pkg/provision/workspace/object.go
+++ b/pkg/provision/workspace/object.go
@@ -14,8 +14,10 @@ package workspace
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
+	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -85,6 +87,9 @@ func SyncObject(object runtimeClient.Object, client runtimeClient.Client, reqLog
 	}
 	if !cmp.Equal(object, found, diffOpt) {
 		reqLogger.Info("Updating "+objType.String(), "namespace", objMeta.GetNamespace(), "name", objMeta.GetName())
+		if config.ControllerCfg.GetExperimentalFeaturesEnabled() {
+			reqLogger.Info(fmt.Sprintf("Diff: %s", cmp.Diff(object, found, diffOpt)))
+		}
 		updateErr := client.Update(context.TODO(), object)
 		if errors.IsConflict(updateErr) {
 			return found, true, nil

--- a/pkg/provision/workspace/routing.go
+++ b/pkg/provision/workspace/routing.go
@@ -94,6 +94,10 @@ func SyncRoutingToCluster(
 	}
 
 	if !cmp.Equal(specRouting, clusterRouting, routingDiffOpts) {
+		clusterAPI.Logger.Info("Updating DevWorkspaceRouting")
+		if config.ControllerCfg.GetExperimentalFeaturesEnabled() {
+			clusterAPI.Logger.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specRouting, clusterRouting, routingDiffOpts)))
+		}
 		clusterRouting.Labels = specRouting.Labels
 		clusterRouting.Annotations = specRouting.Annotations
 		clusterRouting.Spec = specRouting.Spec

--- a/pkg/provision/workspace/serviceaccount.go
+++ b/pkg/provision/workspace/serviceaccount.go
@@ -14,6 +14,7 @@ package workspace
 
 import (
 	"context"
+	"fmt"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/google/go-cmp/cmp"
@@ -25,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/config"
 )
 
 type ServiceAcctProvisioningStatus struct {
@@ -86,6 +88,9 @@ func SyncServiceAccount(
 
 	if !cmp.Equal(specSA.Annotations, clusterSA.Annotations) {
 		clusterAPI.Logger.Info("Updating DevWorkspace ServiceAccount")
+		if config.ControllerCfg.GetExperimentalFeaturesEnabled() {
+			clusterAPI.Logger.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specSA.Annotations, clusterSA.Annotations)))
+		}
 		patch := runtimeClient.MergeFrom(&specSA)
 		err := clusterAPI.Client.Patch(context.TODO(), clusterSA, patch)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?
Use the experimental features flag to enable additional logging when updating objects on the cluster. If experimental features are enabled and a spec object is found to be different from the cluster one, log a
diff between the two.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/581

### Is it tested? How?
1. Start DWO with experimental features enabled
2. Create a devworkspace 
3. Edit e.g. the deployment/service/devworkspacerouting and check logs

Note that since the controller uses json-structured logging, newlines and tabs are escaped in log messages. An easy way to work around this is to pipe to `sed -e 's|\\n|\n|g; s|\\t|    |g'` -- though, note if using `make run` it's also necessary to pipe stderr to stdout, i.e. `make run 2>&1 | sed -e 's|\\n|\n|g; s|\\t|    |g'`. Another option is to copy paste a `msg` and feed it to `printf`.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
