### PR TITLE
Fix checking exit code of happy path test

### DIFF
--- a/.ci/che-happy-path.sh
+++ b/.ci/che-happy-path.sh
@@ -95,7 +95,7 @@ oc rsync -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME}:/tmp/e2e/report/ /tmp/e2e -c
 oc exec -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c download-reports -- touch /tmp/done
 cp -r /tmp/e2e ${ARTIFACT_DIR}
 EXIT_CODE=$(oc logs -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test | grep EXIT_CODE)
-if [[ ${EXIT_CODE} == "+ EXIT_CODE=1" ]]; then
+if [[ ${EXIT_CODE} != "+ EXIT_CODE=0" ]]; then
     echo "[ERROR] Happy-path test failed."
     exit 1
 fi


### PR DESCRIPTION
### What does this PR do?
Fix checking exit code of happy path test.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
