### PR TITLE
fix: Allow to remove not started workspaces

### DIFF
--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
@@ -84,9 +84,6 @@ func (r *DevWorkspaceRoutingReconciler) Reconcile(ctx context.Context, req ctrl.
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	if instance.Annotations != nil && instance.Annotations[constants.DevWorkspaceStartedStatusAnnotation] == "false" {
-		return reconcile.Result{}, nil
-	}
 
 	reqLogger = reqLogger.WithValues(constants.DevWorkspaceIDLoggerKey, instance.Spec.DevWorkspaceId)
 	reqLogger.Info("Reconciling DevWorkspaceRouting")
@@ -108,6 +105,10 @@ func (r *DevWorkspaceRoutingReconciler) Reconcile(ctx context.Context, req ctrl.
 	if instance.GetDeletionTimestamp() != nil {
 		reqLogger.Info("Finalizing DevWorkspaceRouting")
 		return reconcile.Result{}, r.finalize(solver, instance)
+	}
+
+	if instance.Annotations != nil && instance.Annotations[constants.DevWorkspaceStartedStatusAnnotation] == "false" {
+		return reconcile.Result{}, nil
 	}
 
 	if instance.Status.Phase == controllerv1alpha1.RoutingFailed {


### PR DESCRIPTION
### What does this PR do?
Cherry-pick changes from https://github.com/devfile/devworkspace-operator/pull/761 to the 0.12.x release branch

### What issues does this PR fix or reference?
Required for https://github.com/eclipse/che/issues/21039

### Is it tested? How?
Create a DevWorkspace that uses a routingClass that requires finalizers.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
