### PR TITLE
feat: Add WorkspaceEngineFailure reason to the devworkspace_fai…

### DIFF
--- a/controllers/workspace/condition.go
+++ b/controllers/workspace/condition.go
@@ -39,6 +39,10 @@ type workspaceConditions struct {
 }
 
 func (c *workspaceConditions) setConditionTrue(conditionType dw.DevWorkspaceConditionType, msg string) {
+	c.setConditionTrueWithReason(conditionType, msg, "")
+}
+
+func (c *workspaceConditions) setConditionTrueWithReason(conditionType dw.DevWorkspaceConditionType, msg string, reason string) {
 	if c.conditions == nil {
 		c.conditions = map[dw.DevWorkspaceConditionType]dw.DevWorkspaceCondition{}
 	}
@@ -46,6 +50,7 @@ func (c *workspaceConditions) setConditionTrue(conditionType dw.DevWorkspaceCond
 	c.conditions[conditionType] = dw.DevWorkspaceCondition{
 		Status:  corev1.ConditionTrue,
 		Message: msg,
+		Reason:  reason,
 	}
 }
 

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -379,7 +379,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	deploymentStatus := wsprovision.SyncDeploymentToCluster(workspace, allPodAdditions, serviceAcctName, clusterAPI)
 	if !deploymentStatus.Continue {
 		if deploymentStatus.FailStartup {
-			failureReason := wsprovision.DetermineStartupFailureReason(deploymentStatus.Info())
+			failureReason := metrics.DetermineProvisioningFailureReason(deploymentStatus)
 			return r.failWorkspace(workspace, deploymentStatus.Info(), failureReason, reqLogger, &reconcileStatus)
 		}
 		reqLogger.Info("Waiting on deployment to be ready")
@@ -493,7 +493,7 @@ func (r *DevWorkspaceReconciler) doStop(workspace *dw.DevWorkspace, logger logr.
 func (r *DevWorkspaceReconciler) failWorkspace(workspace *dw.DevWorkspace, msg string, reason metrics.FailureReason, logger logr.Logger, status *currentStatus) (reconcile.Result, error) {
 	logger.Info("DevWorkspace failed to start: " + msg)
 	status.phase = devworkspacePhaseFailing
-	status.setConditionTrueWithReason(dw.DevWorkspaceFailedStart, msg, reason.CamelCase())
+	status.setConditionTrueWithReason(dw.DevWorkspaceFailedStart, msg, reason.GetReason())
 	if workspace.Spec.Started {
 		return reconcile.Result{Requeue: true}, nil
 	}

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -492,7 +492,7 @@ func (r *DevWorkspaceReconciler) doStop(workspace *dw.DevWorkspace, logger logr.
 func (r *DevWorkspaceReconciler) failWorkspace(workspace *dw.DevWorkspace, msg string, logger logr.Logger, status *currentStatus) (reconcile.Result, error) {
 	logger.Info("DevWorkspace failed to start: " + msg)
 	status.phase = devworkspacePhaseFailing
-	status.setConditionTrue(dw.DevWorkspaceFailedStart, msg)
+	status.setConditionTrue(dw.DevWorkspaceFailedStart, metrics.WorkspaceEngineFailurePrefix+msg)
 	if workspace.Spec.Started {
 		return reconcile.Result{Requeue: true}, nil
 	}

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -199,7 +199,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// encountered in main reconcile loop.
 		if err == nil {
 			if timeoutErr := checkForStartTimeout(clusterWorkspace); timeoutErr != nil {
-				reconcileResult, err = r.failWorkspace(workspace, timeoutErr.Error(), reqLogger, &reconcileStatus)
+				reconcileResult, err = r.failWorkspace(workspace, timeoutErr.Error(), metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus)
 			}
 		}
 		return r.updateWorkspaceStatus(clusterWorkspace, reqLogger, &reconcileStatus, reconcileResult, err)
@@ -208,7 +208,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if workspace.Annotations[constants.DevWorkspaceRestrictedAccessAnnotation] == "true" {
 		msg, err := r.validateCreatorLabel(clusterWorkspace)
 		if err != nil {
-			return r.failWorkspace(workspace, msg, reqLogger, &reconcileStatus)
+			return r.failWorkspace(workspace, msg, metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus)
 		}
 	}
 
@@ -229,7 +229,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	flattenedWorkspace, warnings, err := flatten.ResolveDevWorkspace(&workspace.Spec.Template, flattenHelpers)
 	if err != nil {
-		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), reqLogger, &reconcileStatus)
+		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus)
 	}
 	if warnings != nil {
 		reconcileStatus.setConditionTrue(conditions.DevWorkspaceWarning, flatten.FormatVariablesWarning(warnings))
@@ -244,13 +244,13 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if components != nil {
 		eventErrors := devfilevalidation.ValidateComponents(components)
 		if eventErrors != nil {
-			return r.failWorkspace(workspace, eventErrors.Error(), reqLogger, &reconcileStatus)
+			return r.failWorkspace(workspace, eventErrors.Error(), metrics.ReasonBadRequest, reqLogger, &reconcileStatus)
 		}
 	}
 
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {
-		return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", err), reqLogger, &reconcileStatus)
+		return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus)
 	}
 
 	// Set finalizer on DevWorkspace if necessary
@@ -267,7 +267,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	devfilePodAdditions, err := containerlib.GetKubeContainersFromDevfile(&workspace.Spec.Template)
 	if err != nil {
-		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), reqLogger, &reconcileStatus)
+		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus)
 	}
 
 	err = storageProvisioner.ProvisionStorage(devfilePodAdditions, workspace, clusterAPI)
