### PR TITLE
Set PROJECT_SOURCE env var correctly in DevWorkspaces

### DIFF
--- a/pkg/library/constants/constants.go
+++ b/pkg/library/constants/constants.go
@@ -17,6 +17,6 @@ package constants
 
 const (
 	ProjectsRootEnvVar   = "PROJECTS_ROOT"
-	ProjectsSourceEnvVar = "PROJECTS_SOURCE"
+	ProjectsSourceEnvVar = "PROJECT_SOURCE"
 	ProjectsVolumeName   = "projects"
 )

--- a/pkg/library/container/container.go
+++ b/pkg/library/container/container.go
@@ -62,7 +62,7 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec) (*v1al
 		if err != nil {
 			return nil, err
 		}
-		handleMountSources(k8sContainer, component.Container)
+		handleMountSources(k8sContainer, component.Container, workspace.Projects)
 		podAdditions.Containers = append(podAdditions.Containers, *k8sContainer)
 	}
 
@@ -75,7 +75,7 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec) (*v1al
 		if err != nil {
 			return nil, err
 		}
-		handleMountSources(k8sContainer, container.Container)
+		handleMountSources(k8sContainer, container.Container, workspace.Projects)
 		podAdditions.InitContainers = append(podAdditions.InitContainers, *k8sContainer)
 	}
 

--- a/pkg/library/container/testdata/component/converts-all-fields.yaml
+++ b/pkg/library/container/testdata/component/converts-all-fields.yaml
@@ -57,8 +57,8 @@ output:
             value: "TEST_VALUE"
           - name: "PROJECTS_ROOT"
             value: "/source-mapping"
-          - name: "PROJECTS_SOURCE"
-            value: "/source-mapping" # Temp value until projects is figured out
+          - name: "PROJECT_SOURCE"
+            value: "/source-mapping"
         command:
           - "test"
           - "command"

--- a/pkg/library/container/testdata/mountsources/projects-source-is-set-correctly-from-clonepath.yaml
+++ b/pkg/library/container/testdata/mountsources/projects-source-is-set-correctly-from-clonepath.yaml
@@ -1,0 +1,92 @@
+name: "Sets PROJECT_SOURCE env var based on project's clonePath"
+
+input:
+  projects:
+  - name: test_project
+    clonePath: clone-path
+  - name: test_project_unused
+    clonePath: ignored/since/not/first
+  components:
+    - name: testing-container-1
+      container:
+        image: testing-image-1
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
+        sourceMapping: "/testdir1"
+        # no mountSources defined -> should mount sources
+    - name: testing-container-2
+      container:
+        image: testing-image-2
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
+        # No sourceMapping -> defaults to "/projects"
+        mountSources: true # mountSources: true -> should mount sources
+    - name: testing-container-3
+      container:
+        image: testing-image-3
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
+        sourceMapping: "/projects"
+        mountSources: false # mountSources: false -> should not mount sources
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image-1
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
+          limits:
+            memory: "-1"
+            cpu: "-1"
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/testdir1"
+        env:
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-1"
+          - name: "PROJECTS_ROOT"
+            value: "/testdir1"
+          - name: "PROJECT_SOURCE"
+            value: "/testdir1/clone-path"
+      - name: testing-container-2
+        image: testing-image-2
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
+          limits:
+            memory: "-1"
+            cpu: "-1"
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects"
+        env:
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-2"
+          - name: "PROJECTS_ROOT"
+            value: "/projects"
+          - name: "PROJECT_SOURCE"
+            value: "/projects/clone-path"
+      - name: testing-container-3
+        image: testing-image-3
+        imagePullPolicy: Always
+        env:
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-3"
+        resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
+          limits:
+            memory: "-1"
+            cpu: "-1"

