### PR TITLE
fix: Update devworkspace git credentials automounting to only use one conf…

### DIFF
--- a/pkg/provision/workspace/automount/common.go
+++ b/pkg/provision/workspace/automount/common.go
@@ -15,10 +15,8 @@ package automount
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -38,9 +36,8 @@ func (e *FatalError) Unwrap() error {
 	return e.Err
 }
 
-func GetAutoMountResources(devworkspace *dw.DevWorkspace, client k8sclient.Client, scheme *runtime.Scheme) ([]v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
-	namespace := devworkspace.GetNamespace()
-	gitCMPodAdditions, err := getDevWorkspaceGitConfig(devworkspace, client, scheme)
+func GetAutoMountResources(client k8sclient.Client, namespace string) ([]v1alpha1.PodAdditions, []corev1.EnvFromSource, error) {
+	gitCMPodAdditions, err := getDevWorkspaceGitConfig(client, namespace)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -84,7 +84,7 @@ func SyncDeploymentToCluster(
 	saName string,
 	clusterAPI ClusterAPI) DeploymentProvisioningStatus {
 
-	automountPodAdditions, automountEnv, err := automount.GetAutoMountResources(workspace, clusterAPI.Client, clusterAPI.Scheme)
+	automountPodAdditions, automountEnv, err := automount.GetAutoMountResources(clusterAPI.Client, workspace.GetNamespace())
 	if err != nil {
 		var fatalErr *automount.FatalError
 		if errors.As(err, &fatalErr) {


### PR DESCRIPTION
…igmap and one secret

### What does this PR do?
This PR makes it so that instead of having one configmap and one secret to store gitconfig and gitcredentials per workspace, there is a global one that are shared across devworkspaces

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/580

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Create a secret on the cluster containing:
```
kind: Secret
apiVersion: v1
metadata:
  name: git-credentials-secret
  namespace: devworkspace-controller
  annotations:
    controller.devfile.io/mount-path: /home/theia/.git-credentials/
  labels:
    controller.devfile.io/git-credential: 'true'
data:
  credentials: >- ${your base64 credentials here}
type: Opaque
```
${your base64 credentials here} should be base64 encoded in the format of "https://{USERNAME}:{PERSONAL_ACCESS_TOKEN}@github.com". E.g. `echo -n "https://{USERNAME}:{PERSONAL_ACCESS_TOKEN}@github.com" | base64` 
2. Create a devworkspace
3. Verify that one configmap is created (devworkspace-gitconfig) storing the gitconfig and one secret is created (devworkspace-merged-git-credentials) storing the git credentials
4. Create another devworkspace
5. Verify that the devworkspace-gitconfig configmap and devworkspace-merged-git-credentials secrets are used there as well and no new secrets/configmaps were created

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
