### PR TITLE
fix: Impose max length of 25 chars on DevWorkspace ID override

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -604,7 +604,9 @@ func (r *DevWorkspaceReconciler) removeStartedAtFromCluster(
 
 func (r *DevWorkspaceReconciler) getWorkspaceId(ctx context.Context, workspace *dw.DevWorkspace) (string, error) {
 	if idOverride := workspace.Annotations[constants.WorkspaceIdOverrideAnnotation]; idOverride != "" {
-		// TODO: Check overridden workspace ID's length (what should max be?)
+		if len(idOverride) > 25 {
+			return "", fmt.Errorf("maximum length for DevWorkspace ID override is 25 characters")
+		}
 		dwList := &dw.DevWorkspaceList{}
 		if err := r.Client.List(ctx, dwList, &client.ListOptions{Namespace: workspace.Namespace}); err != nil {
 			return "", fmt.Errorf("failed to check DevWorkspace ID override: %w", err)


### PR DESCRIPTION
### What does this PR do?
Sets the max length of DevWorkspace IDs defined by the `controller.devfile.io/devworkspace_id_override` annotation to 25 characters, to match the length used by default DevWorkspace IDs.

### What issues does this PR fix or reference?
Follow up to https://github.com/devfile/devworkspace-operator/pull/747 that I forgot

### Is it tested? How?
Attempt to create a DevWorkspace with ID longer than 25 characters

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
