### PR TITLE
Add support for node selectors and pod tolerations via attribute

### DIFF
--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -17,10 +17,22 @@ package constants
 
 // Constants that are used in attributes on DevWorkspace elements (components, endpoints, etc.)
 const (
+	// PodTolerationsAttribute defines tolerations that should be applied to the DevWorkspace's pod. Tolerations
+	// should be defined in the same format as in Kubernetes, e.g.
+	//   - key: "example-key"
+	//     operator: "Exists"
+	//     effect: "NoSchedule"
+	PodTolerationsAttribute = "pod-tolerations"
+
+	// NodeSelectorAttribute defines the node selector that should be used for the DevWorkspace's pod. Should be
+	// defined as a key-value map.
+	NodeSelectorAttribute = "node-selector"
+
 	// PluginSourceAttribute is an attribute added to components, commands, and projects in a flattened
 	// DevWorkspace representation to signify where the respective component came from (i.e. which plugin
 	// or parent imported it)
 	PluginSourceAttribute = "controller.devfile.io/imported-by"
+
 	// EndpointURLAttribute is an attribute added to endpoints to denote the endpoint on the cluster that
 	// was created to route to this endpoint
 	EndpointURLAttribute = "controller.devfile.io/endpoint-url"

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -324,6 +324,22 @@ func getSpecDeployment(
 		deployment.Spec.Template.Annotations = maputils.Append(deployment.Spec.Template.Annotations, constants.DevWorkspaceRestrictedAccessAnnotation, restrictedAccess)
 	}
 
+	if workspace.Spec.Template.Attributes.Exists(constants.PodTolerationsAttribute) {
+		var tolerations []corev1.Toleration
+		if err := workspace.Spec.Template.Attributes.GetInto(constants.PodTolerationsAttribute, &tolerations); err != nil {
+			return nil, fmt.Errorf("failed to parse %s attribute: %w", constants.PodTolerationsAttribute, err)
+		}
+		deployment.Spec.Template.Spec.Tolerations = tolerations
+	}
+
+	if workspace.Spec.Template.Attributes.Exists(constants.NodeSelectorAttribute) {
+		nodeSelector := map[string]string{}
+		if err := workspace.Spec.Template.Attributes.GetInto(constants.NodeSelectorAttribute, &nodeSelector); err != nil {
+			return nil, fmt.Errorf("failed to parse %s attribute: %w", constants.NodeSelectorAttribute, err)
+		}
+		deployment.Spec.Template.Spec.NodeSelector = nodeSelector
+	}
+
 	err = controllerutil.SetControllerReference(workspace, deployment, scheme)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?
Add support for pod tolerations and node selectors via attributes:
- `pod-tolerations`
- `node-selector`

This PR should be left on-hold until https://github.com/devfile/api/issues/689 is resolved

### What issues does this PR fix or reference?
DWO-side implementation of https://github.com/devfile/api/issues/689 until that issue is resolved and devfile/api dependency is updated.

Closes https://github.com/devfile/devworkspace-operator/issues/614

### Is it tested? How?
E.g. in minikube:
```bash
# Apply a taint to the minikube node
kubectl taint nodes minikube key1=value1:NoSchedule
# Apply a new label to the minikube node
kubectl label nodes minikube test-node-selector=test
# Create a DW that tolerates the taint and uses a node selector: 
cat <<EOF | kubectl apply -f - 
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: nodeselector-test
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
      pod-tolerations:
      - key: "key1"
        operator: "Equal"
        value: "value1"
        effect: "NoSchedule"
      node-selector:
        test-node-selector: test
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:latest
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
EOF
```
The Pod created for the Workspace should have
```json
  {
    "effect": "NoSchedule",
    "key": "key1",
    "operator": "Equal",
    "value": "value1"
  },
```
in its `.spec.tolerations` and
```json
{
  "test-node-selector": "test"
}
```
in its `.spec.nodeSelector`.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
