### PR TITLE
fix: Fixup error message when trying to import DWT from another namespace

### DIFF
--- a/pkg/library/flatten/flatten.go
+++ b/pkg/library/flatten/flatten.go
@@ -221,7 +221,7 @@ func resolveElementByKubernetesImport(
 	}
 
 	if !canImportDWT(tools.WorkspaceNamespace, &dwTemplate) {
-		return nil, fmt.Errorf("could not find DevWorkspaceTemplate")
+		return nil, fmt.Errorf("plugin for component %s not found", name)
 	}
 
 	return &dwTemplate.Spec, nil

--- a/pkg/library/flatten/testdata/namespace-restriction/error_read-dwt-from-non-approved-namespace.yaml
+++ b/pkg/library/flatten/testdata/namespace-restriction/error_read-dwt-from-non-approved-namespace.yaml
@@ -24,4 +24,4 @@ input:
               image: test-img
 
 output:
-  errRegexp: "could not find DevWorkspaceTemplate"
+  errRegexp: "plugin for component plugin-a not found"

--- a/pkg/library/flatten/testdata/namespace-restriction/error_read-plain-dwt-from-another-namespace copy.yaml
+++ b/pkg/library/flatten/testdata/namespace-restriction/error_read-plain-dwt-from-another-namespace copy.yaml
@@ -24,4 +24,4 @@ input:
               image: test-img
 
 output:
-  errRegexp: "could not find DevWorkspaceTemplate"
+  errRegexp: "plugin for component plugin-a not found"

--- a/pkg/library/flatten/testdata/namespace-restriction/error_read-plain-dwt-from-another-namespace.yaml
+++ b/pkg/library/flatten/testdata/namespace-restriction/error_read-plain-dwt-from-another-namespace.yaml
@@ -22,4 +22,4 @@ input:
               image: test-img
 
 output:
-  errRegexp: "could not find DevWorkspaceTemplate"
+  errRegexp: "plugin for component plugin-a not found"


### PR DESCRIPTION
### What does this PR do?
Updates error message used when trying to import a DWT from a not-allowed namespace to print
```
plugin for component my-component not found
```
instead of 
```
could not find DevWorkspaceTemplate
```

The new message includes the component name for easier debugging and matches the message when a DWT is actually not found to prevent telling the user that a DWT exists in a namespace they have no access to.

### What issues does this PR fix or reference?
Minor annoyance I came across

### Is it tested? How?
Start a workspace that references a DWT in another namespace (and the DWT does not have the `import-from` annotation).

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
