### PR TITLE
Introduce timeout for hanging workspaces

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -61,6 +61,11 @@ type WorkspaceConfig struct {
 	// requires support in the workspace being started. If not specified, the default
 	// value of "15m" is used.
 	IdleTimeout string `json:"idleTimeout,omitempty"`
+	// StartProgressTimeout determines the maximum duration a DevWorkspace can be in
+	// a "Starting" phase without progressing before it is automatically failed.
+	// Duration should be specified in a format parseable by Go's time package, e.g.
+	// "15m", "20s", "1h30m", etc. If not specified, the default value of "5m" is used.
+	StartProgressTimeout string `json:"startProgressTimeout,omitempty"`
 	// IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
 	// be ignored when deciding to fail a DevWorkspace startup. This option should be used
 	// if a transient cluster issue is triggering false-positives (for example, if

--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -61,11 +61,11 @@ type WorkspaceConfig struct {
 	// requires support in the workspace being started. If not specified, the default
 	// value of "15m" is used.
 	IdleTimeout string `json:"idleTimeout,omitempty"`
-	// StartProgressTimeout determines the maximum duration a DevWorkspace can be in
-	// a "Starting" phase without progressing before it is automatically failed.
+	// ProgressTimeout determines the maximum duration a DevWorkspace can be in
+	// a "Starting" or "Failing" phase without progressing before it is automatically failed.
 	// Duration should be specified in a format parseable by Go's time package, e.g.
 	// "15m", "20s", "1h30m", etc. If not specified, the default value of "5m" is used.
-	StartProgressTimeout string `json:"startProgressTimeout,omitempty"`
+	ProgressTimeout string `json:"progressTimeout,omitempty"`
 	// IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
 	// be ignored when deciding to fail a DevWorkspace startup. This option should be used
 	// if a transient cluster issue is triggering false-positives (for example, if

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -241,15 +241,15 @@ func updateMetricsForPhase(workspace *dw.DevWorkspace, oldPhase, newPhase dw.Dev
 	}
 }
 
-// checkForStartTimeOut checks if the provided workspace has not progressed for longer than the configured
+// checkForStartTimeout checks if the provided workspace has not progressed for longer than the configured
 // startup timeout. This is determined by checking to see if the last condition transition time is more
 // than [timeout] duration ago. Workspaces that are not in the "Starting" phase cannot timeout. Returns
 // an error with message when timeout is reached.
-func checkForStartTimeOut(workspace *dw.DevWorkspace, logger logr.Logger, status *currentStatus) error {
+func checkForStartTimeout(workspace *dw.DevWorkspace) error {
 	if workspace.Status.Phase != dw.DevWorkspaceStatusStarting {
 		return nil
 	}
-	timeout, err := time.ParseDuration(config.Workspace.StartProgressTimeout)
+	timeout, err := time.ParseDuration(config.Workspace.ProgressTimeout)
 	if err != nil {
 		return fmt.Errorf("invalid duration specified for timeout: %w", err)
 	}
@@ -262,7 +262,32 @@ func checkForStartTimeOut(workspace *dw.DevWorkspace, logger logr.Logger, status
 	}
 	if !lastUpdateTime.IsZero() && lastUpdateTime.Add(timeout).Before(currTime) {
 		return fmt.Errorf("devworkspace failed to progress past phase '%s' for longer than timeout (%s)",
-			workspace.Status.Phase, config.Workspace.StartProgressTimeout)
+			workspace.Status.Phase, config.Workspace.ProgressTimeout)
 	}
 	return nil
+}
+
+// checkForFailingTimeout checks that the current workspace has not been in the "Failing" state for longer than the
+// configured progress timeout. If the workspace is not in the Failing state or does not have a DevWorkspaceFailed
+// condition set, returns false. Otherwise, returns true if the workspace has timed out. Returns an error if
+// timeout is configured with an unparsable duration.
+func checkForFailingTimeout(workspace *dw.DevWorkspace) (isTimedOut bool, err error) {
+	if workspace.Status.Phase != devworkspacePhaseFailing {
+		return false, nil
+	}
+	timeout, err := time.ParseDuration(config.Workspace.ProgressTimeout)
+	if err != nil {
+		return false, fmt.Errorf("invalid duration specified for timeout: %w", err)
+	}
+	currTime := clock.Now()
+	failedTime := time.Time{}
+	for _, condition := range workspace.Status.Conditions {
+		if condition.Type == dw.DevWorkspaceFailedStart {
+			failedTime = condition.LastTransitionTime.Time
+		}
+	}
+	if !failedTime.IsZero() && failedTime.Add(timeout).Before(currTime) {
+		return true, nil
+	}
+	return false, nil
 }

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"time"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	"github.com/devfile/devworkspace-operator/pkg/conditions"
+	"github.com/devfile/devworkspace-operator/pkg/config"
 	wsprovision "github.com/devfile/devworkspace-operator/pkg/provision/workspace"
 )
 
