### PR TITLE
Make project-clone work in a temporary directory; copy files at end

### DIFF
--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -18,46 +18,68 @@ package git
 import (
 	"fmt"
 	"log"
+	"os"
+	"path"
 
-	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 
 	"github.com/devfile/devworkspace-operator/project-clone/internal"
 )
 
-func SetupGitProject(project v1alpha2.Project) error {
+func SetupGitProject(project dw.Project) error {
 	needClone, needRemotes, err := internal.CheckProjectState(&project)
 	if err != nil {
 		return fmt.Errorf("failed to check state of repo on disk: %s", err)
 	}
 	if needClone {
-		err := CloneProject(&project)
-		if err != nil {
-			return fmt.Errorf("failed to clone project: %s", err)
-		}
-		repo, err := internal.OpenRepo(&project)
-		if err != nil {
-			return fmt.Errorf("failed to open existing project in filesystem: %s", err)
-		} else if repo == nil {
-			return fmt.Errorf("unexpected error while setting up remotes for project: git repository not present")
-		}
-		if err := SetupRemotes(repo, &project); err != nil {
-			return fmt.Errorf("failed to set up remotes for project: %s", err)
-		}
-		if err := CheckoutReference(repo, &project); err != nil {
-			return fmt.Errorf("failed to checkout revision: %s", err)
-		}
+		return doInitialGitClone(&project)
 	} else if needRemotes {
-		repo, err := internal.OpenRepo(&project)
-		if err != nil {
-			return fmt.Errorf("failed to open existing project in filesystem: %s", err)
-		} else if repo == nil {
-			return fmt.Errorf("unexpected error while setting up remotes for project: git repository not present")
-		}
-		if err := SetupRemotes(repo, &project); err != nil {
-			return fmt.Errorf("failed to set up remotes for project: %s", err)
-		}
+		return setupRemotesForExistingProject(&project)
 	} else {
 		log.Printf("Project '%s' is already cloned and has all remotes configured", project.Name)
+		return nil
+	}
+}
+
+func doInitialGitClone(project *dw.Project) error {
+	// Clone into a temp dir and then move set up project to PROJECTS_ROOT to try and make clone atomic in case
+	// project-clone container is terminated
+	tmpClonePath := path.Join(internal.CloneTmpDir, internal.GetClonePath(project))
+	err := CloneProject(project, tmpClonePath)
+	if err != nil {
+		return fmt.Errorf("failed to clone project: %s", err)
+	}
+	repo, err := internal.OpenRepo(tmpClonePath)
+	if err != nil {
+		return fmt.Errorf("failed to open existing project in filesystem: %s", err)
+	} else if repo == nil {
+		return fmt.Errorf("unexpected error while setting up remotes for project: git repository not present")
+	}
+	if err := SetupRemotes(repo, project, tmpClonePath); err != nil {
+		return fmt.Errorf("failed to set up remotes for project: %s", err)
+	}
+	if err := CheckoutReference(repo, project, tmpClonePath); err != nil {
+		return fmt.Errorf("failed to checkout revision: %s", err)
+	}
+
+	projectPath := path.Join(internal.ProjectsRoot, internal.GetClonePath(project))
+	log.Printf("Moving cloned project %s from temporary dir %s to %s", project.Name, tmpClonePath, projectPath)
+	if err := os.Rename(tmpClonePath, projectPath); err != nil {
+		return fmt.Errorf("failed to move cloned project to PROJECTS_ROOT: %w", err)
+	}
+	return nil
+}
+
+func setupRemotesForExistingProject(project *dw.Project) error {
+	projectPath := path.Join(internal.ProjectsRoot, internal.GetClonePath(project))
+	repo, err := internal.OpenRepo(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to open existing project in filesystem: %s", err)
+	} else if repo == nil {
+		return fmt.Errorf("unexpected error while setting up remotes for project: git repository not present")
+	}
+	if err := SetupRemotes(repo, project, projectPath); err != nil {
+		return fmt.Errorf("failed to set up remotes for project: %s", err)
 	}
 	return nil
 }

--- a/project-clone/internal/global.go
+++ b/project-clone/internal/global.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	ProjectsRoot string
+	CloneTmpDir  string
 )
 
 // Read and store ProjectsRoot env var for reuse throughout project-clone.
