### PR TITLE
Document the default workspace SA permissions

### DIFF
--- a/doc/workspace-capabilities.md
+++ b/doc/workspace-capabilities.md
@@ -76,7 +76,7 @@ rules:
 
 Additional permissions can be bound to the DevWorkspace ServiceAccount as follows:
 
-1. Find the *DevWorkspace ID* for the DevWorksapce in question. This is available on the `.status.devworkspaceId` field in the object, which can be obtained using `jq`:
+1. Find the *DevWorkspace ID* for the DevWorkspace in question. This is available on the `.status.devworkspaceId` field in the object, which can be obtained using `jq`:
     ```bash
     DEVWORKSPACE_ID=$(kubectl get devworkspaces <workspace-name> -o json | jq -r '.status.devworkspaceId')
     ```

--- a/doc/workspace-capabilities.md
+++ b/doc/workspace-capabilities.md
@@ -43,6 +43,17 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - ""
+  resourceNames:
+  - workspace-preferences-configmap
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+  - patch
+  - delete
+- apiGroups:
   - workspace.devfile.io
   resources:
   - devworkspaces

--- a/doc/workspace-capabilities.md
+++ b/doc/workspace-capabilities.md
@@ -1,0 +1,101 @@
+# Default DevWorkspace cluster permissions
+
+This document outlines the permissions that are provisioned for the DevWorkspace service account by default. The role attached to the workspace ServiceAccount is defined in [rbac.go](../pkg/provision/workspace/rbac.go). As a regular Kubernetes role definition, this is
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workspace
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - workspace-credentials-secret
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - patch
+  - delete
+- apiGroups:
+  - workspace.devfile.io
+  resources:
+  - devworkspaces
+  verbs:
+  - get
+  - watch
+  - list
+  - patch
+  - update
+- apiGroups:
+  - controller.devfile.io
+  resources:
+  - devworkspaceroutings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - workspace.devfile.io
+  resources:
+  - devworkspacetemplates
+  verbs:
+  - get
+  - create
+  - patch
+  - update
+  - delete
+  - list
+  - watch
+```
+
+Additional permissions can be bound to the DevWorkspace ServiceAccount as follows:
+
+1. Find the *DevWorkspace ID* for the DevWorksapce in question. This is available on the `.status.devworkspaceId` field in the object, which can be obtained using `jq`:
+    ```bash
+    DEVWORKSPACE_ID=$(kubectl get devworkspaces <workspace-name> -o json | jq -r '.status.devworkspaceId')
+    ```
+    The service account created for the DevWorkspace will be named `${DEVWORKSPACE_ID}-sa`
+2. Create a rolebinding to attach a custom role to the workspace service account:
+    ```yaml
+    cat << EOF | kubectl apply -f -
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: workspace-${DEVWORKSPACE_ID}-custom-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: <custom role name>
+    subjects:
+    - kind: ServiceAccount
+      name: ${DEVWORKSPACE_ID}-sa
+      namespace: <current namespace>
+    EOF
+    ```
+    where `<current namespace>` is the namespace of the workspace, and `<custom role name>` is the name of role to be bound to the DevWorkspace.

--- a/pkg/provision/workspace/rbac.go
+++ b/pkg/provision/workspace/rbac.go
@@ -47,7 +47,8 @@ func SyncRBAC(workspace *dw.DevWorkspace, clusterAPI sync.ClusterAPI) Provisioni
 }
 
 func generateRBAC(namespace string) []client.Object {
-	// TODO: The rolebindings here are created namespace-wide; find a way to limit this, given that each workspace
+	// TODO: The rolebindings here are created namespace-wide; find a way to limit this, given that each workspace is only
+	//       interested in a specific set of resources (e.g. the workspace shouldn't need to watch other pods, etc.)
 	return []client.Object{
 		&rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### What does this PR do?
Add a doc file for default `DevWorkspace` serviceaccount permissions.

### What issues does this PR fix or reference?
N/A, just occurred to me and is pretty easy to do.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
