### PR TITLE
Fix async storage cleanup on workspace delete

### DIFF
--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -198,6 +198,17 @@ func (p *AsyncStorageProvisioner) CleanupWorkspaceStorage(workspace *dw.DevWorks
 		return err
 	}
 
+	retry, err := asyncstorage.RemoveAuthorizedKeyFromConfigMap(workspace, clusterAPI)
+	if err != nil {
+		return &ProvisioningError{
+			Message: "Failed to remove authorized key from async storage configmap",
+			Err:     err,
+		}
+	}
+	if retry {
+		return &NotReadyError{Message: "Removing authorized key from async storage configmap"}
+	}
+
 	// Delete the async deployment if there are no workspaces except for the one being deleted
 	if totalWorkspaces <= 1 {
 		err := clusterAPI.Client.Delete(clusterAPI.Ctx, asyncDeploy)

--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -22,7 +22,6 @@ import (
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
-
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/pkg/provision/storage/asyncstorage/cleanup.go
+++ b/pkg/provision/storage/asyncstorage/cleanup.go
@@ -16,6 +16,7 @@ package asyncstorage
 import (
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	coputil "github.com/redhat-cop/operator-utils/pkg/util"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -57,6 +58,15 @@ func RemoveAuthorizedKeyFromConfigMap(workspace *dw.DevWorkspace, api sync.Clust
 			return true, nil
 		}
 		return false, err
+	}
+
+	if coputil.HasFinalizer(sshSecret, asyncStorageFinalizer) {
+		coputil.RemoveFinalizer(sshSecret, asyncStorageFinalizer)
+		err := api.Client.Update(api.Ctx, sshSecret)
+		if err != nil && !k8sErrors.IsConflict(err) {
+			return false, err
+		}
+		return true, nil
 	}
 
 	return false, nil

--- a/pkg/provision/storage/asyncstorage/cleanup.go
+++ b/pkg/provision/storage/asyncstorage/cleanup.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package asyncstorage
+
+import (
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// RemoveAuthorizedKeyFromConfigMap removes the ssh key used by a given workspace from the common async storage
+// authorized keys configmap.
+func RemoveAuthorizedKeyFromConfigMap(workspace *dw.DevWorkspace, api sync.ClusterAPI) (retry bool, err error) {
+	sshSecret, err := getSSHSidecarSecretCluster(workspace, api)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	pubkey, _, err := ExtractSSHKeyPairFromSecret(sshSecret)
+	if err != nil {
+		return false, err
+	}
+
+	configmap, err := getSSHAuthorizedKeysConfigMapCluster(workspace.Namespace, api)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	didChange, err := removeAuthorizedKeyFromConfigMap(configmap, pubkey)
+	if err != nil {
+		return false, err
+	}
+	if !didChange {
+		return false, nil
+	}
+
+	err = api.Client.Update(api.Ctx, configmap)
+	if err != nil {
+		if k8sErrors.IsConflict(err) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	return false, nil
+}

--- a/pkg/provision/storage/asyncstorage/configmap.go
+++ b/pkg/provision/storage/asyncstorage/configmap.go
@@ -79,3 +79,25 @@ func addAuthorizedKeyToConfigMap(configmap *corev1.ConfigMap, authorizedKeyBytes
 	configmap.Data[authorizedKeysFilename] = authorizedKeys + authorizedKey
 	return true, nil
 }
+
+func removeAuthorizedKeyFromConfigMap(configmap *corev1.ConfigMap, authorizedKeyBytes []byte) (didChange bool, err error) {
+	authorizedKeys, ok := configmap.Data[authorizedKeysFilename]
+	if !ok {
+		return false, fmt.Errorf("could not find authorized_keys in configmap %s", configmap.Name)
+	}
+	authorizedKey := string(authorizedKeyBytes)
+	authorizedKeyTrimmed := strings.TrimRight(authorizedKey, "\n")
+	changed := false
+	var newKeys []string
+	for _, key := range strings.Split(authorizedKeys, "\n") {
+		if key == authorizedKeyTrimmed {
+			changed = true
+		} else {
+			newKeys = append(newKeys, key)
+		}
+	}
+	if changed {
+		configmap.Data[authorizedKeysFilename] = strings.Join(newKeys, "\n")
+	}
+	return changed, nil
+}

--- a/pkg/provision/storage/asyncstorage/configuration.go
+++ b/pkg/provision/storage/asyncstorage/configuration.go
@@ -54,6 +54,7 @@ func GetOrCreateSSHConfig(workspace *dw.DevWorkspace, clusterAPI sync.ClusterAPI
 		if err != nil {
 			return nil, nil, err
 		}
+
 		// Create secret now to make sure we don't add pubKey to the configmap and then fail to create corresponding secret
 		err = clusterAPI.Client.Create(clusterAPI.Ctx, specSecret)
 		if err != nil && !k8sErrors.IsAlreadyExists(err) {

--- a/pkg/provision/storage/asyncstorage/constants.go
+++ b/pkg/provision/storage/asyncstorage/constants.go
@@ -26,6 +26,8 @@ const (
 	asyncSidecarMemoryLimit   = "512Mi"
 	asyncServerMemoryRequest  = "256Mi"
 	asyncServerMemoryLimit    = "512Mi"
+
+	asyncStorageFinalizer = "controller.devfile.io/async-storage"
 )
 
 var asyncServerLabels = map[string]string{

--- a/pkg/provision/storage/asyncstorage/secret.go
+++ b/pkg/provision/storage/asyncstorage/secret.go
@@ -45,13 +45,15 @@ func getSSHSidecarSecretSpec(workspace *dw.DevWorkspace, privateKey []byte) *cor
 				"app.kubernetes.io/part-of":            "devworkspace-operator",
 				constants.DevWorkspaceWatchSecretLabel: "true",
 			},
+			Finalizers: []string{
+				asyncStorageFinalizer,
+			},
 		},
 		Data: map[string][]byte{
 			rsyncSSHKeyFilename: privateKey,
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
-
 	return secret
 }
 


### PR DESCRIPTION
### What does this PR do?
Updates the cleanup function for async storage to also remove authorized keys from the async storage server configmap. This requires
1. Adding a finalizer to secrets created to hold async storage SSH keys
2. Removing the public key for a workspace from the common `async-storage-config` configmap when a workspace is deleted
3. Remove finalizer from async storage secret when 2. is done.

### What issues does this PR fix or reference?
The `async-storage-config` accrues more and more authorized keys over time

### Is it tested? How?
1. Create a DevWorkspace that uses async storage (has attribute `controller.devfile.io/storage-type: async`), wait for workspace to start
2. Stop this workspace
3. Create another DevWorkspace that uses async storage, wait for it to start
4. Verify that there are two secrets with name `<workspaceID>-asyncsshkey`, and that `.data.authorized_keys` in `async-storage-config` configmap contains two ssh keys
5. Delete the workspace created in step 3, wait for workspace to be removed from cluster
6. Verify that corresponding `<workspaceID>-asyncsshkey` secret is removed, and that entry is removed from `.data.authorized_keys` in `async-storage-config` configmap
7. Delete workspace created in step 1, wait for workspace to be removed from cluster
8. Verify that `async-storage-config` configmap and `<workspaceID>-asyncsshkey` secret are removed

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
