### PR TITLE
Fix using DevWorkspaceRouting reconciler as a library

### DIFF
--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -99,8 +99,12 @@ func SetupControllerConfig(client crclient.Client) error {
 	return nil
 }
 
+func IsSetUp() bool {
+	return internalConfig != nil
+}
+
 func ExperimentalFeaturesEnabled() bool {
-	if internalConfig.EnableExperimentalFeatures == nil {
+	if internalConfig == nil || internalConfig.EnableExperimentalFeatures == nil {
 		return false
 	}
 	return *internalConfig.EnableExperimentalFeatures

--- a/pkg/provision/sync/sync.go
+++ b/pkg/provision/sync/sync.go
@@ -125,7 +125,7 @@ func isMutableObject(obj crclient.Object) bool {
 }
 
 func printDiff(specObj, clusterObj crclient.Object, log logr.Logger) {
-	if config.ExperimentalFeaturesEnabled() {
+	if config.IsSetUp() && config.ExperimentalFeaturesEnabled() {
 		var diffOpts cmp.Options
 		switch specObj.(type) {
 		case *rbacv1.Role:


### PR DESCRIPTION
### What does this PR do?
Since the sync package depends on the controller configuration being set up, using the DevWorkspaceRouting reconciler without doing the initial config set up can cause a panic. Instead, we guard against this so that
the controller functions as expected outside of the DevWorkspace Operator.

### What issues does this PR fix or reference?


### Is it tested? How?
This use case should be covered as part of https://github.com/devfile/devworkspace-operator/issues/735

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
