### PR TITLE
feat: Use `claim-che-workspace` PVC if it exists

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -76,6 +76,10 @@ type WorkspaceConfig struct {
 	// PVCName defines the name used for the persistent volume claim created
 	// to support workspace storage when the 'common' storage class is used.
 	// If not specified, the default value of `claim-devworkspace` is used.
+	// Note that changing this configuration value after workspaces have been
+	// created will disconnect all existing workspaces from the previously-used
+	// persistent volume claim, and will require manual removal of the old PVCs
+	// in the cluster.
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	PVCName string `json:"pvcName,omitempty"`

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -166,7 +166,7 @@ spec:
                     description: ProgressTimeout determines the maximum duration a DevWorkspace can be in a "Starting" or "Failing" phase without progressing before it is automatically failed. Duration should be specified in a format parseable by Go's time package, e.g. "15m", "20s", "1h30m", etc. If not specified, the default value of "5m" is used.
                     type: string
                   pvcName:
-                    description: PVCName defines the name used for the persistent volume claim created to support workspace storage when the 'common' storage class is used. If not specified, the default value of `claim-devworkspace` is used.
+                    description: PVCName defines the name used for the persistent volume claim created to support workspace storage when the 'common' storage class is used. If not specified, the default value of `claim-devworkspace` is used. Note that changing this configuration value after workspaces have been created will disconnect all existing workspaces from the previously-used persistent volume claim, and will require manual removal of the old PVCs in the cluster.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -287,7 +287,11 @@ spec:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
                       storage class is used. If not specified, the default value of
-                      `claim-devworkspace` is used.
+                      `claim-devworkspace` is used. Note that changing this configuration
+                      value after workspaces have been created will disconnect all
+                      existing workspaces from the previously-used persistent volume
+                      claim, and will require manual removal of the old PVCs in the
+                      cluster.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -287,7 +287,11 @@ spec:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
                       storage class is used. If not specified, the default value of
-                      `claim-devworkspace` is used.
+                      `claim-devworkspace` is used. Note that changing this configuration
+                      value after workspaces have been created will disconnect all
+                      existing workspaces from the previously-used persistent volume
+                      claim, and will require manual removal of the old PVCs in the
+                      cluster.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -287,7 +287,11 @@ spec:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
                       storage class is used. If not specified, the default value of
-                      `claim-devworkspace` is used.
+                      `claim-devworkspace` is used. Note that changing this configuration
+                      value after workspaces have been created will disconnect all
+                      existing workspaces from the previously-used persistent volume
+                      claim, and will require manual removal of the old PVCs in the
+                      cluster.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -287,7 +287,11 @@ spec:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
                       storage class is used. If not specified, the default value of
-                      `claim-devworkspace` is used.
+                      `claim-devworkspace` is used. Note that changing this configuration
+                      value after workspaces have been created will disconnect all
+                      existing workspaces from the previously-used persistent volume
+                      claim, and will require manual removal of the old PVCs in the
+                      cluster.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -286,7 +286,11 @@ spec:
                     description: PVCName defines the name used for the persistent
                       volume claim created to support workspace storage when the 'common'
                       storage class is used. If not specified, the default value of
-                      `claim-devworkspace` is used.
+                      `claim-devworkspace` is used. Note that changing this configuration
+                      value after workspaces have been created will disconnect all
+                      existing workspaces from the previously-used persistent volume
+                      claim, and will require manual removal of the old PVCs in the
+                      cluster.
                     maxLength: 63
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -74,6 +74,10 @@ const (
 	// so do not require cleanup. When a DevWorkspace is stopped, all local changes are lost.
 	EphemeralStorageClassType = "ephemeral"
 
+	// CheCommonPVCName is the name of the common PVC equivalent used by Che. If present in the namespace, this PVC is mounted instead
+	// of the default PVC when the 'common' or 'async' storage classes are used.
+	CheCommonPVCName = "claim-che-workspace"
+
 	// Constants describing configuration for automatic project cloning
 
 	// ProjectCloneDisable specifies that project cloning should be disabled.

--- a/pkg/provision/storage/asyncstorage/deployment.go
+++ b/pkg/provision/storage/asyncstorage/deployment.go
@@ -27,13 +27,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func SyncWorkspaceSyncDeploymentToCluster(namespace string, sshConfigMap *corev1.ConfigMap, storage *corev1.PersistentVolumeClaim, clusterAPI sync.ClusterAPI) (*appsv1.Deployment, error) {
+func SyncWorkspaceSyncDeploymentToCluster(namespace string, sshConfigMap *corev1.ConfigMap, pvcName string, clusterAPI sync.ClusterAPI) (*appsv1.Deployment, error) {
 	podTolerations, nodeSelector, err := nsconfig.GetNamespacePodTolerationsAndNodeSelector(namespace, clusterAPI)
 	if err != nil {
 		return nil, err
 	}
 
-	specDeployment := getWorkspaceSyncDeploymentSpec(namespace, sshConfigMap, storage, podTolerations, nodeSelector)
+	specDeployment := getWorkspaceSyncDeploymentSpec(namespace, sshConfigMap, pvcName, podTolerations, nodeSelector)
 	clusterObj, err := sync.SyncObjectWithCluster(specDeployment, clusterAPI)
 	switch err.(type) {
 	case nil:
@@ -56,7 +56,7 @@ func SyncWorkspaceSyncDeploymentToCluster(namespace string, sshConfigMap *corev1
 func getWorkspaceSyncDeploymentSpec(
 	namespace string,
 	sshConfigMap *corev1.ConfigMap,
-	storage *corev1.PersistentVolumeClaim,
+	pvcName string,
 	tolerations []corev1.Toleration,
 	nodeSelector map[string]string) *appsv1.Deployment {
 
@@ -130,7 +130,7 @@ func getWorkspaceSyncDeploymentSpec(
 							Name: "async-storage-data",
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: storage.Name,
+									ClaimName: pvcName,
 								},
 							},
 						},

--- a/pkg/provision/storage/cleanup.go
+++ b/pkg/provision/storage/cleanup.go
@@ -100,7 +100,15 @@ func runCommonPVCCleanupJob(workspace *dw.DevWorkspace, clusterAPI sync.ClusterA
 
 func getSpecCommonPVCCleanupJob(workspace *dw.DevWorkspace, clusterAPI sync.ClusterAPI) (*batchv1.Job, error) {
 	workspaceId := workspace.Status.DevWorkspaceId
-	pvcName := config.Workspace.PVCName
+
+	pvcName, err := checkForExistingCommonPVC(workspace.Namespace, clusterAPI)
+	if err != nil {
+		return nil, err
+	}
+	if pvcName == "" {
+		pvcName = config.Workspace.PVCName
+	}
+
 	jobLabels := map[string]string{
 		constants.DevWorkspaceIDLabel: workspaceId,
 	}

--- a/pkg/provision/storage/shared.go
+++ b/pkg/provision/storage/shared.go
@@ -35,8 +35,6 @@ import (
 	nsconfig "github.com/devfile/devworkspace-operator/pkg/provision/config"
 )
 
-const cheCommonPVCName = "claim-che-workspace"
-
 func getCommonPVCSpec(namespace string, size string) (*corev1.PersistentVolumeClaim, error) {
 	pvcStorageQuantity, err := resource.ParseQuantity(size)
 	if err != nil {
@@ -226,7 +224,7 @@ func processProjectsVolume(workspace *dw.DevWorkspaceTemplateSpec) (projectsComp
 // PVC is found,
 func checkForExistingCommonPVC(namespace string, api sync.ClusterAPI) (string, error) {
 	existingPVC := &corev1.PersistentVolumeClaim{}
-	namespacedName := types.NamespacedName{Name: cheCommonPVCName, Namespace: namespace}
+	namespacedName := types.NamespacedName{Name: constants.CheCommonPVCName, Namespace: namespace}
 	err := api.Client.Get(api.Ctx, namespacedName, existingPVC)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {


### PR DESCRIPTION
### What does this PR do?
Makes DWO automatically reuse PVCs named `claim-che-workspace` if they are present in a DevWorkspace's namespace to make migration of devfile v1 workspaces created by Eclipse Che easier. While not an ideal solution, this allows DWO to continue using its own PVC in new namespaces while supporting existing workspaces created by Eclipse Che. The alternative (configuring PVC name in the devworkspace operator config CR) results in all DevWorkspaces using the alternate name.

This PR is a draft until we decide this is the route we want to take. Merging this PR comes with some caveats:
* It makes this repo have an explicit reference to an Eclipse Che naming convention
* Once merged, DWO must support `claim-che-workspace` ongoing until there is a safe migration strategy (i.e. this feature cannot be easily dropped).
* This change makes DWO use `claim-che-workspace` by default regardless of the value in the DevWorkspaceOperatorConfig, meaning this feature cannot be disabled if a `claim-che-workspace` PVC exists.

### What issues does this PR fix or reference?
Part of https://github.com/eclipse/che/issues/21038
Full solution would also require https://github.com/devfile/devworkspace-operator/pull/747

### Is it tested? How?
To test:
1. Create claim-che-workspace PVC in namespace, e.g. by copying the config of the claim-devworkspace PVC if it exists:
    ```
    kubectl get pvc claim-devworkspace -o json | \
      jq '{
          "metadata": {
            "name": "claim-che-workspace"
          }, apiVersion, kind, spec
        } | del(.spec.volumeMode) | del(.spec.volumeName)' | \
      kubectl apply -f -
    ```
2. Create a DevWorkspace: `kubectl apply -f samples/theia-next.yaml`
3. Verify that claim-che-workspace PVC is mounted instead of claim-devworkspace

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
