### PR TITLE
Propagate DevWorkspace .spec.started status to an annotation on routings

### DIFF
--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
@@ -81,6 +81,10 @@ func (r *DevWorkspaceRoutingReconciler) Reconcile(ctx context.Context, req ctrl.
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	if instance.Annotations != nil && instance.Annotations[constants.DevWorkspaceStartedStatusAnnotation] == "false" {
+		return reconcile.Result{}, nil
+	}
+
 	reqLogger = reqLogger.WithValues(constants.DevWorkspaceIDLoggerKey, instance.Spec.DevWorkspaceId)
 	reqLogger.Info("Reconciling DevWorkspaceRouting")
 

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -417,7 +417,7 @@ func (r *DevWorkspaceReconciler) doStop(workspace *dw.DevWorkspace, logger logr.
 		return false, err
 	}
 
-	// Update DevWorkspaceRouting to have .spec.started=false
+	// Update DevWorkspaceRouting to have `devworkspace-started` annotation "false"
 	routing := &v1alpha1.DevWorkspaceRouting{}
 	routingRef := types.NamespacedName{
 		Name:      common.DevWorkspaceRoutingName(workspace.Status.DevWorkspaceId),

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -20,6 +20,10 @@ import (
 
 var NonAlphaNumRegexp = regexp.MustCompile(`[^a-z0-9]+`)
 
+func DevWorkspaceRoutingName(workspaceId string) string {
+	return fmt.Sprintf("routing-%s", workspaceId)
+}
+
 func EndpointName(endpointName string) string {
 	name := strings.ToLower(endpointName)
 	name = NonAlphaNumRegexp.ReplaceAllString(name, "-")

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -56,6 +56,11 @@ const (
 	// Operator also propagates it to the devworkspace-related objects to perform authorization.
 	DevWorkspaceRestrictedAccessAnnotation = "controller.devfile.io/restricted-access"
 
+	// DevWorkspaceStartedStatusAnnotation is applied to subresources of DevWorkspaces to indicate the owning object's
+	// .spec.started value. This annotation is applied to DevWorkspaceRoutings to trigger reconciles when a DevWorkspace
+	// is started or stopped.
+	DevWorkspaceStartedStatusAnnotation = "controller.devfile.io/devworkspace-started"
+
 	// DevWorkspaceStopReasonAnnotation marks the reason why the devworkspace was stopped; when a devworkspace is restarted
 	// this annotation will be cleared
 	DevWorkspaceStopReasonAnnotation = "controller.devfile.io/stopped-by"

--- a/pkg/provision/workspace/routing.go
+++ b/pkg/provision/workspace/routing.go
@@ -154,7 +154,7 @@ func getSpecRouting(
 	if val, ok := workspace.Annotations[constants.DevWorkspaceRestrictedAccessAnnotation]; ok {
 		annotations = maputils.Append(annotations, constants.DevWorkspaceRestrictedAccessAnnotation, val)
 	}
-	annotations[constants.DevWorkspaceStartedStatusAnnotation] = "true"
+	annotations = maputils.Append(annotations, constants.DevWorkspaceStartedStatusAnnotation, "true")
 
 	// copy the annotations for the specific routingClass from the workspace object to the routing
 	expectedAnnotationPrefix := workspace.Spec.RoutingClass + constants.RoutingAnnotationInfix

--- a/pkg/provision/workspace/routing.go
+++ b/pkg/provision/workspace/routing.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	maputils "github.com/devfile/devworkspace-operator/internal/map"
+	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 
@@ -153,6 +154,7 @@ func getSpecRouting(
 	if val, ok := workspace.Annotations[constants.DevWorkspaceRestrictedAccessAnnotation]; ok {
 		annotations = maputils.Append(annotations, constants.DevWorkspaceRestrictedAccessAnnotation, val)
 	}
+	annotations[constants.DevWorkspaceStartedStatusAnnotation] = "true"
 
 	// copy the annotations for the specific routingClass from the workspace object to the routing
 	expectedAnnotationPrefix := workspace.Spec.RoutingClass + constants.RoutingAnnotationInfix
@@ -169,7 +171,7 @@ func getSpecRouting(
 
 	routing := &v1alpha1.DevWorkspaceRouting{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("routing-%s", workspace.Status.DevWorkspaceId),
+			Name:      common.DevWorkspaceRoutingName(workspace.Status.DevWorkspaceId),
 			Namespace: workspace.Namespace,
 			Labels: map[string]string{
 				constants.DevWorkspaceIDLabel: workspace.Status.DevWorkspaceId,


### PR DESCRIPTION
This is a backwards-compatible re-do of https://github.com/devfile/devworkspace-operator/pull/604

### What does this PR do?
Add annotation 'controller.devfile.io/devworkspace-started' to be applied to DevWorkspaceRoutings. If a workspace is stopped, the annotation is set to "false", otherwise it is "true". If the DevWorkspaceRouting reconciler encounters a DevWorkspaceRouting with the annotation set to false, it ends the reconcile early.

This ensures that every workspace start/stop event triggers a reconcile, and allows the routing to clean up resources if necessary.

### What issues does this PR fix or reference?
Re-closes #602 

### Is it tested? How?
Check that DevWorkspaceRoutings get the annotation, *and that this doesn't break the Che operator*.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
