### PR TITLE
Install python version of yq in next-build GH workflow

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -108,6 +108,8 @@ jobs:
 
       - name: "Build Bundle & Index images"
         run: |
+          # Ubuntu latest comes with the _other_ version of yq.
+          pip install yq
           ./build/scripts/build_index_image.sh \
             --bundle-repo ${DWO_BUNDLE_REPO} \
             --bundle-tag ${DWO_BUNDLE_TAG} \


### PR DESCRIPTION
### What does this PR do?
Install `yq` from `pip` like we do in the pull release workflow, as `yq` is required by the `build_index_image.sh` script.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
