### PR TITLE
Namespace pod tolerations

### DIFF
--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -102,4 +102,12 @@ const (
 	// NamespacedConfigLabelKey is a label applied to configmaps to mark them as a configuration for all DevWorkspaces in
 	// the current namespace.
 	NamespacedConfigLabelKey = "controller.devfile.io/namespaced-config"
+
+	// NamespacePodTolerationsAnnotation is an annotation applied to a namespace to configure pod tolerations for all workspaces
+	// in that namespace. Value should be json-encoded []corev1.Toleration struct.
+	NamespacePodTolerationsAnnotation = "controller.devfile.io/pod-tolerations"
+
+	// NamespaceNodeSelectorAnnotation is an annotation applied to a namespace to configure the node selector for all workspaces
+	// in that namespace. Value should be json-encoded map[string]string
+	NamespaceNodeSelectorAnnotation = "controller.devfile.io/node-selector"
 )

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -17,6 +17,7 @@ package workspace
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -113,9 +114,20 @@ func SyncDeploymentToCluster(
 		envFromSourceAdditions = append(envFromSourceAdditions, automountEnv...)
 	}
 
+	podTolerations, nodeSelector, err := getNamespacePodTolerationsAndNodeSelector(workspace.Namespace, clusterAPI)
+	if err != nil {
+		return DeploymentProvisioningStatus{
+			ProvisioningStatus{
+				Message:     "failed to read pod tolerations and node selector from namespace",
+				Err:         err,
+				FailStartup: true,
+			},
+		}
+	}
+
 	// [design] we have to pass components and routing pod additions separately because we need mountsources from each
 	// component.
-	specDeployment, err := getSpecDeployment(workspace, podAdditions, envFromSourceAdditions, saName, clusterAPI.Scheme)
+	specDeployment, err := getSpecDeployment(workspace, podAdditions, envFromSourceAdditions, saName, podTolerations, nodeSelector, clusterAPI.Scheme)
 	if err != nil {
 		return DeploymentProvisioningStatus{
 			ProvisioningStatus{
@@ -228,6 +240,8 @@ func getSpecDeployment(
 	podAdditionsList []v1alpha1.PodAdditions,
 	envFromSourceAdditions []corev1.EnvFromSource,
 	saName string,
+	podTolerations []corev1.Toleration,
+	nodeSelector map[string]string,
 	scheme *runtime.Scheme) (*appsv1.Deployment, error) {
 	replicas := int32(1)
 	terminationGracePeriod := int64(10)
@@ -292,6 +306,13 @@ func getSpecDeployment(
 				},
 			},
 		},
+	}
+
+	if podTolerations != nil && len(podTolerations) > 0 {
+		deployment.Spec.Template.Spec.Tolerations = podTolerations
+	}
+	if nodeSelector != nil && len(nodeSelector) > 0 {
+		deployment.Spec.Template.Spec.NodeSelector = nodeSelector
 	}
 
 	if needsPVCWorkaround(podAdditions) {
@@ -493,4 +514,30 @@ func checkIfUnrecoverableEventIgnored(reason string) (ignored bool) {
 		}
 	}
 	return false
+}
+
+func getNamespacePodTolerationsAndNodeSelector(namespace string, api sync.ClusterAPI) ([]corev1.Toleration, map[string]string, error) {
+	ns := &corev1.Namespace{}
+	err := api.Client.Get(api.Ctx, types.NamespacedName{Name: namespace}, ns)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var podTolerations []corev1.Toleration
+	podTolerationsAnnot, ok := ns.Annotations[constants.NamespacePodTolerationsAnnotation]
+	if ok && podTolerationsAnnot != "" {
+		if err := json.Unmarshal([]byte(podTolerationsAnnot), &podTolerations); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse %s annotation: %w", constants.NamespacePodTolerationsAnnotation, err)
+		}
+	}
+
+	nodeSelector := map[string]string{}
+	nodeSelectorAnnot, ok := ns.Annotations[constants.NamespaceNodeSelectorAnnotation]
+	if ok && nodeSelectorAnnot != "" {
+		if err := json.Unmarshal([]byte(nodeSelectorAnnot), &nodeSelector); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse %s annotation: %w", constants.NamespaceNodeSelectorAnnotation, err)
+		}
+	}
+
+	return podTolerations, nodeSelector, nil
 }


### PR DESCRIPTION
### What does this PR do?
Adds support for namespace-level configuration of pod tolerations and node selector via *namespace* annotations

* `"controller.devfile.io/pod-tolerations"`
* `"controller.devfile.io/node-selector"`

The value of the tolerations annotation must be json-formatted `[]corev1.Toleration`. The value of the node-selector annotation must be `map[string]string`. If these annotations are applied to a namespace, their values are used for *all* pods created for workspaces in that namespace. This includes:
* The workspace pod itself
* The pod created as part of the PVC cleanup job
* The async storage server deployment

### What issues does this PR fix or reference? 
Closes https://github.com/devfile/devworkspace-operator/issues/614 (assuming this implementation is sufficient)

### Is it tested? How?
Instructions written for minikube, on other clusters node name should be changed
1. Taint a node and add a label to it
    ```bash
    # Apply a taint to the minikube node
    kubectl taint nodes minikube key1=value1:NoSchedule
    # Apply a new label to the minikube node
    kubectl label nodes minikube test-node-selector=test
    ```
2. Add annotations to the namespace to be used:
    ```yaml
    metadata:
      annotations:
        controller.devfile.io/node-selector: |
          {
            "test-node-selector": "test"
          }
        controller.devfile.io/pod-tolerations: |
          [
            {
              "key": "key1",
              "operator": "Equal",
              "value": "value1",
              "effect": "NoSchedule"
            }
          ]
    ```
    Note: formatting can be finicky, if annotations cannot be unmarshalled, all DWO activity in the namespace fails.
3. Create DevWorkspace and verify it can start in the cluster (and deployment has appropriate nodeSelector/tolerations)
    ```bash
    kubectl apply -f samples/theia-next.yaml
    ```
4. Once workspace is started, delete it and verify cleanup succeeds
    ```
    kubectl delete dw theia-next --wait
    ```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
