### PR TITLE
Update to OPM v1.19.5 and use file-based catalog for next index

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -53,7 +53,7 @@ jobs:
       DWO_BUNDLE_REPO: quay.io/devfile/devworkspace-operator-bundle
       DWO_BUNDLE_TAG: next
       DWO_INDEX_IMG: quay.io/devfile/devworkspace-operator-index:next
-      OPM_VERSION: v1.19.1
+      OPM_VERSION: v1.19.5
       OPERATOR_SDK_VERSION: v1.8.0
     steps:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
   release:
     env:
       OPERATOR_SDK_VERSION: v1.8.0
-      OPM_VERSION: v1.19.1
+      OPM_VERSION: v1.19.5
     runs-on: ubuntu-20.04
     steps:
       - name: Clone source code

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ifneq (,$(shell which kubectl 2>/dev/null)$(shell which oc 2>/dev/null))
 endif
 
 OPERATOR_SDK_VERSION = v1.8.0
-OPM_VERSION = v1.19.1
+OPM_VERSION = v1.19.5
 
 CONTROLLER_GEN_VERSION = v0.6.1
 CONTROLLER_GEN=$(GOBIN)/controller-gen-$(CONTROLLER_GEN_VERSION)


### PR DESCRIPTION
### What does this PR do?
Updates the `next` upstream DevWorkspace Operator index build to use file-based catalogs and makes use of `skipRange` to enable existing releases of the DevWorkspace Operator to update to the `next` (nightly) images.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
1. Install DWO from regular release catalog (v0.11.0 (Red Hat catalog) or v0.12.0 (upstream catalog) are the current releases)
2. Install a custom catalogsource to use an `next` index built from this PR:
    ```yaml
    cat <<EOF | oc apply -f -
    apiVersion: operators.coreos.com/v1alpha1
    kind: CatalogSource
    metadata:
      name: devworkspace-operator-testing-catalog
      namespace: openshift-marketplace
    spec:
      sourceType: grpc
      image: quay.io/amisevsk/devworkspace-operator-index-test:test-next
      publisher: DWO Testing
      displayName: DevWorkspace Operator Catalog
    EOF
    ```
3. Update the Subscription created for the already-installed DWO to use this catalog and switch the OLM channel to `next`:
    ```bash
    oc patch subs devworkspace-operator -n openshift-operators --type merge -p '
    spec:
      channel: next
      source: devworkspace-operator-testing-catalog
    '
    ```
4. Check that an update for DWO is available (or automatically installed if the "Automatic" update strategy is used), and that the new version of DWO is `v1.13.0-dev`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che

### Additional info
See also: https://github.com/devfile/devworkspace-operator/issues/759