### PR TITLE
Install OPM in GitHub release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
   release:
     env:
       OPERATOR_SDK_VERSION: v1.8.0
+      OPM_VERSION: v1.19.1
     runs-on: ubuntu-20.04
     steps:
       - name: Clone source code
@@ -47,25 +48,44 @@ jobs:
             echo "[INFO] No existing tags detected for $VERSION"
           fi
 
-      -
-        name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
+      - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
         uses: actions/cache@v2
         id: cache-operator-sdk
         with:
           path: ~/cache
           key: operator-sdk-${{ env.OPERATOR_SDK_VERSION }}
-      -
-        name: Download Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
+
+      - name: Download Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
         if: steps.cache-operator-sdk.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/cache
           wget https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64 -O ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} > /dev/null -O ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} > /dev/null
           chmod +x ~/cache/operator-sdk-${OPERATOR_SDK_VERSION}
-      -
-        name: Install Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
+
+      - name: Install Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
         run: |
           mkdir -p ~/bin
           cp ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} ~/bin/operator-sdk
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Cache OPM ${{ env.OPM_VERSION }}
+        uses: actions/cache@v2
+        id: cache-opm
+        with:
+          path: ~/cache
+          key: opm-${{ env.OPM_VERSION }}
+
+      - name: Download OPM ${{ env.OPM_VERSION }}
+        if: steps.cache-opm.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/cache
+          wget https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm -O ~/cache/opm${OPM_VERSION} > /dev/null
+          #${OPM_VERSION} is used in binary name to prevent caching after upgrading
+          chmod +x ~/cache/opm${OPM_VERSION}
+      - name: Install OPM ${{ env.OPM_VERSION }}
+        run: |
+          mkdir -p ~/bin
+          cp ~/cache/opm${OPM_VERSION} ~/bin/opm
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Login to quay.io


### PR DESCRIPTION
### What does this PR do?
Installs OPM during the release GitHub action.

### What issues does this PR fix or reference?
The release job now depends on OPM: https://github.com/devfile/devworkspace-operator/actions/runs/1505588209

### Is it tested? How?
This commit was pushed to the 0.11.x branch and used in [this run](https://github.com/devfile/devworkspace-operator/actions/runs/1505603052) of the release job.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