@@ -33,4 +34,13 @@ func init() {
 		log.Printf("Required environment variable %s is unset", constants.ProjectsRootEnvVar)
 		os.Exit(1)
 	}
+	// Have to use path within PROJECTS_ROOT in case it is a mounted directory; otherwise, moving files will fail
+	// (os.Rename fails when source and dest are on different partitions)
+	tmpDir, err := os.MkdirTemp(ProjectsRoot, "project-clone-")
+	if err != nil {
+		log.Printf("Failed to get temporary directory for setting up projects: %s", err)
+		os.Exit(1)
+	}
+	log.Printf("Using temporary directory %s", tmpDir)
+	CloneTmpDir = tmpDir
 }

--- a/project-clone/internal/utils.go
+++ b/project-clone/internal/utils.go
@@ -32,12 +32,12 @@ import (
 // The git repo can have additional remotes -- they will be ignored here. If both the project and git repo have remote
 // A configured, but the corresponding remote URL is different, needRemotes will be true.
 func CheckProjectState(project *dw.Project) (needClone, needRemotes bool, err error) {
-	repo, err := OpenRepo(project)
+	repo, err := OpenRepo(path.Join(ProjectsRoot, GetClonePath(project)))
 	if err != nil {
 		return false, false, err
 	}
 	if repo == nil {
-		return true, true, nil
+		return true, false, nil
 	}
 
 	for projRemote, projRemoteURL := range project.Git.Remotes {
@@ -63,12 +63,11 @@ func CheckProjectState(project *dw.Project) (needClone, needRemotes bool, err er
 
 // OpenRepo returns the git repo on disk described by the devworkspace Project. If the repo does not
 // currently exist, returns nil. Returns an error if an unexpected error occurs opening the git repo.
-func OpenRepo(project *dw.Project) (*git.Repository, error) {
-	clonePath := GetClonePath(project)
-	repo, err := git.PlainOpen(path.Join(ProjectsRoot, clonePath))
+func OpenRepo(repoPath string) (*git.Repository, error) {
+	repo, err := git.PlainOpen(repoPath)
 	if err != nil {
 		if err != git.ErrRepositoryNotExists {
-			return nil, fmt.Errorf("encountered error reading git repo at %s: %s", clonePath, err)
+			return nil, fmt.Errorf("encountered error reading git repo at %s: %s", repoPath, err)
 		}
 		return nil, nil
 	}


### PR DESCRIPTION
### What does this PR do?
In order to avoid issues where the project-clone container is killed during its initial run, leaving repos in a half-configured state, do all operations in a temporary directory and copy repos to their expected locations at the very end.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/699

### Is it tested? How?
Can be tested using the image `quay.io/amisevsk/project-clone:atomic-clone` (e.g. in the relevant `RELATED_IMAGE` env var or by setting `PROJECT_CLONE_IMG` when installing DWO). To test both git and zip type projects, use the devfile
```yaml
cat <<EOF | kubectl apply -f - 
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
      - name: devworkspace-operator-zip
        zip:
          location: https://github.com/devfile/devworkspace-operator/archive/refs/heads/main.zip
    components:
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
          components:
            - name: theia-ide
              container:
                env:
                  - name: THEIA_HOST
                    value: 0.0.0.0
EOF
```
and check that
1. Projects are setup successfully
2. Project-clone does nothing when the workspace is restarted
3. No temp directories or files are present in `$PROJECTS_ROOT`
4. (If you can figure out how) kill project clone while it's preparing projects and make sure the subsequent run behaves as above

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
