### PR TITLE
Remove sleshche from codeowners, make JPinkney a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @sleshchenko @amisevsk
+* @amisevsk @JPinkney

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
 reviewers:
-  - sleshchenko
   - amisevsk
   - jpinkney
 approvers:
-  - sleshchenko
   - amisevsk
   - jpinkney
 component: DevWorkspace Operator

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -428,8 +428,6 @@ spec:
   maintainers:
   - email: amisevsk@redhat.com
     name: Angel Misevski
-  - email: sleshche@redhat.com
-    name: Serhii Leshchenko
   - email: jpinkney@redhat.com
     name: Josh Pinkney
   maturity: alpha

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -87,8 +87,6 @@ spec:
   maintainers:
   - email: amisevsk@redhat.com
     name: Angel Misevski
-  - email: sleshche@redhat.com
-    name: Serhii Leshchenko
   - email: jpinkney@redhat.com
     name: Josh Pinkney
   maturity: alpha


### PR DESCRIPTION
### What does this PR do?
* Remove @sleshchenko as codeowner (:cry:) 
* Make @JPinkney a codeowner (no idea why that wasn't already the case)

So long Serhii, nice workin' with you :tada: 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
