### PR TITLE
Update to Go 1.16

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.13
+        go-version: 1.16.6
     -
       name: Set up Python 3.8
       uses: actions/setup-python@v2
@@ -72,9 +72,7 @@ jobs:
     -
       name: Check format
       run: |
-        # Have to use older version of addlicense as newer versions *require* Go 1.16. This
-        # requirement can be removed once this project moves to Go 1.16
-        go get -u github.com/google/addlicense@99ebc9c9db7bceb8623073e894533b978d7b7c8a
+        go get -u github.com/google/addlicense
         go get -u golang.org/x/tools/cmd/goimports
         git reset HEAD --hard
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/devworkspace-operator
 
-go 1.15
+go 1.16
 
 require (
 	github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460

--- a/go.sum
+++ b/go.sum
@@ -133,7 +133,6 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -580,7 +579,6 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449 h1:xUIPaMhvROX9dhPvRCenIJtU78+lbEenGbgqB5hfHCQ=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/infrastructure/namespace.go
+++ b/pkg/infrastructure/namespace.go
@@ -17,7 +17,6 @@ package infrastructure
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -30,7 +29,7 @@ const (
 //
 // This function was ported over from Operator SDK 0.17.0 and modified.
 func GetOperatorNamespace() (string, error) {
-	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", fmt.Errorf("could not read namespace from mounted serviceaccount info")

--- a/pkg/library/container/container_test.go
+++ b/pkg/library/container/container_test.go
@@ -17,7 +17,7 @@ package container
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -52,7 +52,7 @@ func setupControllerCfg() {
 }
 
 func loadAllTestCasesOrPanic(t *testing.T, fromDir string) []testCase {
-	files, err := ioutil.ReadDir(fromDir)
+	files, err := os.ReadDir(fromDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func loadAllTestCasesOrPanic(t *testing.T, fromDir string) []testCase {
 }
 
 func loadTestCaseOrPanic(t *testing.T, testPath string) testCase {
-	bytes, err := ioutil.ReadFile(testPath)
+	bytes, err := os.ReadFile(testPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/library/flatten/internal/testutil/common.go
+++ b/pkg/library/flatten/internal/testutil/common.go
@@ -16,7 +16,7 @@
 package testutil
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -72,7 +72,7 @@ type TestOutput struct {
 }
 
 func LoadTestCaseOrPanic(t *testing.T, testFilepath string) TestCase {
-	bytes, err := ioutil.ReadFile(testFilepath)
+	bytes, err := os.ReadFile(testFilepath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func LoadTestCaseOrPanic(t *testing.T, testFilepath string) TestCase {
 }
 
 func LoadAllTestsOrPanic(t *testing.T, fromDir string) []TestCase {
-	files, err := ioutil.ReadDir(fromDir)
+	files, err := os.ReadDir(fromDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/library/flatten/network/fetch.go
+++ b/pkg/library/flatten/network/fetch.go
@@ -17,7 +17,7 @@ package network
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -37,7 +37,7 @@ func FetchDevWorkspaceTemplate(location string, httpClient HTTPGetter) (*dw.DevW
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("could not fetch file from %s: got status %d", location, resp.StatusCode)
 	}
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("could not read data from %s: %w", location, err)
 	}

--- a/pkg/library/lifecycle/poststart_test.go
+++ b/pkg/library/lifecycle/poststart_test.go
@@ -14,7 +14,7 @@
 package lifecycle
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -41,7 +41,7 @@ type postStartTestOutput struct {
 }
 
 func loadPostStartTestCaseOrPanic(t *testing.T, testPath string) postStartTestCase {
-	bytes, err := ioutil.ReadFile(testPath)
+	bytes, err := os.ReadFile(testPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func loadPostStartTestCaseOrPanic(t *testing.T, testPath string) postStartTestCa
 }
 
 func loadAllPostStartTestCasesOrPanic(t *testing.T, fromDir string) []postStartTestCase {
-	files, err := ioutil.ReadDir(fromDir)
+	files, err := os.ReadDir(fromDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/library/lifecycle/prestart_test.go
+++ b/pkg/library/lifecycle/prestart_test.go
@@ -17,7 +17,7 @@ package lifecycle
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,7 +40,7 @@ type preStartTestOutput struct {
 
 func loadPreStartTestCaseOrPanic(t *testing.T, testFilename string) preStartTestCase {
 	testPath := filepath.Join("./testdata/prestart", testFilename)
-	bytes, err := ioutil.ReadFile(testPath)
+	bytes, err := os.ReadFile(testPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -16,7 +16,7 @@
 package storage
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -76,7 +76,7 @@ func setupControllerCfg() {
 }
 
 func loadTestCaseOrPanic(t *testing.T, testFilepath string) testCase {
-	bytes, err := ioutil.ReadFile(testFilepath)
+	bytes, err := os.ReadFile(testFilepath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func loadTestCaseOrPanic(t *testing.T, testFilepath string) testCase {
 }
 
 func loadAllTestCasesOrPanic(t *testing.T, fromDir string) []testCase {
-	files, err := ioutil.ReadDir(fromDir)
+	files, err := os.ReadDir(fromDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/project-clone/internal/devfile.go
+++ b/project-clone/internal/devfile.go
@@ -17,7 +17,6 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -43,7 +42,7 @@ func ReadFlattenedDevWorkspace() (*dw.DevWorkspaceTemplateSpec, error) {
 		return nil, fmt.Errorf("required environment variable %s is unset", metadata.FlattenedDevfileMountPathEnvVar)
 	}
 
-	fileBytes, err := ioutil.ReadFile(flattenedDevWorkspacePath)
+	fileBytes, err := os.ReadFile(flattenedDevWorkspacePath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading YAML file: %s", err)
 	}

--- a/project-clone/internal/zip/setup.go
+++ b/project-clone/internal/zip/setup.go
@@ -19,7 +19,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -173,8 +172,7 @@ func unzip(archivePath string, destPath string) error {
 // and removes directory /projects/my-project/my-project-master/
 // If the specified path contains additional files or directories, no changes are made.
 func dropTopLevelFolder(projectPath string) error {
-	// Use ioutil ReadDir() since os.ReadDir is unavailable in Go 1.15
-	files, err := ioutil.ReadDir(projectPath)
+	files, err := os.ReadDir(projectPath)
 	if err != nil {
 		return err
 	}
@@ -188,7 +186,7 @@ func dropTopLevelFolder(projectPath string) error {
 	}
 	topLevelPath := path.Join(projectPath, topLevelFolder.Name())
 	log.Printf("Moving files from %s to %s", topLevelPath, projectPath)
-	topLevelContents, err := ioutil.ReadDir(topLevelPath)
+	topLevelContents, err := os.ReadDir(topLevelPath)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/pkg/client/client.go
+++ b/test/e2e/pkg/client/client.go
@@ -17,13 +17,13 @@ package client
 
 import (
 	"fmt"
+	"os"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
-	"io/ioutil"
 	"log"
 	"os/exec"
 	"strconv"
@@ -124,12 +124,12 @@ func (c *K8sClient) Kube() kubernetes.Interface {
 
 //read a source file and copy to the selected path
 func copyFile(sourceFile string, destinationFile string) error {
-	input, err := ioutil.ReadFile(sourceFile)
+	input, err := os.ReadFile(sourceFile)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(destinationFile, input, 0644)
+	err = os.WriteFile(destinationFile, input, 0644)
 	if err != nil {
 		return err
 	}

--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -17,7 +17,6 @@ package server
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -86,7 +85,7 @@ func ConfigureWebhookServer(mgr manager.Manager) error {
 		return nil
 	}
 
-	CABundle, err = ioutil.ReadFile(WebhookServerCertDir + "/tls.crt")
+	CABundle, err = os.ReadFile(WebhookServerCertDir + "/tls.crt")
 	if os.IsNotExist(err) {
 		return errors.New("CA certificate is not found. Unable to setup webhook server")
 	}


### PR DESCRIPTION
### What does this PR do?
* Update Github action to use Go v1.16.6
* Update go.mod to specify Go 1.16
* Replaces uses of deprecated ioutil package with replacements

### What issues does this PR fix or reference?
Allows us to use Go 1.16 features

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