@@ -237,4 +239,30 @@ func updateMetricsForPhase(workspace *dw.DevWorkspace, oldPhase, newPhase dw.Dev
 	case dw.DevWorkspaceStatusStarting:
 		metrics.WorkspaceStarted(workspace, logger)
 	}
+}
+
+// checkForStartTimeOut checks if the provided workspace has not progressed for longer than the configured
+// startup timeout. This is determined by checking to see if the last condition transition time is more
+// than [timeout] duration ago. Workspaces that are not in the "Starting" phase cannot timeout. Returns
+// an error with message when timeout is reached.
+func checkForStartTimeOut(workspace *dw.DevWorkspace, logger logr.Logger, status *currentStatus) error {
+	if workspace.Status.Phase != dw.DevWorkspaceStatusStarting {
+		return nil
+	}
+	timeout, err := time.ParseDuration(config.Workspace.StartProgressTimeout)
+	if err != nil {
+		return fmt.Errorf("invalid duration specified for timeout: %w", err)
+	}
+	currTime := clock.Now()
+	lastUpdateTime := time.Time{}
+	for _, condition := range workspace.Status.Conditions {
+		if condition.LastTransitionTime.Time.After(lastUpdateTime) {
+			lastUpdateTime = condition.LastTransitionTime.Time
+		}
+	}
+	if !lastUpdateTime.IsZero() && lastUpdateTime.Add(timeout).Before(currTime) {
+		return fmt.Errorf("devworkspace failed to progress past phase '%s' for longer than timeout (%s)",
+			workspace.Status.Phase, config.Workspace.StartProgressTimeout)
+	}
+	return nil
 }

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -61,13 +61,13 @@ spec:
                     - Always
                     - Never
                     type: string
+                  progressTimeout:
+                    description: ProgressTimeout determines the maximum duration a DevWorkspace can be in a "Starting" or "Failing" phase without progressing before it is automatically failed. Duration should be specified in a format parseable by Go's time package, e.g. "15m", "20s", "1h30m", etc. If not specified, the default value of "5m" is used.
+                    type: string
                   pvcName:
                     description: PVCName defines the name used for the persistent volume claim created to support workspace storage when the 'common' storage class is used. If not specified, the default value of `claim-devworkspace` is used.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                    type: string
-                  startProgressTimeout:
-                    description: StartProgressTimeout determines the maximum duration a DevWorkspace can be in a "Starting" phase without progressing before it is automatically failed. Duration should be specified in a format parseable by Go's time package, e.g. "15m", "20s", "1h30m", etc. If not specified, the default value of "5m" is used.
                     type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass to use for persistent volume claims created to support DevWorkspaces

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -66,6 +66,9 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
+                  startProgressTimeout:
+                    description: StartProgressTimeout determines the maximum duration a DevWorkspace can be in a "Starting" phase without progressing before it is automatically failed. Duration should be specified in a format parseable by Go's time package, e.g. "15m", "20s", "1h30m", etc. If not specified, the default value of "5m" is used.
+                    type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass to use for persistent volume claims created to support DevWorkspaces
                     type: string

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -87,6 +87,14 @@ spec:
                     - Always
                     - Never
                     type: string
