### PR TITLE
Add polling to the custom catalog source to enable finding new bundles

### DIFF
--- a/catalog-source.yaml
+++ b/catalog-source.yaml
@@ -8,3 +8,6 @@ spec:
   image: quay.io/devfile/devworkspace-operator-index:next
   publisher: Red Hat
   displayName: DevWorkspace Operator Catalog
+  updateStrategy:
+    registryPoll:
+      interval: 1d


### PR DESCRIPTION
### What does this PR do?
Adds polling to the custom catalogsource to enable it to find new bundles as they are pushed.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
