### PR TITLE
feat: Add attribute to allow specifyin deployment labels/annotations

### DIFF
--- a/docs/additional-configuration.md
+++ b/docs/additional-configuration.md
@@ -122,6 +122,24 @@ data:
 
 Note: As for automatically mounting secrets, it is necessary to apply the `controller.devfile.io/watch-secret` label to git credentials secrets
 
+## Applying labels and annotations to the workspace deployment
+In some cases, it is useful to apply additional labels or annotations to the deployment that is created for a DevWorkspace. This is supported by setting attributes `controller.devfile.io/deployment-labels` and `controller.devfile.io/deployment-annotations` in the DevWorkspace's attributes field. The value of these attributes should be specified as a string map, as it is for regular metadata labels and annotations. For example:
+```
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-workspace
+spec:
+  template:
+    attributes:
+      controller.devfile.io/deployment-labels:
+        my-label: foo
+        my-other-label: bar
+      controller.devfile.io/deployment-annotations:
+        my-attribute: foo
+        my-other-attribute: bar
+```
+
 ## Debugging a failing workspace
 Normally, when a workspace fails to start, the deployment will be scaled down and the workspace will be stopped in a `Failed` state. This can make it difficult to debug misconfiguration errors, so the annotation `controller.devfile.io/debug-start: "true"` can be applied to DevWorkspaces to leave resources for failed workspaces on the cluster. This allows viewing logs from workspace containers.
 

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -65,6 +65,14 @@ const (
 	//               will not be cloned into the workspace on start.
 	ProjectCloneAttribute = "controller.devfile.io/project-clone"
 
+	// DeployLabelsAttribute is an DevWorkspace attribute used in .spec.attributes that defines additional labels
+	// that should be applied to the workspace deployment. Value should be a map[string]string
+	DeployLabelsAttribute = "controller.devfile.io/deployment-labels"
+
+	// DeployAnnotationsAttribute is an DevWorkspace attribute used in .spec.attributes that defines additional annotations
+	// that should be applied to the workspace deployment. Value should be a map[string]string
+	DeployAnnotationsAttribute = "controller.devfile.io/deployment-annotations"
+
 	// PluginSourceAttribute is an attribute added to components, commands, and projects in a flattened
 	// DevWorkspace representation to signify where the respective component came from (i.e. which plugin
 	// or parent imported it)


### PR DESCRIPTION
### What does this PR do?
Add attributes `controller.devfile.io/deployment-labels` and `controller.devfile.io/deployment-annotations` which can be used to specify labels and annotations to be applied to the workspace deployment

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/698

### Is it tested? How?
To test, apply the DevWorkspace
```yaml
cat <<EOF | kubectl apply -f -
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: plain
spec:
  routingClass: basic
  started: true
  template:
    attributes:
      controller.devfile.io/storage-type: ephemeral
      controller.devfile.io/deployment-labels: 
        my-label: foo
        my-other-label: bar
      controller.devfile.io/deployment-annotations: 
        my-attribute: foo
        my-other-attribute: bar
    components:
    - container:
        command:
        - tail
        - -f
        - /dev/null
        image: quay.io/amisevsk/web-terminal-tooling:dev
        memoryLimit: 512Mi
        mountSources: true
      name: web-terminal
EOF
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