+                  progressTimeout:
+                    description: ProgressTimeout determines the maximum duration a
+                      DevWorkspace can be in a "Starting" or "Failing" phase without
+                      progressing before it is automatically failed. Duration should
+                      be specified in a format parseable by Go's time package, e.g.
+                      "15m", "20s", "1h30m", etc. If not specified, the default value
+                      of "5m" is used.
+                    type: string
                   pvcName:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
@@ -94,14 +102,6 @@ spec:
                       `claim-devworkspace` is used.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                    type: string
-                  startProgressTimeout:
-                    description: StartProgressTimeout determines the maximum duration
-                      a DevWorkspace can be in a "Starting" phase without progressing
-                      before it is automatically failed. Duration should be specified
-                      in a format parseable by Go's time package, e.g. "15m", "20s",
-                      "1h30m", etc. If not specified, the default value of "5m" is
-                      used.
                     type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -95,6 +95,14 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
+                  startProgressTimeout:
+                    description: StartProgressTimeout determines the maximum duration
+                      a DevWorkspace can be in a "Starting" phase without progressing
+                      before it is automatically failed. Duration should be specified
+                      in a format parseable by Go's time package, e.g. "15m", "20s",
+                      "1h30m", etc. If not specified, the default value of "5m" is
+                      used.
+                    type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass
                       to use for persistent volume claims created to support DevWorkspaces

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -87,6 +87,14 @@ spec:
                     - Always
                     - Never
                     type: string
+                  progressTimeout:
+                    description: ProgressTimeout determines the maximum duration a
+                      DevWorkspace can be in a "Starting" or "Failing" phase without
+                      progressing before it is automatically failed. Duration should
+                      be specified in a format parseable by Go's time package, e.g.
+                      "15m", "20s", "1h30m", etc. If not specified, the default value
+                      of "5m" is used.
+                    type: string
                   pvcName:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
@@ -94,14 +102,6 @@ spec:
                       `claim-devworkspace` is used.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                    type: string
-                  startProgressTimeout:
-                    description: StartProgressTimeout determines the maximum duration
-                      a DevWorkspace can be in a "Starting" phase without progressing
-                      before it is automatically failed. Duration should be specified
-                      in a format parseable by Go's time package, e.g. "15m", "20s",
-                      "1h30m", etc. If not specified, the default value of "5m" is
-                      used.
                     type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -95,6 +95,14 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
+                  startProgressTimeout:
+                    description: StartProgressTimeout determines the maximum duration
+                      a DevWorkspace can be in a "Starting" phase without progressing
+                      before it is automatically failed. Duration should be specified
+                      in a format parseable by Go's time package, e.g. "15m", "20s",
+                      "1h30m", etc. If not specified, the default value of "5m" is
+                      used.
+                    type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass
                       to use for persistent volume claims created to support DevWorkspaces

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -87,6 +87,14 @@ spec:
                     - Always
                     - Never
                     type: string
+                  progressTimeout:
+                    description: ProgressTimeout determines the maximum duration a
+                      DevWorkspace can be in a "Starting" or "Failing" phase without
+                      progressing before it is automatically failed. Duration should
+                      be specified in a format parseable by Go's time package, e.g.
+                      "15m", "20s", "1h30m", etc. If not specified, the default value
+                      of "5m" is used.
+                    type: string
                   pvcName:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
@@ -94,14 +102,6 @@ spec:
                       `claim-devworkspace` is used.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                    type: string
-                  startProgressTimeout:
-                    description: StartProgressTimeout determines the maximum duration
-                      a DevWorkspace can be in a "Starting" phase without progressing
-                      before it is automatically failed. Duration should be specified
-                      in a format parseable by Go's time package, e.g. "15m", "20s",
-                      "1h30m", etc. If not specified, the default value of "5m" is
-                      used.
                     type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -95,6 +95,14 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
