### PR TITLE
Provision project-clone container separately from devfile Components

### DIFF
--- a/pkg/library/projects/clone.go
+++ b/pkg/library/projects/clone.go
@@ -33,6 +33,13 @@ const (
 )
 
 func GetProjectCloneInitContainer(workspace *dw.DevWorkspaceTemplateSpec) (*corev1.Container, error) {
+	if len(workspace.Projects) == 0 {
+		return nil, nil
+	}
+	if workspace.Attributes.GetString(constants.ProjectCloneAttribute, nil) == constants.ProjectCloneDisable {
+		return nil, nil
+	}
+
 	cloneImage := images.GetProjectClonerImage()
 	if cloneImage == "" {
 		// Assume project clone is intentionally disabled if project clone image is not defined


### PR DESCRIPTION
### What does this PR do?
Don't add project-clone container to flattened DevWorkspace as used internally, instead add it as an init container on the deployment directly.

### What issues does this PR fix or reference?
Mounted flattened devfile (`$DEVWORKSPACE_FLATTENED_DEVFILE`) contains project-clone. Accidentally applying this template causes the workspace to fail to start (DWO adds a second project-clone container).

### Is it tested? How?
1. Start a DevWorkspace
2. Open exec into workspace deployment
3. `cat $DEVWORKSPACE_FLATTENED_DEVFILE` should not container project-clone component, command, or event.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
