### PR TITLE
Clean up integration tests scripts

### DIFF
--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -65,4 +65,4 @@ deployChe() {
 installChectl
 deployDWO
 deployChe
-"${SCRIPT_DIR}"/che-happy-path.sh
+"${SCRIPT_DIR}/che-happy-path.sh"

--- a/.ci/resources/users.htpasswd
+++ b/.ci/resources/users.htpasswd
@@ -1,1 +1,2 @@
+# login: che-user. password: user
 che-user:{SHA}Et6pb+wgWTVmq3VpLJlJWWgzrck=


### PR DESCRIPTION
### What does this PR do?
Clean up integration tests scripts.


### What issues does this PR fix or reference?
It addresses review comments from https://github.com/devfile/devworkspace-operator/pull/576/files

### Is it tested? How?
e2e tests do the work for me.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
