### PR TITLE
Update devfile/api to a commit that sets v1alpha1 DW/DWT crds as serv…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export PROJECT_CLONE_IMG ?= quay.io/devfile/project-clone:next
 export PULL_POLICY ?= Always
 export DEFAULT_ROUTING ?= basic
 export KUBECONFIG ?= ${HOME}/.kube/config
-export DEVWORKSPACE_API_VERSION ?= 089a48011460cbd9f06f200bad5452137a25f34b
+export DEVWORKSPACE_API_VERSION ?= e38e88c50482f0619639dce90eeb17447822816e
 
 # Enable using Podman instead of Docker
 export DOCKER ?= docker

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/devworkspace-operator
 go 1.15
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460
+	github.com/devfile/api/v2 v2.0.0-20211006183648-e38e88c50482
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
-github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460 h1:cmd+3poyUwevcWchYdvE02YT1nQU4SJpA5/wrdLrpWE=
-github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460/go.mod h1:kLX/nW93gigOHXK3NLeJL2fSS/sgEe+OHu8bo3aoOi4=
+github.com/devfile/api/v2 v2.0.0-20211006183648-e38e88c50482 h1:jLTpuclZ84yIGFDsOFSimJAaTreACfqU7QAn18/sRBI=
+github.com/devfile/api/v2 v2.0.0-20211006183648-e38e88c50482/go.mod h1:kLX/nW93gigOHXK3NLeJL2fSS/sgEe+OHu8bo3aoOi4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=


### PR DESCRIPTION
…ed: false

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR updates the devfile api to the commit that marks v1alpha1 DW's and DWT's as `served: false`. This is the first step to deprecating v1alpha1 :partying_face: 

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/599

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
