### PR TITLE
Reformat variable using spaces as indentation for directives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SHELL := bash
 .DEFAULT_GOAL := help
 
 ifndef VERBOSE
-MAKEFLAGS += --silent
+  MAKEFLAGS += --silent
 endif
 
 export NAMESPACE ?= devworkspace-controller
@@ -42,7 +42,7 @@ include build/make/version.mk
 include build/make/olm.mk
 
 ifneq (,$(shell which kubectl 2>/dev/null)$(shell which oc 2>/dev/null))
-include build/make/deploy.mk
+  include build/make/deploy.mk
 endif
 
 OPERATOR_SDK_VERSION = v1.8.0
@@ -56,9 +56,9 @@ CRD_OPTIONS ?= "crd:crdVersions=v1,trivialVersions=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+  GOBIN=$(shell go env GOPATH)/bin
 else
-GOBIN=$(shell go env GOBIN)
+  GOBIN=$(shell go env GOBIN)
 endif
 
 all: help
@@ -126,44 +126,44 @@ generate_default_deployment:
 ### manifests: Generates the manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=role webhook paths="./..." \
-			output:crd:artifacts:config=deploy/templates/crd/bases \
-			output:rbac:artifacts:config=deploy/templates/components/rbac
+	    output:crd:artifacts:config=deploy/templates/crd/bases \
+	    output:rbac:artifacts:config=deploy/templates/components/rbac
 	patch/patch_crds.sh
 
 ### fmt: Runs go fmt against code
 fmt:
-ifneq ($(shell command -v goimports 2> /dev/null),)
-	find . -name '*.go' -exec goimports -w {} \;
-else
-	@echo "WARN: goimports is not installed -- formatting using go fmt instead."
-	@echo "      Please install goimports to ensure file imports are consistent."
-	go fmt -x ./...
-endif
+  ifneq ($(shell command -v goimports 2> /dev/null),)
+	  find . -name '*.go' -exec goimports -w {} \;
+  else
+	  @echo "WARN: goimports is not installed -- formatting using go fmt instead."
+	  @echo "      Please install goimports to ensure file imports are consistent."
+	  go fmt -x ./...
+  endif
 
 ### fmt_license: Ensures the license header is set on all files
 fmt_license:
-ifneq ($(shell command -v addlicense 2> /dev/null),)
-	@echo 'addlicense -v -f license_header.txt **/*.go'
-	addlicense -v -f license_header.txt $$(find . -name '*.go')
-else
-	$(error addlicense must be installed for this rule: go get -u github.com/google/addlicense)
-endif
+  ifneq ($(shell command -v addlicense 2> /dev/null),)
+	  @echo 'addlicense -v -f license_header.txt **/*.go'
+	  addlicense -v -f license_header.txt $$(find . -name '*.go')
+  else
+	  $(error addlicense must be installed for this rule: go get -u github.com/google/addlicense)
+  endif
 
 ### check_fmt: Checks the formatting on files in repo
 check_fmt:
-ifeq ($(shell command -v goimports 2> /dev/null),)
-	$(error "goimports must be installed for this rule" && exit 1)
-endif
-ifeq ($(shell command -v addlicense 2> /dev/null),)
-	$(error "error addlicense must be installed for this rule: go get -u github.com/google/addlicense")
-endif
+  ifeq ($(shell command -v goimports 2> /dev/null),)
+	  $(error "goimports must be installed for this rule" && exit 1)
+  endif
+  ifeq ($(shell command -v addlicense 2> /dev/null),)
+	  $(error "error addlicense must be installed for this rule: go get -u github.com/google/addlicense")
+  endif
 	@{
-		if [[ $$(find . -name '*.go' -exec goimports -l {} \;) != "" ]]; then \
-			echo "Files not formatted; run 'make fmt'"; exit 1 ;\
-		fi ;\
-		if ! addlicense -check -f license_header.txt $$(find . -name '*.go'); then \
-			echo "Licenses are not formatted; run 'make fmt_license'"; exit 1 ;\
-		fi \
+	  if [[ $$(find . -name '*.go' -exec goimports -l {} \;) != "" ]]; then \
+	    echo "Files not formatted; run 'make fmt'"; exit 1 ;\
+	  fi ;\
+	  if ! addlicense -check -f license_header.txt $$(find . -name '*.go'); then \
+	    echo "Licenses are not formatted; run 'make fmt_license'"; exit 1 ;\
+	  fi \
 	}
 
 ### vet: Runs go vet against code
