### PR TITLE
Add ability to use SCCs in DevWorkspaces on OpenShift

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -355,7 +355,9 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	serviceAcctStatus := wsprovision.SyncServiceAccount(workspace, saAnnotations, clusterAPI)
 	if !serviceAcctStatus.Continue {
-		// FailStartup is not possible for generating the serviceaccount
+		if serviceAcctStatus.FailStartup {
+			return r.failWorkspace(workspace, serviceAcctStatus.Message, metrics.ReasonBadRequest, reqLogger, &reconcileStatus)
+		}
 		reqLogger.Info("Waiting for workspace ServiceAccount")
 		reconcileStatus.setConditionFalse(dw.DevWorkspaceServiceAccountReady, "Waiting for DevWorkspace ServiceAccount")
 		if !serviceAcctStatus.Requeue && serviceAcctStatus.Err == nil {

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -84,6 +84,7 @@ type DevWorkspaceReconciler struct {
 // +kubebuilder:rbac:groups="",resources=namespaces;events,verbs=get;list;watch
 // +kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;create;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews;localsubjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthclients,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -260,7 +260,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Set finalizer on DevWorkspace if necessary
 	// Note: we need to check the flattened workspace to see if a finalizer is needed, as plugins could require storage
-	if isFinalizerNecessary(workspace, storageProvisioner) {
+	if storageProvisioner.NeedsStorage(&workspace.Spec.Template) {
 		coputil.AddFinalizer(clusterWorkspace, storageCleanupFinalizer)
 		if err := r.Update(ctx, clusterWorkspace); err != nil {
 			return reconcile.Result{}, err
@@ -367,6 +367,13 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		return reconcile.Result{Requeue: serviceAcctStatus.Requeue}, serviceAcctStatus.Err
 	}
+	if wsprovision.NeedsServiceAccountFinalizer(&workspace.Spec.Template) {
+		coputil.AddFinalizer(clusterWorkspace, serviceAccountCleanupFinalizer)
+		if err := r.Update(ctx, clusterWorkspace); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	serviceAcctName := serviceAcctStatus.ServiceAccountName
 	reconcileStatus.setConditionTrue(dw.DevWorkspaceServiceAccountReady, "DevWorkspace serviceaccount ready")
 

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -70,8 +70,9 @@ const (
 // DevWorkspaceReconciler reconciles a DevWorkspace object
 type DevWorkspaceReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	NonCachingClient client.Client
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
 }
 
 /////// CRD-related RBAC roles
@@ -99,10 +100,11 @@ type DevWorkspaceReconciler struct {
 func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcileResult ctrl.Result, err error) {
 	reqLogger := r.Log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 	clusterAPI := sync.ClusterAPI{
-		Client: r.Client,
-		Scheme: r.Scheme,
-		Logger: reqLogger,
-		Ctx:    ctx,
+		Client:           r.Client,
+		NonCachingClient: r.NonCachingClient,
+		Scheme:           r.Scheme,
+		Logger:           reqLogger,
+		Ctx:              ctx,
 	}
 
 	// Fetch the Workspace instance

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -181,6 +181,13 @@ spec:
           - list
           - watch
         - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - localsubjectaccessreviews
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
           - batch
           resources:
           - jobs

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -19809,6 +19809,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -108,6 +108,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -19809,6 +19809,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -108,6 +108,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/deploy/templates/components/rbac/role.yaml
+++ b/deploy/templates/components/rbac/role.yaml
@@ -107,6 +107,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -75,6 +76,9 @@ func init() {
 		utilruntime.Must(routev1.Install(scheme))
 		utilruntime.Must(templatev1.Install(scheme))
 		utilruntime.Must(oauthv1.Install(scheme))
+		// Enable controller to manage SCCs in OpenShift; permissions to do this are not requested
+		// by default and must be added by a cluster-admin.
+		utilruntime.Must(securityv1.Install(scheme))
 	}
 
 	// +kubebuilder:scaffold:scheme

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -37,6 +37,20 @@ const (
 	//         value: VAL_2
 	WorkspaceEnvAttribute = "workspaceEnv"
 
+	// WorkspaceSCCAttribute defines additional SCCs that should be added to the DevWorkspace. The user adding
+	// this attribute to a workspace must have the RBAC permissions to "use" the SCC with the given name. For example,
+	// to add the 'anyuid' SCC to the workspace Pod, the DevWorkspace should contain
+	//
+	//     spec:
+	//       template:
+	//         attributes:
+	//           controller.devfile.io/scc: "anyuid"
+	//
+	// Creating a workspace with this attribute, or updating an existing workspace to include this attribute will fail
+	// if the user making the request does not have the "use" permission for the "anyuid" SCC.
+	// Only supported on OpenShift.
+	WorkspaceSCCAttribute = "controller.devfile.io/scc"
+
 	// ProjectCloneAttribute configures how the DevWorkspace will treat project cloning. By default, an init container
 	// will be added to the workspace deployment to clone projects to the workspace before it starts. This attribute
 	// must be applied to top-level attributes field in the DevWorkspace.

--- a/pkg/provision/sync/cluster_api.go
+++ b/pkg/provision/sync/cluster_api.go
@@ -24,10 +24,11 @@ import (
 )
 
 type ClusterAPI struct {
-	Client crclient.Client
-	Scheme *runtime.Scheme
-	Logger logr.Logger
-	Ctx    context.Context
+	Client           crclient.Client
+	NonCachingClient crclient.Client
+	Scheme           *runtime.Scheme
+	Logger           logr.Logger
+	Ctx              context.Context
 }
 
 // NotInSyncError is returned when a spec object is out-of-sync with its cluster counterpart

--- a/pkg/provision/workspace/serviceaccount.go
+++ b/pkg/provision/workspace/serviceaccount.go
@@ -16,11 +16,16 @@
 package workspace
 
 import (
+	"fmt"
+
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	securityv1 "github.com/openshift/api/security/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
@@ -79,10 +84,60 @@ func SyncServiceAccount(
 		return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{Err: err}}
 	}
 
+	if workspace.Spec.Template.Attributes.Exists(constants.WorkspaceSCCAttribute) {
+		sccName := workspace.Spec.Template.Attributes.GetString(constants.WorkspaceSCCAttribute, nil)
+		retry, err := addSCCToServiceAccount(specSA.Name, specSA.Namespace, sccName, clusterAPI)
+		if err != nil {
+			return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{FailStartup: true, Err: err}}
+		}
+		if retry {
+			return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{Requeue: true}}
+		}
+	}
+
 	return ServiceAcctProvisioningStatus{
 		ProvisioningStatus: ProvisioningStatus{
 			Continue: true,
 		},
 		ServiceAccountName: saName,
 	}
+}
+
+func addSCCToServiceAccount(saName, namespace, sccName string, clusterAPI sync.ClusterAPI) (retry bool, err error) {
+	serviceaccount := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, saName)
+
+	// TODO: Check if we can access the SCC
+
+	scc := &securityv1.SecurityContextConstraints{}
+	if err := clusterAPI.Client.Get(clusterAPI.Ctx, types.NamespacedName{Name: sccName}, scc); err != nil {
+		switch {
+		case k8sErrors.IsUnauthorized(err):
+			return false, fmt.Errorf("operator does not have permissions to get the '%s' SecurityContextConstraint", sccName)
+		case k8sErrors.IsNotFound(err):
+			return false, fmt.Errorf("requested SCC '%s' not found on cluster", sccName)
+		default:
+			return false, err
+		}
+	}
+
+	for _, user := range scc.Users {
+		if user == serviceaccount {
+			// This serviceaccount is already added to the SCC
+			return false, nil
+		}
+	}
+
+	scc.Users = append(scc.Users, serviceaccount)
+	if err := clusterAPI.Client.Update(clusterAPI.Ctx, scc); err != nil {
+		switch {
+		case k8sErrors.IsUnauthorized(err):
+			return false, fmt.Errorf("operator does not have permissions to update the '%s' SecurityContextConstraint", sccName)
+		case k8sErrors.IsConflict(err):
+			return true, nil
+		default:
+			return false, err
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/provision/workspace/serviceaccount.go
+++ b/pkg/provision/workspace/serviceaccount.go
@@ -22,6 +22,7 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 	securityv1 "github.com/openshift/api/security/v1"
+	v1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,7 +80,7 @@ func SyncServiceAccount(
 	case *sync.NotInSyncError:
 		return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{Requeue: true}}
 	case *sync.UnrecoverableSyncError:
-		return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{FailStartup: true, Err: t.Cause}}
+		return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{FailStartup: true, Message: t.Cause.Error()}}
 	default:
 		return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{Err: err}}
 	}
@@ -88,7 +89,7 @@ func SyncServiceAccount(
 		sccName := workspace.Spec.Template.Attributes.GetString(constants.WorkspaceSCCAttribute, nil)
 		retry, err := addSCCToServiceAccount(specSA.Name, specSA.Namespace, sccName, clusterAPI)
 		if err != nil {
-			return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{FailStartup: true, Err: err}}
+			return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{FailStartup: true, Message: err.Error()}}
 		}
 		if retry {
 			return ServiceAcctProvisioningStatus{ProvisioningStatus: ProvisioningStatus{Requeue: true}}
@@ -106,15 +107,22 @@ func SyncServiceAccount(
 func addSCCToServiceAccount(saName, namespace, sccName string, clusterAPI sync.ClusterAPI) (retry bool, err error) {
 	serviceaccount := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, saName)
 
-	// TODO: Check if we can access the SCC
+	canList, canWatch, err := checkControllerSCCAccess(sccName, clusterAPI)
+	if err != nil {
+		return false, fmt.Errorf("failed to check access to %s SecurityContextConstraints: %w", sccName, err)
+	} else if !canList {
+		return false, fmt.Errorf("controller is not permitted to list SecurityContextConstraints")
+	} else if !canWatch {
+		return false, fmt.Errorf("controller is not permitted to watch SecurityContextConstraints")
+	}
 
 	scc := &securityv1.SecurityContextConstraints{}
 	if err := clusterAPI.Client.Get(clusterAPI.Ctx, types.NamespacedName{Name: sccName}, scc); err != nil {
 		switch {
 		case k8sErrors.IsUnauthorized(err):
-			return false, fmt.Errorf("operator does not have permissions to get the '%s' SecurityContextConstraint", sccName)
+			return false, fmt.Errorf("operator does not have permissions to get the '%s' SecurityContextConstraints", sccName)
 		case k8sErrors.IsNotFound(err):
-			return false, fmt.Errorf("requested SCC '%s' not found on cluster", sccName)
+			return false, fmt.Errorf("requested SecurityContextConstraints '%s' not found on cluster", sccName)
 		default:
 			return false, err
 		}
@@ -131,7 +139,7 @@ func addSCCToServiceAccount(saName, namespace, sccName string, clusterAPI sync.C
 	if err := clusterAPI.Client.Update(clusterAPI.Ctx, scc); err != nil {
 		switch {
 		case k8sErrors.IsUnauthorized(err):
-			return false, fmt.Errorf("operator does not have permissions to update the '%s' SecurityContextConstraint", sccName)
+			return false, fmt.Errorf("operator does not have permissions to update the '%s' SecurityContextConstraints", sccName)
 		case k8sErrors.IsConflict(err):
 			return true, nil
 		default:
@@ -140,4 +148,54 @@ func addSCCToServiceAccount(saName, namespace, sccName string, clusterAPI sync.C
 	}
 
 	return false, nil
+}
+
+// checkControllerSCCAccess checks RBAC *prerequisites* for managing SecurityContextConstraints on OpenShift.
+// Checking this specifically is required the controller does not have these permissions by default, and the
+// internal cache in controller-runtime attempts to use listWatches under the hood. Attempting to use SCCs in
+// workspaces without the additional RBAC will lock the reconcile as any client actions that depend on the
+// cache will fail to return an error.
+func checkControllerSCCAccess(sccName string, clusterAPI sync.ClusterAPI) (canList, canWatch bool, err error) {
+	// Controller caching functionality depends on being able to list and watch resources. Errors due to these
+	// RBAC verbs not being available will be thrown out-of-band with the reconcile and cannot be detected by
+	// e.g. a failed Get()
+	listSSAR := &v1.SelfSubjectAccessReview{
+		Spec: v1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &v1.ResourceAttributes{
+				Verb:     "list",
+				Group:    "security.openshift.io",
+				Version:  "v1",
+				Resource: "securitycontextconstraints",
+				Name:     sccName,
+			},
+		},
+	}
+	if err := clusterAPI.Client.Create(clusterAPI.Ctx, listSSAR); err != nil {
+		return false, false, err
+	}
+
+	if !listSSAR.Status.Allowed {
+		return false, false, nil
+	}
+
+	watchSSAR := &v1.SelfSubjectAccessReview{
+		Spec: v1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &v1.ResourceAttributes{
+				Verb:     "watch",
+				Group:    "security.openshift.io",
+				Version:  "v1",
+				Resource: "securitycontextconstraints",
+				Name:     sccName,
+			},
+		},
+	}
+	if err := clusterAPI.Client.Create(clusterAPI.Ctx, watchSSAR); err != nil {
+		return true, false, err
+	}
+
+	if !watchSSAR.Status.Allowed {
+		return true, false, nil
+	}
+
+	return true, true, nil
 }

--- a/pkg/webhook/cluster_roles.go
+++ b/pkg/webhook/cluster_roles.go
@@ -120,6 +120,7 @@ func getSpecClusterRole() (*v1.ClusterRole, error) {
 				},
 				Resources: []string{
 					"subjectaccessreviews",
+					"localsubjectaccessreviews",
 				},
 				Verbs: []string{
 					"create",

--- a/webhook/workspace/handler/access_control.go
+++ b/webhook/workspace/handler/access_control.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	v1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// validateUserPermissions validates that the user making the request has permissions to create/update the given workspace.
+// In case we're validating a workspace on creation, parameter oldWksp should be set to nil. Returns an error if the user
+// cannot perform the requested changes, or if an unexpected error occurs.
+// Note: we only perform validation on v1alpha2 DevWorkspaces at the moment, as v1alpha1 DevWorkspaces do not support attributes.
+func (h *WebhookHandler) validateUserPermissions(ctx context.Context, req admission.Request, newWksp, oldWksp *dwv2.DevWorkspace) error {
+	if !newWksp.Spec.Template.Attributes.Exists(constants.WorkspaceSCCAttribute) {
+		// Workspace is not requesting anything we need to check RBAC for.
+		return nil
+	}
+
+	var attributeDecodeErr error
+	newSCCAttr := newWksp.Spec.Template.Attributes.GetString(constants.WorkspaceSCCAttribute, &attributeDecodeErr)
+	if attributeDecodeErr != nil {
+		return fmt.Errorf("failed to read %s attribute in DevWorkspace: %s", constants.WorkspaceSCCAttribute, attributeDecodeErr)
+	}
+
+	if oldWksp != nil && oldWksp.Spec.Template.Attributes.Exists(constants.WorkspaceSCCAttribute) {
+		// If we're updating a DevWorkspace, check RBAC only if the relevant attribute is modified to avoid performing too many SARs.
+		oldSCCAttr := oldWksp.Spec.Template.Attributes.GetString(constants.WorkspaceSCCAttribute, &attributeDecodeErr)
+		if attributeDecodeErr != nil {
+			return fmt.Errorf("failed to read %s attribute in DevWorkspace: %s", constants.WorkspaceSCCAttribute, attributeDecodeErr)
+		}
+		if oldSCCAttr == newSCCAttr {
+			// RBAC has already been checked for this setting, don't recheck
+			return nil
+		}
+		if oldSCCAttr != newSCCAttr {
+			// Don't allow attribute to be changed once it is set, otherwise we can't clean up the SCC when the workspace is deleted.
+			return fmt.Errorf("%s attribute cannot be modified after being set -- workspace must be deleted", constants.WorkspaceSCCAttribute)
+		}
+	}
+
+	if err := h.validateOpenShiftSCC(ctx, req, newSCCAttr); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *WebhookHandler) validateOpenShiftSCC(ctx context.Context, req admission.Request, scc string) error {
+	if !infrastructure.IsOpenShift() {
+		// We can only check the appropriate capability on OpenShift currently (via securitycontextconstraints.security.openshift.io)
+		// so forbid using this attribute
+		return fmt.Errorf("specifying additional SCCs is only permitted on OpenShift")
+	}
+
+	if scc == "" {
+		return fmt.Errorf("empty value for attribute %s is invalid", constants.WorkspaceSCCAttribute)
+	}
+
+	sar := &v1.LocalSubjectAccessReview{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: req.Namespace,
+		},
+		Spec: v1.SubjectAccessReviewSpec{
+			ResourceAttributes: &v1.ResourceAttributes{
+				Namespace: req.Namespace,
+				Verb:      "use",
+				Group:     "security.openshift.io",
+				Resource:  "securitycontextconstraints",
+				Name:      scc,
+			},
+			User:   req.UserInfo.Username,
+			Groups: req.UserInfo.Groups,
+			UID:    req.UserInfo.UID,
+		},
+	}
+
+	err := h.Client.Create(ctx, sar)
+	if err != nil {
+		return fmt.Errorf("failed to create subjectaccessreview for request: %w", err)
+	}
+
+	if !sar.Status.Allowed {
+		if sar.Status.Reason != "" {
+			return fmt.Errorf("user is not permitted to use the %s SCC: %s", scc, sar.Status.Reason)
+		}
+		return fmt.Errorf("user is not permitted use the %s SCC", scc)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?
This is a proof-of-concept PR that adds the ability to use SecurityContextConstraints (SCCs) in DevWorkspaces, which can be used to e.g. enable container builds within workspace containers. SCCs used by a DevWorkspace are defined through the attribute `controller.devfile.io/scc: <scc-name>`.

In order to avoid overextending the default DWO RBAC, no ability to view/edit SCCs is granted to the Operator by default, and attempting to use SCCs in workspaces will fail with a message like 
```
operator does not have permissions to get the 'anyuid' SecurityContextConstraints
```

The requirements to use this feature are:
1. The DevWorkspace Operator serviceaccount must explicitly be granted `get` and `update` privileges for a given SCC by a cluster-admin
2. The user creating the DevWorkspace must be granted the `use` privilege on that SCC by a cluster-admin
3. The DevWorkspace must be created with the `controller.devfile.io/scc` attribute by a user with permissions to `use` that SCC.

One benefit in this approach is that the cluster admin can revoke these privileges from users/the controller after the fact without breaking regular workspaces.

Once the `controller.devfile.io/scc` attribute is set on a DevWorkspace, it cannot be modified in order to avoid leaking SAs into existin SCCs. Using the attribute adds a finalizer for SCCs to the DevWorkspace to ensure any changes to SCCs are cleaned up when the workspace is deleted.

Since SCCs are an OpenShift feature, this functionality is disabled on Kubernetes and attempting to use the attribute will be rejected by webhooks.

### What issues does this PR fix or reference?
Closes https://github.com/eclipse/che/issues/20459

### Is it tested? How?
The steps below follow similarly to the [Buildah OpenShift rootless build](https://github.com/containers/buildah/blob/main/docs/tutorials/05-openshift-rootless-build.md) doc.

1. Create a new SCC that grants the specific capabilties that are required (any scc can be used but this is probably best practice here):
    ```yaml
    cat <<EOF | oc apply -f -
    apiVersion: security.openshift.io/v1
    kind: SecurityContextConstraints
    metadata:
      name: container-build
    allowHostDirVolumePlugin: false
    allowHostIPC: false
    allowHostNetwork: false
    allowHostPID: false
    allowHostPorts: false
    allowPrivilegeEscalation: true
    allowPrivilegedContainer: false
    allowedCapabilities: null
    defaultAddCapabilities: null
    fsGroup:
      type: RunAsAny
    priority: 10
    readOnlyRootFilesystem: false
    requiredDropCapabilities:
    - "KILL"
    - "MKNOD"
    runAsUser:
      type: RunAsAny
    seLinuxContext:
      type: MustRunAs
    supplementalGroups:
      type: RunAsAny
    users: []
    volumes:
    - configMap
    - downwardAPI
    - emptyDir
    - persistentVolumeClaim
    - projected
    - secret
    EOF
    ```
    This SCC is a modified version of the `anyuid` SCC with the added requirement that containers drop the `KILL` capability.
2. Grant the DevWorkspace Operator the `get` and `update` privileges for this SCC:
    ```yaml
    NAMESPACE=<namespace-where-dwo-is-deployed>
    
    cat <<EOF | oc apply -f - 
    apiVersion: rbac.authorization.k8s.io/v1
    kind: ClusterRole
    metadata:
      name: dwo-access-to-scc
      labels:
        test: dwo-scc-access
    rules:
    - apiGroups:
        - "security.openshift.io"
      resources:
        - "securitycontextconstraints"
      resourceNames:
        - "container-build"
      verbs:
        - "get"
        - "update"
    ---
    apiVersion: rbac.authorization.k8s.io/v1
    kind: ClusterRoleBinding
    metadata:
      name: dwo-access-to-scc
      labels:
        test: dwo-scc-access
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: dwo-access-to-scc
    subjects:
    - kind: ServiceAccount
      name: devworkspace-controller-serviceaccount
      namespace: ${NAMESPACE}
    EOF
    ```
3. Let the user creating the DevWorkspace `use` the `container-build` SCC:
    ```bash
    oc adm policy add-scc-to-user container-build <username>
    ```
4. Create a DevWorkspace that uses the `container-build` SCC:
    ```yaml
    cat <<EOF | oc apply -f -
    kind: DevWorkspace
    apiVersion: workspace.devfile.io/v1alpha2
    metadata:
      name: container-build
    spec:
      started: true
      routingClass: 'basic'
      template:
        attributes:
          controller.devfile.io/scc: container-build
          controller.devfile.io/storage-type: ephemeral
        components:
          - name: container-build
            container:
              image: quay.io/amisevsk/container-build:dev
              memoryLimit: 512Mi
              mountSources: true
              command:
              - "tail"
              - "-f"
              - "/dev/null"
    EOF
    ```
    The image used in this DevWorkspace is build according to the [buildah doc](https://github.com/containers/buildah/blob/main/docs/tutorials/05-openshift-rootless-build.md) and can be used to run buildah builds.
5. Check that the pod created for this workspace has the `openshift.io/scc: container-build` annotation
6. Exec into the pod and verify configuration is as specified in the [buildah doc](https://github.com/containers/buildah/blob/main/docs/tutorials/05-openshift-rootless-build.md) (e.g. user is 1000, can build images)
7. Delete DevWorkspace, and verify that `.users` field in `container-build` SCC is empty (i.e. that the workspace's ServiceAccount is removed)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
