### PR TITLE
Use BadRequest as failure reason when we can't get containers

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -268,7 +268,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	devfilePodAdditions, err := containerlib.GetKubeContainersFromDevfile(&workspace.Spec.Template)
 	if err != nil {
-		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus)
+		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus)
 	}
 
 	err = storageProvisioner.ProvisionStorage(devfilePodAdditions, workspace, clusterAPI)


### PR DESCRIPTION
### What does this PR do?
Treat failures to extract containers/initContainers from a DevWorkspace as a BadRequest failure, as this will typically be due to an issue in the DevWorkspace itself.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/20751

Note this issue is _also_ fixed by https://github.com/devfile/api/pull/685, which will cause workspace start to fail earlier and with a better message.

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