@@ -184,51 +184,51 @@ docker-build:
 
 ### docker-push: Pushes the controller image
 docker-push:
-ifneq ($(INITIATOR),CI)
-ifeq ($(DWO_IMG),quay.io/devfile/devworkspace-controller:next)
-	@echo -n "Are you sure you want to push $(DWO_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
-endif
-endif
+  ifneq ($(INITIATOR),CI)
+    ifeq ($(DWO_IMG),quay.io/devfile/devworkspace-controller:next)
+	    @echo -n "Are you sure you want to push $(DWO_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
+    endif
+  endif
 	$(DOCKER) push ${DWO_IMG}
 
 ### controller-gen: Finds or downloads controller-gen
 # download controller-gen if necessary
 controller-gen:
-ifeq (, $(shell which controller-gen-$(CONTROLLER_GEN_VERSION) 2>/dev/null))
-	@echo "Installing controller gen as $(GOBIN)/controller-gen-$(CONTROLLER_GEN_VERSION)"
-	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get -d -v sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
-	go build -o $(GOBIN)/controller-gen-$(CONTROLLER_GEN_VERSION) sigs.k8s.io/controller-tools/cmd/controller-gen
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	}
-else
-	@echo "Using installed $(GOBIN)/controller-gen-$(CONTROLLER_GEN_VERSION)"
-endif
+  ifeq (, $(shell which controller-gen-$(CONTROLLER_GEN_VERSION) 2>/dev/null))
+	  @echo "Installing controller gen as $(GOBIN)/controller-gen-$(CONTROLLER_GEN_VERSION)"
+	  @{ \
+	  set -e ;\
+	  CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
+	  cd $$CONTROLLER_GEN_TMP_DIR ;\
+	  go mod init tmp ;\
+	  go get -d -v sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
+	  go build -o $(GOBIN)/controller-gen-$(CONTROLLER_GEN_VERSION) sigs.k8s.io/controller-tools/cmd/controller-gen
+	  rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	  }
+  else
+	  @echo "Using installed $(GOBIN)/controller-gen-$(CONTROLLER_GEN_VERSION)"
+  endif
 
 ### compile-devworkspace-controller: Compiles the devworkspace-controller binary
 .PHONY: compile-devworkspace-controller
 compile-devworkspace-controller:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GO111MODULE=on go build \
-	-a -o _output/bin/devworkspace-controller \
-	-gcflags all=-trimpath=/ \
-	-asmflags all=-trimpath=/ \
-	-ldflags "-X $(GO_PACKAGE_PATH)/version.Commit=$(GIT_COMMIT_ID) \
-	-X $(GO_PACKAGE_PATH)/version.BuildTime=$(BUILD_TIME)" \
+	  -a -o _output/bin/devworkspace-controller \
+	  -gcflags all=-trimpath=/ \
+	  -asmflags all=-trimpath=/ \
+	  -ldflags "-X $(GO_PACKAGE_PATH)/version.Commit=$(GIT_COMMIT_ID) \
+	  -X $(GO_PACKAGE_PATH)/version.BuildTime=$(BUILD_TIME)" \
 	main.go
 
 ### compile-webhook-server: Compiles the webhook-server
 .PHONY: compile-webhook-server
 compile-webhook-server:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) GO111MODULE=on go build \
-	-o _output/bin/webhook-server \
-	-gcflags all=-trimpath=/ \
-	-asmflags all=-trimpath=/ \
-	-ldflags "-X $(GO_PACKAGE_PATH)/version.Commit=$(GIT_COMMIT_ID) \
-	-X $(GO_PACKAGE_PATH)/version.BuildTime=$(BUILD_TIME)" \
+	  -o _output/bin/webhook-server \
+	  -gcflags all=-trimpath=/ \
+	  -asmflags all=-trimpath=/ \
+	  -ldflags "-X $(GO_PACKAGE_PATH)/version.Commit=$(GIT_COMMIT_ID) \
+	  -X $(GO_PACKAGE_PATH)/version.BuildTime=$(BUILD_TIME)" \
 	webhook/main.go
 
 .PHONY: help

--- a/build/make/olm.mk
+++ b/build/make/olm.mk
@@ -11,56 +11,56 @@
 
 ### generate_olm_bundle: Generate yaml files for building an OLM bundle image
 generate_olm_bundle_yaml: _check_operator_sdk_version _generate_olm_deployment_files
