### PR TITLE
Use sync package for reconciling async storage service

### DIFF
--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -127,6 +127,13 @@ func (p *AsyncStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdd
 				RequeueAfter: 1 * time.Second,
 			}
 		}
+		var unrecoverableErr *sync.UnrecoverableSyncError
+		if errors.As(err, &unrecoverableErr) {
+			return &ProvisioningError{
+				Message: "Failed to set up async storage service",
+				Err:     unrecoverableErr.Cause,
+			}
+		}
 		return err
 	}
 

--- a/pkg/provision/sync/diff.go
+++ b/pkg/provision/sync/diff.go
@@ -42,7 +42,7 @@ var diffFuncs = map[reflect.Type]diffFunc{
 	reflect.TypeOf(corev1.ConfigMap{}):             basicDiffFunc(configmapDiffOpts),
 	reflect.TypeOf(v1alpha1.DevWorkspaceRouting{}): allDiffFuncs(routingDiffFunc, labelsAndAnnotationsDiffFunc, basicDiffFunc(routingDiffOpts)),
 	reflect.TypeOf(batchv1.Job{}):                  jobDiffFunc,
-	reflect.TypeOf(corev1.Service{}):               serviceDiffFunc,
+	reflect.TypeOf(corev1.Service{}):               allDiffFuncs(labelsAndAnnotationsDiffFunc, serviceDiffFunc),
 	reflect.TypeOf(networkingv1.Ingress{}):         basicDiffFunc(ingressDiffOpts),
 	reflect.TypeOf(routev1.Route{}):                basicDiffFunc(routeDiffOpts),
 }


### PR DESCRIPTION
### What does this PR do?
Uses the `sync` package to sync the service used by the async storage server. This wasn't done earlier due to a few differences in handling that have since been resolved.

### What issues does this PR fix or reference?
No issue created, minor maintenance task.

### Is it tested? How?
Workspaces should start as normal (functionally, no changes)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
