### PR TITLE
docs: Adding skopeo to the prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ metadata:
 - sed
 - jq
 - yq (python-yq from https://github.com/kislyuk/yq#installation, other distributions may not work)
+- skopeo
 - docker
 
 Note: kustomize `v4.0.5` is required for most tasks. It is downloaded automatically to the `.kustomize` folder in this repo when required. This downloaded version is used regardless of whether or not kustomize is already installed on the system.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ metadata:
 - sed
 - jq
 - yq (python-yq from https://github.com/kislyuk/yq#installation, other distributions may not work)
-- skopeo
+- skopeo (if building the OLM catalogsource)
 - docker
 
 Note: kustomize `v4.0.5` is required for most tasks. It is downloaded automatically to the `.kustomize` folder in this repo when required. This downloaded version is used regardless of whether or not kustomize is already installed on the system.


### PR DESCRIPTION
### What does this PR do?
Adding skopeo to the prerequisites

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
```
[ibuziuk@fedora devworkspace-operator]$ make register_catalogsource
Skopeo is required for building and deploying bundle, but it is not instealled.
make: *** [build/make/olm.mk:109: _check_skopeo_installed] Error 1
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