-# Note: operator-sdk provides no way to specify output dir for bundle.Dockerfile so
-# we have to move it manually
-#
-# `<&-` closes stdin to workaround cases when a tty is not allocated,
-# so stdin behaves like a pipe, like in Github actions case.
-# Operator SDK checks if stdin is an open pipe and assumes it's reading 
-# from stdin in that case. To make Operator SDK work correctly here,
-# we need to explicitly close stdin. 
-# See issue: https://github.com/actions/runner/issues/241
+  # Note: operator-sdk provides no way to specify output dir for bundle.Dockerfile so
+  # we have to move it manually
+  #
+  # `<&-` closes stdin to workaround cases when a tty is not allocated,
+  # so stdin behaves like a pipe, like in Github actions case.
+  # Operator SDK checks if stdin is an open pipe and assumes it's reading
+  # from stdin in that case. To make Operator SDK work correctly here,
+  # we need to explicitly close stdin.
+  # See issue: https://github.com/actions/runner/issues/241
 	rm -rf deploy/bundle/manifests
 	operator-sdk generate bundle \
-		--deploy-dir deploy/deployment/olm \
-		--output-dir deploy/bundle \
-		--manifests \
-		--channels fast \
-		--metadata <&- && \
+	  --deploy-dir deploy/deployment/olm \
+	  --output-dir deploy/bundle \
+	  --manifests \
+	  --channels fast \
+	  --metadata <&- && \
 	mv bundle.Dockerfile build/
-# Operator SDK v1.8.0 does not output webhooks in a stable order, so we have to sort the yaml files to avoid
-# spurious changes. See issue https://github.com/operator-framework/operator-sdk/issues/5022
+  # Operator SDK v1.8.0 does not output webhooks in a stable order, so we have to sort the yaml files to avoid
+  # spurious changes. See issue https://github.com/operator-framework/operator-sdk/issues/5022
 	yq -iY '.spec.webhookdefinitions |= sort' deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
-# OLM creates a configmap that contains the files in bundle when an operator is installed. Since the maximum size
-# of a resource in etcd is 1MiB, we need to do a bit of squishing on our yaml files to get the total bundle under the
-# 1MiB limit. This command puts all YAML strings on a single line, avoiding ~200KiB of newlines and indentation.
+  # OLM creates a configmap that contains the files in bundle when an operator is installed. Since the maximum size
+  # of a resource in etcd is 1MiB, we need to do a bit of squishing on our yaml files to get the total bundle under the
+  # 1MiB limit. This command puts all YAML strings on a single line, avoiding ~200KiB of newlines and indentation.
 	find deploy/bundle/manifests -name '*.yaml' -exec yq --indentless -w 1000000000 -iY . {} \;
 
 ### build_bundle_image: build and push DevWorkspace Operator bundle image
 build_bundle_image: _print_vars _check_operator_sdk_version
-ifneq ($(INITIATOR),CI)
-ifeq ($(DWO_BUNDLE_IMG),quay.io/devfile/devworkspace-operator-bundle:next)
-	@echo -n "Are you sure you want to push $(DWO_BUNDLE_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
-endif
-endif
+  ifneq ($(INITIATOR),CI)
+    ifeq ($(DWO_BUNDLE_IMG),quay.io/devfile/devworkspace-operator-bundle:next)
+	    @echo -n "Are you sure you want to push $(DWO_BUNDLE_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
+    endif
+  endif
 	$(DOCKER) build . -t $(DWO_BUNDLE_IMG) -f build/bundle.Dockerfile
 	$(DOCKER) push $(DWO_BUNDLE_IMG)
 
 ### build_index_image: build and push DevWorkspace Operator index image
 build_index_image: _print_vars _check_skopeo_installed _check_opm_version