@@ -278,7 +278,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			reconcileStatus.setConditionFalse(conditions.StorageReady, fmt.Sprintf("Provisioning storage: %s", storageErr.Message))
 			return reconcile.Result{Requeue: true, RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
-			return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", storageErr), reqLogger, &reconcileStatus)
+			return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", storageErr), metrics.ReasonInfrastructureFailure, reqLogger, &reconcileStatus)
 		default:
 			return reconcile.Result{}, storageErr
 		}
@@ -297,7 +297,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	routingStatus := wsprovision.SyncRoutingToCluster(workspace, clusterAPI)
 	if !routingStatus.Continue {
 		if routingStatus.FailStartup {
-			return r.failWorkspace(workspace, routingStatus.Message, reqLogger, &reconcileStatus)
+			return r.failWorkspace(workspace, routingStatus.Message, metrics.ReasonInfrastructureFailure, reqLogger, &reconcileStatus)
 		}
 		reqLogger.Info("Waiting on routing to be ready")
 		message := "Preparing networking"
@@ -332,7 +332,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			reqLogger.Info(provisionErr.Message)
 			return reconcile.Result{Requeue: true, RequeueAfter: provisionErr.RequeueAfter}, nil
 		case *metadata.ProvisioningError:
-			return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning metadata configmap: %s", provisionErr), reqLogger, &reconcileStatus)
+			return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning metadata configmap: %s", provisionErr), metrics.ReasonInfrastructureFailure, reqLogger, &reconcileStatus)
 		default:
 			return reconcile.Result{}, provisionErr
 		}
