### PR TITLE
feat: Allow to clone git-lfs repositories

### DIFF
--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -38,7 +38,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM registry.access.redhat.com/ubi8-minimal:8.4-208
-RUN microdnf -y update && microdnf install -y time git && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
+RUN microdnf -y update && microdnf install -y time git git-lfs && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/project-clone
 


### PR DESCRIPTION
### What does this PR do?
Make it working when using git/LFS repositories

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20642

### Is it tested? How?
Try to clone https://github.com/Apress/repo-with-large-file-storage

Expect to see a Zip file with 199MB and not a few bytes containing

```
oid sha256:6e1b890dafa9956b1bdff43b3fd46aaf273085a1d2041bde7efce6cf5eb0262b
size 207809687
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [x] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