+                  startProgressTimeout:
+                    description: StartProgressTimeout determines the maximum duration
+                      a DevWorkspace can be in a "Starting" phase without progressing
+                      before it is automatically failed. Duration should be specified
+                      in a format parseable by Go's time package, e.g. "15m", "20s",
+                      "1h30m", etc. If not specified, the default value of "5m" is
+                      used.
+                    type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass
                       to use for persistent volume claims created to support DevWorkspaces

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -87,6 +87,14 @@ spec:
                     - Always
                     - Never
                     type: string
+                  progressTimeout:
+                    description: ProgressTimeout determines the maximum duration a
+                      DevWorkspace can be in a "Starting" or "Failing" phase without
+                      progressing before it is automatically failed. Duration should
+                      be specified in a format parseable by Go's time package, e.g.
+                      "15m", "20s", "1h30m", etc. If not specified, the default value
+                      of "5m" is used.
+                    type: string
                   pvcName:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
@@ -94,14 +102,6 @@ spec:
                       `claim-devworkspace` is used.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                    type: string
-                  startProgressTimeout:
-                    description: StartProgressTimeout determines the maximum duration
-                      a DevWorkspace can be in a "Starting" phase without progressing
-                      before it is automatically failed. Duration should be specified
-                      in a format parseable by Go's time package, e.g. "15m", "20s",
-                      "1h30m", etc. If not specified, the default value of "5m" is
-                      used.
                     type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -95,6 +95,14 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
+                  startProgressTimeout:
+                    description: StartProgressTimeout determines the maximum duration
+                      a DevWorkspace can be in a "Starting" phase without progressing
+                      before it is automatically failed. Duration should be specified
+                      in a format parseable by Go's time package, e.g. "15m", "20s",
+                      "1h30m", etc. If not specified, the default value of "5m" is
+                      used.
+                    type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass
                       to use for persistent volume claims created to support DevWorkspaces

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -86,6 +86,14 @@ spec:
                     - Always
                     - Never
                     type: string
+                  progressTimeout:
+                    description: ProgressTimeout determines the maximum duration a
+                      DevWorkspace can be in a "Starting" or "Failing" phase without
+                      progressing before it is automatically failed. Duration should
+                      be specified in a format parseable by Go's time package, e.g.
+                      "15m", "20s", "1h30m", etc. If not specified, the default value
+                      of "5m" is used.
+                    type: string
                   pvcName:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
@@ -93,14 +101,6 @@ spec:
                       `claim-devworkspace` is used.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                    type: string
