### PR TITLE
Fix handling of query params and fragments in endpoint paths

### DIFF
--- a/controllers/controller/devworkspacerouting/solvers/resolve_endpoints.go
+++ b/controllers/controller/devworkspacerouting/solvers/resolve_endpoints.go
@@ -58,13 +58,13 @@ func resolveURLForEndpoint(
 	routingObj RoutingObjects) (string, error) {
 	for _, route := range routingObj.Routes {
 		if route.Annotations[constants.DevWorkspaceEndpointNameAnnotation] == endpoint.Name {
-			return getURLForEndpoint(endpoint, route.Spec.Host, route.Spec.Path, route.Spec.TLS != nil), nil
+			return getURLForEndpoint(endpoint, route.Spec.Host, route.Spec.Path, route.Spec.TLS != nil)
 		}
 	}
 	for _, ingress := range routingObj.Ingresses {
 		if ingress.Annotations[constants.DevWorkspaceEndpointNameAnnotation] == endpoint.Name {
 			if len(ingress.Spec.Rules) == 1 {
-				return getURLForEndpoint(endpoint, ingress.Spec.Rules[0].Host, "", false), nil // no TLS supported for ingresses yet
+				return getURLForEndpoint(endpoint, ingress.Spec.Rules[0].Host, "", false) // no TLS supported for ingresses yet
 			} else {
 				return "", fmt.Errorf("ingress %s contains multiple rules", ingress.Name)
 			}
@@ -73,25 +73,30 @@ func resolveURLForEndpoint(
 	return "", fmt.Errorf("could not find ingress/route for endpoint '%s'", endpoint.Name)
 }
 
-func getURLForEndpoint(endpoint controllerv1alpha1.Endpoint, host, basePath string, secure bool) string {
+func getURLForEndpoint(endpoint controllerv1alpha1.Endpoint, host, basePath string, secure bool) (string, error) {
 	protocol := endpoint.Protocol
 	if secure && endpoint.Secure {
 		protocol = controllerv1alpha1.EndpointProtocol(getSecureProtocol(string(protocol)))
 	}
-	var p string
+
+	// Format host/path ensuring only a single '/' character between the two. Can't use path.Join here as it would drop
+	// a trailing '/' if present
+	basehost := fmt.Sprintf("%s/%s", strings.TrimRight(host, "/"), strings.TrimLeft(basePath, "/"))
+	baseUrl := fmt.Sprintf("%s://%s", protocol, basehost)
+
+	url, err := url.Parse(baseUrl)
+	if err != nil {
+		return "", err
+	}
+
 	if endpoint.Path != "" {
-		// the only one slash should be between these path segments.
-		// Path.join does not suite here since it eats trailing slash which may be critical for the application
-		p = fmt.Sprintf("%s/%s", strings.TrimRight(basePath, "/"), strings.TrimLeft(p, endpoint.Path))
-	} else {
-		p = basePath
+		relPath, err := url.Parse(endpoint.Path)
+		if err != nil {
+			return "", err
+		}
+		url = url.ResolveReference(relPath)
 	}
-	u := url.URL{
-		Scheme: string(protocol),
-		Host:   host,
-		Path:   p,
-	}
-	return u.String()
+	return url.String(), nil
 }
 
 // getSecureProtocol takes a (potentially unsecure protocol e.g. http) and returns the secure version (e.g. https).

--- a/controllers/controller/devworkspacerouting/solvers/resolve_endpoints_test.go
+++ b/controllers/controller/devworkspacerouting/solvers/resolve_endpoints_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solvers
+
+import (
+	"testing"
+
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUrlForEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+
+		host         string
+		basePath     string
+		endpointPath string
+		secure       bool
+
+		outURL string
+		outErr error
+	}{
+		{
+			name:         "Resolves simple URL with no path components",
+			host:         "example.com",
+			basePath:     "",
+			endpointPath: "",
+			secure:       false,
+
+			outURL: "http://example.com/",
+		},
+		{
+			name:         "Resolves secure URL with no path components",
+			host:         "example.com",
+			basePath:     "",
+			endpointPath: "",
+			secure:       true,
+
+			outURL: "https://example.com/",
+		},
+		{
+			name:         "Resolves URL with basepath component, including trailing slash",
+			host:         "example.com",
+			basePath:     "/test/path/",
+			endpointPath: "",
+			secure:       true,
+
+			outURL: "https://example.com/test/path/",
+		},
+		{
+			name:         "Resolves URL with basepath component",
+			host:         "example.com",
+			basePath:     "/test/path",
+			endpointPath: "",
+			secure:       true,
+
+			outURL: "https://example.com/test/path",
+		},
+		{
+			name:         "Resolves URL with endpoint path component",
+			host:         "example.com",
+			basePath:     "",
+			endpointPath: "/endpoint/path/",
+			secure:       true,
+
+			outURL: "https://example.com/endpoint/path/",
+		},
+		{
+			name:         "Resolves URL with endpoint and base path components",
+			host:         "example.com",
+			basePath:     "base/path/",
+			endpointPath: "endpoint/path/",
+			secure:       true,
+
+			outURL: "https://example.com/base/path/endpoint/path/",
+		},
+		{
+			name:         "Resolves URL with query param in endpoint path",
+			host:         "example.com",
+			basePath:     "",
+			endpointPath: "?test=param",
+			secure:       true,
+
+			outURL: "https://example.com/?test=param",
+		},
+		{
+			name:         "Resolves URL with query param in endpoint path and base path",
+			host:         "example.com",
+			basePath:     "/base/path/",
+			endpointPath: "?test=param",
+			secure:       true,
+
+			outURL: "https://example.com/base/path/?test=param",
+		},
+		{
+			name:         "Resolves URL with query param and path in endpoint path",
+			host:         "example.com",
+			basePath:     "base/path/",
+			endpointPath: "endpoint/path?test=param",
+			secure:       true,
+
+			outURL: "https://example.com/base/path/endpoint/path?test=param",
+		},
+		{
+			name:         "Resolves URL with fragment in endpoint path",
+			host:         "example.com",
+			basePath:     "base/path/",
+			endpointPath: "endpoint/path#test",
+			secure:       true,
+
+			outURL: "https://example.com/base/path/endpoint/path#test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint := controllerv1alpha1.Endpoint{
+				Protocol: "http",
+				Path:     tt.endpointPath,
+				Secure:   true,
+			}
+			url, err := getURLForEndpoint(endpoint, tt.host, tt.basePath, tt.secure)
+			if tt.outErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tt.outErr)
+			} else {
+				if !assert.NoError(t, err) {
+					return
+				}
+				assert.Equal(t, tt.outURL, url)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Fixes handling of query params and fragments when getting the URL for a given endpoint.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/713

### Is it tested? How?
Test cases are included. Can be tested with reproducer from #713 :
```
kubectl apply -f https://eclipse-che.github.io/che-devfile-registry/main/devfiles/java-web-spring/devworkspace-che-code-insiders.yaml
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
