### PR TITLE
Update next GitHub CI action to use new bundle build

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -50,7 +50,8 @@ jobs:
   build-next-olm-imgs:
     runs-on: ubuntu-latest
     env:
-      DWO_BUNDLE_IMG: quay.io/devfile/devworkspace-operator-bundle:next
+      DWO_BUNDLE_REPO: quay.io/devfile/devworkspace-operator-bundle
+      DWO_BUNDLE_TAG: next
       DWO_INDEX_IMG: quay.io/devfile/devworkspace-operator-index:next
       OPM_VERSION: v1.19.1
       OPERATOR_SDK_VERSION: v1.8.0
@@ -107,7 +108,12 @@ jobs:
 
       - name: "Build Bundle & Index images"
         run: |
-          make build_bundle_image build_index_image
+          ./build/scripts/build_index_image.sh \
+            --bundle-repo ${DWO_BUNDLE_REPO} \
+            --bundle-tag ${DWO_BUNDLE_TAG} \
+            --index-image ${DWO_INDEX_IMG} \
+            --container-tool docker \
+            --force
 
       - name: "Docker Logout"
         run: docker logout


### PR DESCRIPTION
### What does this PR do?
Fixes oversight from https://github.com/devfile/devworkspace-operator/pull/672, where the [Next container build](https://github.com/devfile/devworkspace-operator/actions/workflows/next-build.yml) GH action was still using old makefile rules

### What issues does this PR fix or reference?
`next` builds of controller.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
