### PR TITLE
Automatically migrate old configmap-based configuration to new CRD

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,5 +191,8 @@ func setupControllerConfig(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
+	if err := config.MigrateConfigFromConfigMap(nonCachedClient); err != nil {
+		return err
+	}
 	return config.SetupControllerConfig(nonCachedClient)
 }

--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	routev1 "github.com/openshift/api/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+)
+
+const testNamespace = "test-namespace"
+
+var (
+	scheme   = runtime.NewScheme()
+	trueBool = true
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(dw.AddToScheme(scheme))
+	utilruntime.Must(routev1.Install(scheme))
+}
+
+func setupForTest(t *testing.T) {
+	if err := os.Setenv("WATCH_NAMESPACE", testNamespace); err != nil {
+		t.Fatalf("failed to set up for test: %s", err)
+	}
+	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
+	configNamespace = testNamespace
+	originalDefaultConfig := DefaultConfig.DeepCopy()
+	t.Cleanup(func() {
+		internalConfig = nil
+		DefaultConfig = originalDefaultConfig
+	})
+}
+
+func buildConfig(config *v1alpha1.OperatorConfiguration) *v1alpha1.DevWorkspaceOperatorConfig {
+	return &v1alpha1.DevWorkspaceOperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      OperatorConfigName,
+			Namespace: testNamespace,
+		},
+		Config: config,
+	}
+}

--- a/pkg/config/configmap/config.go
+++ b/pkg/config/configmap/config.go
@@ -18,21 +18,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
-	"github.com/devfile/devworkspace-operator/pkg/constants"
-	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
-
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	routeV1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 )
 
 var ControllerCfg ControllerConfig
@@ -57,27 +49,31 @@ func (wc *ControllerConfig) update(configMap *corev1.ConfigMap) {
 	wc.configMap = configMap
 }
 