--- a/pkg/library/container/testdata/mountsources/projects-source-is-set-correctly-from-project-name.yaml
+++ b/pkg/library/container/testdata/mountsources/projects-source-is-set-correctly-from-project-name.yaml
@@ -1,0 +1,91 @@
+name: "Sets PROJECT_SOURCE env var based on project's name when no clonePath"
+
+input:
+  projects:
+  - name: test_project
+  - name: test_project_unused
+    clonePath: ignored/since/not/first
+  components:
+    - name: testing-container-1
+      container:
+        image: testing-image-1
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
+        sourceMapping: "/testdir1"
+        # no mountSources defined -> should mount sources
+    - name: testing-container-2
+      container:
+        image: testing-image-2
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
+        # No sourceMapping -> defaults to "/projects"
+        mountSources: true # mountSources: true -> should mount sources
+    - name: testing-container-3
+      container:
+        image: testing-image-3
+        memoryRequest: "-1"  # isolate test to not include this field
+        memoryLimit: "-1"  # isolate test to not include this field
+        cpuRequest: "-1"  # isolate test to not include this field
+        cpuLimit: "-1"  # isolate test to not include this field
+        sourceMapping: "/projects"
+        mountSources: false # mountSources: false -> should not mount sources
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image-1
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
+          limits:
+            memory: "-1"
+            cpu: "-1"
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/testdir1"
+        env:
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-1"
+          - name: "PROJECTS_ROOT"
+            value: "/testdir1"
+          - name: "PROJECT_SOURCE"
+            value: "/testdir1/test_project"
+      - name: testing-container-2
+        image: testing-image-2
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
+          limits:
+            memory: "-1"
+            cpu: "-1"
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects"
+        env:
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-2"
+          - name: "PROJECTS_ROOT"
+            value: "/projects"
+          - name: "PROJECT_SOURCE"
+            value: "/projects/test_project"
+      - name: testing-container-3
+        image: testing-image-3
+        imagePullPolicy: Always
+        env:
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-3"
+        resources:
+          requests:
+            memory: "-1"
+            cpu: "-1"
+          limits:
+            memory: "-1"
+            cpu: "-1"

--- a/pkg/library/container/testdata/volume/container-that-mounts-projects-directly.yaml
+++ b/pkg/library/container/testdata/volume/container-that-mounts-projects-directly.yaml
@@ -39,5 +39,5 @@ output:
             value: "testing-container-1"
           - name: "PROJECTS_ROOT"
             value: "/not-source-mapping"
-          - name: "PROJECTS_SOURCE"
-            value: "/not-source-mapping" # Temp value until projects is figured out
+          - name: "PROJECT_SOURCE"
+            value: "/not-source-mapping"

--- a/pkg/library/container/testdata/volume/mountSources.yaml
+++ b/pkg/library/container/testdata/volume/mountSources.yaml
@@ -50,8 +50,8 @@ output:
             value: "testing-container-1"
           - name: "PROJECTS_ROOT"
             value: "/testdir1"
-          - name: "PROJECTS_SOURCE"
-            value: "/testdir1" # Temp value until projects is figured out
+          - name: "PROJECT_SOURCE"
+            value: "/testdir1"
       - name: testing-container-2
         image: testing-image-2
         imagePullPolicy: Always
@@ -70,9 +70,8 @@ output:
             value: "testing-container-2"
           - name: "PROJECTS_ROOT"
             value: "/projects"
-          - name: "PROJECTS_SOURCE"
-            value: "/projects" # Temp value until projects is figured out
-
+          - name: "PROJECT_SOURCE"
+            value: "/projects"
       - name: testing-container-3
         image: testing-image-3
         imagePullPolicy: Always


### PR DESCRIPTION
### What does this PR do?
Updates DWO to properly handle the `PROJECT_SOURCE` environment variable:
> `$PROJECT_SOURCE`: A path to a project source (`$PROJECTS_ROOT/\u003cproject-name\u003e`). If there are multiple projects, this will point to the directory of the first one."

Adds test cases to cover this functionality.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/677

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
