### PR TITLE
Add scorecard tests to operator bundle

### DIFF
--- a/deploy/bundle/tests/scorecard/config.yaml
+++ b/deploy/bundle/tests/scorecard/config.yaml
@@ -4,4 +4,68 @@ metadata:
   name: config
 stages:
 - parallel: true
-  tests: []
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  # Default test bootstrapped in new operator-sdk projects; currently failing for DWO.
+  # - entrypoint:
+  #   - scorecard-test
+  #   - olm-crds-have-resources
+  #   image: quay.io/operator-framework/scorecard-test:v1.13.1
+  #   labels:
+  #     suite: olm
+  #     test: olm-crds-have-resources-test
+  #   storage:
+  #     spec:
+  #       mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
### What does this PR do?
Adds scorecard tests to the OLM bundle. These are the defaults generated by current versions of `operator-sdk`, minus one that will require updating CRDs.

### What issues does this PR fix or reference?
Workaround for a release blocker, potentially.

### Is it tested? How?
```
export DWO_BUNDLE_IMG=<image>
make build_bundle_image
operator-sdk scorecard --config deploy/bundle/tests/scorecard/config.yaml ${DWO_BUNDLE_IMG}
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
