### PR TITLE
Set defaults when creating DevWorkspaceRouting on cluster

### DIFF
--- a/controllers/controller/devworkspacerouting/conversion/conversion.go
+++ b/controllers/controller/devworkspacerouting/conversion/conversion.go
@@ -35,11 +35,21 @@ func convertSecure(secure interface{}) bool {
 }
 
 func convertDevfileEndpoint(dwEndpoint dw.Endpoint) v1alpha1.Endpoint {
+	// Make sure to set defaults explicitly
+	endpointExposure := v1alpha1.EndpointExposure(dwEndpoint.Exposure)
+	if endpointExposure == "" {
+		endpointExposure = v1alpha1.PublicEndpointExposure
+	}
+	protocol := v1alpha1.EndpointProtocol(dwEndpoint.Protocol)
+	if protocol == "" {
+		protocol = "http"
+	}
+
 	return v1alpha1.Endpoint{
 		Name:       dwEndpoint.Name,
 		TargetPort: dwEndpoint.TargetPort,
-		Exposure:   v1alpha1.EndpointExposure(dwEndpoint.Exposure),
-		Protocol:   v1alpha1.EndpointProtocol(dwEndpoint.Protocol),
+		Exposure:   endpointExposure,
+		Protocol:   protocol,
 		Secure:     convertSecure(dwEndpoint.Secure),
 		Path:       dwEndpoint.Path,
 		Attributes: v1alpha1.Attributes(dwEndpoint.Attributes),


### PR DESCRIPTION
### What does this PR do?
Explicitly set defaults values on endpoint fields before applying a DevWorkspaceRouting to the cluster to avoid a loop where the spec has those values unset but the cluster defines them explicitly. 

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/768

### Is it tested? How?
Tested using devfile 
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: test-parent-basic
spec:
  started: true
  routingClass: 'basic'
  template:
    parent:
      id: nodejs
      registryUrl: "https://registry.devfile.io/devfiles"
    components:
      - name: theia-ide
        plugin:
          uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/eclipse/che-theia/next/devfile.yaml
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
