### PR TITLE
Treat all 4xx status codes as "unimplemented" when doing server check

### DIFF
--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -172,12 +172,8 @@ func checkServerStatus(workspace *dw.DevWorkspace) (ok bool, err error) {
 	if err != nil {
 		return false, err
 	}
-	if resp.StatusCode == 401 || resp.StatusCode == 403 {
-		// Assume endpoint is unimplemented and * is covered with authentication.
-		return true, nil
-	}
-	if resp.StatusCode == 404 {
-		// Compatibility: assume endpoint is unimplemented.
+	if (resp.StatusCode / 100) == 4 {
+		// Assume endpoint is unimplemented and/or * is covered with authentication.
 		return true, nil
 	}
 	ok = (resp.StatusCode / 100) == 2


### PR DESCRIPTION
### What does this PR do?
Some editors return HTTP 400 for the /healthz endpoint, breaking the
server readiness check and leaving DevWorkspaces in a "Waiting for
editor to start" state forever. Since health checks are kind of flaky to
begin with, this commit relaxes the check to treat any 4xx response code
as "unimplemented or behind auth" in order to not block workspace
startup.

### What issues does this PR fix or reference?
Issue in another PR: https://github.com/devfile/devworkspace-operator/pull/659#issuecomment-953785318

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
