### PR TITLE
feat: [Draft] Allow DevWorkspaceID to be overridden via annotation

### DIFF
--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -20,6 +20,11 @@ const (
 	// DevWorkspaceIDLabel is the label key to store workspace identifier
 	DevWorkspaceIDLabel = "controller.devfile.io/devworkspace_id"
 
+	// WorkspaceIdOverrideAnnotation is an annotation that can be applied to DevWorkspaces
+	// to override the default DevWorkspace ID assigned by the Operator. Is only respected
+	// when a DevWorkspace is created. Once a DevWorkspace has an ID set, it cannot be changed.
+	WorkspaceIdOverrideAnnotation = "controller.devfile.io/devworkspace_id_override"
+
 	// DevWorkspaceCreatorLabel is the label key for storing the UID of the user who created the workspace
 	DevWorkspaceCreatorLabel = "controller.devfile.io/creator"
 

--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -63,6 +63,11 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha1OnUpdate(_ context.Context, req 
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+
+	if oldWksp.Status.WorkspaceId != "" && newWksp.Status.WorkspaceId != oldWksp.Status.WorkspaceId {
+		return admission.Denied("DevWorkspace ID cannot be changed once it is set")
+	}
+
 	allowed, msg := h.checkRestrictedAccessWorkspaceV1alpha1(oldWksp, newWksp, req.UserInfo.UID)
 	if !allowed {
 		return admission.Denied(msg)
@@ -96,6 +101,11 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnUpdate(ctx context.Context, re
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+
+	if oldWksp.Status.DevWorkspaceId != "" && newWksp.Status.DevWorkspaceId != oldWksp.Status.DevWorkspaceId {
+		return admission.Denied("DevWorkspace ID cannot be changed once it is set")
+	}
+
 	allowed, msg := h.checkRestrictedAccessWorkspaceV1alpha2(oldWksp, newWksp, req.UserInfo.UID)
 	if !allowed {
 		return admission.Denied(msg)


### PR DESCRIPTION
### What does this PR do?
Allow overriding the default DevWorkspace ID (derived from the DevWorkspace CR's UUID) via the annotation
```
controller.devfile.io/devworkspace_id_override
```
with the caveats:
* DWO attempts to check if the DevWorkspaceID is already in use for another workspace in the current namespace and fails the workspace if it does
* The annotation is only read on workspace creation and ignored once workspace ID is set to avoid losing data
* Controller webhooks are updated to explicitly block updates to `.status.devworkspaceId`

This PR is in draft status for testing if this feature is useful for migrating Che workspaces to the DevWorkspace controller.

Before merging, this PR needs a polishing pass. We should also decide on a max length for overridden workspace IDs, as the controller implicitly assumes the length of the ID is fixed in a few places (where workspace ID is used as part of a k8s object name, for example).

Changes can be tested using the image `quay.io/amisevsk/devworkspace-controller:override-dw-id` (for both controller and webhooks server)

### What issues does this PR fix or reference?
N/A for now.

### Is it tested? How?
No changes if annotation is not used; otherwise, workspace ID should be set to value of annotation.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
