### PR TITLE
fix: Fixup issues with async storage in DevWorkspaces

### DIFF
--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -144,7 +144,7 @@ func (p *AsyncStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdd
 	}
 
 	sshSecretVolume := asyncstorage.GetVolumeFromSecret(secret)
-	asyncSidecar := asyncstorage.GetAsyncSidecar(sshSecretVolume.Name, volumes)
+	asyncSidecar := asyncstorage.GetAsyncSidecar(workspace.Status.DevWorkspaceId, sshSecretVolume.Name, volumes)
 	podAdditions.Containers = append(podAdditions.Containers, *asyncSidecar)
 	podAdditions.Volumes = append(podAdditions.Volumes, *sshSecretVolume)
 

--- a/pkg/provision/storage/asyncstorage/sidecar.go
+++ b/pkg/provision/storage/asyncstorage/sidecar.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"github.com/devfile/devworkspace-operator/internal/images"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -29,7 +28,7 @@ import (
 // are mounted to `/volume.Name`, and the sshVolume is mounted to /etc/ssh/private as read-only.
 //
 // Note: in the current implementation, the image used for the async sidecar only syncs from ${CHE_PROJECTS_ROOT}
-func GetAsyncSidecar(sshVolumeName string, volumes []corev1.Volume) *corev1.Container {
+func GetAsyncSidecar(devworkspaceID, sshVolumeName string, volumes []corev1.Volume) *corev1.Container {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      sshVolumeName,
@@ -58,6 +57,14 @@ func GetAsyncSidecar(sshVolumeName string, volumes []corev1.Volume) *corev1.Cont
 			{
 				Name:  "RSYNC_PORT",
 				Value: strconv.Itoa(rsyncPort),
+			},
+			{
+				Name:  "CHE_PROJECTS_ROOT",
+				Value: "/projects",
+			},
+			{
+				Name:  "CHE_WORKSPACE_ID",
+				Value: devworkspaceID,
 			},
 		},
 		Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
### What does this PR do?
Fix issues with async-storage found while testing the v0.12.0 release:
- DWO is checking the "one async-storage workspace at a time" restriction cluster-wide instead of per-namespace
- Async storage sidecar is failing to sync data: https://github.com/devfile/devworkspace-operator/issues/754

### What issues does this PR fix or reference?
- Can only start one async-storage workspace at a time _cluster wide_ :upside_down_face: 
- Closes https://github.com/devfile/devworkspace-operator/issues/754

### Is it tested? How?
Create two async storage workspaces in two namespaces; workspaces should both start (though see https://github.com/devfile/devworkspace-operator/issues/754). Editing a file, stopping and restarting the workspace should persist changes.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
