### PR TITLE
Fix issue where ephemeral projects volume is mounted twice in async

### DIFF
--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -219,13 +219,8 @@ func (*AsyncStorageProvisioner) addVolumesForAsyncStorage(podAdditions *v1alpha1
 
 	projectsVolume, needed := processProjectsVolume(&workspace.Spec.Template)
 	if needed {
-		if projectsVolume != nil && !isEphemeral(projectsVolume.Volume) {
-			vol, err := addEphemeralVolumesToPodAdditions(podAdditions, []dw.Component{*projectsVolume})
-			if err != nil {
-				return nil, err
-			}
-			volumes = append(volumes, vol...)
-		} else {
+		if projectsVolume == nil {
+			// No explicit projects volume defined, add emptyDir volume
 			vol := corev1.Volume{
 				Name: devfileConstants.ProjectsVolumeName,
 				VolumeSource: corev1.VolumeSource{
@@ -234,6 +229,13 @@ func (*AsyncStorageProvisioner) addVolumesForAsyncStorage(podAdditions *v1alpha1
 			}
 			podAdditions.Volumes = append(podAdditions.Volumes, vol)
 			volumes = append(volumes, vol)
+		} else if !isEphemeral(projectsVolume.Volume) {
+			// Case of explicitly defined ephemeral projects volume is handled earlier alongside other ephemeral volumes
+			vol, err := addEphemeralVolumesToPodAdditions(podAdditions, []dw.Component{*projectsVolume})
+			if err != nil {
+				return nil, err
+			}
+			volumes = append(volumes, vol...)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?
Fix issue where workspaces that explicitly define an ephemeral projects
volume fail to start with async storage due to the controller adding
the projects volume twice.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/730

### Is it tested? How?
Check that workspace in issue starts correctly.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
