### PR TITLE
feat: Add support for setting RuntimeClass in DevWorkspaces

### DIFF
--- a/docs/additional-configuration.md
+++ b/docs/additional-configuration.md
@@ -124,3 +124,18 @@ Note: As for automatically mounting secrets, it is necessary to apply the `contr
 
 ## Debugging a failing workspace
 Normally, when a workspace fails to start, the deployment will be scaled down and the workspace will be stopped in a `Failed` state. This can make it difficult to debug misconfiguration errors, so the annotation `controller.devfile.io/debug-start: "true"` can be applied to DevWorkspaces to leave resources for failed workspaces on the cluster. This allows viewing logs from workspace containers.
+
+## Setting RuntimeClass for workspace pods
+To run a DevWorkspace with a specific RuntimeClass, the attribute `controller.devfile.io/runtime-class` can be set on the DevWorkspace with the name of the RuntimeClass to be used. If the specified RuntimeClass does not exist, the workspace will fail to start. For example, to run a DevWorkspace using the [kata containers](https://github.com/kata-containers/kata-containers) runtime in clusters where this is enabled, the DevWorkspace can be specified:
+```yaml
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-workspace
+spec:
+  template:
+    attributes:
+      controller.devfile.io/runtime-class: kata
+```
+
+For documentation on Runtime Classes, see https://kubernetes.io/docs/concepts/containers/runtime-class/

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -27,6 +27,10 @@ const (
 	//                stopped.
 	DevWorkspaceStorageTypeAttribute = "controller.devfile.io/storage-type"
 
+	// RuntimeClassNameAttribute is an attribute added to a DevWorkspace to specify a runtimeClassName for container
+	// components in the DevWorkspace (pod.spec.runtimeClassName). If empty, no runtimeClassName is added.
+	RuntimeClassNameAttribute = "controller.devfile.io/runtime-class"
+
 	// WorkspaceEnvAttribute is an attribute that specifies a set of environment variables provided by a component
 	// that should be added to all workspace containers. The structure of the attribute value should be a list of
 	// Devfile 2.0 EnvVar, e.g.

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -284,6 +284,12 @@ func getSpecDeployment(
 	if nodeSelector != nil && len(nodeSelector) > 0 {
 		deployment.Spec.Template.Spec.NodeSelector = nodeSelector
 	}
+	if workspace.Spec.Template.Attributes.Exists(constants.RuntimeClassNameAttribute) {
+		runtimeClassName := workspace.Spec.Template.Attributes.GetString(constants.RuntimeClassNameAttribute, nil)
+		if runtimeClassName != "" {
+			deployment.Spec.Template.Spec.RuntimeClassName = &runtimeClassName
+		}
+	}
 
 	if needPVC, pvcName := needsPVCWorkaround(podAdditions); needPVC {
 		// Kubernetes creates directories in a PVC to support subpaths such that only the leaf directory has g+rwx permissions.


### PR DESCRIPTION
### What does this PR do?
Add support for setting RuntimeClass for workspaces via attribute `controller.devfile.io/runtime-class`. The value of this attribute is propagated directly to pods in the workspace's deployment.

Internal documentation is updated to mention this attribute.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/788
Part of https://github.com/eclipse/che/issues/21105

### Is it tested? How?
Create DevWorkspace
```yaml
cat <<EOF | oc apply -f -
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: plain
spec:
  routingClass: basic
  started: true
  template:
    attributes:
      controller.devfile.io/storage-type: ephemeral
      controller.devfile.io/runtime-class: kata
    components:
    - container:
        command:
        - tail
        - -f
        - /dev/null
        image: quay.io/amisevsk/web-terminal-tooling:dev
        memoryLimit: 512Mi
        mountSources: true
      name: web-terminal
EOF
```
Workspace should fail to start immediately unless `kata` runtime is enabled in the cluster.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
