### PR TITLE
fix: Use git binary for checking out references to avoid go-git issues

### DIFF
--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -71,6 +71,40 @@ func GitFetchRemote(projectPath, remote string) error {
 	return executeCommand("git", "fetch", remote)
 }
 
+func GitCheckoutRef(projectPath, reference string) error {
+	currDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %s", err)
+	}
+	defer func() {
+		if err := os.Chdir(currDir); err != nil {
+			log.Printf("failed to return to original working directory: %s", err)
+		}
+	}()
+	err = os.Chdir(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to move to project directory %s: %s", projectPath, err)
+	}
+	return executeCommand("git", "checkout", reference)
+}
+
+func GitCheckoutBranch(projectPath, branchName, remote string) error {
+	currDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %s", err)
+	}
+	defer func() {
+		if err := os.Chdir(currDir); err != nil {
+			log.Printf("failed to return to original working directory: %s", err)
+		}
+	}()
+	err = os.Chdir(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to move to project directory %s: %s", projectPath, err)
+	}
+	return executeCommand("git", "checkout", "-b", branchName, "--track", fmt.Sprintf("%s/%s", remote, branchName))
+}
+
 func executeCommand(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
### What does this PR do?
Instead of using the go-git library for checking out tags, commits, and branches, delegate these tasks to the git binary installed in project clone.

In some cases, go-git will fail to checkout references if a repository is large and/or if the changeset between the main and the reference is significant.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/739

### Is it tested? How?
1. Test that clone succeeds for the reproducer:
    ```yaml
    kind: DevWorkspace
    apiVersion: workspace.devfile.io/v1alpha2
    metadata:
      name: test-project-clone
    spec:
      started: true
      template:
        projects:
        - git:
            checkoutFrom:
              revision: 60e69ce868b9b1ed821e7617878f644c0d898cc1
            remotes:
              origin: https://github.com/benoitf/che-code.git
          name: che-code
        components:
          - name: theia
            plugin:
              uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
              components:
                - name: theia-ide
                  container:
                    env:
                      - name: THEIA_HOST
                        value: 0.0.0.0
    ```
2. Test all project-clone flows that involve git:
    ```yaml
    apiVersion: workspace.devfile.io/v1alpha2
    kind: DevWorkspace
    metadata:
      name: plain
    spec:
      routingClass: basic
      started: true
      template:
        attributes:
          controller.devfile.io/storage-type: ephemeral
        projects:
        - name: 1-devworkspace-operator-default
          git:
            remotes:
              origin: https://github.com/devfile/devworkspace-operator.git
        - name: 2-devworkspace-operator-tag
          git:
            remotes:
              origin: https://github.com/devfile/devworkspace-operator.git
            checkoutFrom:
              revision: v0.11.0
        - name: 3-devworkspace-operator-branch
          git:
            remotes:
              origin: https://github.com/devfile/devworkspace-operator.git
            checkoutFrom:
              revision: 0.11.x
        - name: 4-devworkspace-operator-branch-with-remote
          git:
            remotes:
              origin: https://github.com/devfile/devworkspace-operator.git
              amisevsk: https://github.com/amisevsk/devworkspace-operator.git
            checkoutFrom:
              revision: 0.11.x
              remote: amisevsk
        - name: 5-devworkspace-operator-hash
          git:
            remotes:
              origin: https://github.com/devfile/devworkspace-operator.git
            checkoutFrom:
              revision: cbd808f5d13bb87dd8597e7e1312c72e11ab080f
        components:
        - container:
            command:
            - tail
            - -f
            - /dev/null
            image: quay.io/amisevsk/web-terminal-tooling:dev
            memoryLimit: 512Mi
            mountSources: true
            sourceMapping: /projects
          name: web-terminal
    ```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
