### PR TITLE
Update storage-type attribute doc to mention ephemeral

### DIFF
--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -20,9 +20,11 @@ const (
 	// DevWorkspaceStorageTypeAttribute defines the strategy used for provisioning storage for the workspace.
 	// If empty, the common PVC strategy is used.
 	// Supported options:
-	// - "common": Create one PVC per namespace, and store data for all workspaces in that namespace in that PVC
-	// - "async" : Create one PVC per namespace, and create a remote server that syncs data from workspaces to the PVC.
-	//             All volumeMounts used for devworkspaces are emptyDir
+	// - "common":    Create one PVC per namespace, and store data for all workspaces in that namespace in that PVC
+	// - "async" :    Create one PVC per namespace, and create a remote server that syncs data from workspaces to the PVC.
+	//                All volumeMounts used for devworkspaces are emptyDir
+	// - "ephemeral": Use emptyDir volumes for all volumes in the DevWorkspace. All data is lost when the workspace is
+	//                stopped.
 	DevWorkspaceStorageTypeAttribute = "controller.devfile.io/storage-type"
 
 	// WorkspaceEnvAttribute is an attribute that specifies a set of environment variables provided by a component


### PR DESCRIPTION
### What does this PR do?
Updates godoc on the `storage-type` attribute to also mention ephemeral mode.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
