### PR TITLE
Build OLM bundle and index on releases

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -52,7 +52,7 @@ jobs:
     env:
       DWO_BUNDLE_IMG: quay.io/devfile/devworkspace-operator-bundle:next
       DWO_INDEX_IMG: quay.io/devfile/devworkspace-operator-index:next
-      OPM_VERSION: v1.17.1
+      OPM_VERSION: v1.19.1
       OPERATOR_SDK_VERSION: v1.8.0
     steps:
 

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -107,10 +107,6 @@ jobs:
 
       - name: "Build Bundle & Index images"
         run: |
-          # next OLM images is just for quick testing and don't have all versions.
-          # so, drop it from there
-          sed -i '/replaces: devworkspace-operator.v*/d' deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
-
           make build_bundle_image build_index_image
 
       - name: "Docker Logout"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ifneq (,$(shell which kubectl 2>/dev/null)$(shell which oc 2>/dev/null))
 endif
 
 OPERATOR_SDK_VERSION = v1.8.0
-OPM_VERSION = v1.17.1
+OPM_VERSION = v1.19.1
 
 CONTROLLER_GEN_VERSION = v0.6.1
 CONTROLLER_GEN=$(GOBIN)/controller-gen-$(CONTROLLER_GEN_VERSION)

--- a/build/index.next.Dockerfile
+++ b/build/index.next.Dockerfile
@@ -1,0 +1,14 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM quay.io/operator-framework/opm:latest
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs"]
+
+# Copy declarative config root into image at /configs
+ADD olm-catalog/next /configs
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/build/index.release.Dockerfile
+++ b/build/index.release.Dockerfile
@@ -1,0 +1,14 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM quay.io/operator-framework/opm:latest
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs"]
+
+# Copy declarative config root into image at /configs
+ADD olm-catalog/release /configs
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/build/scripts/build_index_image.sh
+++ b/build/scripts/build_index_image.sh
@@ -68,7 +68,7 @@ parse_args "$@"
 if [ "$RELEASE" == "true" ]; then
   # Set up for release and check arguments
   BUNDLE_REPO="${BUNDLE_REPO:-DEFAULT_BUNDLE_REPO}"
-  if [ -z $BUNDLE_TAG ]; then
+  if [ -z "$BUNDLE_TAG" ]; then
     error "Argument --bundle-tag is required when --release is specified (should be release version)"
   fi
   TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
@@ -105,6 +105,7 @@ LATEST_MINOR_RELEASE=$(echo "$CHANNEL_ENTRIES" | grep "\.0$" | sort -V | tail -n
 LATEST_BUGFIX=$(echo "$CHANNEL_ENTRIES" | grep "${LATEST_MINOR_RELEASE%.0}" | sort -V | tail -n 1)
 
 if [ "$RELEASE" == "true" ]; then
+  # shellcheck disable=SC2016
   yq -Yi --arg replaces "$LATEST_BUGFIX" '.spec.replaces = $replaces' \
     deploy/templates/components/csv/clusterserviceversion.yaml
 else
@@ -143,6 +144,7 @@ echo "Adding $BUNDLE_NAME to channel"
 if [ "$RELEASE" == "true" ]; then
   # Generate a new channel entry that replaces the last release
   # TODO: Also generate a skipRange so that e.g. v0.10.0 replaces v0.9.3 and skips v0.9.0-v0.9.2
+  # shellcheck disable=SC2016
   ENTRY_JSON=$(yq --arg replaces "$LATEST_BUGFIX" '{name, replaces: $replaces}' "$BUNDLE_FILE")
 else
   # Generate a basic entry with no upgrade path for nightly releases

--- a/build/scripts/build_index_image.sh
+++ b/build/scripts/build_index_image.sh
@@ -9,7 +9,12 @@ DEBUG="false"
 DEFAULT_BUNDLE_REPO="quay.io/devfile/devworkspace-operator-bundle"
 DEFAULT_BUNDLE_TAG="next"
 DEFAULT_INDEX_IMAGE="quay.io/devfile/devworkspace-operator-index:next"
+DEFAULT_RELEASE_INDEX_IMAGE="quay.io/devfile/devworkspace-operator-index:release"
 
+error() {
+  echo "[ERROR] $1"
+  exit 1
+}
 
 usage() {
 cat <<EOF
@@ -19,6 +24,12 @@ Usage:
   $0 [args...]
 
 Arguments:
+  --release               : Build bundle and index as part of a release (i.e. include an upgrade path
+                            from previous versions of the operator). This option overrides defaults below.
+                            If specified, the --bundle-tag argument is required, and must be in the format
+                            'vX.Y.Z'
+                            ** Use of this argument requires all previous releases to be present in **
+                            ** olm-catalog/release. This is a manual process                        **
   --bundle-repo <REPO>    : Image repo to use for OLM bundle image (default: $DEFAULT_BUNDLE_REPO)
   --bundle-tag <TAG>      : Image tag to use for the OLM bundle image (default: $DEFAULT_BUNDLE_TAG)
   --index-image <IMAGE>   : Image repo to use for OLM index image (default: $DEFAULT_INDEX_IMAGE)
@@ -31,7 +42,7 @@ Examples:
   1. Build and push bundle and index using default image repos
       $0 --force
   2. Build index and bundle using custom images
-      $0 --bundle-image <my_bundle_image> --index-image <my_index_image>
+      $0 --bundle-repo <my_bundle_repo> --bundle-tag dev --index-image <my_index_image>
 
 EOF
 }
@@ -43,6 +54,7 @@ parse_args() {
       '--bundle-tag') BUNDLE_TAG="$2"; shift 1;;
       '--index-image') INDEX_IMAGE="$2"; shift 1;;
       '--container-tool') PODMAN="$2"; shift 1;;
