### PR TITLE
Workaround issue where makefile can't run commands after oc logout

### DIFF
--- a/build/make/deploy.mk
+++ b/build/make/deploy.mk
@@ -11,12 +11,14 @@ K8S_CLI := kubectl <&-
 # Check if logged in and warn if not
 ifeq ($(findstring Please enter Username,$(shell kubectl auth can-i '*' '*' <&- 2>&1)),Please enter Username)
 $(info Warning: current context is not authenticated with a cluster)
+LOGGED_IN="false"
 endif
 else
 K8S_CLI := oc <&-
 # Check if logged in and warn if not
 ifeq ($(findstring Forbidden,$(shell oc whoami 2>&1)),Forbidden)
 $(info Warning: current context is not authenticated with a cluster)
+LOGGED_IN="false"
 endif
 endif
 
@@ -107,9 +109,11 @@ endif
 
 _check_cert_manager:
 ifeq ($(PLATFORM),kubernetes)
-	if ! ${K8S_CLI} api-versions | grep -q '^cert-manager.io/v1$$' ; then \
-		echo "Cert-manager is required for deploying on Kubernetes. See 'make install_cert_manager'" ;\
-		exit 1 ;\
+	if [ ! -z "$$LOGGED_IN" ]; then \
+		if ! ${K8S_CLI} api-versions | grep -q '^cert-manager.io/v1$$' ; then \
+			echo "Cert-manager is required for deploying on Kubernetes. See 'make install_cert_manager'" ;\
+			exit 1 ;\
+		fi \
 	fi
 endif
 


### PR DESCRIPTION
### What does this PR do?
Closes `stdin` for all top-level kubectl/oc commands (i.e. ones that are run before any rules). 

Executing `oc logout` drops user info from kubeconfig. This does not pose a problem for `oc` as it understands what it has done, but kubectl will prompt for login info when executing commands. The order in which we evaluate `$K8S_CLI` makes it so that kubectl is used if available.

This causes any make rule to hang if the kubectl is installed, as deploy.mk is imported and contains a check for `kubectl api-resources`. Since this call will try to read a password from stdin, the call will never return and so the comparison will hang silently.

This PR also adds a warning if the current context does not appear to be authenticated, to hopefully make it clearer what's going wrong if you e.g. `make install`

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/562

### Is it tested? How?
1. Login to OpenShift cluster
2. Run `oc logout`
3. Try to run make rules (e.g. `make fmt`)
4. For good measure, make rules that require cluster interaction (e.g. deploy) should fail 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