-func (wc *ControllerConfig) GetWorkspacePVCName() string {
-	return wc.GetPropertyOrDefault(workspacePVCName, defaultWorkspacePVCName)
+func (wc *ControllerConfig) GetWorkspacePVCName() *string {
+	return wc.GetProperty(workspacePVCName)
 }
 
-func (wc *ControllerConfig) GetDefaultRoutingClass() string {
-	return wc.GetPropertyOrDefault(routingClass, defaultRoutingClass)
+func (wc *ControllerConfig) GetDefaultRoutingClass() *string {
+	return wc.GetProperty(routingClass)
+}
+
+func (wc *ControllerConfig) GetClusterRoutingSuffix() *string {
+	return wc.GetProperty(routingSuffix)
 }
 
 //GetExperimentalFeaturesEnabled returns true if experimental features should be enabled.
 //DO NOT TURN ON IT IN THE PRODUCTION.
 //Experimental features are not well tested and may be totally removed without announcement.
-func (wc *ControllerConfig) GetExperimentalFeaturesEnabled() bool {
-	return wc.GetPropertyOrDefault(experimentalFeaturesEnabled, defaultExperimentalFeaturesEnabled) == "true"
+func (wc *ControllerConfig) GetExperimentalFeaturesEnabled() *string {
+	return wc.GetProperty(experimentalFeaturesEnabled)
 }
 
 func (wc *ControllerConfig) GetPVCStorageClassName() *string {
 	return wc.GetProperty(workspacePVCStorageClassName)
 }
 
-func (wc *ControllerConfig) GetSidecarPullPolicy() string {
-	return wc.GetPropertyOrDefault(sidecarPullPolicy, defaultSidecarPullPolicy)
+func (wc *ControllerConfig) GetSidecarPullPolicy() *string {
+	return wc.GetProperty(sidecarPullPolicy)
 }
 
 func (wc *ControllerConfig) GetProperty(name string) *string {
@@ -88,20 +84,12 @@ func (wc *ControllerConfig) GetProperty(name string) *string {
 	return nil
 }
 
-func (wc *ControllerConfig) GetPropertyOrDefault(name string, defaultValue string) string {
-	val, exists := wc.configMap.Data[name]
-	if exists {
-		return val
-	}
-	return defaultValue
-}
-
 func (wc *ControllerConfig) Validate() error {
 	return nil
 }
 
-func (wc *ControllerConfig) GetWorkspaceIdleTimeout() string {
-	return wc.GetPropertyOrDefault(devworkspaceIdleTimeout, defaultDevWorkspaceIdleTimeout)
+func (wc *ControllerConfig) GetWorkspaceIdleTimeout() *string {
+	return wc.GetProperty(devworkspaceIdleTimeout)
 }
 
 func syncConfigmapFromCluster(client client.Client, obj client.Object) {
@@ -113,56 +101,36 @@ func syncConfigmapFromCluster(client client.Client, obj client.Object) {
 		ControllerCfg.update(cm)
 		return
 	}
-
-	configMap := &corev1.ConfigMap{}
-	err := client.Get(context.TODO(), ConfigMapReference, configMap)
-	if err != nil {
-		log.Error(err, fmt.Sprintf("Cannot find the '%s' ConfigMap in namespace '%s'", ConfigMapReference.Name, ConfigMapReference.Namespace))
-	}
-	ControllerCfg.update(configMap)
 }
 
-func WatchControllerConfig(mgr manager.Manager) error {
-	customConfig := false
+func LoadControllerConfig(nonCachedClient client.Client) (found bool, err error) {
 	configMapName, found := os.LookupEnv(ConfigMapNameEnvVar)
 	if found && len(configMapName) > 0 {
 		ConfigMapReference.Name = configMapName
-		customConfig = true
 	}
 	configMapNamespace, found := os.LookupEnv(ConfigMapNamespaceEnvVar)
 	if found && len(configMapNamespace) > 0 {
 		ConfigMapReference.Namespace = configMapNamespace
-		customConfig = true
+	} else {
+		namespace, err := infrastructure.GetNamespace()
+		if err != nil {
+			return false, err
+		}
+		ConfigMapReference.Namespace = namespace
 	}
 
 	if ConfigMapReference.Namespace == "" {
-		return fmt.Errorf("you should set the namespace of the controller config map through the '%s' environment variable", ConfigMapNamespaceEnvVar)
+		return false, fmt.Errorf("you should set the namespace of the controller config map through the '%s' environment variable", ConfigMapNamespaceEnvVar)
 	}
 
 	configMap := &corev1.ConfigMap{}
-	nonCachedClient, err := client.New(mgr.GetConfig(), client.Options{
-		Scheme: mgr.GetScheme(),
-	})
-	if err != nil {
-		return err
-	}
 	log.Info(fmt.Sprintf("Searching for config map '%s' in namespace '%s'", ConfigMapReference.Name, ConfigMapReference.Namespace))
 	err = nonCachedClient.Get(context.TODO(), ConfigMapReference, configMap)
 	if err != nil {
 		if !k8sErrors.IsNotFound(err) {
-			return err
+			return false, err
 		}
-		if customConfig {
-			return fmt.Errorf("cannot find the '%s' ConfigMap in namespace '%s'", ConfigMapReference.Name, ConfigMapReference.Namespace)
-		}
-
-		buildDefaultConfigMap(configMap)
-
-		err = nonCachedClient.Create(context.TODO(), configMap)
-		if err != nil {
-			return err
-		}
-		log.Info(fmt.Sprintf("  => created config map '%s' in namespace '%s'", configMap.GetObjectMeta().GetName(), configMap.GetObjectMeta().GetNamespace()))
+		return false, nil
 	} else {
 		log.Info(fmt.Sprintf("  => found config map '%s' in namespace '%s'", configMap.GetObjectMeta().GetName(), configMap.GetObjectMeta().GetNamespace()))
 	}
@@ -170,84 +138,7 @@ func WatchControllerConfig(mgr manager.Manager) error {
 	if configMap.Data == nil {
 		configMap.Data = map[string]string{}
 	}
-	err = fillOpenShiftRouteSuffixIfNecessary(nonCachedClient, configMap)
-	if err != nil {
-		return err
-	}
-
 	syncConfigmapFromCluster(nonCachedClient, configMap)
 
-	return nil
-}
-
-func SetupConfigForTesting(cm *corev1.ConfigMap) {
-	ControllerCfg.update(cm)
-}
-
-func buildDefaultConfigMap(cm *corev1.ConfigMap) {
-	cm.Name = ConfigMapReference.Name
-	cm.Namespace = ConfigMapReference.Namespace
-	cm.Labels = constants.ControllerAppLabels()
-
-	cm.Data = map[string]string{}
-}
-
-func fillOpenShiftRouteSuffixIfNecessary(nonCachedClient client.Client, configMap *corev1.ConfigMap) error {
-	if !infrastructure.IsOpenShift() {
-		return nil
-	}
-
-	testRoute := &routeV1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: configMap.Namespace,
-			Name:      "devworkspace-controller-test-route",
-		},
-		Spec: routeV1.RouteSpec{
-			To: routeV1.RouteTargetReference{
-				Kind: "Service",
-				Name: "devworkspace-controller-test-route",
-			},
-		},
-	}
-
-	err := nonCachedClient.Create(context.TODO(), testRoute)
-	if err != nil {
-		return err
-	}
-	defer nonCachedClient.Delete(context.TODO(), testRoute)
-	host := testRoute.Spec.Host
-	if host != "" {
-		prefixToRemove := "devworkspace-controller-test-route-" + configMap.Namespace + "."
-		configMap.Data[RoutingSuffix] = strings.TrimPrefix(host, prefixToRemove)
-	}
-
-	err = nonCachedClient.Update(context.TODO(), configMap)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func ConfigMapPredicates(mgr manager.Manager) predicate.Predicate {
-	return predicate.Funcs{
-		UpdateFunc: func(evt event.UpdateEvent) bool {
-			if evt.ObjectNew.GetName() == ConfigMapReference.Name && evt.ObjectNew.GetNamespace() == ConfigMapReference.Namespace {
-				syncConfigmapFromCluster(mgr.GetClient(), evt.ObjectNew)
-			}
-			return false
-		},
-		CreateFunc: func(evt event.CreateEvent) bool {
-			if evt.Object.GetName() == ConfigMapReference.Name && evt.Object.GetNamespace() == ConfigMapReference.Namespace {
-				syncConfigmapFromCluster(mgr.GetClient(), evt.Object)
-			}
-			return false
-		},
-		DeleteFunc: func(evt event.DeleteEvent) bool {
-			return false
-		},
-		GenericFunc: func(evt event.GenericEvent) bool {
-			return false
-		},
-	}
+	return true, nil
 }

--- a/pkg/config/configmap/property.go
+++ b/pkg/config/configmap/property.go
@@ -29,10 +29,10 @@ const (
 	routingClass        = "devworkspace.default_routing_class"
 	defaultRoutingClass = "basic"
 
-	// RoutingSuffix is the base domain for routes/ingresses created on the cluster. All
-	// routes/ingresses will be created with URL http(s)://<unique-to-workspace-part>.<RoutingSuffix>
+	// routingSuffix is the base domain for routes/ingresses created on the cluster. All
+	// routes/ingresses will be created with URL http(s)://<unique-to-workspace-part>.<routingSuffix>
 	// is supposed to be used by embedded routing solvers only
-	RoutingSuffix = "devworkspace.routing.cluster_host_suffix"
+	routingSuffix = "devworkspace.routing.cluster_host_suffix"
 
 	experimentalFeaturesEnabled        = "devworkspace.experimental_features_enabled"
 	defaultExperimentalFeaturesEnabled = "false"

--- a/pkg/config/migrate.go
+++ b/pkg/config/migrate.go
@@ -1,0 +1,151 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package config
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	dw "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/config/configmap"
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+)
+
+func MigrateConfigFromConfigMap(client crclient.Client) error {
+	migratedConfig, err := convertConfigMapToConfigCRD(client)
+	if err != nil {
+		return err
+	}
+	if migratedConfig == nil {
+		return nil
+	}
+
+	namespace, err := infrastructure.GetNamespace()
+	if err != nil {
+		return err
+	}
+	clusterConfig, err := getClusterConfig(namespace, client)
+	if err != nil {
+		return err
+	}
+	if clusterConfig != nil {
+		// Check using DeepDerivative in case cluster config contains default/additional values -- we only care
+		// that values in migratedConfig are propagated to the cluster DWOC.
+		if equality.Semantic.DeepDerivative(migratedConfig.Config, clusterConfig.Config) {
+			log.Info("Found deprecated operator configmap matching config custom resource. Deleting.")
+			// In case we migrated before but failed to delete
+			return deleteMigratedConfigmap(client)
+		}
+		return fmt.Errorf("found both DevWorkspaceOperatorConfig and configmap on cluster -- cannot migrate")
+	}
+
+	// Set namespace in case obsolete env vars were used to specify a custom namespace for the configmap
+	migratedConfig.Namespace = namespace
+	if err := client.Create(context.Background(), migratedConfig); err != nil {
+		return err
+	}
+	log.Info("Migrated operator configuration from configmap")
+	return deleteMigratedConfigmap(client)
+}
+
+func deleteMigratedConfigmap(client crclient.Client) error {
+	obsoleteConfigmap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmap.ConfigMapReference.Name,
+			Namespace: configmap.ConfigMapReference.Namespace,
+		},
+	}
+	return client.Delete(context.Background(), obsoleteConfigmap)
+}
+
+// convertConfigMapToConfigCRD converts a earlier devworkspace configuration configmap (if present)
+// into a DevWorkspaceOperatorConfig. Values matching the current default config settings are ignored.
+// If the configmap is not present, or if the configmap is present but all values are default, returns
+// nil. Returns an error if we fail to load the controller config from configmap.
+func convertConfigMapToConfigCRD(client crclient.Client) (*dw.DevWorkspaceOperatorConfig, error) {
+	found, err := configmap.LoadControllerConfig(client)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+
+	migratedRoutingConfig := &dw.RoutingConfig{}
+	setRoutingConfig := false
+	routingSuffix := configmap.ControllerCfg.GetClusterRoutingSuffix()
+	if routingSuffix != nil && *routingSuffix != DefaultConfig.Routing.ClusterHostSuffix {
+		migratedRoutingConfig.ClusterHostSuffix = *routingSuffix
+		setRoutingConfig = true
+	}
+	defaultRoutingClass := configmap.ControllerCfg.GetDefaultRoutingClass()
+	if defaultRoutingClass != nil && *defaultRoutingClass != DefaultConfig.Routing.DefaultRoutingClass {
+		migratedRoutingConfig.DefaultRoutingClass = *defaultRoutingClass
+		setRoutingConfig = true
+	}
+
+	migratedWorkspaceConfig := &dw.WorkspaceConfig{}
+	setWorkspaceConfig := false
+	storageClassName := configmap.ControllerCfg.GetPVCStorageClassName()
+	if storageClassName != DefaultConfig.Workspace.StorageClassName {
+		migratedWorkspaceConfig.StorageClassName = storageClassName
+		setWorkspaceConfig = true
+	}
+	sidecarPullPolicy := configmap.ControllerCfg.GetSidecarPullPolicy()
+	if sidecarPullPolicy != nil && *sidecarPullPolicy != DefaultConfig.Workspace.ImagePullPolicy {
+		migratedWorkspaceConfig.ImagePullPolicy = *sidecarPullPolicy
+		setWorkspaceConfig = true
+	}
+	idleTimeout := configmap.ControllerCfg.GetWorkspaceIdleTimeout()
+	if idleTimeout != nil && *idleTimeout != DefaultConfig.Workspace.IdleTimeout {
+		migratedWorkspaceConfig.IdleTimeout = *idleTimeout
+		setWorkspaceConfig = true
+	}
+	pvcName := configmap.ControllerCfg.GetWorkspacePVCName()
+	if pvcName != nil && *pvcName != DefaultConfig.Workspace.PVCName {
+		migratedWorkspaceConfig.PVCName = *pvcName
+		setWorkspaceConfig = true
+	}
+
+	var experimentalFeatures *bool
+	experimentalFeaturesStr := configmap.ControllerCfg.GetExperimentalFeaturesEnabled()
+	if experimentalFeaturesStr != nil && *experimentalFeaturesStr == "true" {
+		trueBool := true
+		experimentalFeatures = &trueBool
+	}
+
+	if !setRoutingConfig && !setWorkspaceConfig && experimentalFeatures == nil {
+		return nil, nil
+	}
+
+	migratedConfig := &dw.DevWorkspaceOperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      OperatorConfigName,
+			Namespace: configmap.ConfigMapReference.Namespace,
+		},
+		Config: &dw.OperatorConfiguration{},
+	}
+	migratedConfig.Config.EnableExperimentalFeatures = experimentalFeatures
+	if setRoutingConfig {
+		migratedConfig.Config.Routing = migratedRoutingConfig
+	}
+	if setWorkspaceConfig {
+		migratedConfig.Config.Workspace = migratedWorkspaceConfig
+	}
+	return migratedConfig, nil
+}

--- a/pkg/config/migrate_test.go
+++ b/pkg/config/migrate_test.go
@@ -1,0 +1,307 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/config/configmap"
+)
+
+func TestMigrateConfigDoesNothingWhenNoConfigMap(t *testing.T) {
+	setupForTest(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	err := MigrateConfigFromConfigMap(client)
+	assert.NoError(t, err, "Should not return error when there is no configmap")
+
+	clusterConfig := &v1alpha1.DevWorkspaceOperatorConfig{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Name:      OperatorConfigName,
+		Namespace: testNamespace,
+	}, clusterConfig)
+	if assert.Error(t, err, "test client should return error when trying to get nonexistent clusterConfig") {
+		assert.True(t, k8sErrors.IsNotFound(err), "expect error to be NotFound")
+	}
+}
+
+func TestMigrateConfigErrorWhenConfigAndConfigMapPresent(t *testing.T) {
+	setupForTest(t)
+	existingConfig := buildConfig(&v1alpha1.OperatorConfiguration{
+		Workspace: &v1alpha1.WorkspaceConfig{
+			ImagePullPolicy: "testImagePullPolicy",
+		},
+	})
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmap.ConfigMapReference.Name,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"devworkspace.default_routing_class": "testRoutingClass",
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCM, existingConfig).Build()
+	err := MigrateConfigFromConfigMap(client)
+	assert.Error(t, err, "Should return error")
+	assert.Equal(t, "found both DevWorkspaceOperatorConfig and configmap on cluster -- cannot migrate", err.Error())
+}
+
+func TestMigrateConfigDeletesConfigMapWhenAlreadyMigrated(t *testing.T) {
+	setupForTest(t)
+	existingConfig := buildConfig(&v1alpha1.OperatorConfiguration{
+		Routing: &v1alpha1.RoutingConfig{
+			DefaultRoutingClass: "testRoutingClass",
+		},
+	})
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmap.ConfigMapReference.Name,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"devworkspace.default_routing_class": "testRoutingClass",
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCM, existingConfig).Build()
+	err := MigrateConfigFromConfigMap(client)
+	if !assert.NoError(t, err, "Should not error") {
+		return
+	}
+	clusterCM := &corev1.ConfigMap{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Name:      configmap.ConfigMapReference.Name,
+		Namespace: testNamespace,
+	}, clusterCM)
+	assert.Error(t, err, "Expect error on trying to find configmap as it is deleted")
+	assert.True(t, k8sErrors.IsNotFound(err), "Expect error to be IsNotFound")
+}
+
+func TestMigrateConfigCreatesCRFromConfigMap(t *testing.T) {
+	setupForTest(t)
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmap.ConfigMapReference.Name,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"devworkspace.default_routing_class":         "testRoutingClass",
+			"devworkspace.routing.cluster_host_suffix":   "testHostSuffix",
+			"devworkspace.sidecar.image_pull_policy":     "testImagePullPolicy",
+			"devworkspace.pvc.name":                      "testPVCName",
+			"devworkspace.idle_timeout":                  "testIdleTimeout",
+			"devworkspace.experimental_features_enabled": "true",
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingCM).Build()
+
+	expectedConfig := buildConfig(&v1alpha1.OperatorConfiguration{
+		Routing: &v1alpha1.RoutingConfig{
+			DefaultRoutingClass: "testRoutingClass",
+			ClusterHostSuffix:   "testHostSuffix",
+		},
+		Workspace: &v1alpha1.WorkspaceConfig{
+			ImagePullPolicy: "testImagePullPolicy",
+			PVCName:         "testPVCName",
+			IdleTimeout:     "testIdleTimeout",
+		},
+		EnableExperimentalFeatures: &trueBool,
+	})
+
+	err := MigrateConfigFromConfigMap(client)
+	if !assert.NoError(t, err, "Should not error") {
+		return
+	}
+	clusterConfig := &v1alpha1.DevWorkspaceOperatorConfig{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Name:      OperatorConfigName,
+		Namespace: testNamespace,
+	}, clusterConfig)
+	if !assert.NoError(t, err, "Should create config CRD on cluster from configmap") {
+		return
+	}
+	assert.Equal(t, expectedConfig.Config, clusterConfig.Config, "Expect configmap to be converted to config CRD")
+	clusterCM := &corev1.ConfigMap{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Name:      configmap.ConfigMapReference.Name,
+		Namespace: testNamespace,
+	}, clusterCM)
+	assert.Error(t, err, "Expect error on trying to find configmap as it is deleted")
+	assert.True(t, k8sErrors.IsNotFound(err), "Expect error to be IsNotFound")
+}
+
+func TestMigrateConfigSucceedsWhenCRDHasAllValuesFromConfigMap(t *testing.T) {
+	setupForTest(t)
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmap.ConfigMapReference.Name,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"devworkspace.default_routing_class":       "testRoutingClass",
+			"devworkspace.routing.cluster_host_suffix": "testHostSuffix",
+		},
+	}
+	existingConfig := buildConfig(&v1alpha1.OperatorConfiguration{
+		Routing: &v1alpha1.RoutingConfig{
+			DefaultRoutingClass: "testRoutingClass",
+			ClusterHostSuffix:   "testHostSuffix",
+		},
+		Workspace: &v1alpha1.WorkspaceConfig{
+			ImagePullPolicy: "testImagePullPolicy",
+			PVCName:         "testPVCName",
+			IdleTimeout:     "testIdleTimeout",
+		},
+	})
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingConfig, existingCM).Build()
+
+	expectedConfig := existingConfig.DeepCopy()
+
+	err := MigrateConfigFromConfigMap(client)
+	if !assert.NoError(t, err, "Should not error") {
+		return
+	}
+	clusterConfig := &v1alpha1.DevWorkspaceOperatorConfig{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Name:      OperatorConfigName,
+		Namespace: testNamespace,
+	}, clusterConfig)
+	if !assert.NoError(t, err, "Config CRD should exist on cluster after successful migration") {
+		return
+	}
+	assert.Equal(t, expectedConfig.Config, clusterConfig.Config, "Expect config CRD to be unchanged")
+	clusterCM := &corev1.ConfigMap{}
+	err = client.Get(context.Background(), types.NamespacedName{
+		Name:      configmap.ConfigMapReference.Name,
+		Namespace: testNamespace,
+	}, clusterCM)
+	assert.Error(t, err, "Expect error on trying to find configmap as it is deleted")
+	assert.True(t, k8sErrors.IsNotFound(err), "Expect error to be IsNotFound")
+}
+
+func TestConvertConfigMapDoesNothingWhenNoConfigmap(t *testing.T) {
+	setupForTest(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	migratedConfig, err := convertConfigMapToConfigCRD(client)
+	assert.NoError(t, err, "Should not return error when there is no configmap")
+	assert.Nil(t, migratedConfig, "Should not create migrated config object when there is no configmap")
+}
+
+func TestConvertConfigMapGetsAllOldConfigValues(t *testing.T) {
+	setupForTest(t)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmap.ConfigMapReference.Name,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"devworkspace.default_routing_class":         "testRoutingClass",
+			"devworkspace.routing.cluster_host_suffix":   "testHostSuffix",
+			"devworkspace.sidecar.image_pull_policy":     "testImagePullPolicy",
+			"devworkspace.pvc.name":                      "testPVCName",
+			"devworkspace.pvc.storage_class.name":        "testStorageClassName",
+			"devworkspace.idle_timeout":                  "testIdleTimeout",
+			"devworkspace.experimental_features_enabled": "true",
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+	testStorageClassName := "testStorageClassName"
+	expectedConfig := buildConfig(&v1alpha1.OperatorConfiguration{
+		Routing: &v1alpha1.RoutingConfig{
+			DefaultRoutingClass: "testRoutingClass",
+			ClusterHostSuffix:   "testHostSuffix",
+		},
+		Workspace: &v1alpha1.WorkspaceConfig{
+			ImagePullPolicy:  "testImagePullPolicy",
+			PVCName:          "testPVCName",
+			StorageClassName: &testStorageClassName,
+			IdleTimeout:      "testIdleTimeout",
+		},
+		EnableExperimentalFeatures: &trueBool,
+	})
+
+	migratedConfig, err := convertConfigMapToConfigCRD(client)
+	if !assert.NoError(t, err, "Should not return error when there is no configmap") {
+		return
+	}
+	assert.Equal(t, expectedConfig, migratedConfig, "Should pick up all values in config")
+}
+
+func TestConvertConfigMapIgnoresValuesThatAreDefault(t *testing.T) {
+	setupForTest(t)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmap.ConfigMapReference.Name,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"devworkspace.default_routing_class":         "basic",
+			"devworkspace.routing.cluster_host_suffix":   "testHostSuffix",
+			"devworkspace.sidecar.image_pull_policy":     "Always",
+			"devworkspace.pvc.name":                      "testPVCName",
+			"devworkspace.idle_timeout":                  "testIdleTimeout",
+			"devworkspace.experimental_features_enabled": "false",
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+	expectedConfig := buildConfig(&v1alpha1.OperatorConfiguration{
+		Routing: &v1alpha1.RoutingConfig{
+			ClusterHostSuffix: "testHostSuffix",
+		},
+		Workspace: &v1alpha1.WorkspaceConfig{
+			PVCName:     "testPVCName",
+			IdleTimeout: "testIdleTimeout",
+		},
+	})
+
+	migratedConfig, err := convertConfigMapToConfigCRD(client)
+	if !assert.NoError(t, err, "Should not return error when there is no configmap") {
+		return
+	}
+	assert.Equal(t, expectedConfig, migratedConfig, "Should drop default values in configmap")
+}
+
+func TestConvertConfigMapReturnsNilWhenAllDefault(t *testing.T) {
+	setupForTest(t)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmap.ConfigMapReference.Name,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"devworkspace.default_routing_class":         "basic",
+			"devworkspace.sidecar.image_pull_policy":     "Always",
+			"devworkspace.pvc.name":                      "claim-devworkspace",
+			"devworkspace.idle_timeout":                  "15m",
+			"devworkspace.experimental_features_enabled": "false",
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+	migratedConfig, err := convertConfigMapToConfigCRD(client)
+	if !assert.NoError(t, err, "Should not return error when there is no configmap") {
+		return
+	}
+	assert.Nil(t, migratedConfig, "Should return (nil, nil) when configmap is all default")
+}


### PR DESCRIPTION
### What does this PR do?
Automatically converts configmaps from older versions of DWO to the new CRD. After migration is complete, the configmap is deleted from the cluster.
* Default values in the configmap are omitted (to avoid incidentally overriding new defaults in the CRD)
* If both a configmap and config CR exist:
   * If they are identical or if all custom values in the configmap are in the CR, migration proceeds (and deletes the configmap)
   * If they are differnent, an error is thrown.

### What issues does this PR fix or reference?
Unfinished followup to https://github.com/devfile/devworkspace-operator/pull/598

### Is it tested? How?
Tests are included with PR (with decent coverage, at least). To test directly:
```bash
git checkout ec05d064 # Last pre-#598 commit
make uninstall docker install
kubectl get cm devworkspace-controller-configmap # Verify configmap exists
git checkout <pr-branch>
make docker install restart
kubectl get cm devworkspace-controller-configmap # Verify configmap is deleted
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
