### PR TITLE
Fail controller startup when conflicting webhook definition present

### DIFF
--- a/build/make/deploy.mk
+++ b/build/make/deploy.mk
@@ -74,7 +74,7 @@ restart_webhook:
 	$(K8S_CLI) rollout restart -n $(NAMESPACE) deployment/devworkspace-webhook-server
 
 ### uninstall: Removes the controller resources from the cluster
-uninstall: generate_deployment
+uninstall: _print_vars generate_deployment
 # It's safer to delete all workspaces before deleting the controller; otherwise we could
 # leave workspaces in a hanging state if we add finalizers.
 	$(K8S_CLI) delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait || true

--- a/pkg/webhook/init_cfg.go
+++ b/pkg/webhook/init_cfg.go
@@ -16,10 +16,12 @@ import (
 	"context"
 	"fmt"
 
+	admv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/devfile/devworkspace-operator/webhook/workspace"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // WebhookCfgsInit initializes the webhook that denies everything until webhook server is started successfully
@@ -30,11 +32,25 @@ func WebhookCfgsInit(client crclient.Client, ctx context.Context, namespace stri
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			log.Info(fmt.Sprintf("Mutating webhooks configuration %s already exists", configuration.Name))
-			return nil
+			return checkExistingConfigForConflict(client, ctx, namespace)
 		} else {
 			return err
 		}
 	}
 	log.Info(fmt.Sprintf("Created webhooks configuration %s", configuration.Name))
+	return nil
+}
+
+func checkExistingConfigForConflict(client crclient.Client, ctx context.Context, serviceNamespace string) error {
+	existingCfg := &admv1.MutatingWebhookConfiguration{}
+	err := client.Get(ctx, types.NamespacedName{Name: workspace.MutateWebhookCfgName}, existingCfg)
+	if err != nil {
+		return err
+	}
+	for _, webhook := range existingCfg.Webhooks {
+		if webhook.ClientConfig.Service.Namespace != serviceNamespace {
+			return fmt.Errorf("conflicting webhook definition found on cluster, webhook %s clientConfig points at namespace %s", webhook.Name, webhook.ClientConfig.Service.Namespace)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
Check webhooks when starting the controller, and abort startup if the existing webhook configuration points at a different namespace.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/585

### Is it tested? How?
Try to install operator in two namespaces.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
