### PR TITLE
Update handling of registryUrls to match expectation from registry.devfile.io

### DIFF
--- a/pkg/library/flatten/flatten.go
+++ b/pkg/library/flatten/flatten.go
@@ -248,7 +248,9 @@ func resolveElementById(
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse registry URL for component %s: %w", name, err)
 	}
-	pluginURL.Path = path.Join(pluginURL.Path, id)
+
+	// convention: elements specified by id are served at <registryUrl>/devfiles/<id>
+	pluginURL.Path = path.Join(pluginURL.Path, "devfiles", id)
 
 	dwt, err := network.FetchDevWorkspaceTemplate(pluginURL.String(), tools.HttpClient)
 	if err != nil {

--- a/pkg/library/flatten/testdata/parent/resolve-parent-by-id.yaml
+++ b/pkg/library/flatten/testdata/parent/resolve-parent-by-id.yaml
@@ -17,7 +17,7 @@ input:
           image: regular-test-image
           name: regular-container
   devfileResources:
-    "https://test-registry.io/test/parent/id":
+    "https://test-registry.io/devfiles/test/parent/id":
       schemaVersion: 2.1.0
       metadata:
         name: parent-devfile

--- a/pkg/library/flatten/testdata/plugin-id/error_fetch-unparseable-file.yaml
+++ b/pkg/library/flatten/testdata/plugin-id/error_fetch-unparseable-file.yaml
@@ -8,7 +8,7 @@ input:
           id: my/test/plugin
           registryUrl: "https://test-registry.io/subpath"
   devworkspaceResources:
-    "https://test-registry.io/subpath/my/test/plugin":
+    "https://test-registry.io/subpath/devfiles/my/test/plugin":
       metadata:
         name: test-plugin
       spec:
@@ -20,4 +20,4 @@ input:
 
 
 output:
-  errRegexp: "could not find devfile or devworkspace object at 'https://test-registry.io/subpath/my/test/plugin'"
+  errRegexp: "could not find devfile or devworkspace object at 'https://test-registry.io/subpath/devfiles/my/test/plugin'"

--- a/pkg/library/flatten/testdata/plugin-id/error_invalid-schema-version.yaml
+++ b/pkg/library/flatten/testdata/plugin-id/error_invalid-schema-version.yaml
@@ -8,7 +8,7 @@ input:
           id: my/test/plugin
           registryUrl: "https://test-registry.io/subpath"
   devfileResources:
-    "https://test-registry.io/subpath/my/test/plugin":
+    "https://test-registry.io/subpath/devfiles/my/test/plugin":
       schemaVersion: 1.0.0
       metadata:
         name: "plugin-a"

--- a/pkg/library/flatten/testdata/plugin-id/error_on-fetch.yaml
+++ b/pkg/library/flatten/testdata/plugin-id/error_on-fetch.yaml
@@ -8,7 +8,7 @@ input:
           id: my/test/plugin
           registryUrl: "https://test-registry.io/subpath"
   errors:
-    "https://test-registry.io/subpath/my/test/plugin":
+    "https://test-registry.io/subpath/devfiles/my/test/plugin":
       message: "testing error"
 
 output:

--- a/pkg/library/flatten/testdata/plugin-id/error_plugin-not-found.yaml
+++ b/pkg/library/flatten/testdata/plugin-id/error_plugin-not-found.yaml
@@ -8,7 +8,7 @@ input:
           id: my/test/plugin
           registryUrl: "https://test-registry.io/subpath"
   errors:
-    "https://test-registry.io/subpath/my/test/plugin":
+    "https://test-registry.io/subpath/devfiles/my/test/plugin":
       statusCode: 404
 
 output:

--- a/pkg/library/flatten/testdata/plugin-id/resolve-devworkspace-instead-of-devfile.yaml
+++ b/pkg/library/flatten/testdata/plugin-id/resolve-devworkspace-instead-of-devfile.yaml
@@ -8,7 +8,7 @@ input:
           id: my/test/plugin
           registryUrl: "https://test-registry.io/subpath"
   devworkspaceResources:
-    "https://test-registry.io/subpath/my/test/plugin":
+    "https://test-registry.io/subpath/devfiles/my/test/plugin":
       kind: DevWorkspaceTemplate
       apiVersion: workspace.devfile.io/v1alpha2
       metadata:

--- a/pkg/library/flatten/testdata/plugin-id/resolve-plugin-by-id.yaml
+++ b/pkg/library/flatten/testdata/plugin-id/resolve-plugin-by-id.yaml
@@ -8,7 +8,7 @@ input:
           id: my/test/plugin
           registryUrl: "https://test-registry.io/subpath"
   devfileResources:
-    "https://test-registry.io/subpath/my/test/plugin":
+    "https://test-registry.io/subpath/devfiles/my/test/plugin":
       schemaVersion: 2.0.0
       metadata:
         name: "plugin-a"

--- a/pkg/library/flatten/testdata/plugin-id/resolve-plugin-multiple-registries.yaml
+++ b/pkg/library/flatten/testdata/plugin-id/resolve-plugin-multiple-registries.yaml
@@ -12,7 +12,7 @@ input:
           id: my/test/plugin-2
           registryUrl: "https://test-registry-2.io/subpath"
   devfileResources:
-    "https://test-registry.io/subpath/my/test/plugin":
+    "https://test-registry.io/subpath/devfiles/my/test/plugin":
       schemaVersion: 2.0.0
       metadata:
         name: "plugin-a"
@@ -21,7 +21,7 @@ input:
           container:
             name: test-container
             image: test-image
-    "https://test-registry-2.io/subpath/my/test/plugin-2":
+    "https://test-registry-2.io/subpath/devfiles/my/test/plugin-2":
       schemaVersion: 2.0.0
       metadata:
         name: "plugin-b"


### PR DESCRIPTION
### What does this PR do?
Update the flatten library to resolve plugins/parents from `<registryUrl>/devfiles/<id>`, as this appears to be what's expected in the main devfile registry -- e.g. https://registry.devfile.io/viewer/devfiles/Community+nodejs-basic uses 
```yaml
parent:
  id: nodejs
  registryUrl: "https://registry.devfile.io"
```
which refers to the devfile https://registry.devfile.io/devfiles/nodejs

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Test cases are updated.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