@@ -379,7 +379,8 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	deploymentStatus := wsprovision.SyncDeploymentToCluster(workspace, allPodAdditions, serviceAcctName, clusterAPI)
 	if !deploymentStatus.Continue {
 		if deploymentStatus.FailStartup {
-			return r.failWorkspace(workspace, deploymentStatus.Info(), reqLogger, &reconcileStatus)
+			failureReason := wsprovision.DetermineStartupFailureReason(deploymentStatus.Info())
+			return r.failWorkspace(workspace, deploymentStatus.Info(), failureReason, reqLogger, &reconcileStatus)
 		}
 		reqLogger.Info("Waiting on deployment to be ready")
 		reconcileStatus.setConditionFalse(conditions.DeploymentReady, "Waiting for workspace deployment")
@@ -489,10 +490,10 @@ func (r *DevWorkspaceReconciler) doStop(workspace *dw.DevWorkspace, logger logr.
 // failWorkspace marks a workspace as failed by setting relevant fields in the status struct.
 // These changes are not synced to cluster immediately, and are intended to be synced to the cluster via a deferred function
 // in the main reconcile loop. If needed, changes can be flushed to the cluster immediately via `updateWorkspaceStatus()`
-func (r *DevWorkspaceReconciler) failWorkspace(workspace *dw.DevWorkspace, msg string, logger logr.Logger, status *currentStatus) (reconcile.Result, error) {
+func (r *DevWorkspaceReconciler) failWorkspace(workspace *dw.DevWorkspace, msg string, reason metrics.FailureReason, logger logr.Logger, status *currentStatus) (reconcile.Result, error) {
 	logger.Info("DevWorkspace failed to start: " + msg)
 	status.phase = devworkspacePhaseFailing
-	status.setConditionTrue(dw.DevWorkspaceFailedStart, metrics.WorkspaceEngineFailurePrefix+msg)
+	status.setConditionTrueWithReason(dw.DevWorkspaceFailedStart, msg, reason.CamelCase())
 	if workspace.Spec.Started {
 		return reconcile.Result{Requeue: true}, nil
 	}

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -199,7 +199,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// encountered in main reconcile loop.
 		if err == nil {
 			if timeoutErr := checkForStartTimeout(clusterWorkspace); timeoutErr != nil {
-				reconcileResult, err = r.failWorkspace(workspace, timeoutErr.Error(), metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus)
+				reconcileResult, err = r.failWorkspace(workspace, timeoutErr.Error(), metrics.ReasonInfrastructureFailure, reqLogger, &reconcileStatus)
 			}
 		}
 		return r.updateWorkspaceStatus(clusterWorkspace, reqLogger, &reconcileStatus, reconcileResult, err)
@@ -493,7 +493,7 @@ func (r *DevWorkspaceReconciler) doStop(workspace *dw.DevWorkspace, logger logr.
 func (r *DevWorkspaceReconciler) failWorkspace(workspace *dw.DevWorkspace, msg string, reason metrics.FailureReason, logger logr.Logger, status *currentStatus) (reconcile.Result, error) {
 	logger.Info("DevWorkspace failed to start: " + msg)
 	status.phase = devworkspacePhaseFailing
-	status.setConditionTrueWithReason(dw.DevWorkspaceFailedStart, msg, reason.GetReason())
+	status.setConditionTrueWithReason(dw.DevWorkspaceFailedStart, msg, string(reason))
 	if workspace.Spec.Started {
 		return reconcile.Result{Requeue: true}, nil
 	}

--- a/controllers/workspace/metrics/deployment_provisioning.go
+++ b/controllers/workspace/metrics/deployment_provisioning.go
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package metrics
+
+import (
+	"strings"
+
+	"github.com/devfile/devworkspace-operator/pkg/provision/workspace"
+)
+
+var badRequestFailures = []string{
+	"CrashLoopBackOff",
+	"ErrImagePull",
+	"ImagePullBackOff",
+}
+
+var infrastructureFailures = []string{
+	"CreateContainerError",
+	"RunContainerError",
+	"FailedScheduling",
+	"FailedMount",
+}
+
+// DetermineProvisioningFailureReason scans a deployment provisioning status info message
+// and returns the corresponding failure reason.
+// If a failure reason cannot be found, an Unknown reason is returned.
+func DetermineProvisioningFailureReason(status workspace.DeploymentProvisioningStatus) FailureReason {
+	failStartupMsg := status.Info()
+	for _, failure := range badRequestFailures {
+		if strings.Contains(failStartupMsg, failure) {
+			return ReasonBadRequest
+		}
+	}
+	for _, failure := range infrastructureFailures {
+		if strings.Contains(failStartupMsg, failure) {
+			return ReasonInfrastructureFailure
+		}
+	}
+	return ReasonUnknown
+}

--- a/controllers/workspace/metrics/failure_reason.go
+++ b/controllers/workspace/metrics/failure_reason.go
@@ -15,19 +15,16 @@
 
 package metrics
 
-import (
-	"strings"
-)
-
 type FailureReason struct {
 	snakeCase string
+	camelCase string
 }
 
 var (
-	ReasonBadRequest             = FailureReason{snakeCase: "bad_request"}
-	ReasonInfrastructureFailure  = FailureReason{snakeCase: "infrastructure_failure"}
-	ReasonWorkspaceEngineFailure = FailureReason{snakeCase: "workspace_engine_failure"}
-	ReasonUnknown                = FailureReason{snakeCase: "unknown"}
+	ReasonBadRequest             = FailureReason{snakeCase: "bad_request", camelCase: "BadRequest"}
+	ReasonInfrastructureFailure  = FailureReason{snakeCase: "infrastructure_failure", camelCase: "InfrastructureFailure"}
+	ReasonWorkspaceEngineFailure = FailureReason{snakeCase: "workspace_engine_failure", camelCase: "WorkspaceEngineFailure"}
+	ReasonUnknown                = FailureReason{snakeCase: "unknown", camelCase: "Unknown"}
 )
 
 var devworkspaceFailureReasons [4]FailureReason = [4]FailureReason{
@@ -38,7 +35,7 @@ var devworkspaceFailureReasons [4]FailureReason = [4]FailureReason{
 }
 
 func (f *FailureReason) CamelCase() string {
-	return convertSnakeCaseToCamelCase(f.snakeCase)
+	return f.camelCase
 }
 
 func (f *FailureReason) SnakeCase() string {
@@ -49,26 +46,9 @@ func (f *FailureReason) SnakeCase() string {
 // string representation. The input string representation can be snake case or camel case.
 func GetFailureReasonFromStr(reason string) FailureReason {
 	for _, v := range devworkspaceFailureReasons {
-		if v.snakeCase == reason || convertSnakeCaseToCamelCase(v.snakeCase) == reason {
+		if reason == v.snakeCase || reason == v.camelCase {
 			return v
 		}
 	}
 	return ReasonUnknown
-}
-
-// convertSnakeCaseToCamelCase converts the input string from camel case to snake case.
-func convertSnakeCaseToCamelCase(str string) (result string) {
-	result = ""
-	prevUnderscore := false
-	for k, v := range str {
-		if prevUnderscore || k == 0 {
-			result += strings.ToUpper(string(v))
-			prevUnderscore = false
-		} else if v != '_' {
-			result += string(v)
-		} else {
-			prevUnderscore = true
-		}
-	}
-	return result
 }

--- a/controllers/workspace/metrics/failure_reason.go
+++ b/controllers/workspace/metrics/failure_reason.go
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package metrics
+
+import (
+	"strings"
+)
+
+type FailureReason struct {
+	snakeCase string
+}
+
+var (
+	ReasonBadRequest             = FailureReason{snakeCase: "bad_request"}
+	ReasonInfrastructureFailure  = FailureReason{snakeCase: "infrastructure_failure"}
+	ReasonWorkspaceEngineFailure = FailureReason{snakeCase: "workspace_engine_failure"}
+	ReasonUnknown                = FailureReason{snakeCase: "unknown"}
+)
+
+var devworkspaceFailureReasons [4]FailureReason = [4]FailureReason{
+	ReasonBadRequest,
+	ReasonInfrastructureFailure,
+	ReasonWorkspaceEngineFailure,
+	ReasonUnknown,
+}
+
+func (f *FailureReason) CamelCase() string {
+	return convertSnakeCaseToCamelCase(f.snakeCase)
+}
+
+func (f *FailureReason) SnakeCase() string {
+	return f.snakeCase
+}
+
+// GetFailureReasonFromStr returns the corresponding FailureReason given an input
+// string representation. The input string representation can be snake case or camel case.
+func GetFailureReasonFromStr(reason string) FailureReason {
+	for _, v := range devworkspaceFailureReasons {
+		if v.snakeCase == reason || convertSnakeCaseToCamelCase(v.snakeCase) == reason {
+			return v
+		}
+	}
+	return ReasonUnknown
+}
+
+// convertSnakeCaseToCamelCase converts the input string from camel case to snake case.
+func convertSnakeCaseToCamelCase(str string) (result string) {
+	result = ""
+	prevUnderscore := false
+	for k, v := range str {
+		if prevUnderscore || k == 0 {
+			result += strings.ToUpper(string(v))
+			prevUnderscore = false
+		} else if v != '_' {
+			result += string(v)
+		} else {
+			prevUnderscore = true
+		}
+	}
+	return result
+}

--- a/controllers/workspace/metrics/failure_reason.go
+++ b/controllers/workspace/metrics/failure_reason.go
@@ -15,15 +15,18 @@
 
 package metrics
 
-type FailureReason struct {
-	reason string
-}
+import (
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/conditions"
+)
 
-var (
-	ReasonBadRequest             = FailureReason{reason: "BadRequest"}
-	ReasonInfrastructureFailure  = FailureReason{"InfrastructureFailure"}
-	ReasonWorkspaceEngineFailure = FailureReason{"WorkspaceEngineFailure"}
-	ReasonUnknown                = FailureReason{"Unknown"}
+type FailureReason string
+
+const (
+	ReasonBadRequest             FailureReason = "BadRequest"
+	ReasonInfrastructureFailure  FailureReason = "InfrastructureFailure"
+	ReasonWorkspaceEngineFailure FailureReason = "WorkspaceEngineFailure"
+	ReasonUnknown                FailureReason = "Unknown"
 )
 
 var devworkspaceFailureReasons = []FailureReason{
@@ -33,16 +36,14 @@ var devworkspaceFailureReasons = []FailureReason{
 	ReasonUnknown,
 }
 
-func (f *FailureReason) GetReason() string {
-	return f.reason
-}
-
-// GetFailureReasonFromStr returns the corresponding FailureReason given an input
-// string representation. The input string representation can be snake case or camel case.
-func GetFailureReasonFromStr(reason string) FailureReason {
-	for _, v := range devworkspaceFailureReasons {
-		if reason == v.reason {
-			return v
+// GetFailureReason returns the FailureReason of the provided DevWorkspace
+func GetFailureReason(wksp *dw.DevWorkspace) FailureReason {
+	failedCondition := conditions.GetConditionByType(wksp.Status.Conditions, dw.DevWorkspaceFailedStart)
+	if failedCondition != nil {
+		for _, reason := range devworkspaceFailureReasons {
+			if failedCondition.Reason == string(reason) {
+				return reason
+			}
 		}
 	}
 	return ReasonUnknown

--- a/controllers/workspace/metrics/failure_reason.go
+++ b/controllers/workspace/metrics/failure_reason.go
@@ -16,37 +16,32 @@
 package metrics
 
 type FailureReason struct {
-	snakeCase string
-	camelCase string
+	reason string
 }
 
 var (
-	ReasonBadRequest             = FailureReason{snakeCase: "bad_request", camelCase: "BadRequest"}
-	ReasonInfrastructureFailure  = FailureReason{snakeCase: "infrastructure_failure", camelCase: "InfrastructureFailure"}
-	ReasonWorkspaceEngineFailure = FailureReason{snakeCase: "workspace_engine_failure", camelCase: "WorkspaceEngineFailure"}
-	ReasonUnknown                = FailureReason{snakeCase: "unknown", camelCase: "Unknown"}
+	ReasonBadRequest             = FailureReason{reason: "BadRequest"}
+	ReasonInfrastructureFailure  = FailureReason{"InfrastructureFailure"}
+	ReasonWorkspaceEngineFailure = FailureReason{"WorkspaceEngineFailure"}
+	ReasonUnknown                = FailureReason{"Unknown"}
 )
 
-var devworkspaceFailureReasons [4]FailureReason = [4]FailureReason{
+var devworkspaceFailureReasons = []FailureReason{
 	ReasonBadRequest,
 	ReasonInfrastructureFailure,
 	ReasonWorkspaceEngineFailure,
 	ReasonUnknown,
 }
 
-func (f *FailureReason) CamelCase() string {
-	return f.camelCase
-}
-
-func (f *FailureReason) SnakeCase() string {
-	return f.snakeCase
+func (f *FailureReason) GetReason() string {
+	return f.reason
 }
 
 // GetFailureReasonFromStr returns the corresponding FailureReason given an input
 // string representation. The input string representation can be snake case or camel case.
 func GetFailureReasonFromStr(reason string) FailureReason {
 	for _, v := range devworkspaceFailureReasons {
-		if reason == v.snakeCase || reason == v.camelCase {
+		if reason == v.reason {
 			return v
 		}
 	}

--- a/controllers/workspace/metrics/metrics.go
+++ b/controllers/workspace/metrics/metrics.go
@@ -21,29 +21,11 @@ import (
 )
 
 const (
-	WorkspaceEngineFailurePrefix = "Workspace failure: "
-
 	workspaceSourceLabel     = "controller.devfile.io/devworkspace-source"
 	metricSourceLabel        = "source"
 	metricsRoutingClassLabel = "routingclass"
 	metricsReasonLabel       = "reason"
-
-	reasonBadRequest             = "bad_request"
-	reasonInfrastructureFailure  = "infrastructure_failure"
-	reasonWorkspaceEngineFailure = "workspace_engine_failure"
-	reasonUnknown                = "unknown"
 )
-
-var badRequestFailures = []string{
-	"CrashLoopBackOff",
-	"ErrImagePull",
-	"ImagePullBackOff",
-}
-
-var infrastructureFailures = []string{
-	"CreateContainerError",
-	"RunContainerError",
-}
 
 var (
 	workspaceTotal = prometheus.NewCounterVec(

--- a/controllers/workspace/metrics/metrics.go
+++ b/controllers/workspace/metrics/metrics.go
@@ -21,14 +21,17 @@ import (
 )
 
 const (
+	WorkspaceEngineFailurePrefix = "Workspace failure: "
+
 	workspaceSourceLabel     = "controller.devfile.io/devworkspace-source"
 	metricSourceLabel        = "source"
 	metricsRoutingClassLabel = "routingclass"
 	metricsReasonLabel       = "reason"
 
-	reasonBadRequest            = "bad_request"
-	reasonInfrastructureFailure = "infrastructure_failure"
-	reasonUnknown               = "unknown"
+	reasonBadRequest             = "bad_request"
+	reasonInfrastructureFailure  = "infrastructure_failure"
+	reasonWorkspaceEngineFailure = "workspace_engine_failure"
+	reasonUnknown                = "unknown"
 )
 
 var badRequestFailures = []string{

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -66,7 +66,7 @@ func incrementMetricForWorkspaceFailure(metric *prometheus.CounterVec, wksp *dw.
 		sourceLabel = "unknown"
 	}
 	reason := getFailureReason(wksp)
-	ctr, err := metric.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel, metricsReasonLabel: reason.SnakeCase()})
+	ctr, err := metric.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel, metricsReasonLabel: reason.GetReason()})
 	if err != nil {
 		log.Error(err, "Failed to increment metric")
 	}
@@ -75,7 +75,7 @@ func incrementMetricForWorkspaceFailure(metric *prometheus.CounterVec, wksp *dw.
 
 func getFailureReason(wksp *dw.DevWorkspace) FailureReason {
 	failedCondition := conditions.GetConditionByType(wksp.Status.Conditions, dw.DevWorkspaceFailedStart)
-	if failedCondition != nil && len(failedCondition.Reason) > 0 {
+	if failedCondition != nil && failedCondition.Reason != "" {
 		return GetFailureReasonFromStr(failedCondition.Reason)
 	}
 	return ReasonUnknown

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -79,6 +79,9 @@ func incrementMetricForWorkspaceFailure(metric *prometheus.CounterVec, wksp *dw.
 // determinateFailureReason scans devworkspace .status.message and try to match
 // it to the know category. Unknown is return when no one is matched
 func determinateFailureReason(wksp *dw.DevWorkspace) string {
+	if strings.HasPrefix(wksp.Status.Message, WorkspaceEngineFailurePrefix) {
+		return reasonWorkspaceEngineFailure
+	}
 	for _, failure := range badRequestFailures {
 		if strings.Contains(wksp.Status.Message, failure) {
 			return reasonBadRequest

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -65,20 +65,12 @@ func incrementMetricForWorkspaceFailure(metric *prometheus.CounterVec, wksp *dw.
 	if sourceLabel == "" {
 		sourceLabel = "unknown"
 	}
-	reason := getFailureReason(wksp)
-	ctr, err := metric.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel, metricsReasonLabel: reason.GetReason()})
+	reason := GetFailureReason(wksp)
+	ctr, err := metric.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel, metricsReasonLabel: string(reason)})
 	if err != nil {
 		log.Error(err, "Failed to increment metric")
 	}
 	ctr.Inc()
-}
-
-func getFailureReason(wksp *dw.DevWorkspace) FailureReason {
-	failedCondition := conditions.GetConditionByType(wksp.Status.Conditions, dw.DevWorkspaceFailedStart)
-	if failedCondition != nil && failedCondition.Reason != "" {
-		return GetFailureReasonFromStr(failedCondition.Reason)
-	}
-	return ReasonUnknown
 }
 
 func incrementStartTimeBucketForWorkspace(wksp *dw.DevWorkspace, log logr.Logger) {

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -113,6 +113,7 @@ func syncConditions(workspaceStatus *dw.DevWorkspaceStatus, currentStatus *curre
 				workspaceStatus.Conditions[idx].LastTransitionTime = currTransitionTime
 				workspaceStatus.Conditions[idx].Status = corev1.ConditionUnknown
 				workspaceStatus.Conditions[idx].Message = ""
+				workspaceStatus.Conditions[idx].Reason = ""
 			}
 			continue
 		}
@@ -122,6 +123,7 @@ func syncConditions(workspaceStatus *dw.DevWorkspaceStatus, currentStatus *curre
 			workspaceStatus.Conditions[idx].LastTransitionTime = currTransitionTime
 			workspaceStatus.Conditions[idx].Status = currCondition.Status
 			workspaceStatus.Conditions[idx].Message = currCondition.Message
+			workspaceStatus.Conditions[idx].Reason = currCondition.Reason
 		}
 	}
 
@@ -136,6 +138,7 @@ func syncConditions(workspaceStatus *dw.DevWorkspaceStatus, currentStatus *curre
 			Type:               condType,
 			Status:             cond.Status,
 			Message:            cond.Message,
+			Reason:             cond.Reason,
 		})
 	}
 

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -119,7 +119,7 @@ func syncConditions(workspaceStatus *dw.DevWorkspaceStatus, currentStatus *curre
 		}
 
 		// Update condition if needed
-		if workspaceCondition.Status != currCondition.Status || workspaceCondition.Message != currCondition.Message {
+		if workspaceCondition.Status != currCondition.Status || workspaceCondition.Message != currCondition.Message || workspaceCondition.Reason != currCondition.Reason {
 			workspaceStatus.Conditions[idx].LastTransitionTime = currTransitionTime
 			workspaceStatus.Conditions[idx].Status = currCondition.Status
 			workspaceStatus.Conditions[idx].Message = currCondition.Message

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	maputils "github.com/devfile/devworkspace-operator/internal/map"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"
@@ -59,19 +58,6 @@ var unrecoverablePodEventReasons = []string{
 	"FailedScheduling",
 	"FailedCreate",
 	"ReplicaSetCreateError",
-}
-
-var badRequestFailures = []string{
-	"CrashLoopBackOff",
-	"ErrImagePull",
-	"ImagePullBackOff",
-}
-
-var infrastructureFailures = []string{
-	"CreateContainerError",
-	"RunContainerError",
-	"FailedScheduling",
-	"FailedMount",
 }
 
 type DeploymentProvisioningStatus struct {
@@ -267,23 +253,6 @@ func GetDevWorkspaceSecurityContext() *corev1.PodSecurityContext {
 		}
 	}
 	return &corev1.PodSecurityContext{}
-}
-
-// DetermineStartupFailureReason scans a deployment failed startup message and returns
-// the corresponding failure reason.
-// Unknown reason is returned when failure reason cannot be found.
-func DetermineStartupFailureReason(failStartupMsg string) metrics.FailureReason {
-	for _, failure := range badRequestFailures {
-		if strings.Contains(failStartupMsg, failure) {
-			return metrics.ReasonBadRequest
-		}
-	}
-	for _, failure := range infrastructureFailures {
-		if strings.Contains(failStartupMsg, failure) {
-			return metrics.ReasonInfrastructureFailure
-		}
-	}
-	return metrics.ReasonUnknown
 }
 
 func checkDeploymentStatus(deployment *appsv1.Deployment) (ready bool) {

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	maputils "github.com/devfile/devworkspace-operator/internal/map"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/config"
@@ -58,6 +59,19 @@ var unrecoverablePodEventReasons = []string{
 	"FailedScheduling",
 	"FailedCreate",
 	"ReplicaSetCreateError",
+}
+
+var badRequestFailures = []string{
+	"CrashLoopBackOff",
+	"ErrImagePull",
+	"ImagePullBackOff",
+}
+
+var infrastructureFailures = []string{
+	"CreateContainerError",
+	"RunContainerError",
+	"FailedScheduling",
+	"FailedMount",
 }
 
 type DeploymentProvisioningStatus struct {
@@ -253,6 +267,23 @@ func GetDevWorkspaceSecurityContext() *corev1.PodSecurityContext {
 		}
 	}
 	return &corev1.PodSecurityContext{}
+}
+
+// DetermineStartupFailureReason scans a deployment failed startup message and returns
+// the corresponding failure reason.
+// Unknown reason is returned when failure reason cannot be found.
+func DetermineStartupFailureReason(failStartupMsg string) metrics.FailureReason {
+	for _, failure := range badRequestFailures {
+		if strings.Contains(failStartupMsg, failure) {
+			return metrics.ReasonBadRequest
+		}
+	}
+	for _, failure := range infrastructureFailures {
+		if strings.Contains(failStartupMsg, failure) {
+			return metrics.ReasonInfrastructureFailure
+		}
+	}
+	return metrics.ReasonUnknown
 }
 
 func checkDeploymentStatus(deployment *appsv1.Deployment) (ready bool) {


### PR DESCRIPTION
…l_total Prometheus metric

Signed-off-by: David Kwon <dakwon@redhat.com>

### What does this PR do?
Adds the `WorkspaceEngineFailure` to the list of failure reasons.
![image](https://user-images.githubusercontent.com/83611742/137388896-0a91deaa-e41a-4548-8609-9fa5966bfe3f.png)
![image](https://user-images.githubusercontent.com/83611742/137390777-c0d6b71d-ec12-40b7-a7fb-952c36f9015a.png)


The PR does this by adding a prefix to the workspace status when workspace is phase is set to `Failing` from the main reconciliation loop.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/pull/597

### Is it tested? How?
Used these steps: https://github.com/devfile/devworkspace-operator/tree/main/doc/grafana#testing-devworkspace-operator-metrics-locally.

To simulate a timeout error:
1. Set `config.workspace. progressTimeout` to `1s` in the `DevWorkspaceOperatorConfig` instance.
2. Create a new DevWorkspace

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
