### PR TITLE
chore: Add v0.12.1, v0.12.2, and v0.12.3 bundles to release channel

### DIFF
--- a/olm-catalog/release/channel.yaml
+++ b/olm-catalog/release/channel.yaml
@@ -7,3 +7,7 @@ entries:
     replaces: devworkspace-operator.v0.10.0
   - name: devworkspace-operator.v0.12.0
     replaces: devworkspace-operator.v0.11.0
+  - name: devworkspace-operator.v0.12.1
+    replaces: devworkspace-operator.v0.12.0
+  - name: devworkspace-operator.v0.12.2
+    replaces: devworkspace-operator.v0.12.1

--- a/olm-catalog/release/channel.yaml
+++ b/olm-catalog/release/channel.yaml
@@ -11,3 +11,5 @@ entries:
     replaces: devworkspace-operator.v0.12.0
   - name: devworkspace-operator.v0.12.2
     replaces: devworkspace-operator.v0.12.1
+  - name: devworkspace-operator.v0.12.3
+    replaces: devworkspace-operator.v0.12.2

--- a/olm-catalog/release/devworkspace-operator.v0.12.1.bundle.yaml
+++ b/olm-catalog/release/devworkspace-operator.v0.12.1.bundle.yaml
@@ -1,0 +1,62 @@
+image: quay.io/devfile/devworkspace-operator-bundle@sha256:db317692d5da85dc2e26bbf1bfd20a800d2fbf7e2fa33a9bcaf96fc56be86cc1
+name: devworkspace-operator.v0.12.1
+package: devworkspace-operator
+properties:
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceOperatorConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceRouting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha2
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha2
+- type: olm.package
+  value:
+    packageName: devworkspace-operator
+    version: 0.12.1
+relatedImages:
+- image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+  name: kube_rbac_proxy
+- image: quay.io/devfile/devworkspace-controller:next
+  name: devworkspace_webhook_server
+- image: quay.io/devfile/devworkspace-controller:v0.12.1
+  name: ""
+- image: quay.io/devfile/devworkspace-operator-bundle@sha256:db317692d5da85dc2e26bbf1bfd20a800d2fbf7e2fa33a9bcaf96fc56be86cc1
+  name: ""
+- image: quay.io/devfile/project-clone:next
+  name: project_clone
+- image: quay.io/eclipse/che-machine-exec:nightly
+  name: plugin_redhat_developer_web_terminal_4_5_0
+- image: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
+  name: async_storage_sidecar
+- image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
+  name: async_storage_server
+- image: quay.io/wto/web-terminal-tooling:latest
+  name: web_terminal_tooling
+- image: registry.access.redhat.com/ubi8-micro:8.4-81
+  name: pvc_cleanup_job
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+  name: ""
+schema: olm.bundle

--- a/olm-catalog/release/devworkspace-operator.v0.12.2.bundle.yaml
+++ b/olm-catalog/release/devworkspace-operator.v0.12.2.bundle.yaml
@@ -1,0 +1,62 @@
+image: quay.io/devfile/devworkspace-operator-bundle@sha256:4c3d338c3155a8bf06e4626d3c0652cb0363fcc5b42489941c77a662a00dadb7
+name: devworkspace-operator.v0.12.2
+package: devworkspace-operator
+properties:
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceOperatorConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceRouting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha2
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha2
+- type: olm.package
+  value:
+    packageName: devworkspace-operator
+    version: 0.12.2
+relatedImages:
+- image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+  name: kube_rbac_proxy
+- image: quay.io/devfile/devworkspace-controller:next
+  name: devworkspace_webhook_server
+- image: quay.io/devfile/devworkspace-controller:v0.12.2
+  name: ""
+- image: quay.io/devfile/devworkspace-operator-bundle@sha256:4c3d338c3155a8bf06e4626d3c0652cb0363fcc5b42489941c77a662a00dadb7
+  name: ""
+- image: quay.io/devfile/project-clone:next
+  name: project_clone
+- image: quay.io/eclipse/che-machine-exec:nightly
+  name: plugin_redhat_developer_web_terminal_4_5_0
+- image: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
+  name: async_storage_sidecar
+- image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
+  name: async_storage_server
+- image: quay.io/wto/web-terminal-tooling:latest
+  name: web_terminal_tooling
+- image: registry.access.redhat.com/ubi8-micro:8.4-81
+  name: pvc_cleanup_job
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+  name: ""
+schema: olm.bundle

--- a/olm-catalog/release/devworkspace-operator.v0.12.3.bundle.yaml
+++ b/olm-catalog/release/devworkspace-operator.v0.12.3.bundle.yaml
@@ -1,0 +1,62 @@
+image: quay.io/devfile/devworkspace-operator-bundle@sha256:6d76ea33151e0fadbeccc58560e1fcf001e7581449bb0309921d0e4a9faf30ea
+name: devworkspace-operator.v0.12.3
+package: devworkspace-operator
+properties:
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceOperatorConfig
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: controller.devfile.io
+    kind: DevWorkspaceRouting
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspace
+    version: v1alpha2
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: workspace.devfile.io
+    kind: DevWorkspaceTemplate
+    version: v1alpha2
+- type: olm.package
+  value:
+    packageName: devworkspace-operator
+    version: 0.12.3
+relatedImages:
+- image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+  name: kube_rbac_proxy
+- image: quay.io/devfile/devworkspace-controller:next
+  name: devworkspace_webhook_server
+- image: quay.io/devfile/devworkspace-controller:v0.12.3
+  name: ""
+- image: quay.io/devfile/devworkspace-operator-bundle@sha256:6d76ea33151e0fadbeccc58560e1fcf001e7581449bb0309921d0e4a9faf30ea
+  name: ""
+- image: quay.io/devfile/project-clone:next
+  name: project_clone
+- image: quay.io/eclipse/che-machine-exec:nightly
+  name: plugin_redhat_developer_web_terminal_4_5_0
+- image: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
+  name: async_storage_sidecar
+- image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
+  name: async_storage_server
+- image: quay.io/wto/web-terminal-tooling:latest
+  name: web_terminal_tooling
+- image: registry.access.redhat.com/ubi8-micro:8.4-81
+  name: pvc_cleanup_job
+- image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+  name: ""
+schema: olm.bundle


### PR DESCRIPTION
### What does this PR do?
Adds bundles for v0.12.1, v0.12.2, and v0.12.3 to the main-branch olm `release` channel.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
