### PR TITLE
fix: Add support for syncing secrets in sync package

### DIFF
--- a/pkg/provision/sync/diff.go
+++ b/pkg/provision/sync/diff.go
@@ -40,6 +40,7 @@ var diffFuncs = map[reflect.Type]diffFunc{
 	reflect.TypeOf(corev1.ServiceAccount{}):        labelsAndAnnotationsDiffFunc,
 	reflect.TypeOf(appsv1.Deployment{}):            allDiffFuncs(deploymentDiffFunc, labelsAndAnnotationsDiffFunc, basicDiffFunc(deploymentDiffOpts)),
 	reflect.TypeOf(corev1.ConfigMap{}):             allDiffFuncs(labelsAndAnnotationsDiffFunc, basicDiffFunc(configmapDiffOpts)),
+	reflect.TypeOf(corev1.Secret{}):                allDiffFuncs(labelsAndAnnotationsDiffFunc, basicDiffFunc(secretDiffOpts)),
 	reflect.TypeOf(v1alpha1.DevWorkspaceRouting{}): allDiffFuncs(routingDiffFunc, labelsAndAnnotationsDiffFunc, basicDiffFunc(routingDiffOpts)),
 	reflect.TypeOf(batchv1.Job{}):                  allDiffFuncs(labelsAndAnnotationsDiffFunc, jobDiffFunc),
 	reflect.TypeOf(corev1.Service{}):               allDiffFuncs(labelsAndAnnotationsDiffFunc, serviceDiffFunc),

--- a/pkg/provision/sync/diffopts.go
+++ b/pkg/provision/sync/diffopts.go
@@ -56,6 +56,10 @@ var configmapDiffOpts = cmp.Options{
 	cmpopts.IgnoreFields(corev1.ConfigMap{}, "TypeMeta", "ObjectMeta"),
 }
 
+var secretDiffOpts = cmp.Options{
+	cmpopts.IgnoreFields(corev1.Secret{}, "TypeMeta", "ObjectMeta"),
+}
+
 var routingDiffOpts = cmp.Options{
 	cmpopts.IgnoreFields(v1alpha1.DevWorkspaceRouting{}, "ObjectMeta", "TypeMeta", "Status"),
 }


### PR DESCRIPTION
### What does this PR do?
Adds support for using the `pkg/provision/sync` package for secrets.

### What issues does this PR fix or reference?
Attempting to sync a secret using this package will fail with `attempting to sync unrecognized object: v1.Secret`

In commits cd7b1e49b741318dce10adf6296168dd2e4eb752..74fa148b3f2d907f2432e298ad028c28158fdf80, this results in workspaces failing to start when a secret with label `controller.devfile.io/git-credential` is present in the namespace.

### Is it tested? How?
Sync code is not used for secrets at all in current main branch.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
