### PR TITLE
Wksp metrics rbac

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -94,6 +94,7 @@ type DevWorkspaceReconciler struct {
 // +kubebuilder:rbac:groups=apps;extensions,resources=deployments,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,resourceNames=workspace-credentials-secret,verbs=get;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,resourceNames=workspace-preferences-configmap,verbs=get;create;patch;delete
+// +kubebuilder:rbac:groups="metrics.k8s.io",resources=pods,verbs=get;list;watch
 
 func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcileResult ctrl.Result, err error) {
 	reqLogger := r.Log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -221,6 +221,14 @@ spec:
           - get
           - update
         - apiGroups:
+          - metrics.k8s.io
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - servicemonitors

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -19849,6 +19849,14 @@ rules:
   - get
   - update
 - apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -148,6 +148,14 @@ rules:
   - get
   - update
 - apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -19849,6 +19849,14 @@ rules:
   - get
   - update
 - apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -148,6 +148,14 @@ rules:
   - get
   - update
 - apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/deploy/templates/components/rbac/role.yaml
+++ b/deploy/templates/components/rbac/role.yaml
@@ -147,6 +147,14 @@ rules:
   - get
   - update
 - apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/pkg/provision/workspace/rbac.go
+++ b/pkg/provision/workspace/rbac.go
@@ -67,6 +67,11 @@ func generateRBAC(namespace string) []client.Object {
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
+					Resources: []string{"pods"},
+					APIGroups: []string{"metrics.k8s.io"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
 					Resources: []string{"deployments", "replicasets"},
 					APIGroups: []string{"apps", "extensions"},
 					Verbs:     []string{"get", "list", "watch"},


### PR DESCRIPTION
### What does this PR do?
Adds permissions
```yaml
- apiGroups:
  - metrics.k8s.io
  resources:
  - pods
  verbs:
  - get
  - list
  - watch
```
to the workspace ServiceAccount

### What issues does this PR fix or reference?
Needed for https://github.com/eclipse/che/issues/20800

### Is it tested? How?
Create a DevWorkspace and verify `workspace` role is updated.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
