### PR TITLE
Configure GH Actions builds to use matching container tool

### DIFF
--- a/build/scripts/build_index_image.sh
+++ b/build/scripts/build_index_image.sh
@@ -168,11 +168,13 @@ if [ "$RELEASE" == "true" ]; then
   opm index add \
     --bundles "$BUNDLE_DIGEST" \
     --from-index "$INDEX_IMAGE" \
-    --tag "$INDEX_IMAGE"
+    --tag "$INDEX_IMAGE" \
+    --container-tool "$PODMAN"
 else
   opm index add \
     --bundles "$BUNDLE_DIGEST" \
-    --tag "$INDEX_IMAGE"
+    --tag "$INDEX_IMAGE" \
+    --container-tool "$PODMAN"
 fi
 $PODMAN push "$INDEX_IMAGE" 2>&1 | sed 's|^|    |'
 


### PR DESCRIPTION
### What does this PR do?
Make sure `opm` commands use the same container tool as the later `push`.

### What issues does this PR fix or reference?
`next` action is building the index image successfully but not pushing it.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
