### PR TITLE
Update release process to accomodate downstream process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,8 @@ jobs:
 
       - name: Release
         run: |
-          git config --global user.name "Mykhailo Kuznietsov"
-          git config --global user.email "mkuznets@redhat.com"
+          git config --global user.name "Angel Misevski"
+          git config --global user.email "amisevsk@redhat.com"
 
           export GITHUB_TOKEN=${{ secrets.CHE_INCUBATOR_BOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
### What does this PR do?
Update the make-release script to more closely align with what's expected in downstreams:

1. Make the '--prerelease' flag create a release branch (e.g. 0.8.x) and update all images/versions in templates to reflect the next version (e.g. v0.8.0)
2. Make the '--release' flag just tag the current commit as released and build the current release's quay images (e.g. tagged v0.8.0). Afterwards, bump images/version in templates to the next bugfix version (e.g. v0.8.1)

This makes it so that commits can be freely cherry-picked to release branches, and make-release can be used with the --release flag to tag commits for each bugfix version.

### What issues does this PR fix or reference?
The `--release` step creates a new commit, making it hard to match the tested commit in the release branch with the commit that gets tagged, e.g. the commit history for the `0.9.x` branch looks like:
```shortlog
* 8e1f518 - (upstream/0.9.x) [release] Bump to 0.9.1 in 0.9.x mkuznets@redhat.com (8 weeks ago)
* d20389a - (tag: v0.9.0) [release] Release v0.9.0 mkuznets@redhat.com (8 weeks ago)
* b3f84b2 - [prerelease] Remove dev from version sleshche@redhat.com (9 weeks ago)
* [main branch...]
```
Ideally we would test and use `d20389a` for release, but instead we have to test on `b3f84b2` since the tag and commit are created at the same time.

### Is it tested? How?
Tested by running locally with `--dry-run`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
