### PR TITLE
Add automount subpaths option

### DIFF
--- a/docs/additional-configuration.md
+++ b/docs/additional-configuration.md
@@ -92,8 +92,11 @@ By default, resources will be mounted based on the resource name:
 Mounting resources can be additionally configured via **annotations**:
 * `controller.devfile.io/mount-path`: configure where the resource should be mounted
 * `controller.devfile.io/mount-as`: for secrets and configmaps only, configure how the resource should be mounted to the workspace
-    * If `controller.devfile.io/mount-as: file`, the configmap/secret will be mounted as files within the mount path. This is the default behavior
-    * If `controller.devfile.io/mount-as: env`, the keys and values in the configmap/secret will be mounted as environment variables in all containers in the DevWorkspace
+    * If `controller.devfile.io/mount-as: file`, the configmap/secret will be mounted as files within the mount path. This is the default behavior.
+    * If `controller.devfile.io/mount-as: subpath`, the keys and values in the configmap/secret will be mounted as files within the mount path using subpath volume mounts.
+    * If `controller.devfile.io/mount-as: env`, the keys and values in the configmap/secret will be mounted as environment variables in all containers in the DevWorkspace.
+
+  When "file" is used, the configmap is mounted as a directory within the workspace, erasing any files/directories already present. When "subpath" is used, each key in the configmap/secret is mounted as a subpath volume mount in the mount path, leaving existing files intact but preventing changes to the secret/configmap from propagating into the workspace without a restart.
 * `controller.devfile.io/read-only`: for persistent volume claims, mount the resource as read-only
 
 ## Adding image pull secrets to workspaces

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -34,7 +34,7 @@ const (
 	// secrets that should be seen by the controller
 	DevWorkspaceWatchSecretLabel = "controller.devfile.io/watch-secret"
 
-	// DevWorkspaceMountLabel is the label key to store if a configmap or secret should be mounted to the devworkspace
+	// DevWorkspaceMountLabel is the label key to store if a configmap, secret, or PVC should be mounted to the devworkspace
 	DevWorkspaceMountLabel = "controller.devfile.io/mount-to-devworkspace"
 
 	// DevWorkspaceGitCredentialLabel is the label key to specify if the secret is a git credential. All secrets who
@@ -61,7 +61,12 @@ const (
 	// DevWorkspaceMountAsAnnotation is the annotation key to configure the way how configmaps or secrets should be mounted.
 	// Supported options:
 	// - "env" - mount as environment variables
-	// - "file" - mount as a file
+	// - "file" - mount as files within the mount path
+	// - "subpath" - mount keys as subpath volume mounts within the mount path
+	// When a configmap or secret is mounted via "file", the keys within the configmap/secret are mounted as files
+	// within a directory, erasing all contents of the directory. Mounting via "subpath" leaves existing files in the
+	// mount directory changed, but prevents on-cluster changes to the configmap/secret propagating to the container
+	// until it is restarted.
 	// If mountAs is not provided, the default behaviour will be to mount as a file.
 	DevWorkspaceMountAsAnnotation = "controller.devfile.io/mount-as"
 

--- a/pkg/provision/workspace/automount/configmaps.go
+++ b/pkg/provision/workspace/automount/configmaps.go
@@ -90,7 +90,7 @@ func GetAutoMountConfigMapSubpathVolumeMounts(mountPath string, cm corev1.Config
 		workspaceVolumeMounts = append(workspaceVolumeMounts, corev1.VolumeMount{
 			Name:      common.AutoMountConfigMapVolumeName(cm.Name),
 			ReadOnly:  true,
-			MountPath: mountPath,
+			MountPath: path.Join(mountPath, configmapKey),
 			SubPath:   configmapKey,
 		})
 	}

--- a/pkg/provision/workspace/automount/git-config.go
+++ b/pkg/provision/workspace/automount/git-config.go
@@ -62,6 +62,10 @@ func provisionGitConfig(api sync.ClusterAPI, namespace string, userMountPath str
 		return podAdditions, nil
 	}
 
+	if gitconfig == "" {
+		// Nothing to store in configmap, so don't create one
+		return nil, nil
+	}
 	configMapPodAdditions, err := mountGitConfigMap(gitCredentialsConfigMapName, namespace, api, gitconfig)
 	if err != nil {
 		return configMapPodAdditions, err

--- a/pkg/provision/workspace/automount/git-provisioner.go
+++ b/pkg/provision/workspace/automount/git-provisioner.go
@@ -52,8 +52,10 @@ func provisionGitConfiguration(api sync.ClusterAPI, namespace string) (*v1alpha1
 		return podAdditions, err
 	}
 
-	podAdditions.Volumes = append(podAdditions.Volumes, gitConfigAdditions.Volumes...)
-	podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, gitConfigAdditions.VolumeMounts...)
+	if gitConfigAdditions != nil {
+		podAdditions.Volumes = append(podAdditions.Volumes, gitConfigAdditions.Volumes...)
+		podAdditions.VolumeMounts = append(podAdditions.VolumeMounts, gitConfigAdditions.VolumeMounts...)
+	}
 
 	// Grab the credentials additions
 	if len(credentials) > 0 {

--- a/pkg/provision/workspace/automount/secret.go
+++ b/pkg/provision/workspace/automount/secret.go
@@ -88,7 +88,7 @@ func GetAutoMountSecretSubpathVolumeMounts(mountPath string, secret corev1.Secre
 		workspaceVolumeMounts = append(workspaceVolumeMounts, corev1.VolumeMount{
 			Name:      common.AutoMountSecretVolumeName(secret.Name),
 			ReadOnly:  true,
-			MountPath: mountPath,
+			MountPath: path.Join(mountPath, secretKey),
 			SubPath:   secretKey,
 		})
 	}


### PR DESCRIPTION
### What does this PR do?
Add `subpath` option to the `controller.devfile.io/mount-as` annotation, enabling configmaps/secrets to be mounted as subpath volumemounts in the devworkspace.

This change also makes it so that the DevWorkspace Operator does not create the `devworkspace-gitconfig` map when it would be empty, as this interfered with what I was trying to test (mounting my gitconfig into workspaces)

### What issues does this PR fix or reference?
The main use-case here is mounting files from a configmap/secret to an already-populated directory in the container. The benefit of using "subpath" is that files can be mounted into existing directories, with the downside that changes on the cluster side are not propagated into running workspaces.

### Is it tested? How?
E.g. provisioning your local `~/.gitconfig` into all DevWorkspaces in a namespace:
1. Create configmap with gitconfig contents:
    ```bash
    kubectl create configmap git-config \
      --from-file=gitconfig=${HOME}/.gitconfig
    
    kubectl patch cm git-config --type merge -p '
    metadata:
      labels:
        controller.devfile.io/mount-to-devworkspace: "true"
        controller.devfile.io/watch-configmap: "true"
      annotations:
        controller.devfile.io/mount-path: "/etc/"
        controller.devfile.io/mount-as: "subpath"
    '
    ```
2. Start a DevWorkspace
3. Exec into the workspace and execute `git config --list --show-origin`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
