### PR TITLE
fix: Use correct version tag for bugfix releases

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -289,7 +289,7 @@ release() {
   [[ ${VERSION#v} =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]] \
     && BASE="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}";  \
     NEXT="${BASH_REMATCH[3]}"; (( NEXT=NEXT+1 )) # for VERSION=0.1.2, get BASE=0.1, NEXT=3
-  NEXT_VERSION_Z="${BASE}.${NEXT}"
+  NEXT_VERSION_Z="v${BASE}.${NEXT}"
 
   update_version "$NEXT_VERSION_Z"
   update_images "$NEXT_VERSION_Z"


### PR DESCRIPTION
### What does this PR do?
Updates make-release.sh script to correct bump the next bugfix version in release branches. I.e., instead of bumping to version `0.13.1`, use version `v0.13.1`

### What issues does this PR fix or reference?
Automated process for v0.12.0 release incorrectly bumped the version, making the v0.12.1 bundle reference a non-existent image: [commit](https://github.com/devfile/devworkspace-operator/commit/27c4c8c5126084362575e0f346d6b9867482fe3d)

### Is it tested? How?
Tested by running script locally 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
