### PR TITLE
Allow workspaces to disable project cloning

### DIFF
--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -37,6 +37,14 @@ const (
 	//         value: VAL_2
 	WorkspaceEnvAttribute = "workspaceEnv"
 
+	// ProjectCloneAttribute configures how the DevWorkspace will treat project cloning. By default, an init container
+	// will be added to the workspace deployment to clone projects to the workspace before it starts. This attribute
+	// must be applied to top-level attributes field in the DevWorkspace.
+	// Supported options:
+	// - "disable" - Disable automatic project cloning. No init container will be added to the workspace and projects
+	//               will not be cloned into the workspace on start.
+	ProjectCloneAttribute = "controller.devfile.io/project-clone"
+
 	// PluginSourceAttribute is an attribute added to components, commands, and projects in a flattened
 	// DevWorkspace representation to signify where the respective component came from (i.e. which plugin
 	// or parent imported it)

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -17,10 +17,31 @@ package constants
 
 // Constants that are used in attributes on DevWorkspace elements (components, endpoints, etc.)
 const (
+	// DevWorkspaceStorageTypeAttribute defines the strategy used for provisioning storage for the workspace.
+	// If empty, the common PVC strategy is used.
+	// Supported options:
+	// - "common": Create one PVC per namespace, and store data for all workspaces in that namespace in that PVC
+	// - "async" : Create one PVC per namespace, and create a remote server that syncs data from workspaces to the PVC.
+	//             All volumeMounts used for devworkspaces are emptyDir
+	DevWorkspaceStorageTypeAttribute = "controller.devfile.io/storage-type"
+
+	// WorkspaceEnvAttribute is an attribute that specifies a set of environment variables provided by a component
+	// that should be added to all workspace containers. The structure of the attribute value should be a list of
+	// Devfile 2.0 EnvVar, e.g.
+	//
+	//   attributes:
+	//     workspaceEnv:
+	//       - name: ENV_1
+	//         value: VAL_1
+	//       - name: ENV_2
+	//         value: VAL_2
+	WorkspaceEnvAttribute = "workspaceEnv"
+
 	// PluginSourceAttribute is an attribute added to components, commands, and projects in a flattened
 	// DevWorkspace representation to signify where the respective component came from (i.e. which plugin
 	// or parent imported it)
 	PluginSourceAttribute = "controller.devfile.io/imported-by"
+
 	// EndpointURLAttribute is an attribute added to endpoints to denote the endpoint on the cluster that
 	// was created to route to this endpoint
 	EndpointURLAttribute = "controller.devfile.io/endpoint-url"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// package constants defines constant values used throughout the DevWorkspace Operator
+
+// Package constants defines constant values used throughout the DevWorkspace Operator
 package constants
 
 // Labels which should be used for controller related objects
@@ -62,6 +63,7 @@ const (
 	ProjectCloneCPURequest    = "100m"
 
 	// Constants describing storage classes supported by the controller
+
 	// CommonStorageClassType defines the 'common' storage policy -- one PVC is provisioned per namespace and all devworkspace storage
 	// is mounted in it on subpaths according to devworkspace ID.
 	CommonStorageClassType = "common"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -73,4 +73,9 @@ const (
 	// EphemeralStorageClassType defines the 'ephemeral' storage policy: all volumes are allocated as emptyDir volumes and
 	// so do not require cleanup. When a DevWorkspace is stopped, all local changes are lost.
 	EphemeralStorageClassType = "ephemeral"
+
+	// Constants describing configuration for automatic project cloning
+
+	// ProjectCloneDisable specifies that project cloning should be disabled.
+	ProjectCloneDisable = "disable"
 )

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -95,14 +95,14 @@ const (
 	//             All volumeMounts used for devworkspaces are emptyDir
 	DevWorkspaceStorageTypeAtrr = "controller.devfile.io/storage-type"
 
-	// WorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
+	// DevWorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
 	DevWorkspaceEndpointNameAnnotation = "controller.devfile.io/endpoint_name"
 
 	// DevWorkspaceDiscoverableServiceAnnotation marks a service in a devworkspace as created for a discoverable endpoint,
 	// as opposed to a service created to support the devworkspace itself.
 	DevWorkspaceDiscoverableServiceAnnotation = "controller.devfile.io/discoverable-service"
 
-	// PullSecretLabel marks the intention that secret should be used as pull secret for devworkspaces withing namespace
+	// DevWorkspacePullSecretLabel marks the intention that secret should be used as pull secret for devworkspaces withing namespace
 	// Only secrets with 'true' value will be mount as pull secret
 	// Should be assigned to secrets with type docker config types (kubernetes.io/dockercfg and kubernetes.io/dockerconfigjson)
 	DevWorkspacePullSecretLabel = "controller.devfile.io/devworkspace_pullsecret"

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -15,7 +15,7 @@
 
 package constants
 
-// Constants that are used in labels and annotation on DevWorkspace-related resources.
+// Constants that are used in labels and annotations on DevWorkspace-related resources.
 const (
 	// DevWorkspaceIDLabel is the label key to store workspace identifier
 	DevWorkspaceIDLabel = "controller.devfile.io/devworkspace_id"
@@ -86,14 +86,6 @@ const (
 	// RoutingAnnotationInfix is the infix of the annotations of DevWorkspace that are passed down as annotation to the DevWorkspaceRouting objects.
 	// The full annotation name is supposed to be "<routingClass>.routing.controller.devfile.io/<anything>"
 	RoutingAnnotationInfix = ".routing.controller.devfile.io/"
-
-	// DevWorkspaceStorageTypeAtrr defines the strategy used for provisioning storage for the workspace.
-	// If empty, the common PVC strategy is used.
-	// Supported options:
-	// - "common": Create one PVC per namespace, and store data for all workspaces in that namespace in that PVC
-	// - "async" : Create one PVC per namespace, and create a remote server that syncs data from workspaces to the PVC.
-	//             All volumeMounts used for devworkspaces are emptyDir
-	DevWorkspaceStorageTypeAtrr = "controller.devfile.io/storage-type"
 
 	// DevWorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
 	DevWorkspaceEndpointNameAnnotation = "controller.devfile.io/endpoint_name"

--- a/pkg/library/flatten/workspaceEnv.go
+++ b/pkg/library/flatten/workspaceEnv.go
@@ -19,20 +19,7 @@ import (
 	"fmt"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-)
-
-const (
-	// WorkspaceEnvAttribute is an attribute that specifies a set of environment variables provided by a component
-	// that should be added to all workspace containers. The structure of the attribute value should be a list of
-	// Devfile 2.0 EnvVar, e.g.
-	//
-	//   attributes:
-	//     workspaceEnv:
-	//       - name: ENV_1
-	//         value: VAL_1
-	//       - name: ENV_2
-	//         value: VAL_2
-	WorkspaceEnvAttribute = "workspaceEnv"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
 )
 
 func resolveWorkspaceEnvVar(flattenedDW *dw.DevWorkspaceTemplateSpec) error {
@@ -58,14 +45,14 @@ func collectWorkspaceEnv(flattenedDW *dw.DevWorkspaceTemplateSpec) ([]dw.EnvVar,
 	envVarToComponent := map[string]string{}
 
 	for _, component := range flattenedDW.Components {
-		if !component.Attributes.Exists(WorkspaceEnvAttribute) {
+		if !component.Attributes.Exists(constants.WorkspaceEnvAttribute) {
 			continue
 		}
 
 		var componentEnv []dw.EnvVar
-		err := component.Attributes.GetInto(WorkspaceEnvAttribute, &componentEnv)
+		err := component.Attributes.GetInto(constants.WorkspaceEnvAttribute, &componentEnv)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read attribute %s on component %s: %w", WorkspaceEnvAttribute, getSourceForComponent(component), err)
+			return nil, fmt.Errorf("failed to read attribute %s on component %s: %w", constants.WorkspaceEnvAttribute, getSourceForComponent(component), err)
 		}
 
 		for _, envVar := range componentEnv {

--- a/pkg/library/projects/clone.go
+++ b/pkg/library/projects/clone.go
@@ -28,6 +28,9 @@ const (
 )
 
 func AddProjectClonerComponent(workspace *dw.DevWorkspaceTemplateSpec) {
+	if workspace.Attributes.GetString(constants.ProjectCloneAttribute, nil) == constants.ProjectCloneDisable {
+		return
+	}
 	if len(workspace.Projects) == 0 {
 		return
 	}

--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -250,7 +250,7 @@ func (*AsyncStorageProvisioner) getAsyncWorkspaceCount(api sync.ClusterAPI) (sta
 		return 0, 0, err
 	}
 	for _, workspace := range workspaces.Items {
-		storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAtrr, nil)
+		storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
 		if storageClass == constants.AsyncStorageClassType {
 			total++
 			if workspace.Spec.Started {

--- a/pkg/provision/storage/provisioner.go
+++ b/pkg/provision/storage/provisioner.go
@@ -44,7 +44,7 @@ func GetProvisioner(workspace *dw.DevWorkspace) (Provisioner, error) {
 	// TODO: Figure out what to do if a workspace changes the storage type after its been created
 	// e.g. common -> async so as to not leave files on PVCs after removal. Maybe block changes to
 	// this label via webhook?
-	storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAtrr, nil)
+	storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
 	if storageClass == "" {
 		return &CommonStorageProvisioner{}, nil
 	}


### PR DESCRIPTION
### What does this PR do?
Adds top-level attribute `controller.devfile.io/project-clone` to enable workspaces to disable automatic project clone.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/607

### Is it tested? How?
Create a DevWorkspace with 
```
    attributes:
      controller.devfile.io/project-clone: disable
```
and verify that no project-clone init container is created.

E.g.
```yaml
cat <<EOF | oc apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next
spec:
  started: true
  template:
    attributes:
      controller.devfile.io/project-clone: disable
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
          components:
            - name: theia-ide
              container:
                env:
                  - name: THEIA_HOST
                    value: 0.0.0.0
    commands:
      - id: say-hello
        exec:
          component: theia-ide
          commandLine: echo "Hello from $(pwd)"
          workingDir: ${PROJECTS_ROOT}/project/app
EOF
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
