### PR TITLE
Make sure goimports is installed during release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,11 @@ jobs:
 
       - name: Release
         run: |
+          # Need to grab goimports otherwise formatting after this step will fail
+          # PR checks.
+          go get -u golang.org/x/tools/cmd/goimports
+          git reset HEAD --hard
+
           git config --global user.name "Angel Misevski"
           git config --global user.email "amisevsk@redhat.com"
 


### PR DESCRIPTION
### What does this PR do?
Install goimports in release action to avoid formatting issues as in e.g. https://github.com/devfile/devworkspace-operator/pull/688

### What issues does this PR fix or reference?
Autogenerated files do not match `goimports` specification, annoyingly.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
