### PR TITLE
Add blank line between license header and package

### DIFF
--- a/apis/controller/v1alpha1/common.go
+++ b/apis/controller/v1alpha1/common.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package v1alpha1
 
 import v1 "k8s.io/api/core/v1"

--- a/apis/controller/v1alpha1/devfile.go
+++ b/apis/controller/v1alpha1/devfile.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package v1alpha1
 
 type EndpointAttribute string

--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package v1alpha1
 
 import (

--- a/apis/controller/v1alpha1/devworkspacerouting_types.go
+++ b/apis/controller/v1alpha1/devworkspacerouting_types.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package v1alpha1
 
 import (

--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package devworkspacerouting
 
 import (

--- a/controllers/controller/devworkspacerouting/predicates.go
+++ b/controllers/controller/devworkspacerouting/predicates.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package devworkspacerouting
 
 import (

--- a/controllers/controller/devworkspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/basic_solver.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package solvers
 
 import (

--- a/controllers/controller/devworkspacerouting/solvers/cluster_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/cluster_solver.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package solvers
 
 import (

--- a/controllers/controller/devworkspacerouting/solvers/common.go
+++ b/controllers/controller/devworkspacerouting/solvers/common.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package solvers
 
 import (

--- a/controllers/controller/devworkspacerouting/solvers/errors.go
+++ b/controllers/controller/devworkspacerouting/solvers/errors.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package solvers
 
 import (

--- a/controllers/controller/devworkspacerouting/solvers/resolve_endpoints.go
+++ b/controllers/controller/devworkspacerouting/solvers/resolve_endpoints.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package solvers
 
 import (

--- a/controllers/controller/devworkspacerouting/solvers/solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/solver.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package solvers
 
 import (

--- a/controllers/controller/devworkspacerouting/sync_ingresses.go
+++ b/controllers/controller/devworkspacerouting/sync_ingresses.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package devworkspacerouting
 
 import (

--- a/controllers/controller/devworkspacerouting/sync_routes.go
+++ b/controllers/controller/devworkspacerouting/sync_routes.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package devworkspacerouting
 
 import (

--- a/controllers/controller/devworkspacerouting/sync_services.go
+++ b/controllers/controller/devworkspacerouting/sync_services.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package devworkspacerouting
 
 import (

--- a/controllers/workspace/condition.go
+++ b/controllers/workspace/condition.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package controllers
 
 import (

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package controllers
 
 import (

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package controllers
 
 import (

--- a/controllers/workspace/metrics/metrics.go
+++ b/controllers/workspace/metrics/metrics.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package metrics
 
 import (

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package metrics
 
 import (

--- a/controllers/workspace/predicates.go
+++ b/controllers/workspace/predicates.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package controllers
 
 import (

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package controllers
 
 import (

--- a/controllers/workspace/validation.go
+++ b/controllers/workspace/validation.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package controllers
 
 import (

--- a/internal/map/map.go
+++ b/internal/map/map.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package maputils
 
 func Append(target map[string]string, key, value string) map[string]string {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package main
 
 import (

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package common
 
 import (

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package conditions
 
 import dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"

--- a/pkg/config/configmap/config.go
+++ b/pkg/config/configmap/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package configmap
 
 import (

--- a/pkg/config/configmap/doc.go
+++ b/pkg/config/configmap/doc.go
@@ -22,4 +22,5 @@
 // - . is used to separate subcomponents
 // - _ is used to separate words in the component name
 //
+
 package configmap

--- a/pkg/config/configmap/property.go
+++ b/pkg/config/configmap/property.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package configmap
 
 const (

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package config
 
 import "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package config
 
 import (

--- a/pkg/config/predicates.go
+++ b/pkg/config/predicates.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package config
 
 import (

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package config
 
 import (

--- a/pkg/config/sync_test.go
+++ b/pkg/config/sync_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package config
 
 import (

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package constants
 
 // Constants that are used in attributes on DevWorkspace elements (components, endpoints, etc.)

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package constants
 
 const (

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package constants
 
 // Constants that are used in labels and annotation on DevWorkspace-related resources.

--- a/pkg/infrastructure/cluster.go
+++ b/pkg/infrastructure/cluster.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package infrastructure
 
 import (

--- a/pkg/infrastructure/namespace.go
+++ b/pkg/infrastructure/namespace.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package infrastructure
 
 import (

--- a/pkg/infrastructure/webhook.go
+++ b/pkg/infrastructure/webhook.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package infrastructure
 
 import (

--- a/pkg/library/annotate/annotations.go
+++ b/pkg/library/annotate/annotations.go
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package annotate

--- a/pkg/library/annotate/plugins.go
+++ b/pkg/library/annotate/plugins.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package annotate
 
 import (

--- a/pkg/library/annotate/urls.go
+++ b/pkg/library/annotate/urls.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package annotate
 
 import (

--- a/pkg/library/container/container_test.go
+++ b/pkg/library/container/container_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package container
 
 import (

--- a/pkg/library/container/conversion.go
+++ b/pkg/library/container/conversion.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package container
 
 import (

--- a/pkg/library/container/mountSources.go
+++ b/pkg/library/container/mountSources.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package container
 
 import (

--- a/pkg/library/flatten/common.go
+++ b/pkg/library/flatten/common.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package flatten
 
 import dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"

--- a/pkg/library/flatten/flatten.go
+++ b/pkg/library/flatten/flatten.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package flatten
 
 import (

--- a/pkg/library/flatten/flatten_test.go
+++ b/pkg/library/flatten/flatten_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package flatten
 
 import (

--- a/pkg/library/flatten/helper.go
+++ b/pkg/library/flatten/helper.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package flatten
 
 import (

--- a/pkg/library/flatten/internal/testutil/common.go
+++ b/pkg/library/flatten/internal/testutil/common.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package testutil
 
 import (

--- a/pkg/library/flatten/internal/testutil/http.go
+++ b/pkg/library/flatten/internal/testutil/http.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package testutil
 
 import (

--- a/pkg/library/flatten/internal/testutil/internalRegistry.go
+++ b/pkg/library/flatten/internal/testutil/internalRegistry.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package testutil
 
 import (

--- a/pkg/library/flatten/internal/testutil/k8sClient.go
+++ b/pkg/library/flatten/internal/testutil/k8sClient.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package testutil
 
 import (

--- a/pkg/library/flatten/internal_registry/registry.go
+++ b/pkg/library/flatten/internal_registry/registry.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package registry
 
 import (

--- a/pkg/library/flatten/merge.go
+++ b/pkg/library/flatten/merge.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package flatten
 
 import (

--- a/pkg/library/flatten/network/devfile.go
+++ b/pkg/library/flatten/network/devfile.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package network
 
 import (

--- a/pkg/library/flatten/network/fetch.go
+++ b/pkg/library/flatten/network/fetch.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package network
 
 import (

--- a/pkg/library/flatten/workspaceEnv.go
+++ b/pkg/library/flatten/workspaceEnv.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package flatten
 
 import (

--- a/pkg/library/lifecycle/command.go
+++ b/pkg/library/lifecycle/command.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package lifecycle
 
 import (

--- a/pkg/library/lifecycle/common.go
+++ b/pkg/library/lifecycle/common.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package lifecycle
 
 func listContains(query string, list []string) bool {

--- a/pkg/library/lifecycle/lifecycle.go
+++ b/pkg/library/lifecycle/lifecycle.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package lifecycle
 
 import (

--- a/pkg/library/lifecycle/lifecycle_test.go
+++ b/pkg/library/lifecycle/lifecycle_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package lifecycle
 
 import (

--- a/pkg/provision/config/config.go
+++ b/pkg/provision/config/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package config
 
 import (

--- a/pkg/provision/metadata/envvar.go
+++ b/pkg/provision/metadata/envvar.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package metadata
 
 import (

--- a/pkg/provision/metadata/errors.go
+++ b/pkg/provision/metadata/errors.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package metadata
 
 import (

--- a/pkg/provision/metadata/metadata.go
+++ b/pkg/provision/metadata/metadata.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package metadata
 
 import (

--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package storage
 
 import (

--- a/pkg/provision/storage/asyncstorage/configmap.go
+++ b/pkg/provision/storage/asyncstorage/configmap.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package asyncstorage
 
 import (

--- a/pkg/provision/storage/asyncstorage/configuration.go
+++ b/pkg/provision/storage/asyncstorage/configuration.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package asyncstorage
 
 import (

--- a/pkg/provision/storage/asyncstorage/constants.go
+++ b/pkg/provision/storage/asyncstorage/constants.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package asyncstorage
 
 const (

--- a/pkg/provision/storage/asyncstorage/errors.go
+++ b/pkg/provision/storage/asyncstorage/errors.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package asyncstorage
 
 import "errors"

--- a/pkg/provision/storage/asyncstorage/secret.go
+++ b/pkg/provision/storage/asyncstorage/secret.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package asyncstorage
 
 import (

--- a/pkg/provision/storage/asyncstorage/service.go
+++ b/pkg/provision/storage/asyncstorage/service.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package asyncstorage
 
 import (

--- a/pkg/provision/storage/asyncstorage/sidecar.go
+++ b/pkg/provision/storage/asyncstorage/sidecar.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package asyncstorage
 
 import (

--- a/pkg/provision/storage/asyncstorage/ssh.go
+++ b/pkg/provision/storage/asyncstorage/ssh.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package asyncstorage
 
 import (

--- a/pkg/provision/storage/asyncstorage/volume.go
+++ b/pkg/provision/storage/asyncstorage/volume.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package asyncstorage
 
 import corev1 "k8s.io/api/core/v1"

--- a/pkg/provision/storage/cleanup.go
+++ b/pkg/provision/storage/cleanup.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package storage
 
 import (

--- a/pkg/provision/storage/commonStorage.go
+++ b/pkg/provision/storage/commonStorage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package storage
 
 import (

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package storage
 
 import (

--- a/pkg/provision/storage/ephemeralStorage.go
+++ b/pkg/provision/storage/ephemeralStorage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package storage
 
 import (

--- a/pkg/provision/storage/ephemeralStorage_test.go
+++ b/pkg/provision/storage/ephemeralStorage_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package storage
 
 import (

--- a/pkg/provision/storage/errors.go
+++ b/pkg/provision/storage/errors.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package storage
 
 import (

--- a/pkg/provision/storage/provisioner.go
+++ b/pkg/provision/storage/provisioner.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package storage
 
 import (

--- a/pkg/provision/storage/shared.go
+++ b/pkg/provision/storage/shared.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package storage
 
 import (

--- a/pkg/provision/workspace/automount/common.go
+++ b/pkg/provision/workspace/automount/common.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package automount
 
 import (

--- a/pkg/provision/workspace/automount/common_test.go
+++ b/pkg/provision/workspace/automount/common_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package automount
 
 import (

--- a/pkg/provision/workspace/automount/configmaps.go
+++ b/pkg/provision/workspace/automount/configmaps.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package automount
 
 import (

--- a/pkg/provision/workspace/automount/git-credentials.go
+++ b/pkg/provision/workspace/automount/git-credentials.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package automount
 
 import (

--- a/pkg/provision/workspace/automount/pvcs.go
+++ b/pkg/provision/workspace/automount/pvcs.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package automount
 
 import (

--- a/pkg/provision/workspace/automount/secret.go
+++ b/pkg/provision/workspace/automount/secret.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package automount
 
 import (

--- a/pkg/provision/workspace/commonenv.go
+++ b/pkg/provision/workspace/commonenv.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/pkg/provision/workspace/data_types.go
+++ b/pkg/provision/workspace/data_types.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/pkg/provision/workspace/object.go
+++ b/pkg/provision/workspace/object.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/pkg/provision/workspace/pull_secret.go
+++ b/pkg/provision/workspace/pull_secret.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/pkg/provision/workspace/rbac.go
+++ b/pkg/provision/workspace/rbac.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/pkg/provision/workspace/routing.go
+++ b/pkg/provision/workspace/routing.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/pkg/provision/workspace/serviceaccount.go
+++ b/pkg/provision/workspace/serviceaccount.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/pkg/timing/annotations.go
+++ b/pkg/timing/annotations.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package timing
 
 import (

--- a/pkg/timing/timing.go
+++ b/pkg/timing/timing.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package timing
 
 import (

--- a/pkg/webhook/cluster_role_bindings.go
+++ b/pkg/webhook/cluster_role_bindings.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package webhook
 
 import (

--- a/pkg/webhook/cluster_roles.go
+++ b/pkg/webhook/cluster_roles.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package webhook
 
 import (

--- a/pkg/webhook/create.go
+++ b/pkg/webhook/create.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package webhook
 
 import (

--- a/pkg/webhook/deployment.go
+++ b/pkg/webhook/deployment.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package webhook
 
 import (

--- a/pkg/webhook/info.go
+++ b/pkg/webhook/info.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package webhook
 
 import (

--- a/pkg/webhook/init_cfg.go
+++ b/pkg/webhook/init_cfg.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package webhook
 
 import (

--- a/pkg/webhook/kubernetes/tls.go
+++ b/pkg/webhook/kubernetes/tls.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package webhook_k8s
 
 import (

--- a/pkg/webhook/openshift/tls.go
+++ b/pkg/webhook/openshift/tls.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package webhook_openshift
 
 import (

--- a/pkg/webhook/service/log.go
+++ b/pkg/webhook/service/log.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package service
 
 import logf "sigs.k8s.io/controller-runtime/pkg/log"

--- a/pkg/webhook/service/service.go
+++ b/pkg/webhook/service/service.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package service
 
 import (

--- a/pkg/webhook/service_account.go
+++ b/pkg/webhook/service_account.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package webhook
 
 import (

--- a/project-clone/internal/devfile.go
+++ b/project-clone/internal/devfile.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package internal
 
 import (

--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package git
 
 import (

--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package git
 
 import (

--- a/project-clone/internal/global.go
+++ b/project-clone/internal/global.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package internal
 
 import (

--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package shell
 
 import (

--- a/project-clone/internal/utils.go
+++ b/project-clone/internal/utils.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package internal
 
 import (

--- a/project-clone/internal/zip/setup.go
+++ b/project-clone/internal/zip/setup.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package zip
 
 import (

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package main
 
 import (

--- a/test/e2e/cmd/workspaces_test.go
+++ b/test/e2e/cmd/workspaces_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package cmd
 
 import (

--- a/test/e2e/pkg/client/client.go
+++ b/test/e2e/pkg/client/client.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package client
 
 import (

--- a/test/e2e/pkg/client/devws.go
+++ b/test/e2e/pkg/client/devws.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package client
 
 import (

--- a/test/e2e/pkg/client/namespace.go
+++ b/test/e2e/pkg/client/namespace.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package client
 
 import (

--- a/test/e2e/pkg/client/oc.go
+++ b/test/e2e/pkg/client/oc.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package client
 
 import (

--- a/test/e2e/pkg/client/pod.go
+++ b/test/e2e/pkg/client/pod.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package client
 
 import (

--- a/test/e2e/pkg/client/rbac.go
+++ b/test/e2e/pkg/client/rbac.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package client
 
 import (

--- a/test/e2e/pkg/client/webhooks.go
+++ b/test/e2e/pkg/client/webhooks.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package client
 
 import (

--- a/test/e2e/pkg/config/config.go
+++ b/test/e2e/pkg/config/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package config
 
 import "github.com/devfile/devworkspace-operator/test/e2e/pkg/client"

--- a/test/e2e/pkg/metadata/metadata.go
+++ b/test/e2e/pkg/metadata/metadata.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package metadata
 
 type OperatorNamespace struct {

--- a/test/e2e/pkg/tests/devworkspaces_tests.go
+++ b/test/e2e/pkg/tests/devworkspaces_tests.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package tests
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package version
 
 var (

--- a/webhook/main.go
+++ b/webhook/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package main
 
 import (

--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package server
 
 import (

--- a/webhook/workspace/config.go
+++ b/webhook/workspace/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/webhook/workspace/handler/deployment.go
+++ b/webhook/workspace/handler/deployment.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import (

--- a/webhook/workspace/handler/exec.go
+++ b/webhook/workspace/handler/exec.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import (

--- a/webhook/workspace/handler/handler.go
+++ b/webhook/workspace/handler/handler.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import (

--- a/webhook/workspace/handler/immutable.go
+++ b/webhook/workspace/handler/immutable.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import (

--- a/webhook/workspace/handler/kind.go
+++ b/webhook/workspace/handler/kind.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import (

--- a/webhook/workspace/handler/log.go
+++ b/webhook/workspace/handler/log.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import logf "sigs.k8s.io/controller-runtime/pkg/log"

--- a/webhook/workspace/handler/metadata.go
+++ b/webhook/workspace/handler/metadata.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import (

--- a/webhook/workspace/handler/pod.go
+++ b/webhook/workspace/handler/pod.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import (

--- a/webhook/workspace/handler/validate.go
+++ b/webhook/workspace/handler/validate.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import (

--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package handler
 
 import (

--- a/webhook/workspace/log.go
+++ b/webhook/workspace/log.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import logf "sigs.k8s.io/controller-runtime/pkg/log"

--- a/webhook/workspace/mutate.go
+++ b/webhook/workspace/mutate.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/webhook/workspace/mutating_cfg.go
+++ b/webhook/workspace/mutating_cfg.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/webhook/workspace/validate.go
+++ b/webhook/workspace/validate.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (

--- a/webhook/workspace/validating_cfg.go
+++ b/webhook/workspace/validating_cfg.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package workspace
 
 import (


### PR DESCRIPTION
### What does this PR do?
The updated license headers do not have a blank line between the license
body and the 'package XXXXX' directive. This results in Go treating the
license header as package documentation, which is not desired.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
