### PR TITLE
fix: Ensure only one instance of next-build github action runs at a time

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -19,6 +19,9 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: main-container-build
+
 jobs:
 
   build-next-imgs:
@@ -99,12 +102,12 @@ jobs:
       - name: Checkout devworkspace-operator source code
         uses: actions/checkout@v2
 
-      - name: "Docker Quay.io Login with DWO Robot"
-        env:
-          DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin quay.io
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
 
       - name: "Build Bundle & Index images"
         run: |
@@ -116,6 +119,3 @@ jobs:
             --index-image ${DWO_INDEX_IMG} \
             --container-tool docker \
             --force
-
-      - name: "Docker Logout"
-        run: docker logout


### PR DESCRIPTION
### What does this PR do?
Specify concurrency for the next-build GH action to make sure only one
instance of the next container images build runs at once. This avoids an
issue where

1. PR 1 is merged, kicks off next-build CI run
2. PR 2 is merged, kicks off a second CI run
3. CI run for PR 2 completes and pushes next image
4. CI run for PR 1 takes longer and completes second, pushing an
   out-of-date next image

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21114#issuecomment-1032676273

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
