### PR TITLE
Merge duplicate volume components from parent/plugins

### DIFF
--- a/pkg/library/flatten/flatten.go
+++ b/pkg/library/flatten/flatten.go
@@ -27,6 +27,7 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/library/flatten/network"
 	"github.com/devfile/devworkspace-operator/pkg/library/flatten/web_terminal"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -94,13 +95,8 @@ func recursiveResolve(workspace *dw.DevWorkspaceTemplateSpec, tooling ResolverTo
 		annotate.AddSourceAttributesForTemplate("parent", resolvedParentSpec)
 		resolvedParent = &resolvedParentSpec.DevWorkspaceTemplateSpecContent
 	}
-	resolvedContent := &dw.DevWorkspaceTemplateSpecContent{}
-	resolvedContent.Projects = workspace.Projects
-	resolvedContent.StarterProjects = workspace.StarterProjects
-	resolvedContent.Commands = workspace.Commands
-	resolvedContent.Events = workspace.Events
-	resolvedContent.Attributes = workspace.Attributes
-	resolvedContent.Variables = workspace.Variables
+	resolvedContent := workspace.DevWorkspaceTemplateSpecContent.DeepCopy()
+	resolvedContent.Components = nil
 
 	var pluginSpecContents []*dw.DevWorkspaceTemplateSpecContent
 	for _, component := range workspace.Components {
@@ -127,6 +123,9 @@ func recursiveResolve(workspace *dw.DevWorkspaceTemplateSpec, tooling ResolverTo
 		}
 	}
 
