### PR TITLE
fix: Increasing the default PVCStorageSize to 10Gi

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -36,7 +36,7 @@ const (
 	SidecarDefaultCpuLimit   = "" // do not provide any value
 	SidecarDefaultCpuRequest = "" // do not provide any value
 
-	PVCStorageSize = "1Gi"
+	PVCStorageSize = "10Gi"
 
 	// DevWorkspaceIDLoggerKey is the key used to log workspace ID in the reconcile
 	DevWorkspaceIDLoggerKey = "devworkspace_id"

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -106,7 +106,7 @@ func TestRewriteContainerVolumeMountsForCommonStorageClass(t *testing.T) {
 	tests := loadAllTestCasesOrPanic(t, "testdata/common-storage")
 	setupControllerCfg()
 	commonStorage := CommonStorageProvisioner{}
-	commonPVC, err := getCommonPVCSpec("test-namespace", "1Gi")
+	commonPVC, err := getCommonPVCSpec("test-namespace", "10Gi")
 	if err != nil {
 		t.Fatalf("Failure during setup: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Increasing the default PVCStorageSize to 10Gi

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21033

### Is it tested? How?
Verified via cluster-bot 4.9.0-0.nightly-2022-01-17-165424

![image](https://user-images.githubusercontent.com/1461122/149928994-c67d8ca9-fbb3-4938-91fc-ddb53f97f0d8.png)


```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: claim-devworkspace
  namespace: test
  uid: 9dfff810-a3c6-46b1-aea2-ff9517016de6
  resourceVersion: '27025'
  creationTimestamp: '2022-01-18T11:25:54Z'
  annotations:
    pv.kubernetes.io/bind-completed: 'yes'
    pv.kubernetes.io/bound-by-controller: 'yes'
    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/gce-pd
    volume.kubernetes.io/selected-node: ci-ln-3vili0t-72292-x6sft-worker-b-p588l
  finalizers:
    - kubernetes.io/pvc-protection
  managedFields:
    - manager: main
      operation: Update
      apiVersion: v1
      time: '2022-01-18T11:25:54Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          'f:accessModes': {}
          'f:resources':
            'f:requests':
              .: {}
              'f:storage': {}
          'f:volumeMode': {}
    - manager: kube-scheduler
      operation: Update
      apiVersion: v1
      time: '2022-01-18T11:26:02Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            .: {}
            'f:volume.kubernetes.io/selected-node': {}
    - manager: kube-controller-manager
      operation: Update
      apiVersion: v1
      time: '2022-01-18T11:26:04Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:annotations':
            'f:pv.kubernetes.io/bind-completed': {}
            'f:pv.kubernetes.io/bound-by-controller': {}
            'f:volume.beta.kubernetes.io/storage-provisioner': {}
        'f:spec':
          'f:volumeName': {}
    - manager: kube-controller-manager
      operation: Update
      apiVersion: v1
      time: '2022-01-18T11:26:04Z'
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          'f:accessModes': {}
          'f:capacity':
            .: {}
            'f:storage': {}
          'f:phase': {}
      subresource: status
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
  volumeName: pvc-9dfff810-a3c6-46b1-aea2-ff9517016de6
  storageClassName: standard
  volumeMode: Filesystem
status:
  phase: Bound
  accessModes:
    - ReadWriteOnce
  capacity:
    storage: 10Gi
```

On CRC 4.8.5 there is a weird situation with capacity allocation for any PVC which defaults to 100GI for some reason.
the storage request is set correctly though:

![image](https://user-images.githubusercontent.com/1461122/149923865-e35f2e63-436a-4726-9c67-9089d6d97474.png)
  
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