+      '--release') RELEASE="true";;
       '--force') FORCE="true";;
       '--debug') DEBUG="true";;
       *) echo "[ERROR] Unknown parameter is used: $1."; usage; exit 1;;
@@ -53,14 +65,29 @@ parse_args() {
 
 parse_args "$@"
 
-# Set defaults and warn if pushing to main repos in case of accident
-BUNDLE_REPO="${BUNDLE_REPO:-DEFAULT_BUNDLE_REPO}"
-BUNDLE_TAG="${BUNDLE_TAG:-DEFAULT_BUNDLE_TAG}"
-INDEX_IMAGE="${INDEX_IMAGE:-DEFAULT_INDEX_IMAGE}"
-OUTDIR="olm-catalog/next"
+if [ "$RELEASE" == "true" ]; then
+  # Set up for release and check arguments
+  BUNDLE_REPO="${BUNDLE_REPO:-DEFAULT_BUNDLE_REPO}"
+  if [ -z $BUNDLE_TAG ]; then
+    error "Argument --bundle-tag is required when --release is specified (should be release version)"
+  fi
+  TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
+  if [[ ! "$BUNDLE_TAG" =~ $TAG_REGEX ]]; then
+    error "Bundle tag must be specified in the format vX.Y.Z"
+  fi
+  INDEX_IMAGE="${INDEX_IMAGE:-DEFAULT_RELEASE_INDEX_IMAGE}"
+  OUTDIR="olm-catalog/release"
+else
+  # Set defaults and warn if pushing to main repos in case of accident
+  BUNDLE_REPO="${BUNDLE_REPO:-DEFAULT_BUNDLE_REPO}"
+  BUNDLE_TAG="${BUNDLE_TAG:-DEFAULT_BUNDLE_TAG}"
+  INDEX_IMAGE="${INDEX_IMAGE:-DEFAULT_INDEX_IMAGE}"
+  OUTDIR="olm-catalog/next"
+fi
 
 BUNDLE_IMAGE="${BUNDLE_REPO}:${BUNDLE_TAG}"
 
+# Check we're not accidentally pushing to the DWO repos
 if [ "$BUNDLE_REPO" == "quay.io/devfile/devworkspace-operator-bundle" ] && [ "$FORCE" != "true" ]; then
   echo -n "Are you sure you want to push $BUNDLE_IMAGE? [y/N] " && read -r ans && [ "${ans:-N}" = y ] || exit 1
 fi
@@ -75,7 +102,7 @@ $PODMAN build . -t "$BUNDLE_IMAGE" -f build/bundle.Dockerfile | sed 's|^|    |'
 $PODMAN push "$BUNDLE_IMAGE" 2>&1 | sed 's|^|    |'
 
 BUNDLE_SHA=$(skopeo inspect "docker://${BUNDLE_IMAGE}" | jq -r '.Digest')
-BUNDLE_DIGEST="${BUNDLE_IMAGE}@${BUNDLE_SHA}"
+BUNDLE_DIGEST="${BUNDLE_REPO}@${BUNDLE_SHA}"
 echo "Using bundle image $BUNDLE_DIGEST for index"
 
 # Minor workaround to generate bundle file name from bundle: store file in variable
@@ -84,30 +111,48 @@ BUNDLE_YAML=$(opm render "$BUNDLE_DIGEST" --output yaml | sed '/---/d')
 BUNDLE_NAME="$(echo "$BUNDLE_YAML" | yq -r ".name")"
 BUNDLE_FILE="${OUTDIR}/${BUNDLE_NAME}.bundle.yaml"
 if [ -f "$BUNDLE_FILE" ]; then
-  echo "[ERROR] Bundle file $BUNDLE_FILE already exists"
-  exit 1
+  error "Bundle file $BUNDLE_FILE already exists"
 fi
 echo "$BUNDLE_YAML" > "$BUNDLE_FILE"
 
 # Check if bundle with this version is already present in channel
 # shellcheck disable=SC2016
 if yq -e --arg bundle_name "$BUNDLE_NAME" '[.entries[]?.name] | any(. == $bundle_name)' "$CHANNEL_FILE" >/dev/null; then
-  echo "[ERROR] Bundle $BUNDLE_NAME is already present in the channel $CHANNEL_FILE"
-  exit 1
+  error "Bundle $BUNDLE_NAME is already present in the channel $CHANNEL_FILE"
 fi
 
 # Add bundle entry to channel
 echo "Adding $BUNDLE_NAME to channel"
-ENTRY_JSON=$(yq '{name}' "$BUNDLE_FILE")
+if [ "$RELEASE" == "true" ]; then
+  # We need to add a replaces and potentially skipRange field to the channel entry
+  ENTRIES=$(yq -r '.entries[]?.name' "$CHANNEL_FILE")
+  if [ "${BUNDLE_TAG##*.}" != "0" ]; then
+    # Bugfix release: replace previous bugfix release for this minor version.
+    CURR_MAJOR_MINOR="${BUNDLE_NAME%.*}" # Current release, without bugfix
+    PREV_BUGFIX=$(echo "$ENTRIES" | grep "$CURR_MAJOR_MINOR" | sort -V | tail -n 1)
+    ENTRY_JSON=$(yq --arg prev_bugfix "$PREV_BUGFIX" '{name, replaces: $prev_bugfix}' "$BUNDLE_FILE")
+  else
+    # Non-bugfix release: replace previous vX.Y.0 version; skipRange bugfixes for it.
+    LATEST_MINOR=$(echo "$ENTRIES" | grep "\.0$" | sort -V | tail -n 1) # latest non-bugfix release (devworkspace-operator.vX.Y.0)
+    LATEST_MINOR_BUGFIX=$(echo "$ENTRIES" | grep "${LATEST_MINOR%.0}" | sort -V | tail -n 1) # latest bugfix for this minor release
+    SKIP_RANGE=">=${LATEST_MINOR#*.v} <=${LATEST_MINOR_BUGFIX#*.v}" # build version range, dropping 'devworkspace-operator.v' from start
+    ENTRY_JSON=$(yq --arg skip_range "$SKIP_RANGE" --arg replaces "$LATEST_MINOR_BUGFIX" '{name, replaces: $replaces, skipRange: $skip_range}' "$BUNDLE_FILE" )
+  fi
+else
+  ENTRY_JSON=$(yq '{name}' "$BUNDLE_FILE")
+fi
 # shellcheck disable=SC2016
 yq -Y -i --argjson entry "$ENTRY_JSON" '.entries |= . + [$entry]' "$CHANNEL_FILE"
+
+echo "Validating current index"
+opm validate "$OUTDIR"
 
 # Build index container
 echo "Building index image $INDEX_IMAGE"
 $PODMAN build . -t "$INDEX_IMAGE" -f build/index.next.Dockerfile | sed 's|^|    |'
 $PODMAN push "$INDEX_IMAGE" 2>&1 | sed 's|^|    |'
 
-if [ $DEBUG != "true" ]; then
+if [ $DEBUG != "true" ] && [ "$RELEASE" != "true" ]; then
   echo "Cleaning up"
   git restore "$OUTDIR"
   git clean -fd "$OUTDIR"

--- a/build/scripts/build_index_image.sh
+++ b/build/scripts/build_index_image.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -e
+
+PODMAN=podman
+FORCE="false"
+DEBUG="false"
+
+DEFAULT_BUNDLE_REPO="quay.io/devfile/devworkspace-operator-bundle"
+DEFAULT_BUNDLE_TAG="next"
+DEFAULT_INDEX_IMAGE="quay.io/devfile/devworkspace-operator-index:next"
+
+
+usage() {
+cat <<EOF
+This script handles building OLM bundle images and adding them to an index.
+
+Usage:
+  $0 [args...]
+
+Arguments:
+  --bundle-repo <REPO>    : Image repo to use for OLM bundle image (default: $DEFAULT_BUNDLE_REPO)
+  --bundle-tag <TAG>      : Image tag to use for the OLM bundle image (default: $DEFAULT_BUNDLE_TAG)
+  --index-image <IMAGE>   : Image repo to use for OLM index image (default: $DEFAULT_INDEX_IMAGE)
+  --container-tool <TOOL> : Use specific container tool for building/pushing images (default: use podman)
+  --force                 : Do not prompt for confirmation if pushing to default repos. Intended for
+                            use in CI.
+  --debug                 : Don't do any normal cleanup on exit, leaving repo in dirty state
+
+Examples:
+  1. Build and push bundle and index using default image repos
+      $0 --force
+  2. Build index and bundle using custom images
+      $0 --bundle-image <my_bundle_image> --index-image <my_index_image>
+
+EOF
+}
+
+parse_args() {
+  while [[ "$#" -gt 0 ]]; do
+    case $1 in
+      '--bundle-repo') BUNDLE_REPO="$2"; shift 1;;
+      '--bundle-tag') BUNDLE_TAG="$2"; shift 1;;
+      '--index-image') INDEX_IMAGE="$2"; shift 1;;
+      '--container-tool') PODMAN="$2"; shift 1;;
+      '--force') FORCE="true";;
+      '--debug') DEBUG="true";;
+      *) echo "[ERROR] Unknown parameter is used: $1."; usage; exit 1;;
+    esac
+    shift 1
+  done
+}
+
+parse_args "$@"
+
+# Set defaults and warn if pushing to main repos in case of accident
+BUNDLE_REPO="${BUNDLE_REPO:-DEFAULT_BUNDLE_REPO}"
+BUNDLE_TAG="${BUNDLE_TAG:-DEFAULT_BUNDLE_TAG}"
+INDEX_IMAGE="${INDEX_IMAGE:-DEFAULT_INDEX_IMAGE}"
+OUTDIR="olm-catalog/next"
+
+BUNDLE_IMAGE="${BUNDLE_REPO}:${BUNDLE_TAG}"
+
+if [ "$BUNDLE_REPO" == "quay.io/devfile/devworkspace-operator-bundle" ] && [ "$FORCE" != "true" ]; then
+  echo -n "Are you sure you want to push $BUNDLE_IMAGE? [y/N] " && read -r ans && [ "${ans:-N}" = y ] || exit 1
+fi
+if [ "$INDEX_IMAGE" == "quay.io/devfile/devworkspace-operator-index" ] && [ "$FORCE" != "true" ]; then
+  echo -n "Are you sure you want to push $INDEX_IMAGE? [y/N] " && read -r ans && [ "${ans:-N}" = y ] || exit 1
+fi
+
+CHANNEL_FILE="$OUTDIR/channel.yaml"
+
+echo "Building bundle image $BUNDLE_IMAGE"
+$PODMAN build . -t "$BUNDLE_IMAGE" -f build/bundle.Dockerfile | sed 's|^|    |'
+$PODMAN push "$BUNDLE_IMAGE" 2>&1 | sed 's|^|    |'
+
+BUNDLE_SHA=$(skopeo inspect "docker://${BUNDLE_IMAGE}" | jq -r '.Digest')
+BUNDLE_DIGEST="${BUNDLE_IMAGE}@${BUNDLE_SHA}"
+echo "Using bundle image $BUNDLE_DIGEST for index"
+
+# Minor workaround to generate bundle file name from bundle: store file in variable
+# temporarily to allow us to inspect it
+BUNDLE_YAML=$(opm render "$BUNDLE_DIGEST" --output yaml | sed '/---/d')
+BUNDLE_NAME="$(echo "$BUNDLE_YAML" | yq -r ".name")"
+BUNDLE_FILE="${OUTDIR}/${BUNDLE_NAME}.bundle.yaml"
+if [ -f "$BUNDLE_FILE" ]; then
+  echo "[ERROR] Bundle file $BUNDLE_FILE already exists"
+  exit 1
+fi
+echo "$BUNDLE_YAML" > "$BUNDLE_FILE"
+
+# Check if bundle with this version is already present in channel
+# shellcheck disable=SC2016
+if yq -e --arg bundle_name "$BUNDLE_NAME" '[.entries[]?.name] | any(. == $bundle_name)' "$CHANNEL_FILE" >/dev/null; then
+  echo "[ERROR] Bundle $BUNDLE_NAME is already present in the channel $CHANNEL_FILE"
+  exit 1
+fi
+
+# Add bundle entry to channel
+echo "Adding $BUNDLE_NAME to channel"
+ENTRY_JSON=$(yq '{name}' "$BUNDLE_FILE")
+# shellcheck disable=SC2016
+yq -Y -i --argjson entry "$ENTRY_JSON" '.entries |= . + [$entry]' "$CHANNEL_FILE"
+
+# Build index container
+echo "Building index image $INDEX_IMAGE"
+$PODMAN build . -t "$INDEX_IMAGE" -f build/index.next.Dockerfile | sed 's|^|    |'
+$PODMAN push "$INDEX_IMAGE" 2>&1 | sed 's|^|    |'
+
+if [ $DEBUG != "true" ]; then
+  echo "Cleaning up"
+  git restore "$OUTDIR"
+  git clean -fd "$OUTDIR"
+fi

