### PR TITLE
Always get default clusterHostSuffix and store it as a default on OpenShift

### DIFF
--- a/controllers/controller/devworkspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/basic_solver.go
@@ -13,8 +13,6 @@
 package solvers
 
 import (
-	"errors"
-
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
@@ -58,7 +56,7 @@ func (s *BasicSolver) GetSpecObjects(routing *controllerv1alpha1.DevWorkspaceRou
 
 	routingSuffix := config.Routing.ClusterHostSuffix
 	if routingSuffix == "" {
-		return routingObjects, errors.New("basic routing requires .config.routing.clusterHostSuffix to be set in operator config")
+		return routingObjects, &RoutingInvalid{"basic routing requires .config.routing.clusterHostSuffix to be set in operator config"}
 	}
 
 	spec := routing.Spec

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -71,14 +71,13 @@ func SetupControllerConfig(client crclient.Client) error {
 	} else {
 		syncConfigFrom(config)
 	}
+	defaultRoutingSuffix, err := discoverRouteSuffix(client)
+	if err != nil {
+		return err
+	}
+	DefaultConfig.Routing.ClusterHostSuffix = defaultRoutingSuffix
 	if internalConfig.Routing.ClusterHostSuffix == "" {
-		routeSuffix, err := discoverRouteSuffix(client)
-		if err != nil {
-			return err
-		}
-		internalConfig.Routing.ClusterHostSuffix = routeSuffix
-		// Set routing suffix in default config as well to ensure value is persisted across config changes
-		DefaultConfig.Routing.ClusterHostSuffix = routeSuffix
+		internalConfig.Routing.ClusterHostSuffix = defaultRoutingSuffix
 		updatePublicConfig()
 	}
 	return nil


### PR DESCRIPTION
### What does this PR do?
* Always gets `clusterRoutingSuffix` when possible and stores it in default, to avoid an issue when the controller is started with the value overwritten (https://github.com/devfile/devworkspace-operator/issues/623)
* Fail workspaces if `clusterRoutingSuffix` is required and unset.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/623

### Is it tested? How?
Use reproducer in https://github.com/devfile/devworkspace-operator/issues/623

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