-                  startProgressTimeout:
-                    description: StartProgressTimeout determines the maximum duration
-                      a DevWorkspace can be in a "Starting" phase without progressing
-                      before it is automatically failed. Duration should be specified
-                      in a format parseable by Go's time package, e.g. "15m", "20s",
-                      "1h30m", etc. If not specified, the default value of "5m" is
-                      used.
                     type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -94,6 +94,14 @@ spec:
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
+                  startProgressTimeout:
+                    description: StartProgressTimeout determines the maximum duration
+                      a DevWorkspace can be in a "Starting" phase without progressing
+                      before it is automatically failed. Duration should be specified
+                      in a format parseable by Go's time package, e.g. "15m", "20s",
+                      "1h30m", etc. If not specified, the default value of "5m" is
+                      used.
+                    type: string
                   storageClassName:
                     description: StorageClassName defines and optional storageClass
                       to use for persistent volume claims created to support DevWorkspaces

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -21,8 +21,9 @@ var DefaultConfig = &v1alpha1.OperatorConfiguration{
 		ClusterHostSuffix:   "", // is auto discovered when running on OpenShift. Must be defined by CR on Kubernetes.
 	},
 	Workspace: &v1alpha1.WorkspaceConfig{
-		ImagePullPolicy: "Always",
-		PVCName:         "claim-devworkspace",
-		IdleTimeout:     "15m",
+		ImagePullPolicy:      "Always",
+		PVCName:              "claim-devworkspace",
+		IdleTimeout:          "15m",
+		StartProgressTimeout: "5m",
 	},
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -21,9 +21,9 @@ var DefaultConfig = &v1alpha1.OperatorConfiguration{
 		ClusterHostSuffix:   "", // is auto discovered when running on OpenShift. Must be defined by CR on Kubernetes.
 	},
 	Workspace: &v1alpha1.WorkspaceConfig{
-		ImagePullPolicy:      "Always",
-		PVCName:              "claim-devworkspace",
-		IdleTimeout:          "15m",
-		StartProgressTimeout: "5m",
+		ImagePullPolicy: "Always",
+		PVCName:         "claim-devworkspace",
+		IdleTimeout:     "15m",
+		ProgressTimeout: "5m",
 	},
 }

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -205,8 +205,8 @@ func mergeConfig(from, to *controller.OperatorConfiguration) {
 		if from.Workspace.IdleTimeout != "" {
 			to.Workspace.IdleTimeout = from.Workspace.IdleTimeout
 		}
-		if from.Workspace.StartProgressTimeout != "" {
-			to.Workspace.StartProgressTimeout = from.Workspace.StartProgressTimeout
+		if from.Workspace.ProgressTimeout != "" {
+			to.Workspace.ProgressTimeout = from.Workspace.ProgressTimeout
 		}
 		if from.Workspace.IgnoredUnrecoverableEvents != nil {
 			to.Workspace.IgnoredUnrecoverableEvents = from.Workspace.IgnoredUnrecoverableEvents

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -205,6 +205,9 @@ func mergeConfig(from, to *controller.OperatorConfiguration) {
 		if from.Workspace.IdleTimeout != "" {
 			to.Workspace.IdleTimeout = from.Workspace.IdleTimeout
 		}
+		if from.Workspace.StartProgressTimeout != "" {
+			to.Workspace.StartProgressTimeout = from.Workspace.StartProgressTimeout
+		}
 		if from.Workspace.IgnoredUnrecoverableEvents != nil {
 			to.Workspace.IgnoredUnrecoverableEvents = from.Workspace.IgnoredUnrecoverableEvents
 		}


### PR DESCRIPTION
**Note:** this PR depends on https://github.com/devfile/devworkspace-operator/pull/598 and so for now includes those changes as well; ignore all but the last three commits (i.e. https://github.com/devfile/devworkspace-operator/commit/05c04413104aa77642784768623c36dc67130815 to the end). Once #598 is merged, this commit will be a lot simpler.

### What does this PR do?
Introduces config setting `.workspace.startProgressTimeout` that controls how long a workspace can be in the starting phase without progressing before it is automatically failed.

"Progressing" in our case means "updating workspace `.status.conditions`" -- if the last condition change (checked by `lastTransitionTime`) is more than `idleTimeout` ago, we assume the workspace has failed.

Default timeout value is 5 minutes, to allow for e.g. an incredibly slow image pull.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/578

### Is it tested? How?
1. Create or update the `DevWorkspaceOperatorConfig` to ignore `FailedScheduling` events (and optionally set a shorter `idleTimeout`):
    ```bash
    kubectl patch dwoc devworkspace-operator-config --type merge -p \
      '{
        "config": {
          "workspace": {
            "ignoredUnrecoverableEvents": [
              "FailedScheduling"
            ],
            "startProgressTimeout": "30s"
          }
        }
      }'
    ```
2. Create a DevWorkspace that cannot be scheduled:
    ```yaml
    cat <<EOF | kubectl apply -f 
    kind: DevWorkspace
    apiVersion: workspace.devfile.io/v1alpha2
    metadata:
      name: test-devworkspace
    spec:
      started: true
      template:
        components:
          - name: tooling
            container:
              image: quay.io/wto/web-terminal-tooling
              args: ["tail", "-f", "/dev/null"]
              memoryRequest: 100Gi
              memoryLimit: 100Gi
    EOF
    ```
3. Wait 30 seconds; workspace should fail to start.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