--- a/build/scripts/build_index_image.sh
+++ b/build/scripts/build_index_image.sh
@@ -77,12 +77,14 @@ if [ "$RELEASE" == "true" ]; then
   fi
   INDEX_IMAGE="${INDEX_IMAGE:-DEFAULT_RELEASE_INDEX_IMAGE}"
   OUTDIR="olm-catalog/release"
+  DOCKERFILE="build/index.release.Dockerfile"
 else
   # Set defaults and warn if pushing to main repos in case of accident
   BUNDLE_REPO="${BUNDLE_REPO:-DEFAULT_BUNDLE_REPO}"
   BUNDLE_TAG="${BUNDLE_TAG:-DEFAULT_BUNDLE_TAG}"
   INDEX_IMAGE="${INDEX_IMAGE:-DEFAULT_INDEX_IMAGE}"
   OUTDIR="olm-catalog/next"
+  DOCKERFILE="build/index.next.Dockerfile"
 fi
 
 BUNDLE_IMAGE="${BUNDLE_REPO}:${BUNDLE_TAG}"
@@ -153,7 +155,7 @@ opm validate "$OUTDIR"
 
 # Build index container
 echo "Building index image $INDEX_IMAGE"
-$PODMAN build . -t "$INDEX_IMAGE" -f build/index.next.Dockerfile | sed 's|^|    |'
+$PODMAN build . -t "$INDEX_IMAGE" -f "$DOCKERFILE" | sed 's|^|    |'
 $PODMAN push "$INDEX_IMAGE" 2>&1 | sed 's|^|    |'
 
 if [ $DEBUG != "true" ] && [ "$RELEASE" != "true" ]; then

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -451,7 +451,6 @@ spec:
     name: project_clone
   - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
     name: kube_rbac_proxy
