### PR TITLE
Only track fresh starts of workspaces in workspace started metrics

### DIFF
--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -38,8 +38,11 @@ func WorkspaceStarted(wksp *dw.DevWorkspace, log logr.Logger) {
 // encountered, the provided logger is used to log the error. This function assumes the provided workspace has
 // fully-synced conditions (i.e. the WorkspaceReady condition is present).
 func WorkspaceRunning(wksp *dw.DevWorkspace, log logr.Logger) {
-	incrementMetricForWorkspace(workspaceStarts, wksp, log)
-	incrementStartTimeBucketForWorkspace(wksp, log)
+	_, ok := wksp.GetAnnotations()[constants.DevWorkspaceStartedAtAnnotation]
+	if !ok {
+		incrementMetricForWorkspace(workspaceStarts, wksp, log)
+		incrementStartTimeBucketForWorkspace(wksp, log)
+	}
 }
 
 // WorkspaceFailed updates metrics for workspace entering the 'Failed' phase. If an error is encountered, the provided

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -22,12 +22,16 @@ import (
 
 	"github.com/devfile/devworkspace-operator/pkg/conditions"
 	"github.com/devfile/devworkspace-operator/pkg/config"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
 )
 
 // WorkspaceStarted updates metrics for workspaces entering the 'Starting' phase, given a workspace. If an error is
 // encountered, the provided logger is used to log the error.
 func WorkspaceStarted(wksp *dw.DevWorkspace, log logr.Logger) {
-	incrementMetricForWorkspace(workspaceTotal, wksp, log)
+	_, ok := wksp.GetAnnotations()[constants.DevWorkspaceStartedAtAnnotation]
+	if !ok {
+		incrementMetricForWorkspace(workspaceTotal, wksp, log)
+	}
 }
 
 // WorkspaceRunning updates metrics for workspaces entering the 'Running' phase, given a workspace. If an error is

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -238,8 +238,6 @@ func updateMetricsForPhase(workspace *dw.DevWorkspace, oldPhase, newPhase dw.Dev
 		metrics.WorkspaceRunning(workspace, logger)
 	case dw.DevWorkspaceStatusFailed:
 		metrics.WorkspaceFailed(workspace, logger)
-	case dw.DevWorkspaceStatusStarting:
-		metrics.WorkspaceStarted(workspace, logger)
 	}
 }
 

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -83,6 +83,9 @@ const (
 	// WebhookRestartedAtAnnotation holds the the time (unixnano) of when the webhook server was forced to restart by controller
 	WebhookRestartedAtAnnotation = "controller.devfile.io/restarted-at"
 
+	// DevWorkspaceStartedAtAnnotation holds the the time (unixnano) of when the devworkspace was started
+	DevWorkspaceStartedAtAnnotation = "controller.devfile.io/started-at"
+
 	// RoutingAnnotationInfix is the infix of the annotations of DevWorkspace that are passed down as annotation to the DevWorkspaceRouting objects.
 	// The full annotation name is supposed to be "<routingClass>.routing.controller.devfile.io/<anything>"
 	RoutingAnnotationInfix = ".routing.controller.devfile.io/"

--- a/pkg/timing/timing.go
+++ b/pkg/timing/timing.go
@@ -42,7 +42,11 @@ func SetTime(timingInfo map[string]string, event string) {
 	if _, set := timingInfo[event]; set {
 		return
 	}
-	timingInfo[event] = strconv.FormatInt(time.Now().UnixNano()/1e6, 10)
+	timingInfo[event] = CurrentTime()
+}
+
+func CurrentTime() string {
+	return strconv.FormatInt(time.Now().UnixNano()/1e6, 10)
 }
 
 // SummarizeStartup applies aggregate annotations based off event annotations set by


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR makes it so that when an already running workspace is reconciled we don't count that as a workspace start in the metrics

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/618

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Follow the metrics docs to run prometheus/grafana: https://github.com/devfile/devworkspace-operator/tree/main/doc/grafana.
2. Create a devworkspace and wait for it to start `oc apply -f samples/theia-next.yaml`
3. Observe that the workspace start metric was updated in grafana
4. Change the devworkspace such that its reconciled (I tested by adding a postStart event into the devworkspace)
5. Observe that the workspace started metric is not updated
6. Scale the devworkspace down by setting `started: false`
7. Scale the devworkspace up by setting `started: true`
8. Observe that the devworkspace started metric is updated

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
