### PR TITLE
chore: Update from ubi8/go-toolset:1.15.14-18 to ubi8/go-toolset:1.16.7-5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.15.14-18 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.7-5 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /devworkspace-operator

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -34,7 +34,7 @@ RUN make compile-devworkspace-controller
 RUN make compile-webhook-server
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.4-212
+FROM registry.access.redhat.com/ubi8-minimal:8.5-204
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /devworkspace-operator/_output/bin/devworkspace-controller /usr/local/bin/devworkspace-controller

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
   project-clone/main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.4-212
+FROM registry.access.redhat.com/ubi8-minimal:8.5-204
 RUN microdnf -y update && microdnf install -y time git git-lfs && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/project-clone

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -15,7 +15,7 @@
 
 # Build the manager binary
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.15.14-18 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.7-5 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /project-clone


### PR DESCRIPTION
Change-Id: Ic43d32c1a775f5ba3755a43398c6ae1bfeb2656f
Signed-off-by: nickboldt <nboldt@redhat.com>

re: https://github.com/eclipse/che/issues/20774