### PR TITLE
[feat] Provision user and email credentials to gitconfig

### DIFF
--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -54,8 +54,8 @@ const (
 	DevWorkspaceGitTLSLabel = "controller.devfile.io/git-tls-credential"
 
 	// DevWorkspaceGitUserLabel is the label key to specify if the configmap is credentials for accessing a git server.
-	// Configmap must contain the following data:
-	// username: the username of the user in git
+	// Configmap can contain any of the following data:
+	// name: the name of the user in git
 	// email: the email of the user in git
 	DevWorkspaceGitUserLabel = "controller.devfile.io/git-user-credential"
 

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -53,6 +53,12 @@ const (
 	// If the git host is not defined then the certificate will be used for all http repositories.
 	DevWorkspaceGitTLSLabel = "controller.devfile.io/git-tls-credential"
 
+	// DevWorkspaceGitUserLabel is the label key to specify if the configmap is credentials for accessing a git server.
+	// Configmap must contain the following data:
+	// username: the username of the user in git
+	// email: the email of the user in git
+	DevWorkspaceGitUserLabel = "controller.devfile.io/git-user-credential"
+
 	// DevWorkspaceMountPathAnnotation is the annotation key to store the mount path for the secret or configmap.
 	// If no mount path is provided, configmaps will be mounted at /etc/config/<configmap-name>, secrets will
 	// be mounted at /etc/secret/<secret-name>, and persistent volume claims will be mounted to /tmp/<claim-name>

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -53,7 +53,8 @@ const (
 	// If the git host is not defined then the certificate will be used for all http repositories.
 	DevWorkspaceGitTLSLabel = "controller.devfile.io/git-tls-credential"
 
-	// DevWorkspaceGitUserLabel is the label key to specify if the configmap is credentials for accessing a git server.
+	// DevWorkspaceGitUserLabel is the label key to specify if the configmap is git user credentials that should be propogated
+	// into the gitconfig.
 	// Configmap can contain any of the following data:
 	// name: the name of the user in git
 	// email: the email of the user in git

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -53,7 +53,7 @@ const (
 	// If the git host is not defined then the certificate will be used for all http repositories.
 	DevWorkspaceGitTLSLabel = "controller.devfile.io/git-tls-credential"
 
-	// DevWorkspaceGitUserLabel is the label key to specify if the configmap is git user credentials that should be propogated
+	// DevWorkspaceGitUserLabel is the label key to specify if the configmap contains git user credentials that should be propogated
 	// into the gitconfig.
 	// Configmap can contain any of the following data:
 	// name: the name of the user in git

--- a/pkg/provision/workspace/automount/git-config.go
+++ b/pkg/provision/workspace/automount/git-config.go
@@ -30,7 +30,7 @@ import (
 const hostKey = "host"
 const certificateKey = "certificate"
 
-const usernameKey = "username"
+const nameKey = "name"
 const emailKey = "email"
 
 const gitConfigName = "gitconfig"
@@ -54,11 +54,10 @@ const defaultGitServerTemplate = `[http]
 
 // provisionGitConfig takes care of mounting a gitconfig into a devworkspace.
 //	It does so by:
-//		1. Finding all secrets labeled with "controller.devfile.io/git-tls-credential": "true"
-//		2. Fill out the gitconfig with any necessary information:
+//		1. Fill out the gitconfig with any necessary information:
 //			a. Git user credentials if specified
 //			b. Git server credentials if specified
-//		3. Creating and mounting a gitconfig config map to /etc/gitconfig with the above information
+//		2. Creating and mounting a gitconfig config map to /etc/gitconfig with the above information
 func provisionGitConfig(api sync.ClusterAPI, namespace string, userMountPath string) (*v1alpha1.PodAdditions, error) {
 	podAdditions, gitconfig, err := constructGitConfig(api, namespace, userMountPath)
 	if err != nil {
@@ -111,11 +110,11 @@ func constructGitUserConfig(api sync.ClusterAPI, namespace string, gitconfig str
 	}
 	if len(configmap.Items) == 1 {
 		cm := configmap.Items[0]
-		username, usernameFound := cm.Data[usernameKey]
+		name, nameFound := cm.Data[nameKey]
 		email, emailFound := cm.Data[emailKey]
 
-		if usernameFound {
-			gitconfig = gitconfig + fmt.Sprintf("user.name=%s\n", username)
+		if nameFound {
+			gitconfig = gitconfig + fmt.Sprintf("user.name=%s\n", name)
 		}
 
 		if emailFound {

--- a/samples/gituserconfig.yml
+++ b/samples/gituserconfig.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sample-user-credentials
+  namespace: devworkspace-controller
+  labels:
+    controller.devfile.io/git-user-credential: "true"
+    controller.devfile.io/watch-configmap: "true"
+data:
+  username: jpinkney
+  email: jpinkney@redhat.com

--- a/samples/gituserconfig.yml
+++ b/samples/gituserconfig.yml
@@ -7,5 +7,5 @@ metadata:
     controller.devfile.io/git-user-credential: "true"
     controller.devfile.io/watch-configmap: "true"
 data:
-  name: jpinkney
-  email: jpinkney@redhat.com
+  name: sampleName
+  email: sampleName@sampleName.com

--- a/samples/gituserconfig.yml
+++ b/samples/gituserconfig.yml
@@ -7,5 +7,5 @@ metadata:
     controller.devfile.io/git-user-credential: "true"
     controller.devfile.io/watch-configmap: "true"
 data:
-  username: jpinkney
+  name: jpinkney
   email: jpinkney@redhat.com


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR automatically provisions user and email credentials to the gitconfig whenever the label: controller.devfile.io/git-user-credential is true.

If you want to provision git credentials to your gitconfig you can use:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: sample-user-credentials
  namespace: devworkspace-controller
  labels:
    controller.devfile.io/git-user-credential: "true"
    controller.devfile.io/watch-configmap: "true"
data:
  name: sampleName
  email: sampleName@sampleName.com
```

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/694

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested manually using the above configmap, but also added unit tests

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
