### PR TITLE
doc: fixing a typo in the grafana port-forwarding instructions

### DIFF
--- a/doc/grafana/README.md
+++ b/doc/grafana/README.md
@@ -23,7 +23,7 @@ To quickly test metrics locally (without installing Prometheus Grafana in the cl
     ```
 3. In another terminal, use `kubectl port-forward` to expose the controller's service locally
     ```bash
-    kubectl port-forward service/devworkspace-controller-metrics 8443:8443 &&
+    kubectl port-forward service/devworkspace-controller-metrics 8443:8443 &
     kubectl port-forward service/devworkspace-webhookserver 9443:9443
     ```
     We can check that the token works and metrics are accessible:

--- a/doc/grafana/README.md
+++ b/doc/grafana/README.md
@@ -23,7 +23,7 @@ To quickly test metrics locally (without installing Prometheus Grafana in the cl
     ```
 3. In another terminal, use `kubectl port-forward` to expose the controller's service locally
     ```bash
-    kubectl port-forward service/devworkspace-controller-metrics 8443:8443 &;
+    kubectl port-forward service/devworkspace-controller-metrics 8443:8443 &&
     kubectl port-forward service/devworkspace-webhookserver 9443:9443
     ```
     We can check that the token works and metrics are accessible:


### PR DESCRIPTION
### What does this PR do?
fixing a typo in the grafana port-forwarding instructions

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
