### PR TITLE
Document how to use a custom controller image in generated OLM bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,21 @@ You need to register custom catalog source to make it available on your cluster 
 DWO_INDEX_IMG=quay.io/devfile/devworkspace-operator-index:next
 make register_catalogsource
 ```
-After OLM processed created catalog source, DWO should appear on Operators page of OpenShift Console.
+After OLM finishes processing the created catalog source, DWO should appear on Operators page of OpenShift Console.
+
+In order to build a custom bundle, the following env vars should be set:
+| variable | purpose | default value |
+|---|---|---|
+| `DWO_BUNDLE_IMG` | Image used for Operator bundle image | `quay.io/devfile/devworkspace-operator-bundle:next` |
+| `DWO_INDEX_IMG` | Image used for Operator index image | `quay.io/devfile/devworkspace-operator-index:next` |
+| `DEFAULT_DWO_IMG` | Image used for controller when generating defaults | `quay.io/devfile/devworkspace-controller:next` |
+
+To build the index image and register its catalogsource to the cluster, run
+```
+make generate_olm_bundle_yaml build_bundle_image build_index_image register_catalogsource
+```
+
+Note that setting `DEFAULT_DWO_IMG` while generating sources will result in local changes to the repo which should be `git restored` before committing. This can also be done by unsetting the `DEFAULT_DWO_IMG` env var and re-running `make generate_olm_bundle_yaml`
 
 ## Development
 
@@ -81,6 +95,7 @@ The repository contains a Makefile; building and deploying can be configured via
 |variable|purpose|default value|
 |---|---|---|
 | `DWO_IMG` | Image used for controller | `quay.io/devfile/devworkspace-controller:next` |
+| `DEFAULT_DWO_IMG` | Image used for controller when generating default deployment templates. Can be used to override the controller image in the OLM bundle | `quay.io/devfile/devworkspace-controller:next` |
 | `NAMESPACE` | Namespace to use for deploying controller | `devworkspace-controller` |
 | `ROUTING_SUFFIX` | Cluster routing suffix (e.g. `$(minikube ip).nip.io`, `apps-crc.testing`). Required for Kubernetes | `192.168.99.100.nip.io` |
 | `PULL_POLICY` | Image pull policy for controller | `Always` |

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -78,7 +78,7 @@ while [[ "$#" -gt 0 ]]; do
       OUTPUT_DIR="${SCRIPT_DIR%/}/deployment"
       ;;
       --default-image)
-      DEFAULT_IMAGE=$2
+      DEFAULT_DWO_IMG=$2
       shift
       ;;
       --project-clone-image)
@@ -105,7 +105,7 @@ done
 if $USE_DEFAULT_ENV; then
   echo "Using defaults for environment variables"
   export NAMESPACE=devworkspace-controller
-  export DWO_IMG=${DEFAULT_IMAGE:-"quay.io/devfile/devworkspace-controller:next"}
+  export DWO_IMG=${DEFAULT_DWO_IMG:-"quay.io/devfile/devworkspace-controller:next"}
   export PROJECT_CLONE_IMG=${PROJECT_CLONE_IMG:-"quay.io/devfile/project-clone:next"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic


### PR DESCRIPTION
### What does this PR do?
Documents the semi-hidden `DEFAULT_IMAGE` env var (renamed to `DEFAULT_DWO_IMG`), which can be used to set a custom controller image in the OLM development deploy path.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/531

### Is it tested? How?
Set `DEFAULT_DWO_IMG` and build + deploy operator locally.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