-  replaces: devworkspace-operator.v0.10.0
   version: 0.11.0-dev
   webhookdefinitions:
   - admissionReviewVersions:

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/internal-objects: '["devworkspaceroutings.controller.devfile.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-  name: devworkspace-operator.v0.11.0
+  name: devworkspace-operator.v0.11.0-dev
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -452,7 +452,7 @@ spec:
   - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
     name: kube_rbac_proxy
   replaces: devworkspace-operator.v0.10.0
-  version: 0.11.0
+  version: 0.11.0-dev
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     operators.operatorframework.io/internal-objects: '["devworkspaceroutings.controller.devfile.io"]'
-  name: devworkspace-operator.v0.11.0
+  name: devworkspace-operator.v0.11.0-dev
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -93,7 +93,7 @@ spec:
     name: Devfile
     url: https://devfile.io
   replaces: devworkspace-operator.v0.10.0
-  version: 0.11.0
+  version: 0.11.0-dev
   relatedImages:
     - image: quay.io/eclipse/che-machine-exec:nightly
       name: plugin_redhat_developer_web_terminal_4_5_0

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -92,7 +92,6 @@ spec:
   provider:
     name: Devfile
     url: https://devfile.io
-  replaces: devworkspace-operator.v0.10.0
   version: 0.11.0-dev
   relatedImages:
     - image: quay.io/eclipse/che-machine-exec:nightly

