### PR TITLE
Install a newer version of cert manager that's supported on newer ver…

### DIFF
--- a/build/make/deploy.mk
+++ b/build/make/deploy.mk
@@ -128,9 +128,9 @@ _login_with_devworkspace_sa:
 	echo "Logging as controller's SA in $(NAMESPACE)"
 	oc login --token=$(SA_TOKEN) --kubeconfig=$(BUMPED_KUBECONFIG)
 
-### install_cert_manager: Installs Cert Mananger v1.0.4 on the cluster
+### install_cert_manager: Installs Cert Mananger v1.5.4 on the cluster
 install_cert_manager:
-	${K8S_CLI} apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.yaml
+	${K8S_CLI} apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
 
 # it's easier to bump whole kubeconfig instead of grabbing cluster URL from the current context
 _bump_kubeconfig:


### PR DESCRIPTION
…sions of kubernetes

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>
(cherry picked from commit 4afa331672bc27aef6d0c89b46f7ceb7002c4749)

### What does this PR do?
Updates cert-manager so that it can be used on the newest version of kubernetes. The old cert manager fails because it's trying to use too old of a version of mutatingwebhookconfigurations

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
