### PR TITLE
feat: use endpoint names as container port names if they shorter than 16 characters

### DIFF
--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strings"
 
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 )
 
@@ -34,6 +35,13 @@ func EndpointName(endpointName string) string {
 	name = NonAlphaNumRegexp.ReplaceAllString(name, "-")
 	name = strings.Trim(name, "-")
 	return name
+}
+
+func PortName(endpoint dw.Endpoint) string {
+	if len(endpoint.Name) <= 15 {
+		return endpoint.Name
+	}
+	return fmt.Sprintf("%d-%s", endpoint.TargetPort, endpoint.Protocol)
 }
 
 func ServiceName(workspaceId string) string {

--- a/pkg/library/container/conversion.go
+++ b/pkg/library/container/conversion.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/common"
 
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
@@ -62,7 +63,7 @@ func devfileEndpointsToContainerPorts(endpoints []dw.Endpoint) []v1.ContainerPor
 		}
 		containerPorts = append(containerPorts, v1.ContainerPort{
 			// Use meaningless name for port since endpoint.Name does not match requirements for ContainerPort name
-			Name:          fmt.Sprintf("%d-%s", endpoint.TargetPort, endpoint.Protocol),
+			Name:          common.PortName(endpoint),
 			ContainerPort: int32(endpoint.TargetPort),
 			Protocol:      v1.ProtocolTCP,
 		})

--- a/pkg/library/container/testdata/component/converts-all-fields.yaml
+++ b/pkg/library/container/testdata/component/converts-all-fields.yaml
@@ -66,10 +66,10 @@ output:
           - "test"
           - "args"
         ports:
-          - name: "3100-wss"
+          - name: "test-endpoint-1"
             containerPort: 3100
             protocol: TCP
-          - name: "8080-http"
+          - name: "test-endpoint-2"
             containerPort: 8080
             protocol: TCP
         volumeMounts:

--- a/pkg/library/container/testdata/container/endpoints-uses-name-if-shorter-than-15-chars.yaml
+++ b/pkg/library/container/testdata/container/endpoints-uses-name-if-shorter-than-15-chars.yaml
@@ -1,4 +1,4 @@
-name: "Handles container with multiple endpoints with same targetPort"
+name: "Uses endpoint name as port name if it it fits pod spec"
 
 input:
   components:
@@ -11,11 +11,11 @@ input:
         cpuLimit: "-1"  # isolate test to not include this field
         mountSources: false
         endpoints:
-          - name: "test-endpoint-1"
-            targetPort: 3100
+          - name: "short-name" # Should use endpoint name if <=15 chars long (as supported by pod spec)
+            targetPort: 8080
             protocol: http
-          - name: "test-endpoint-2"
-            targetPort: 3100
+          - name: "longer-endpoint-name" # Should fallback to "<port>-<protocol>" for names too long for pod spec
+            targetPort: 8081
             protocol: http
 
 output:
@@ -35,6 +35,9 @@ output:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-1"
         ports:
-          - name: "test-endpoint-1"
-            containerPort: 3100
+          - name: "short-name"
+            containerPort: 8080
+            protocol: TCP
+          - name: "8081-http"
+            containerPort: 8081
             protocol: TCP


### PR DESCRIPTION
### What does this PR do?
Reuse endpoint name as container port name if it is short enough (<=15 chars). Otherwise, use current format (`<portnum>-<protocol>`). 

### What issues does this PR fix or reference?
Container port names can be confusing

### Is it tested? How?
Test cases are added. Functionality should not change as workspace services refer to ports by number and not name.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che

### Additional info
* devfile/api discussion: https://github.com/devfile/api/pull/702
* odo issue: https://github.com/redhat-developer/odo/issues/4737
