### PR TITLE
Add v0.11.0 bundle from release to OLM catalog in main

### DIFF
--- a/olm-catalog/release/channel.yaml
+++ b/olm-catalog/release/channel.yaml
@@ -3,3 +3,5 @@ package: devworkspace-operator
 name: fast
 entries:
   - name: devworkspace-operator.v0.10.0
+  - name: devworkspace-operator.v0.11.0
+    replaces: devworkspace-operator.v0.10.0

--- a/olm-catalog/release/devworkspace-operator.v0.11.0.bundle.yaml
+++ b/olm-catalog/release/devworkspace-operator.v0.11.0.bundle.yaml
@@ -1,0 +1,62 @@
+image: quay.io/devfile/devworkspace-operator-bundle@sha256:6d3693ee349c1c107b7b566d73bb937d9b068c857c3fb7002da5217327a63f79
+name: devworkspace-operator.v0.11.0
+package: devworkspace-operator
+properties:
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceOperatorConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceRouting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha2
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha2
+- type: olm.package
+  value:
+    packageName: devworkspace-operator
+    version: 0.11.0
+relatedImages:
+- image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+  name: kube_rbac_proxy
+- image: quay.io/devfile/devworkspace-controller:next
+  name: devworkspace_webhook_server
+- image: quay.io/devfile/devworkspace-controller:v0.11.0
+  name: ""
+- image: quay.io/devfile/devworkspace-operator-bundle@sha256:6d3693ee349c1c107b7b566d73bb937d9b068c857c3fb7002da5217327a63f79
+  name: ""
+- image: quay.io/devfile/project-clone:next
+  name: project_clone
+- image: quay.io/eclipse/che-machine-exec:nightly
+  name: plugin_redhat_developer_web_terminal_4_5_0
+- image: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
+  name: async_storage_sidecar
+- image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
+  name: async_storage_server
+- image: quay.io/wto/web-terminal-tooling:latest
+  name: web_terminal_tooling
+- image: registry.access.redhat.com/ubi8-micro:8.4-81
+  name: pvc_cleanup_job
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+  name: ""
+schema: olm.bundle


### PR DESCRIPTION
### What does this PR do?
Adds the bundle for v0.11.0 to the OLM catalog and updates channel.yaml to include it as an entry.

### What issues does this PR fix or reference?
Necessary manual step in release process that I had forgotten when v0.11 was released.

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