-ifneq ($(INITIATOR),CI)
-ifeq ($(DWO_INDEX_IMG),quay.io/devfile/devworkspace-operator-index:next)
-	@echo -n "Are you sure you want to push $(DWO_INDEX_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
-endif
-endif
+  ifneq ($(INITIATOR),CI)
+    ifeq ($(DWO_INDEX_IMG),quay.io/devfile/devworkspace-operator-index:next)
+	    @echo -n "Are you sure you want to push $(DWO_INDEX_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
+    endif
+  endif
 	export BUNDLE_DIGEST=$$(skopeo inspect docker://$(DWO_BUNDLE_IMG) | jq -r '.Digest') ;\
 	echo "$$BUNDLE_DIGEST" ;\
 	export BUNDLE_IMG=$(DWO_BUNDLE_IMG) ;\
 	export BUNDLE_IMG_DIGEST="$${BUNDLE_IMG%:*}@$${BUNDLE_DIGEST}" ;\
 	opm index add \
-		--bundles "$${BUNDLE_IMG_DIGEST}" \
-		--tag $(DWO_INDEX_IMG) \
-		--container-tool $(DOCKER)
+	  --bundles "$${BUNDLE_IMG_DIGEST}" \
+	  --tag $(DWO_INDEX_IMG) \
+	  --container-tool $(DOCKER)
 	$(DOCKER) push $(DWO_INDEX_IMG)
 
 export_manifests: _print_vars _check_opm_version
@@ -77,7 +77,7 @@ register_catalogsource: _check_skopeo_installed
 
 	# replace references of catalogsource img with your image
 	sed -e "s|quay.io/devfile/devworkspace-operator-index:next|$${INDEX_IMG_DIGEST}|g" ./catalog-source.yaml \
-		| oc apply -f -
+	  | oc apply -f -
 
 ### unregister_catalogsource: unregister the catalogsource and delete the imageContentSourcePolicy
 unregister_catalogsource:
@@ -88,25 +88,25 @@ _generate_olm_deployment_files:
 
 _check_operator_sdk_version:
 	if ! command -v operator-sdk &>/dev/null; then \
-		echo "Operator SDK is required for this rule; see https://github.com/operator-framework/operator-sdk" ;\
-		exit 1 ;\
+	  echo "Operator SDK is required for this rule; see https://github.com/operator-framework/operator-sdk" ;\
+	  exit 1 ;\
 	fi
 	if [ "$$(operator-sdk version | grep -o 'operator-sdk version: [^ ,]*')" != 'operator-sdk version: "$(OPERATOR_SDK_VERSION)"' ]; then \
-		echo "Operator SDK version $(OPERATOR_SDK_VERSION) is required." ;\
-		exit 1 ;\
+	  echo "Operator SDK version $(OPERATOR_SDK_VERSION) is required." ;\
+	  exit 1 ;\
 	fi
 
 _check_opm_version:
 	if ! command -v opm &>/dev/null; then \
-		echo "The opm binary is required for this rule; see https://github.com/operator-framework/operator-registry" ;\
-		exit 1 ;\
+	  echo "The opm binary is required for this rule; see https://github.com/operator-framework/operator-registry" ;\
+	  exit 1 ;\
 	elif [ "$$(opm version | grep -o 'OpmVersion:[^ ,]*')" != 'OpmVersion:"$(OPM_VERSION)"' ]; then \
-		echo "opm version $(OPM_VERSION) is required." ;\
-		exit 1 ;\
+	  echo "opm version $(OPM_VERSION) is required." ;\
+	  exit 1 ;\
 	fi
 
 _check_skopeo_installed:
 	if ! command -v skopeo &> /dev/null; then \
-		echo "Skopeo is required for building and deploying bundle, but it is not installed." ;\
-		exit 1
+	  echo "Skopeo is required for building and deploying bundle, but it is not installed." ;\
+	  exit 1
 	fi


### PR DESCRIPTION
This PR makes _writing_ the Makefiles a little more tedious (since the new convention is mixing tabs and spaces) but maybe easier to read. Not sure if it's worth merging.

### What does this PR do?
Reformat the Makefiles (since I realized Make directives can be safely indented using spaces):
* Nested directives are indented using spaces, so that e.g.
    ```make
    # minikube handling
    ifeq ($(shell $(K8S_CLI) config current-context 2>&1),minikube)
    # check ingress addon is enabled
    ifeq ($(shell minikube addons list -o json | jq -r .ingress.Status), disabled)
    $(error ingress addon should be enabled on top of minikube)
    endif
    export ROUTING_SUFFIX := $(shell minikube ip).nip.io
    endif
    ```
    becomes
    ```make
    # minikube handling
    ifeq ($(shell $(K8S_CLI) config current-context 2>&1),minikube)
      # check ingress addon is enabled
      ifeq ($(shell minikube addons list -o json | jq -r .ingress.Status), disabled)
        $(error ingress addon should be enabled on top of minikube)
      endif
      export ROUTING_SUFFIX := $(shell minikube ip).nip.io
    endif
    ```
    (note this indentation is done via spaces -- this breaks markdown syntax parsing but should be handled by make okay)
* Reindent regular lines so that first indent is a tab character (as required by Make) and following indentation uses two spaces.

Tested briefly on make `3.81` and indentation seems to cause no issues there either.

### What issues does this PR fix or reference?
Hard to read nested `ifeq`s

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