--- a/make-release.sh
+++ b/make-release.sh
@@ -254,6 +254,13 @@ release() {
     exit 1
   fi
 
+  # Check that CSV has a `replaces` field, since this will be required for adding the new version
+  # to a downstream operator catalog
+  if ! yq -e '.spec.replaces != null' deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml >/dev/null; then
+    echo "[ERROR] ClusterServiceVersion for operator must have manually-added .spec.replaces field"
+    exit 1
+  fi
+
   echo "[INFO] Starting Release procedure"
   # derive bugfix branch from version
   X_BRANCH=${VERSION#v}

--- a/make-release.sh
+++ b/make-release.sh
@@ -254,13 +254,6 @@ release() {
     exit 1
   fi
 
-  # Check that CSV has a `replaces` field, since this will be required for adding the new version
-  # to a downstream operator catalog
-  if ! yq -e '.spec.replaces != null' deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml >/dev/null; then
-    echo "[ERROR] ClusterServiceVersion for operator must have manually-added .spec.replaces field"
-    exit 1
-  fi
-
   echo "[INFO] Starting Release procedure"
   # derive bugfix branch from version
   X_BRANCH=${VERSION#v}

--- a/make-release.sh
+++ b/make-release.sh
@@ -128,14 +128,16 @@ update_images() {
   DWO_BUNDLE_QUAY_IMG="${DWO_BUNDLE_QUAY_REPO}:${VERSION}"
 
   # Update defaults in Makefile
-  sed -i Makefile -r -e \
-    "s|quay.io/devfile/devworkspace-controller:[0-9a-zA-Z._-]+|${DWO_QUAY_IMG}|g"
-  sed -i Makefile -r -e \
-    "s|quay.io/devfile/project-clone:[0-9a-zA-Z._-]+|${PROJECT_CLONE_QUAY_IMG}|g"
-  sed -i Makefile -r -e \
-    "s|quay.io/devfile/devworkspace-operator-bundle:[0-9a-zA-Z._-]+|${DWO_BUNDLE_QUAY_IMG}|g"
-  sed -i Makefile -r -e \
-    "s|quay.io/devfile/devworkspace-operator-index:[0-9a-zA-Z._-]+|${DWO_INDEX_IMAGE}|g"
+  sed -i Makefile -r \
+    -e "s|quay.io/devfile/devworkspace-controller:[0-9a-zA-Z._-]+|${DWO_QUAY_IMG}|g" \
+    -e "s|quay.io/devfile/project-clone:[0-9a-zA-Z._-]+|${PROJECT_CLONE_QUAY_IMG}|g" \
+    -e "s|quay.io/devfile/devworkspace-operator-bundle:[0-9a-zA-Z._-]+|${DWO_BUNDLE_QUAY_IMG}|g" \
+    -e "s|quay.io/devfile/devworkspace-operator-index:[0-9a-zA-Z._-]+|${DWO_INDEX_IMAGE}|g"
+
+  # Update defaults in generate-deployment.sh
+  sed -i deploy/generate-deployment.sh -r \
+    -e "s|quay.io/devfile/devworkspace-controller:[0-9a-zA-Z._-]+|${DWO_QUAY_IMG}|g" \
+    -e "s|quay.io/devfile/project-clone:[0-9a-zA-Z._-]+|${PROJECT_CLONE_QUAY_IMG}|g"
 
   local DEFAULT_DWO_IMG="$DWO_QUAY_IMG"
   local PROJECT_CLONE_IMG="$PROJECT_CLONE_QUAY_IMG"

--- a/olm-catalog/next/channel.yaml
+++ b/olm-catalog/next/channel.yaml
@@ -1,0 +1,3 @@
+schema: olm.channel
+package: devworkspace-operator
+name: next

--- a/olm-catalog/next/package.yaml
+++ b/olm-catalog/next/package.yaml
@@ -1,0 +1,3 @@
+schema: olm.package
+defaultChannel: next
+name: devworkspace-operator

--- a/olm-catalog/release/channel.yaml
+++ b/olm-catalog/release/channel.yaml
@@ -1,3 +1,5 @@
 schema: olm.channel
 package: devworkspace-operator
 name: fast
+entries:
+  - name: devworkspace-operator.v0.10.0

--- a/olm-catalog/release/channel.yaml
+++ b/olm-catalog/release/channel.yaml
@@ -1,0 +1,3 @@
+schema: olm.channel
+package: devworkspace-operator
+name: fast

--- a/olm-catalog/release/devworkspace-operator.v0.10.0.bundle.yaml
+++ b/olm-catalog/release/devworkspace-operator.v0.10.0.bundle.yaml
@@ -1,0 +1,47 @@
+---
+image: quay.io/devfile/devworkspace-operator-bundle@sha256:27ffcea52c7666d4fb13388a1ccef935bc7d55dd52ad973b46879143c67286a0
+name: devworkspace-operator.v0.10.0
+package: devworkspace-operator
+properties:
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceOperatorConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceRouting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha2
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha2
+- type: olm.package
+  value:
+    packageName: devworkspace-operator
+    version: 0.10.0
+relatedImages:
+- image: quay.io/devfile/devworkspace-controller:v0.10.0
+  name: ""
+- image: quay.io/devfile/devworkspace-operator-bundle@sha256:27ffcea52c7666d4fb13388a1ccef935bc7d55dd52ad973b46879143c67286a0
+  name: ""
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+  name: ""
+schema: olm.bundle

--- a/olm-catalog/release/package.yaml
+++ b/olm-catalog/release/package.yaml
@@ -1,0 +1,3 @@
+schema: olm.package
+defaultChannel: fast
+name: devworkspace-operator


### PR DESCRIPTION
### What does this PR do?
Adds steps to `make-release.sh` to automatically build and push a suitable bundle + index image to quay.

Detailed changes:
* Generate `relatedImages` in the CSV 
* Update `opm` to `v1.19.1`
* Switch upstream bundle + index build to use a [file-based catalog](https://olm.operatorframework.io/docs/tasks/creating-a-catalog/), introduced in `opm v1.19.0`
    * This requires storing additional metadata files in the repo and adds a couple of manual steps to the release process
* Build _one_ index for releases that gets updated and includes update paths from previous releases.

### What issues does this PR fix or reference?
This allows us to release an upstream index + bundle for the operator.

### Is it tested? How?
```bash
# Set these env vars to avoid pushing to main repos
export DWO_QUAY_REPO="quay.io/amisevsk/devworkspace-controller-test"
export PROJECT_CLONE_QUAY_REPO="quay.io/amisevsk/project-clone-test"
export DWO_BUNDLE_QUAY_REPO="quay.io/amisevsk/devworkspace-operator-bundle-test"
export DWO_INDEX_IMAGE="quay.io/amisevsk/devworkspace-operator-index-test:release"

# Setup local repo with dummy "remote" to avoid pushing changes to GitHub
cd $(mktemp -d)
git clone git@github.com:amisevsk/devworkspace-operator
mkdir devworkspace-upstream
cd devworkspace-upstream && git init --bare
cd ../devworkspace-operator

# Merge this PR to main
git merge origin/build-bundle-release
git remote set-url origin ../devworkspace-upstream
git push origin main

# Do prerelease for v0.11.0
./make-release.sh --prerelease --version v0.11.0
git checkout 0.11.x

# Manually add `replaces` field to CSV (required)
yq -Yi '.spec.replaces = "devworkspace-operator.v0.10.0"' \
  deploy/templates/components/csv/clusterserviceversion.yaml \
  deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
git commit -am 'add .spec.replaces to CSV'

# Release v0.11.0
./make-release.sh --release --version v0.11.0
```
Once complete, check the commits in `main` and `0.11.x` to ensure fields/versions/images are set correctly.

A built index for a fake `v0.11.1` release is available at https://quay.io/repository/amisevsk/devworkspace-operator-index-test; I haven't fully tested installing/upgrading the operator using it yet, but will do that next week.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
