### PR TITLE
Regenerate all bundle files for next catalog build

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -133,13 +133,10 @@ jobs:
           pip install yq
 
           # Update images used in bundle to use the sha-tagged image rather than just 'next'
+          # make generate_olm_bundle_yaml will be invoked by build_index_image.sh
           export TAG="sha-${{ needs.build-next-imgs.outputs.git-sha }}"
           export DEFAULT_DWO_IMG="quay.io/devfile/devworkspace-controller:$TAG"
           export PROJECT_CLONE_IMG="quay.io/devfile/project-clone:$TAG"
-
-          ./deploy/generate-deployment.sh \
-            --use-defaults \
-            --generate-olm
 
           ./build/scripts/build_index_image.sh \
             --bundle-repo ${DWO_BUNDLE_REPO} \

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -470,22 +470,22 @@ spec:
     name: Devfile
     url: https://devfile.io
   relatedImages:
+  - image: quay.io/devfile/devworkspace-controller:next
+    name: devworkspace_webhook_server
+  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+    name: kube_rbac_proxy
+  - image: quay.io/devfile/project-clone:next
+    name: project_clone
   - image: quay.io/eclipse/che-machine-exec:nightly
     name: plugin_redhat_developer_web_terminal_4_5_0
   - image: quay.io/wto/web-terminal-tooling:latest
     name: web_terminal_tooling
-  - image: quay.io/devfile/devworkspace-controller:next
-    name: devworkspace_webhook_server
   - image: registry.access.redhat.com/ubi8-micro:8.4-81
     name: pvc_cleanup_job
   - image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
     name: async_storage_server
   - image: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
     name: async_storage_sidecar
-  - image: quay.io/devfile/project-clone:next
-    name: project_clone
-  - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-    name: kube_rbac_proxy
   version: 0.13.0-dev
   webhookdefinitions:
   - admissionReviewVersions:

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -195,7 +195,8 @@ if $GEN_OLM; then
   TMPCSV="csv.tmp.yaml"
   yq -Y -s '
     .[0].spec.relatedImages =
-        [ .[1].spec.template.spec.containers[].env |
+        [ .[] | select(.kind == "Deployment") |
+          .spec.template.spec.containers[].env |
           select(length>0) |
           .[] |
           select(.name | test("RELATED_IMAGE.*")) |
@@ -205,7 +206,7 @@ if $GEN_OLM; then
           }
         ] | .[0]' \
     deploy/templates/components/csv/clusterserviceversion.yaml \
-    deploy/templates/components/manager/manager.yaml > "$TMPCSV"
+    deploy/deployment/openshift/combined.yaml > "$TMPCSV"
   mv $TMPCSV deploy/templates/components/csv/clusterserviceversion.yaml
 
   # It's needed to filter out the ServiceAccount object for OLM, as having a serviceaccount that matches the serviceaccount

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -94,19 +94,19 @@ spec:
     url: https://devfile.io
   version: 0.13.0-dev
   relatedImages:
+    - image: quay.io/devfile/devworkspace-controller:next
+      name: devworkspace_webhook_server
+    - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+      name: kube_rbac_proxy
+    - image: quay.io/devfile/project-clone:next
+      name: project_clone
     - image: quay.io/eclipse/che-machine-exec:nightly
       name: plugin_redhat_developer_web_terminal_4_5_0
     - image: quay.io/wto/web-terminal-tooling:latest
       name: web_terminal_tooling
-    - image: quay.io/devfile/devworkspace-controller:next
-      name: devworkspace_webhook_server
     - image: registry.access.redhat.com/ubi8-micro:8.4-81
       name: pvc_cleanup_job
     - image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
       name: async_storage_server
     - image: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
       name: async_storage_sidecar
-    - image: quay.io/devfile/project-clone:next
-      name: project_clone
-    - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-      name: kube_rbac_proxy


### PR DESCRIPTION
### What does this PR do?
Fix the `next` images build to correctly replace images in the bundle files.

### What issues does this PR fix or reference?
Some images in `next` catalog are still using `next` tag

### Is it tested? How?
Tested in my fork

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
