### PR TITLE
Fixup theia samples to avoid need to for a proxy

### DIFF
--- a/samples/theia-latest.yaml
+++ b/samples/theia-latest.yaml
@@ -14,6 +14,12 @@ spec:
       - name: theia
         plugin:
           uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
+          components:
+            - name: theia-ide
+              container:
+                env:
+                  - name: THEIA_HOST
+                    value: 0.0.0.0
     commands:
       - id: say-hello
         exec:

--- a/samples/theia-next.yaml
+++ b/samples/theia-next.yaml
@@ -14,6 +14,12 @@ spec:
       - name: theia
         plugin:
           uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
+          components:
+            - name: theia-ide
+              container:
+                env:
+                  - name: THEIA_HOST
+                    value: 0.0.0.0
     commands:
       - id: say-hello
         exec:


### PR DESCRIPTION
### What does this PR do?
Theia by default listens only on localhost, meaning connecting to the
editor without a proxy within the pod is impossible. To enable quick
testing, override the host with 0.0.0.0 so that basic Theia can be
tested with DWO.


### What issues does this PR fix or reference?
Cannot start Theia sample

### Is it tested? How?
```bash
oc apply -f samples/theia-next.yaml
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
