### PR TITLE
Fix edgecases in handling DevWorkspaces with no container components

### DIFF
--- a/pkg/library/projects/clone.go
+++ b/pkg/library/projects/clone.go
@@ -39,6 +39,10 @@ func GetProjectCloneInitContainer(workspace *dw.DevWorkspaceTemplateSpec) (*core
 	if workspace.Attributes.GetString(constants.ProjectCloneAttribute, nil) == constants.ProjectCloneDisable {
 		return nil, nil
 	}
+	if !hasContainerComponents(workspace) {
+		// Avoid adding project-clone init container when DevWorkspace does not define any containers
+		return nil, nil
+	}
 
 	cloneImage := images.GetProjectClonerImage()
 	if cloneImage == "" {
@@ -90,4 +94,13 @@ func GetProjectCloneInitContainer(workspace *dw.DevWorkspaceTemplateSpec) (*core
 		},
 		ImagePullPolicy: corev1.PullPolicy(config.Workspace.ImagePullPolicy),
 	}, nil
+}
+
+func hasContainerComponents(workspace *dw.DevWorkspaceTemplateSpec) bool {
+	for _, component := range workspace.Components {
+		if component.Container != nil {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -94,6 +94,10 @@ func SyncDeploymentToCluster(
 			},
 		}
 	}
+	if len(specDeployment.Spec.Template.Spec.Containers) == 0 {
+		// DevWorkspace defines no container components, cannot create a deployment
+		return DeploymentProvisioningStatus{ProvisioningStatus{Continue: true}}
+	}
 
 	clusterObj, err := sync.SyncObjectWithCluster(specDeployment, clusterAPI)
 	switch t := err.(type) {


### PR DESCRIPTION
### What does this PR do?
Fix a couple of edgecases in DevWorkspaces that do not define containers:
* Project clone initContainer is added anyways and mounts `projects` volume, but no storage gets provisioned to the workspace
* DWO attempts to create a deployment with no containers

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/772
Fixes https://github.com/eclipse/che/issues/21114

### Is it tested? How?
Attempt to start DevWorkspace
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