+	if err := mergeVolumeComponents(resolvedContent, resolvedParent, pluginSpecContents...); err != nil {
+		return nil, fmt.Errorf("failed to merge DevWorkspace volumes: %w", err)
+	}
 	resolvedContent, err := overriding.MergeDevWorkspaceTemplateSpec(resolvedContent, resolvedParent, pluginSpecContents...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to merge DevWorkspace parents/plugins: %w", err)
@@ -299,6 +298,85 @@ func resolveElementByURI(
 		return nil, fmt.Errorf("failed to resolve component %s by URI: %w", name, err)
 	}
 	return dwt, nil
+}
+
+// mergeVolumeComponents merges volume components sharing the same name according to the following rules
+// * If a volume is defined in main and duplicated in parent/plugins, the copy in parent/plugins is removed
+// * If a volume is defined in parent and duplicated in plugins, the copy in plugins is removed
+// * If a volume is defined in multiple plugins, all but the first definition is removed
+// * If a volume is defined as persistent, all duplicates will be persistent
+// * If duplicate volumes set a size, the larger size will be used.
+// Following the invocation of this function, there are no duplicate volumes defined across the main devworkspace, its
+// parent, and its plugins.
+func mergeVolumeComponents(main, parent *dw.DevWorkspaceTemplateSpecContent, plugins ...*dw.DevWorkspaceTemplateSpecContent) error {
+	volumeComponents := map[string]dw.Component{}
+	for _, component := range main.Components {
+		if component.Volume == nil {
+			continue
+		}
+		if _, exists := volumeComponents[component.Name]; exists {
+			return fmt.Errorf("duplicate volume found in devfile: %s", component.Name)
+		}
+		volumeComponents[component.Name] = component
+	}
+
+	mergeVolumeComponents := func(spec *dw.DevWorkspaceTemplateSpecContent) error {
+		var newComponents []dw.Component
+		for _, component := range spec.Components {
+			if component.Volume == nil {
+				newComponents = append(newComponents, component)
+				continue
+			}
+			if existingVol, exists := volumeComponents[component.Name]; exists {
+				if err := mergeVolume(existingVol.Volume, component.Volume); err != nil {
+					return err
+				}
+			} else {
+				newComponents = append(newComponents, component)
+				volumeComponents[component.Name] = component
+			}
+		}
+		spec.Components = newComponents
+		return nil
+	}
+	if err := mergeVolumeComponents(parent); err != nil {
+		return err
+	}
+
+	for _, plugin := range plugins {
+		if err := mergeVolumeComponents(plugin); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mergeVolume(into, from *dw.VolumeComponent) error {
+	// If the new volume is persistent, make the original persistent
+	if !from.Ephemeral {
+		into.Ephemeral = false
+	}
+	intoSize := into.Size
+	if intoSize == "" {
+		intoSize = "0"
+	}
+	intoSizeQty, err := resource.ParseQuantity(intoSize)
+	if err != nil {
+		return err
+	}
+	fromSize := from.Size
+	if fromSize == "" {
+		fromSize = "0"
+	}
+	fromSizeQty, err := resource.ParseQuantity(fromSize)
+	if err != nil {
+		return err
+	}
+	if fromSizeQty.Cmp(intoSizeQty) > 0 {
+		into.Size = from.Size
+	}
+	return nil
 }
 
 // canImportDW returns true if a DevWorkspace in dwNamespace is allowed to reference the provided DevWorkspaceTemplate

--- a/pkg/library/flatten/flatten_test.go
+++ b/pkg/library/flatten/flatten_test.go
@@ -235,6 +235,30 @@ func TestResolveDevWorkspaceWorkspaceEnv(t *testing.T) {
 	}
 }
 
+func TestMergesDuplicateVolumeComponents(t *testing.T) {
+	tests := testutil.LoadAllTestsOrPanic(t, "testdata/volume_merging")
+	testutil.SetupControllerCfg()
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			// sanity check: input defines components
+			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
+			testResolverTools := getTestingTools(tt.Input, "test-ignored")
+
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
+				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
+			} else {
+				if !assert.NoError(t, err, "Should not return error") {
+					return
+				}
+				assert.Truef(t, cmp.Equal(tt.Output.DevWorkspace, outputWorkspace, testutil.WorkspaceTemplateDiffOpts),
+					"DevWorkspace should match expected output:\n%s",
+					cmp.Diff(tt.Output.DevWorkspace, outputWorkspace, testutil.WorkspaceTemplateDiffOpts))
+			}
+		})
+	}
+}
+
 func getTestingTools(input testutil.TestInput, testNamespace string) ResolverTools {
 	testHttpGetter := &testutil.FakeHTTPGetter{
 		DevfileResources:      input.DevfileResources,

--- a/pkg/library/flatten/merge.go
+++ b/pkg/library/flatten/merge.go
@@ -1,0 +1,114 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package flatten
+
+import (
+	"fmt"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/utils/overriding"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// mergeDevWorkspaceElements merges elements that are duplicated between the DevWorkspace, its parent, and its plugins
+// where appropriate in order to avoid errors when merging elements via the devfile/api methods. Currently, only
+// volumes are merged.
+func mergeDevWorkspaceElements(main, parent *dw.DevWorkspaceTemplateSpecContent, plugins ...*dw.DevWorkspaceTemplateSpecContent) (*dw.DevWorkspaceTemplateSpecContent, error) {
+	if err := mergeVolumeComponents(main, parent, plugins...); err != nil {
+		return nil, fmt.Errorf("failed to merge DevWorkspace volumes: %w", err)
+	}
+	mergedDevWorkspaceTemplateSpec, err := overriding.MergeDevWorkspaceTemplateSpec(main, parent, plugins...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge DevWorkspace parents/plugins: %w", err)
+	}
+	return mergedDevWorkspaceTemplateSpec, nil
+}
+
+// mergeVolumeComponents merges volume components sharing the same name according to the following rules
+// * If a volume is defined in main and duplicated in parent/plugins, the copy in parent/plugins is removed
+// * If a volume is defined in parent and duplicated in plugins, the copy in plugins is removed
+// * If a volume is defined in multiple plugins, all but the first definition is removed
+// * If a volume is defined as persistent, all duplicates will be persistent
+// * If duplicate volumes set a size, the larger size will be used.
+// Following the invocation of this function, there are no duplicate volumes defined across the main devworkspace, its
+// parent, and its plugins.
+func mergeVolumeComponents(main, parent *dw.DevWorkspaceTemplateSpecContent, plugins ...*dw.DevWorkspaceTemplateSpecContent) error {
+	volumeComponents := map[string]dw.Component{}
+	for _, component := range main.Components {
+		if component.Volume == nil {
+			continue
+		}
+		if _, exists := volumeComponents[component.Name]; exists {
+			return fmt.Errorf("duplicate volume found in devfile: %s", component.Name)
+		}
+		volumeComponents[component.Name] = component
+	}
+
+	mergeVolumeComponents := func(spec *dw.DevWorkspaceTemplateSpecContent) error {
+		var newComponents []dw.Component
+		for _, component := range spec.Components {
+			if component.Volume == nil {
+				newComponents = append(newComponents, component)
+				continue
+			}
+			if existingVol, exists := volumeComponents[component.Name]; exists {
+				if err := mergeVolume(existingVol.Volume, component.Volume); err != nil {
+					return err
+				}
+			} else {
+				newComponents = append(newComponents, component)
+				volumeComponents[component.Name] = component
+			}
+		}
+		spec.Components = newComponents
+		return nil
+	}
+	if err := mergeVolumeComponents(parent); err != nil {
+		return err
+	}
+
+	for _, plugin := range plugins {
+		if err := mergeVolumeComponents(plugin); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mergeVolume(into, from *dw.VolumeComponent) error {
+	// If the new volume is persistent, make the original persistent
+	if !from.Ephemeral {
+		into.Ephemeral = false
+	}
+	intoSize := into.Size
+	if intoSize == "" {
+		intoSize = "0"
+	}
+	intoSizeQty, err := resource.ParseQuantity(intoSize)
+	if err != nil {
+		return err
+	}
+	fromSize := from.Size
+	if fromSize == "" {
+		fromSize = "0"
+	}
+	fromSizeQty, err := resource.ParseQuantity(fromSize)
+	if err != nil {
+		return err
+	}
+	if fromSizeQty.Cmp(intoSizeQty) > 0 {
+		into.Size = from.Size
+	}
+	return nil
+}

--- a/pkg/library/flatten/testdata/volume_merging/does-nothing-when-no-merge-needed.yaml
+++ b/pkg/library/flatten/testdata/volume_merging/does-nothing-when-no-merge-needed.yaml
@@ -1,0 +1,41 @@
+name: "Merges volume components from parent and plugins"
+
+input:
+  devworkspace:
+    parent:
+      uri: "parent"
+    components:
+      - name: normal-workspace-volume
+        volume: {}
+      - name: "plugin-1"
+        plugin:
+          uri: "plugin-1"
+  devfileResources:
+    "parent":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "parent"
+      components:
+        - name: new-parent-volume
+          volume: {}
+    "plugin-1":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-1"
+      components:
+        - name: new-plugin-1-volume
+          volume: {}
+
+output:
+  devworkspace:
+    components:
+      - name: normal-workspace-volume
+        volume: {}
+      - name: new-parent-volume
+        attributes:
+          "controller.devfile.io/imported-by": parent
+        volume: {}
+      - name: new-plugin-1-volume
+        attributes:
+          "controller.devfile.io/imported-by": plugin-1
+        volume: {}

--- a/pkg/library/flatten/testdata/volume_merging/error-invalid-size-in-merged-volume.yaml
+++ b/pkg/library/flatten/testdata/volume_merging/error-invalid-size-in-merged-volume.yaml
@@ -1,0 +1,22 @@
+name: "Error when a to-be-merged volume has invalid size"
+
+input:
+  devworkspace:
+    parent:
+      uri: "parent"
+    components:
+      - name: duplicated-volume
+        volume: {}
+
+  devfileResources:
+    "parent":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "parent"
+      components:
+        - name: duplicated-volume
+          volume:
+            size: "invalid"
+
+output:
+  errRegexp: "failed to merge DevWorkspace volumes: quantities.*"

--- a/pkg/library/flatten/testdata/volume_merging/keeps-non-volume-components.yaml
+++ b/pkg/library/flatten/testdata/volume_merging/keeps-non-volume-components.yaml
@@ -1,0 +1,87 @@
+name: "Merging duplicate volumes leaves other elements unchanged"
+
+input:
+  devworkspace:
+    parent:
+      uri: "parent"
+    components:
+      - name: duplicated-volume
+        volume: {}
+      - name: "plugin-1"
+        plugin:
+          uri: "plugin-1"
+      - name: "plugin-2"
+        plugin:
+          uri: "plugin-2"
+      - name: "main-container"
+        container:
+          image: test/image
+  devfileResources:
+    "parent":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "parent"
+      components:
+        - name: duplicated-volume
+          volume: {}
+        - name: new-parent-volume
+          volume: {}
+        - name: "parent-container"
+          container:
+            image: test/image-parent
+    "plugin-1":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-1"
+      components:
+        - name: duplicated-volume
+          volume: {}
+        - name: new-plugin-1-volume
+          volume: {}
+        - name: "plugin-1-container"
+          container:
+            image: test/image-plugin-1
+
+    "plugin-2":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-2"
+      components:
+        - name: duplicated-volume
+          volume: {}
+        - name: "plugin-2-container"
+          container:
+            image: test/image-plugin-2
+
+
+output:
+  devworkspace:
+    components:
+      - name: duplicated-volume
+        volume: {}
+      - name: new-parent-volume
+        attributes:
+          "controller.devfile.io/imported-by": parent
+        volume: {}
+      - name: new-plugin-1-volume
+        attributes:
+          "controller.devfile.io/imported-by": plugin-1
+        volume: {}
+      - name: "main-container"
+        container:
+          image: test/image
+      - name: "parent-container"
+        attributes:
+          "controller.devfile.io/imported-by": parent
+        container:
+          image: test/image-parent
+      - name: "plugin-1-container"
+        attributes:
+          "controller.devfile.io/imported-by": plugin-1
+        container:
+          image: test/image-plugin-1
+      - name: "plugin-2-container"
+        attributes:
+          "controller.devfile.io/imported-by": plugin-2
+        container:
+          image: test/image-plugin-2

--- a/pkg/library/flatten/testdata/volume_merging/makes-merged-volume-persistent-if-needed.yaml
+++ b/pkg/library/flatten/testdata/volume_merging/makes-merged-volume-persistent-if-needed.yaml
@@ -1,0 +1,36 @@
+name: "Makes merged volume persistent if duplicate is persistent"
+
+input:
+  devworkspace:
+    parent:
+      uri: "parent"
+    components:
+      - name: duplicated-volume
+        volume:
+          emphemeral: true
+      - name: "plugin-1"
+        plugin:
+          uri: "plugin-1"
+
+  devfileResources:
+    "parent":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "parent"
+      components:
+        - name: duplicated-volume
+          volume:
+            emphemeral: true
+    "plugin-1":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-1"
+      components:
+        - name: duplicated-volume
+          volume: {}
+
+output:
+  devworkspace:
+    components:
+      - name: duplicated-volume
+        volume: {}

--- a/pkg/library/flatten/testdata/volume_merging/makes-merged-volume-use-largest-size.yaml
+++ b/pkg/library/flatten/testdata/volume_merging/makes-merged-volume-use-largest-size.yaml
@@ -1,0 +1,37 @@
+name: "Makes merged volume persistent use largest size from duplicates"
+
+input:
+  devworkspace:
+    parent:
+      uri: "parent"
+    components:
+      - name: duplicated-volume
+        volume: {}
+      - name: "plugin-1"
+        plugin:
+          uri: "plugin-1"
+
+  devfileResources:
+    "parent":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "parent"
+      components:
+        - name: duplicated-volume
+          volume:
+            size: 2Gi
+    "plugin-1":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-1"
+      components:
+        - name: duplicated-volume
+          volume:
+            size: 1Gi
+
+output:
+  devworkspace:
+    components:
+      - name: duplicated-volume
+        volume:
+          size: 2Gi

--- a/pkg/library/flatten/testdata/volume_merging/merges-volumes-from-parent-and-plugins.yaml
+++ b/pkg/library/flatten/testdata/volume_merging/merges-volumes-from-parent-and-plugins.yaml
@@ -1,0 +1,55 @@
+name: "Merges volume components from parent and plugins"
+
+input:
+  devworkspace:
+    parent:
+      uri: "parent"
+    components:
+      - name: duplicated-volume
+        volume: {}
+      - name: "plugin-1"
+        plugin:
+          uri: "plugin-1"
+      - name: "plugin-2"
+        plugin:
+          uri: "plugin-2"
+  devfileResources:
+    "parent":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "parent"
+      components:
+        - name: duplicated-volume
+          volume: {}
+        - name: new-parent-volume
+          volume: {}
+    "plugin-1":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-1"
+      components:
+        - name: duplicated-volume
+          volume: {}
+        - name: new-plugin-1-volume
+          volume: {}
+    "plugin-2":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-2"
+      components:
+        - name: duplicated-volume
+          volume: {}
+
+output:
+  devworkspace:
+    components:
+      - name: duplicated-volume
+        volume: {}
+      - name: new-parent-volume
+        attributes:
+          "controller.devfile.io/imported-by": parent
+        volume: {}
+      - name: new-plugin-1-volume
+        attributes:
+          "controller.devfile.io/imported-by": plugin-1
+        volume: {}

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -53,7 +53,6 @@ var containerFailureStateReasons = []string{
 var unrecoverablePodEventReasons = []string{
 	"FailedMount",
 	"FailedScheduling",
-	"MountVolume.SetUp failed",
 	"FailedCreate",
 	"ReplicaSetCreateError",
 }


### PR DESCRIPTION
### What does this PR do?
Adds merging functionality to combine volumes that are duplicated in plugins and parents. This is done by removing duplicate volume components from parents/plugins if they are defined earlier in the flattened devworkspace, in the order devworkspace <- parents <- plugins (i.e. if a volume is defined in the devworkspace, duplicates in the parent and plugins are removed). If a volume is defined in multiple plugins, the first processed instance is kept and the rest are dropped.

Duplicated volumes are merged so that the larger size is used, and so that a persistent volume overrides an ephemeral one. This means that if a plugin defines e.g. a `.m2` volume with size `1Gi`, it will overwrite a main-devfile volume with size `512Gi`.  This also means defining volume sizes in plugins can modify main-devfile volumes, which may be undesirable. Generally, a good practice is probably to define plugin volumes as ephemeral unless otherwise necessary, and let the main devworkspace make them persistent if needed.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/586

### Is it tested? How?
Test cases are included in PR.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
