### PR TITLE
fix: Automount resources into the project-clone container

### DIFF
--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -270,11 +270,13 @@ func logCurrentConfig() {
 	if internalConfig.EnableExperimentalFeatures != nil && *internalConfig.EnableExperimentalFeatures {
 		config = append(config, "enableExperimentalFeatures=true")
 	}
+
 	if len(config) == 0 {
-		log.Info("(default config)")
+		log.Info("Updated config to [(default config)]")
 	} else {
-		log.Info("Updated config to [%s]", strings.Join(config, ","))
+		log.Info(fmt.Sprintf("Updated config to [%s]", strings.Join(config, ",")))
 	}
+
 	if internalConfig.Routing.ProxyConfig != nil {
 		log.Info("Resolved proxy configuration", "proxy", internalConfig.Routing.ProxyConfig)
 	}


### PR DESCRIPTION
### What does this PR do?
Automount resources into project-clone to ensure it gets any git credentials needed.

### What issues does this PR fix or reference?
E.g. git credentials are not being mounted to project-clone, preventing the cloning of private repos.

Issue was introduced in https://github.com/devfile/devworkspace-operator/pull/722

### Is it tested? How?
Test any private git repo flow with DevWorkspaces (either ssh key or personal access token).

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
