### PR TITLE
chore: Update devfile API dependency to current main branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export PROJECT_CLONE_IMG ?= quay.io/devfile/project-clone:next
 export PULL_POLICY ?= Always
 export DEFAULT_ROUTING ?= basic
 export KUBECONFIG ?= ${HOME}/.kube/config
-export DEVWORKSPACE_API_VERSION ?= 089a48011460cbd9f06f200bad5452137a25f34b
+export DEVWORKSPACE_API_VERSION ?= 664e02df4202a8d4a9fdc30f25b445546e0c1acf
 
 # Enable using Podman instead of Docker
 export DOCKER ?= docker

--- a/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
+++ b/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
@@ -2962,7 +2962,7 @@ spec:
                         - custom
                       properties:
                         apply:
-                          description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default."
+                          description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -3171,6 +3171,20 @@ spec:
                         container:
                           description: Allows adding and configuring devworkspace-related containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
                               items:
@@ -3191,6 +3205,11 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                     type: object
@@ -3225,6 +3244,7 @@ spec:
                                     description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -3298,6 +3318,9 @@ spec:
                           - required:
                             - dockerfile
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -3314,7 +3337,7 @@ spec:
                                     type: string
                                   type: array
                                 buildContext:
-                                  description: Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container
+                                  description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
                                   type: string
                                 devfileRegistry:
                                   description: Dockerfile's Devfile Registry source
@@ -3385,9 +3408,17 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                     type: object
@@ -3422,6 +3453,7 @@ spec:
                                     description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -3454,9 +3486,17 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                     type: object
@@ -3491,6 +3531,7 @@ spec:
                                     description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -3532,7 +3573,7 @@ spec:
                                   - composite
                                 properties:
                                   apply:
-                                    description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default."
+                                    description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will be applied
@@ -3686,6 +3727,20 @@ spec:
                                   container:
                                     description: Allows adding and configuring devworkspace-related containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
                                         items:
@@ -3706,6 +3761,11 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                               type: object
@@ -3738,6 +3798,7 @@ spec:
                                               description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should be unique.
                                               type: integer
                                           required:
                                           - name
@@ -3790,7 +3851,12 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should be built during startup. \n Default value is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile type build
                                         oneOf:
@@ -3807,7 +3873,7 @@ spec:
                                               type: string
                                             type: array
                                           buildContext:
-                                            description: Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container
+                                            description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry source
@@ -3862,6 +3928,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -3872,9 +3939,17 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                               type: object
@@ -3907,6 +3982,7 @@ spec:
                                               description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should be unique.
                                               type: integer
                                           required:
                                           - name
@@ -3938,9 +4014,17 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                               type: object
@@ -3973,6 +4057,7 @@ spec:
                                               description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should be unique.
                                               type: integer
                                           required:
                                           - name
@@ -4030,6 +4115,10 @@ spec:
                               type: string
                             uri:
                               description: URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -4096,7 +4185,7 @@ spec:
                             - composite
                           properties:
                             apply:
-                              description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default."
+                              description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
                               properties:
                                 component:
                                   description: Describes component that will be applied
@@ -4253,6 +4342,20 @@ spec:
                             container:
                               description: Allows adding and configuring devworkspace-related containers
                               properties:
+                                annotation:
+                                  description: Annotations that should be added to specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
                                 args:
                                   description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
                                   items:
@@ -4273,6 +4376,11 @@ spec:
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                         type: object
@@ -4305,6 +4413,7 @@ spec:
                                         description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -4357,7 +4466,12 @@ spec:
                               oneOf:
                               - required:
                                 - dockerfile
+                              - required:
+                                - autoBuild
                               properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built during startup. \n Default value is `false`"
+                                  type: boolean
                                 dockerfile:
                                   description: Allows specifying dockerfile type build
                                   oneOf:
@@ -4374,7 +4488,7 @@ spec:
                                         type: string
                                       type: array
                                     buildContext:
-                                      description: Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container
+                                      description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
                                       type: string
                                     devfileRegistry:
                                       description: Dockerfile's Devfile Registry source
@@ -4429,6 +4543,7 @@ spec:
                                   description: Type of image
                                   enum:
                                   - Dockerfile
+                                  - AutoBuild
                                   type: string
                               type: object
                             kubernetes:
@@ -4439,9 +4554,17 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                         type: object
@@ -4474,6 +4597,7 @@ spec:
                                         description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -4505,9 +4629,17 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                         type: object
@@ -4540,6 +4672,7 @@ spec:
                                         description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -4580,7 +4713,7 @@ spec:
                                       - composite
                                     properties:
                                       apply:
-                                        description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default."
+                                        description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
                                         properties:
                                           component:
                                             description: Describes component that will be applied
@@ -4734,6 +4867,20 @@ spec:
                                       container:
                                         description: Allows adding and configuring devworkspace-related containers
                                         properties:
+                                          annotation:
+                                            description: Annotations that should be added to specific resources for this container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added to service
+                                                type: object
+                                            type: object
                                           args:
                                             description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
                                             items:
@@ -4754,6 +4901,11 @@ spec:
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                                   type: object
@@ -4786,6 +4938,7 @@ spec:
                                                   description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -4838,7 +4991,12 @@ spec:
                                         oneOf:
                                         - required:
                                           - dockerfile
+                                        - required:
+                                          - autoBuild
                                         properties:
+                                          autoBuild:
+                                            description: "Defines if the image should be built during startup. \n Default value is `false`"
+                                            type: boolean
                                           dockerfile:
                                             description: Allows specifying dockerfile type build
                                             oneOf:
@@ -4855,7 +5013,7 @@ spec:
                                                   type: string
                                                 type: array
                                               buildContext:
-                                                description: Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container
+                                                description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
                                                 type: string
                                               devfileRegistry:
                                                 description: Dockerfile's Devfile Registry source
@@ -4910,6 +5068,7 @@ spec:
                                             description: Type of image
                                             enum:
                                             - Dockerfile
+                                            - AutoBuild
                                             type: string
                                         type: object
                                       kubernetes:
@@ -4920,9 +5079,17 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                                   type: object
@@ -4955,6 +5122,7 @@ spec:
                                                   description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -4986,9 +5154,17 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                                   type: object
@@ -5021,6 +5197,7 @@ spec:
                                                   description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -5076,6 +5253,10 @@ spec:
                                   type: string
                                 uri:
                                   description: URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                                   type: string
                               type: object
                             volume:
@@ -5240,6 +5421,10 @@ spec:
                           type: string
                         description: Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.
                         type: object
+                      version:
+                        description: Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.
+                        pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                        type: string
                     type: object
                   projects:
                     description: Projects worked on in the devworkspace, containing names and sources locations

--- a/deploy/bundle/manifests/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/deploy/bundle/manifests/workspace.devfile.io_devworkspacetemplates.yaml
@@ -2874,7 +2874,7 @@ spec:
                     - custom
                   properties:
                     apply:
-                      description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default."
+                      description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
                       properties:
                         component:
                           description: Describes component that will be applied
@@ -3083,6 +3083,20 @@ spec:
                     container:
                       description: Allows adding and configuring devworkspace-related containers
                       properties:
+                        annotation:
+                          description: Annotations that should be added to specific resources for this container
+                          properties:
+                            deployment:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to deployment
+                              type: object
+                            service:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to service
+                              type: object
+                          type: object
                         args:
                           description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
                           items:
@@ -3103,6 +3117,11 @@ spec:
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                 type: object
@@ -3137,6 +3156,7 @@ spec:
                                 description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -3210,6 +3230,9 @@ spec:
                       - required:
                         - dockerfile
                       properties:
+                        autoBuild:
+                          description: "Defines if the image should be built during startup. \n Default value is `false`"
+                          type: boolean
                         dockerfile:
                           description: Allows specifying dockerfile type build
                           oneOf:
@@ -3226,7 +3249,7 @@ spec:
                                 type: string
                               type: array
                             buildContext:
-                              description: Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container
+                              description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
                               type: string
                             devfileRegistry:
                               description: Dockerfile's Devfile Registry source
@@ -3297,9 +3320,17 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                 type: object
@@ -3334,6 +3365,7 @@ spec:
                                 description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -3366,9 +3398,17 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                 type: object
@@ -3403,6 +3443,7 @@ spec:
                                 description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -3444,7 +3485,7 @@ spec:
                               - composite
                             properties:
                               apply:
-                                description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default."
+                                description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
                                 properties:
                                   component:
                                     description: Describes component that will be applied
@@ -3598,6 +3639,20 @@ spec:
                               container:
                                 description: Allows adding and configuring devworkspace-related containers
                                 properties:
+                                  annotation:
+                                    description: Annotations that should be added to specific resources for this container
+                                    properties:
+                                      deployment:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to deployment
+                                        type: object
+                                      service:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to service
+                                        type: object
+                                    type: object
                                   args:
                                     description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
                                     items:
@@ -3618,6 +3673,11 @@ spec:
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                           type: object
@@ -3650,6 +3710,7 @@ spec:
                                           description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -3702,7 +3763,12 @@ spec:
                                 oneOf:
                                 - required:
                                   - dockerfile
+                                - required:
+                                  - autoBuild
                                 properties:
+                                  autoBuild:
+                                    description: "Defines if the image should be built during startup. \n Default value is `false`"
+                                    type: boolean
                                   dockerfile:
                                     description: Allows specifying dockerfile type build
                                     oneOf:
@@ -3719,7 +3785,7 @@ spec:
                                           type: string
                                         type: array
                                       buildContext:
-                                        description: Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container
+                                        description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
                                         type: string
                                       devfileRegistry:
                                         description: Dockerfile's Devfile Registry source
@@ -3774,6 +3840,7 @@ spec:
                                     description: Type of image
                                     enum:
                                     - Dockerfile
+                                    - AutoBuild
                                     type: string
                                 type: object
                               kubernetes:
@@ -3784,9 +3851,17 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                           type: object
@@ -3819,6 +3894,7 @@ spec:
                                           description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -3850,9 +3926,17 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                           type: object
@@ -3885,6 +3969,7 @@ spec:
                                           description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -3942,6 +4027,10 @@ spec:
                           type: string
                         uri:
                           description: URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.
+                          type: string
+                        version:
+                          description: Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.
+                          pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                           type: string
                       type: object
                     volume:
@@ -4008,7 +4097,7 @@ spec:
                         - composite
                       properties:
                         apply:
-                          description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default."
+                          description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -4165,6 +4254,20 @@ spec:
                         container:
                           description: Allows adding and configuring devworkspace-related containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
                               items:
@@ -4185,6 +4288,11 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                     type: object
@@ -4217,6 +4325,7 @@ spec:
                                     description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -4269,7 +4378,12 @@ spec:
                           oneOf:
                           - required:
                             - dockerfile
+                          - required:
+                            - autoBuild
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -4286,7 +4400,7 @@ spec:
                                     type: string
                                   type: array
                                 buildContext:
-                                  description: Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container
+                                  description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
                                   type: string
                                 devfileRegistry:
                                   description: Dockerfile's Devfile Registry source
@@ -4341,6 +4455,7 @@ spec:
                               description: Type of image
                               enum:
                               - Dockerfile
+                              - AutoBuild
                               type: string
                           type: object
                         kubernetes:
@@ -4351,9 +4466,17 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                     type: object
@@ -4386,6 +4509,7 @@ spec:
                                     description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -4417,9 +4541,17 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                     type: object
@@ -4452,6 +4584,7 @@ spec:
                                     description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -4492,7 +4625,7 @@ spec:
                                   - composite
                                 properties:
                                   apply:
-                                    description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default."
+                                    description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will be applied
@@ -4646,6 +4779,20 @@ spec:
                                   container:
                                     description: Allows adding and configuring devworkspace-related containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
                                         items:
@@ -4666,6 +4813,11 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                               type: object
@@ -4698,6 +4850,7 @@ spec:
                                               description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should be unique.
                                               type: integer
                                           required:
                                           - name
@@ -4750,7 +4903,12 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should be built during startup. \n Default value is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile type build
                                         oneOf:
@@ -4767,7 +4925,7 @@ spec:
                                               type: string
                                             type: array
                                           buildContext:
-                                            description: Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container
+                                            description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry source
@@ -4822,6 +4980,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -4832,9 +4991,17 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                               type: object
@@ -4867,6 +5034,7 @@ spec:
                                               description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should be unique.
                                               type: integer
                                           required:
                                           - name
@@ -4898,9 +5066,17 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
                                               type: object
@@ -4933,6 +5109,7 @@ spec:
                                               description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should be unique.
                                               type: integer
                                           required:
                                           - name
@@ -4988,6 +5165,10 @@ spec:
                               type: string
                             uri:
                               description: URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -5152,6 +5333,10 @@ spec:
                       type: string
                     description: Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.
                     type: object
+                  version:
+                    description: Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.
+                    pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                    type: string
                 type: object
               projects:
                 description: Projects worked on in the devworkspace, containing names and sources locations

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -8571,7 +8571,8 @@ spec:
                             the devworkspace POD, unless the component has its `dedicatedPod`
                             field set to `true`. \n When no `apply` command exist
                             for a given component, it is assumed the component will
-                            be applied at devworkspace start by default."
+                            be applied at devworkspace start by default, unless `deployByDefault`
+                            for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -8827,6 +8828,21 @@ spec:
                           description: Allows adding and configuring devworkspace-related
                             containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific
+                                resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command
                                 running the dockerimage component. The arguments are
@@ -8858,6 +8874,12 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -8928,6 +8950,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -9025,6 +9048,10 @@ spec:
                           - required:
                             - dockerfile
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during
+                                startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -9043,7 +9070,7 @@ spec:
                                   type: array
                                 buildContext:
                                   description: Path of source directory to establish
-                                    build context. Defaults to ${PROJECT_ROOT} in
+                                    build context. Defaults to ${PROJECT_SOURCE} in
                                     the container
                                   type: string
                                 devfileRegistry:
@@ -9143,9 +9170,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -9216,6 +9253,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -9254,9 +9292,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -9327,6 +9375,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -9384,7 +9433,9 @@ spec:
                                       has its `dedicatedPod` field set to `true`.
                                       \n When no `apply` command exist for a given
                                       component, it is assumed the component will
-                                      be applied at devworkspace start by default."
+                                      be applied at devworkspace start by default,
+                                      unless `deployByDefault` for that component
+                                      is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will
@@ -9588,6 +9639,23 @@ spec:
                                     description: Allows adding and configuring devworkspace-related
                                       containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added
+                                          to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the
                                           command running the dockerimage component.
@@ -9620,6 +9688,13 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -9698,6 +9773,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -9772,7 +9849,14 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should
+                                          be built during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile
                                           type build
@@ -9793,7 +9877,7 @@ spec:
                                           buildContext:
                                             description: Path of source directory
                                               to establish build context. Defaults
-                                              to ${PROJECT_ROOT} in the container
+                                              to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry
@@ -9884,6 +9968,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -9898,9 +9983,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -9979,6 +10076,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -10018,9 +10117,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -10099,6 +10210,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -10168,6 +10281,15 @@ spec:
                               description: URI Reference of a parent devfile YAML
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -10260,7 +10382,8 @@ spec:
                                 its `dedicatedPod` field set to `true`. \n When no
                                 `apply` command exist for a given component, it is
                                 assumed the component will be applied at devworkspace
-                                start by default."
+                                start by default, unless `deployByDefault` for that
+                                component is set to false."
                               properties:
                                 component:
                                   description: Describes component that will be applied
@@ -10463,6 +10586,21 @@ spec:
                               description: Allows adding and configuring devworkspace-related
                                 containers
                               properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
                                 args:
                                   description: "The arguments to supply to the command
                                     running the dockerimage component. The arguments
@@ -10494,6 +10632,12 @@ spec:
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -10565,6 +10709,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -10638,7 +10783,13 @@ spec:
                               oneOf:
                               - required:
                                 - dockerfile
+                              - required:
+                                - autoBuild
                               properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built
+                                    during startup. \n Default value is `false`"
+                                  type: boolean
                                 dockerfile:
                                   description: Allows specifying dockerfile type build
                                   oneOf:
@@ -10657,7 +10808,7 @@ spec:
                                       type: array
                                     buildContext:
                                       description: Path of source directory to establish
-                                        build context. Defaults to ${PROJECT_ROOT}
+                                        build context. Defaults to ${PROJECT_SOURCE}
                                         in the container
                                       type: string
                                     devfileRegistry:
@@ -10742,6 +10893,7 @@ spec:
                                   description: Type of image
                                   enum:
                                   - Dockerfile
+                                  - AutoBuild
                                   type: string
                               type: object
                             kubernetes:
@@ -10755,9 +10907,19 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -10829,6 +10991,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -10866,9 +11029,19 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -10940,6 +11113,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -10998,7 +11172,9 @@ spec:
                                           has its `dedicatedPod` field set to `true`.
                                           \n When no `apply` command exist for a given
                                           component, it is assumed the component will
-                                          be applied at devworkspace start by default."
+                                          be applied at devworkspace start by default,
+                                          unless `deployByDefault` for that component
+                                          is set to false."
                                         properties:
                                           component:
                                             description: Describes component that
@@ -11207,6 +11383,24 @@ spec:
                                         description: Allows adding and configuring
                                           devworkspace-related containers
                                         properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
                                           args:
                                             description: "The arguments to supply
                                               to the command running the dockerimage
@@ -11241,6 +11435,13 @@ spec:
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -11325,6 +11526,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -11403,7 +11606,14 @@ spec:
                                         oneOf:
                                         - required:
                                           - dockerfile
+                                        - required:
+                                          - autoBuild
                                         properties:
+                                          autoBuild:
+                                            description: "Defines if the image should
+                                              be built during startup. \n Default
+                                              value is `false`"
+                                            type: boolean
                                           dockerfile:
                                             description: Allows specifying dockerfile
                                               type build
@@ -11424,7 +11634,7 @@ spec:
                                               buildContext:
                                                 description: Path of source directory
                                                   to establish build context. Defaults
-                                                  to ${PROJECT_ROOT} in the container
+                                                  to ${PROJECT_SOURCE} in the container
                                                 type: string
                                               devfileRegistry:
                                                 description: Dockerfile's Devfile
@@ -11519,6 +11729,7 @@ spec:
                                             description: Type of image
                                             enum:
                                             - Dockerfile
+                                            - AutoBuild
                                             type: string
                                         type: object
                                       kubernetes:
@@ -11533,9 +11744,21 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -11620,6 +11843,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -11660,9 +11885,21 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -11747,6 +11984,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -11816,6 +12055,16 @@ spec:
                                   description: URI Reference of a parent devfile YAML
                                     file. It can be a full URL or a relative URI with
                                     the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                                   type: string
                               type: object
                             volume:
@@ -12028,6 +12277,15 @@ spec:
                           devfile. Overriding is done according to K8S strategic merge
                           patch standard rules.
                         type: object
+                      version:
+                        description: Specific stack/sample version to pull the parent
+                          devfile from, when using id in the parent reference. To
+                          specify `version`, `id` must be defined and used as the
+                          import reference source. `version` can be either a specific
+                          stack version, or `latest`. If no `version` specified, default
+                          version will be used.
+                        pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                        type: string
                     type: object
                   projects:
                     description: Projects worked on in the devworkspace, containing
@@ -16245,7 +16503,8 @@ spec:
                         unless the component has its `dedicatedPod` field set to `true`.
                         \n When no `apply` command exist for a given component, it
                         is assumed the component will be applied at devworkspace start
-                        by default."
+                        by default, unless `deployByDefault` for that component is
+                        set to false."
                       properties:
                         component:
                           description: Describes component that will be applied
@@ -16491,6 +16750,21 @@ spec:
                       description: Allows adding and configuring devworkspace-related
                         containers
                       properties:
+                        annotation:
+                          description: Annotations that should be added to specific
+                            resources for this container
+                          properties:
+                            deployment:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to deployment
+                              type: object
+                            service:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to service
+                              type: object
+                          type: object
                         args:
                           description: "The arguments to supply to the command running
                             the dockerimage component. The arguments are supplied
@@ -16520,6 +16794,12 @@ spec:
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -16586,6 +16866,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -16682,6 +16963,10 @@ spec:
                       - required:
                         - dockerfile
                       properties:
+                        autoBuild:
+                          description: "Defines if the image should be built during
+                            startup. \n Default value is `false`"
+                          type: boolean
                         dockerfile:
                           description: Allows specifying dockerfile type build
                           oneOf:
@@ -16700,7 +16985,7 @@ spec:
                               type: array
                             buildContext:
                               description: Path of source directory to establish build
-                                context. Defaults to ${PROJECT_ROOT} in the container
+                                context. Defaults to ${PROJECT_SOURCE} in the container
                               type: string
                             devfileRegistry:
                               description: Dockerfile's Devfile Registry source
@@ -16799,9 +17084,19 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed
+                            during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -16868,6 +17163,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -16906,9 +17202,19 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed
+                            during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -16975,6 +17281,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -17031,7 +17338,9 @@ spec:
                                   unless the component has its `dedicatedPod` field
                                   set to `true`. \n When no `apply` command exist
                                   for a given component, it is assumed the component
-                                  will be applied at devworkspace start by default."
+                                  will be applied at devworkspace start by default,
+                                  unless `deployByDefault` for that component is set
+                                  to false."
                                 properties:
                                   component:
                                     description: Describes component that will be
@@ -17233,6 +17542,21 @@ spec:
                                 description: Allows adding and configuring devworkspace-related
                                   containers
                                 properties:
+                                  annotation:
+                                    description: Annotations that should be added
+                                      to specific resources for this container
+                                    properties:
+                                      deployment:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to deployment
+                                        type: object
+                                      service:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to service
+                                        type: object
+                                    type: object
                                   args:
                                     description: "The arguments to supply to the command
                                       running the dockerimage component. The arguments
@@ -17264,6 +17588,12 @@ spec:
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -17336,6 +17666,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -17410,7 +17741,13 @@ spec:
                                 oneOf:
                                 - required:
                                   - dockerfile
+                                - required:
+                                  - autoBuild
                                 properties:
+                                  autoBuild:
+                                    description: "Defines if the image should be built
+                                      during startup. \n Default value is `false`"
+                                    type: boolean
                                   dockerfile:
                                     description: Allows specifying dockerfile type
                                       build
@@ -17430,7 +17767,7 @@ spec:
                                         type: array
                                       buildContext:
                                         description: Path of source directory to establish
-                                          build context. Defaults to ${PROJECT_ROOT}
+                                          build context. Defaults to ${PROJECT_SOURCE}
                                           in the container
                                         type: string
                                       devfileRegistry:
@@ -17516,6 +17853,7 @@ spec:
                                     description: Type of image
                                     enum:
                                     - Dockerfile
+                                    - AutoBuild
                                     type: string
                                 type: object
                               kubernetes:
@@ -17529,9 +17867,20 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should
+                                      be deployed during startup. \n Default value
+                                      is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -17604,6 +17953,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -17642,9 +17992,20 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should
+                                      be deployed during startup. \n Default value
+                                      is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -17717,6 +18078,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -17785,6 +18147,15 @@ spec:
                           description: URI Reference of a parent devfile YAML file.
                             It can be a full URL or a relative URI with the current
                             devfile as the base URI.
+                          type: string
+                        version:
+                          description: Specific stack/sample version to pull the parent
+                            devfile from, when using id in the parent reference. To
+                            specify `version`, `id` must be defined and used as the
+                            import reference source. `version` can be either a specific
+                            stack version, or `latest`. If no `version` specified,
+                            default version will be used.
+                          pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                           type: string
                       type: object
                     volume:
@@ -17875,7 +18246,8 @@ spec:
                             the devworkspace POD, unless the component has its `dedicatedPod`
                             field set to `true`. \n When no `apply` command exist
                             for a given component, it is assumed the component will
-                            be applied at devworkspace start by default."
+                            be applied at devworkspace start by default, unless `deployByDefault`
+                            for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -18071,6 +18443,21 @@ spec:
                           description: Allows adding and configuring devworkspace-related
                             containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific
+                                resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command
                                 running the dockerimage component. The arguments are
@@ -18102,6 +18489,12 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -18170,6 +18563,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -18240,7 +18634,13 @@ spec:
                           oneOf:
                           - required:
                             - dockerfile
+                          - required:
+                            - autoBuild
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during
+                                startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -18259,7 +18659,7 @@ spec:
                                   type: array
                                 buildContext:
                                   description: Path of source directory to establish
-                                    build context. Defaults to ${PROJECT_ROOT} in
+                                    build context. Defaults to ${PROJECT_SOURCE} in
                                     the container
                                   type: string
                                 devfileRegistry:
@@ -18340,6 +18740,7 @@ spec:
                               description: Type of image
                               enum:
                               - Dockerfile
+                              - AutoBuild
                               type: string
                           type: object
                         kubernetes:
@@ -18353,9 +18754,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -18424,6 +18835,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -18461,9 +18873,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -18532,6 +18954,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -18588,7 +19011,9 @@ spec:
                                       has its `dedicatedPod` field set to `true`.
                                       \n When no `apply` command exist for a given
                                       component, it is assumed the component will
-                                      be applied at devworkspace start by default."
+                                      be applied at devworkspace start by default,
+                                      unless `deployByDefault` for that component
+                                      is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will
@@ -18792,6 +19217,23 @@ spec:
                                     description: Allows adding and configuring devworkspace-related
                                       containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added
+                                          to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the
                                           command running the dockerimage component.
@@ -18824,6 +19266,13 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -18902,6 +19351,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -18976,7 +19427,14 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should
+                                          be built during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile
                                           type build
@@ -18997,7 +19455,7 @@ spec:
                                           buildContext:
                                             description: Path of source directory
                                               to establish build context. Defaults
-                                              to ${PROJECT_ROOT} in the container
+                                              to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry
@@ -19088,6 +19546,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -19102,9 +19561,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -19183,6 +19654,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -19222,9 +19695,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -19303,6 +19788,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -19370,6 +19857,15 @@ spec:
                               description: URI Reference of a parent devfile YAML
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -19577,6 +20073,15 @@ spec:
                       Overriding is done according to K8S strategic merge patch standard
                       rules.
                     type: object
+                  version:
+                    description: Specific stack/sample version to pull the parent
+                      devfile from, when using id in the parent reference. To specify
+                      `version`, `id` must be defined and used as the import reference
+                      source. `version` can be either a specific stack version, or
+                      `latest`. If no `version` specified, default version will be
+                      used.
+                    pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                    type: string
                 type: object
               projects:
                 description: Projects worked on in the devworkspace, containing names

--- a/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -4179,7 +4179,8 @@ spec:
                             the devworkspace POD, unless the component has its `dedicatedPod`
                             field set to `true`. \n When no `apply` command exist
                             for a given component, it is assumed the component will
-                            be applied at devworkspace start by default."
+                            be applied at devworkspace start by default, unless `deployByDefault`
+                            for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -4435,6 +4436,21 @@ spec:
                           description: Allows adding and configuring devworkspace-related
                             containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific
+                                resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command
                                 running the dockerimage component. The arguments are
@@ -4466,6 +4482,12 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -4536,6 +4558,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -4633,6 +4656,10 @@ spec:
                           - required:
                             - dockerfile
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during
+                                startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -4651,7 +4678,7 @@ spec:
                                   type: array
                                 buildContext:
                                   description: Path of source directory to establish
-                                    build context. Defaults to ${PROJECT_ROOT} in
+                                    build context. Defaults to ${PROJECT_SOURCE} in
                                     the container
                                   type: string
                                 devfileRegistry:
@@ -4751,9 +4778,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -4824,6 +4861,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -4862,9 +4900,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -4935,6 +4983,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -4992,7 +5041,9 @@ spec:
                                       has its `dedicatedPod` field set to `true`.
                                       \n When no `apply` command exist for a given
                                       component, it is assumed the component will
-                                      be applied at devworkspace start by default."
+                                      be applied at devworkspace start by default,
+                                      unless `deployByDefault` for that component
+                                      is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will
@@ -5196,6 +5247,23 @@ spec:
                                     description: Allows adding and configuring devworkspace-related
                                       containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added
+                                          to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the
                                           command running the dockerimage component.
@@ -5228,6 +5296,13 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -5306,6 +5381,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -5380,7 +5457,14 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should
+                                          be built during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile
                                           type build
@@ -5401,7 +5485,7 @@ spec:
                                           buildContext:
                                             description: Path of source directory
                                               to establish build context. Defaults
-                                              to ${PROJECT_ROOT} in the container
+                                              to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry
@@ -5492,6 +5576,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -5506,9 +5591,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -5587,6 +5684,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -5626,9 +5725,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -5707,6 +5818,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -5776,6 +5889,15 @@ spec:
                               description: URI Reference of a parent devfile YAML
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -5868,7 +5990,8 @@ spec:
                                 its `dedicatedPod` field set to `true`. \n When no
                                 `apply` command exist for a given component, it is
                                 assumed the component will be applied at devworkspace
-                                start by default."
+                                start by default, unless `deployByDefault` for that
+                                component is set to false."
                               properties:
                                 component:
                                   description: Describes component that will be applied
@@ -6071,6 +6194,21 @@ spec:
                               description: Allows adding and configuring devworkspace-related
                                 containers
                               properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
                                 args:
                                   description: "The arguments to supply to the command
                                     running the dockerimage component. The arguments
@@ -6102,6 +6240,12 @@ spec:
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -6173,6 +6317,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -6246,7 +6391,13 @@ spec:
                               oneOf:
                               - required:
                                 - dockerfile
+                              - required:
+                                - autoBuild
                               properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built
+                                    during startup. \n Default value is `false`"
+                                  type: boolean
                                 dockerfile:
                                   description: Allows specifying dockerfile type build
                                   oneOf:
@@ -6265,7 +6416,7 @@ spec:
                                       type: array
                                     buildContext:
                                       description: Path of source directory to establish
-                                        build context. Defaults to ${PROJECT_ROOT}
+                                        build context. Defaults to ${PROJECT_SOURCE}
                                         in the container
                                       type: string
                                     devfileRegistry:
@@ -6350,6 +6501,7 @@ spec:
                                   description: Type of image
                                   enum:
                                   - Dockerfile
+                                  - AutoBuild
                                   type: string
                               type: object
                             kubernetes:
@@ -6363,9 +6515,19 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -6437,6 +6599,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -6474,9 +6637,19 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -6548,6 +6721,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -6606,7 +6780,9 @@ spec:
                                           has its `dedicatedPod` field set to `true`.
                                           \n When no `apply` command exist for a given
                                           component, it is assumed the component will
-                                          be applied at devworkspace start by default."
+                                          be applied at devworkspace start by default,
+                                          unless `deployByDefault` for that component
+                                          is set to false."
                                         properties:
                                           component:
                                             description: Describes component that
@@ -6815,6 +6991,24 @@ spec:
                                         description: Allows adding and configuring
                                           devworkspace-related containers
                                         properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
                                           args:
                                             description: "The arguments to supply
                                               to the command running the dockerimage
@@ -6849,6 +7043,13 @@ spec:
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -6933,6 +7134,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -7011,7 +7214,14 @@ spec:
                                         oneOf:
                                         - required:
                                           - dockerfile
+                                        - required:
+                                          - autoBuild
                                         properties:
+                                          autoBuild:
+                                            description: "Defines if the image should
+                                              be built during startup. \n Default
+                                              value is `false`"
+                                            type: boolean
                                           dockerfile:
                                             description: Allows specifying dockerfile
                                               type build
@@ -7032,7 +7242,7 @@ spec:
                                               buildContext:
                                                 description: Path of source directory
                                                   to establish build context. Defaults
-                                                  to ${PROJECT_ROOT} in the container
+                                                  to ${PROJECT_SOURCE} in the container
                                                 type: string
                                               devfileRegistry:
                                                 description: Dockerfile's Devfile
@@ -7127,6 +7337,7 @@ spec:
                                             description: Type of image
                                             enum:
                                             - Dockerfile
+                                            - AutoBuild
                                             type: string
                                         type: object
                                       kubernetes:
@@ -7141,9 +7352,21 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -7228,6 +7451,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -7268,9 +7493,21 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -7355,6 +7592,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -7424,6 +7663,16 @@ spec:
                                   description: URI Reference of a parent devfile YAML
                                     file. It can be a full URL or a relative URI with
                                     the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                                   type: string
                               type: object
                             volume:
@@ -7636,6 +7885,15 @@ spec:
                           devfile. Overriding is done according to K8S strategic merge
                           patch standard rules.
                         type: object
+                      version:
+                        description: Specific stack/sample version to pull the parent
+                          devfile from, when using id in the parent reference. To
+                          specify `version`, `id` must be defined and used as the
+                          import reference source. `version` can be either a specific
+                          stack version, or `latest`. If no `version` specified, default
+                          version will be used.
+                        pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                        type: string
                     type: object
                   projects:
                     description: Projects worked on in the devworkspace, containing

--- a/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -3953,7 +3953,8 @@ spec:
                         unless the component has its `dedicatedPod` field set to `true`.
                         \n When no `apply` command exist for a given component, it
                         is assumed the component will be applied at devworkspace start
-                        by default."
+                        by default, unless `deployByDefault` for that component is
+                        set to false."
                       properties:
                         component:
                           description: Describes component that will be applied
@@ -4199,6 +4200,21 @@ spec:
                       description: Allows adding and configuring devworkspace-related
                         containers
                       properties:
+                        annotation:
+                          description: Annotations that should be added to specific
+                            resources for this container
+                          properties:
+                            deployment:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to deployment
+                              type: object
+                            service:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to service
+                              type: object
+                          type: object
                         args:
                           description: "The arguments to supply to the command running
                             the dockerimage component. The arguments are supplied
@@ -4228,6 +4244,12 @@ spec:
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -4294,6 +4316,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -4390,6 +4413,10 @@ spec:
                       - required:
                         - dockerfile
                       properties:
+                        autoBuild:
+                          description: "Defines if the image should be built during
+                            startup. \n Default value is `false`"
+                          type: boolean
                         dockerfile:
                           description: Allows specifying dockerfile type build
                           oneOf:
@@ -4408,7 +4435,7 @@ spec:
                               type: array
                             buildContext:
                               description: Path of source directory to establish build
-                                context. Defaults to ${PROJECT_ROOT} in the container
+                                context. Defaults to ${PROJECT_SOURCE} in the container
                               type: string
                             devfileRegistry:
                               description: Dockerfile's Devfile Registry source
@@ -4507,9 +4534,19 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed
+                            during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -4576,6 +4613,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -4614,9 +4652,19 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed
+                            during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -4683,6 +4731,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -4739,7 +4788,9 @@ spec:
                                   unless the component has its `dedicatedPod` field
                                   set to `true`. \n When no `apply` command exist
                                   for a given component, it is assumed the component
-                                  will be applied at devworkspace start by default."
+                                  will be applied at devworkspace start by default,
+                                  unless `deployByDefault` for that component is set
+                                  to false."
                                 properties:
                                   component:
                                     description: Describes component that will be
@@ -4941,6 +4992,21 @@ spec:
                                 description: Allows adding and configuring devworkspace-related
                                   containers
                                 properties:
+                                  annotation:
+                                    description: Annotations that should be added
+                                      to specific resources for this container
+                                    properties:
+                                      deployment:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to deployment
+                                        type: object
+                                      service:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to service
+                                        type: object
+                                    type: object
                                   args:
                                     description: "The arguments to supply to the command
                                       running the dockerimage component. The arguments
@@ -4972,6 +5038,12 @@ spec:
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -5044,6 +5116,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -5118,7 +5191,13 @@ spec:
                                 oneOf:
                                 - required:
                                   - dockerfile
+                                - required:
+                                  - autoBuild
                                 properties:
+                                  autoBuild:
+                                    description: "Defines if the image should be built
+                                      during startup. \n Default value is `false`"
+                                    type: boolean
                                   dockerfile:
                                     description: Allows specifying dockerfile type
                                       build
@@ -5138,7 +5217,7 @@ spec:
                                         type: array
                                       buildContext:
                                         description: Path of source directory to establish
-                                          build context. Defaults to ${PROJECT_ROOT}
+                                          build context. Defaults to ${PROJECT_SOURCE}
                                           in the container
                                         type: string
                                       devfileRegistry:
@@ -5224,6 +5303,7 @@ spec:
                                     description: Type of image
                                     enum:
                                     - Dockerfile
+                                    - AutoBuild
                                     type: string
                                 type: object
                               kubernetes:
@@ -5237,9 +5317,20 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should
+                                      be deployed during startup. \n Default value
+                                      is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -5312,6 +5403,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -5350,9 +5442,20 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should
+                                      be deployed during startup. \n Default value
+                                      is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -5425,6 +5528,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -5493,6 +5597,15 @@ spec:
                           description: URI Reference of a parent devfile YAML file.
                             It can be a full URL or a relative URI with the current
                             devfile as the base URI.
+                          type: string
+                        version:
+                          description: Specific stack/sample version to pull the parent
+                            devfile from, when using id in the parent reference. To
+                            specify `version`, `id` must be defined and used as the
+                            import reference source. `version` can be either a specific
+                            stack version, or `latest`. If no `version` specified,
+                            default version will be used.
+                          pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                           type: string
                       type: object
                     volume:
@@ -5583,7 +5696,8 @@ spec:
                             the devworkspace POD, unless the component has its `dedicatedPod`
                             field set to `true`. \n When no `apply` command exist
                             for a given component, it is assumed the component will
-                            be applied at devworkspace start by default."
+                            be applied at devworkspace start by default, unless `deployByDefault`
+                            for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -5779,6 +5893,21 @@ spec:
                           description: Allows adding and configuring devworkspace-related
                             containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific
+                                resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command
                                 running the dockerimage component. The arguments are
@@ -5810,6 +5939,12 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -5878,6 +6013,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -5948,7 +6084,13 @@ spec:
                           oneOf:
                           - required:
                             - dockerfile
+                          - required:
+                            - autoBuild
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during
+                                startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -5967,7 +6109,7 @@ spec:
                                   type: array
                                 buildContext:
                                   description: Path of source directory to establish
-                                    build context. Defaults to ${PROJECT_ROOT} in
+                                    build context. Defaults to ${PROJECT_SOURCE} in
                                     the container
                                   type: string
                                 devfileRegistry:
@@ -6048,6 +6190,7 @@ spec:
                               description: Type of image
                               enum:
                               - Dockerfile
+                              - AutoBuild
                               type: string
                           type: object
                         kubernetes:
@@ -6061,9 +6204,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -6132,6 +6285,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -6169,9 +6323,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -6240,6 +6404,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -6296,7 +6461,9 @@ spec:
                                       has its `dedicatedPod` field set to `true`.
                                       \n When no `apply` command exist for a given
                                       component, it is assumed the component will
-                                      be applied at devworkspace start by default."
+                                      be applied at devworkspace start by default,
+                                      unless `deployByDefault` for that component
+                                      is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will
@@ -6500,6 +6667,23 @@ spec:
                                     description: Allows adding and configuring devworkspace-related
                                       containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added
+                                          to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the
                                           command running the dockerimage component.
@@ -6532,6 +6716,13 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -6610,6 +6801,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -6684,7 +6877,14 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should
+                                          be built during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile
                                           type build
@@ -6705,7 +6905,7 @@ spec:
                                           buildContext:
                                             description: Path of source directory
                                               to establish build context. Defaults
-                                              to ${PROJECT_ROOT} in the container
+                                              to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry
@@ -6796,6 +6996,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -6810,9 +7011,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -6891,6 +7104,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -6930,9 +7145,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -7011,6 +7238,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -7078,6 +7307,15 @@ spec:
                               description: URI Reference of a parent devfile YAML
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -7285,6 +7523,15 @@ spec:
                       Overriding is done according to K8S strategic merge patch standard
                       rules.
                     type: object
+                  version:
+                    description: Specific stack/sample version to pull the parent
+                      devfile from, when using id in the parent reference. To specify
+                      `version`, `id` must be defined and used as the import reference
+                      source. `version` can be either a specific stack version, or
+                      `latest`. If no `version` specified, default version will be
+                      used.
+                    pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                    type: string
                 type: object
               projects:
                 description: Projects worked on in the devworkspace, containing names

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -8571,7 +8571,8 @@ spec:
                             the devworkspace POD, unless the component has its `dedicatedPod`
                             field set to `true`. \n When no `apply` command exist
                             for a given component, it is assumed the component will
-                            be applied at devworkspace start by default."
+                            be applied at devworkspace start by default, unless `deployByDefault`
+                            for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -8827,6 +8828,21 @@ spec:
                           description: Allows adding and configuring devworkspace-related
                             containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific
+                                resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command
                                 running the dockerimage component. The arguments are
@@ -8858,6 +8874,12 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -8928,6 +8950,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -9025,6 +9048,10 @@ spec:
                           - required:
                             - dockerfile
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during
+                                startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -9043,7 +9070,7 @@ spec:
                                   type: array
                                 buildContext:
                                   description: Path of source directory to establish
-                                    build context. Defaults to ${PROJECT_ROOT} in
+                                    build context. Defaults to ${PROJECT_SOURCE} in
                                     the container
                                   type: string
                                 devfileRegistry:
@@ -9143,9 +9170,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -9216,6 +9253,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -9254,9 +9292,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -9327,6 +9375,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -9384,7 +9433,9 @@ spec:
                                       has its `dedicatedPod` field set to `true`.
                                       \n When no `apply` command exist for a given
                                       component, it is assumed the component will
-                                      be applied at devworkspace start by default."
+                                      be applied at devworkspace start by default,
+                                      unless `deployByDefault` for that component
+                                      is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will
@@ -9588,6 +9639,23 @@ spec:
                                     description: Allows adding and configuring devworkspace-related
                                       containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added
+                                          to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the
                                           command running the dockerimage component.
@@ -9620,6 +9688,13 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -9698,6 +9773,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -9772,7 +9849,14 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should
+                                          be built during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile
                                           type build
@@ -9793,7 +9877,7 @@ spec:
                                           buildContext:
                                             description: Path of source directory
                                               to establish build context. Defaults
-                                              to ${PROJECT_ROOT} in the container
+                                              to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry
@@ -9884,6 +9968,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -9898,9 +9983,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -9979,6 +10076,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -10018,9 +10117,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -10099,6 +10210,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -10168,6 +10281,15 @@ spec:
                               description: URI Reference of a parent devfile YAML
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -10260,7 +10382,8 @@ spec:
                                 its `dedicatedPod` field set to `true`. \n When no
                                 `apply` command exist for a given component, it is
                                 assumed the component will be applied at devworkspace
-                                start by default."
+                                start by default, unless `deployByDefault` for that
+                                component is set to false."
                               properties:
                                 component:
                                   description: Describes component that will be applied
@@ -10463,6 +10586,21 @@ spec:
                               description: Allows adding and configuring devworkspace-related
                                 containers
                               properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
                                 args:
                                   description: "The arguments to supply to the command
                                     running the dockerimage component. The arguments
@@ -10494,6 +10632,12 @@ spec:
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -10565,6 +10709,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -10638,7 +10783,13 @@ spec:
                               oneOf:
                               - required:
                                 - dockerfile
+                              - required:
+                                - autoBuild
                               properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built
+                                    during startup. \n Default value is `false`"
+                                  type: boolean
                                 dockerfile:
                                   description: Allows specifying dockerfile type build
                                   oneOf:
@@ -10657,7 +10808,7 @@ spec:
                                       type: array
                                     buildContext:
                                       description: Path of source directory to establish
-                                        build context. Defaults to ${PROJECT_ROOT}
+                                        build context. Defaults to ${PROJECT_SOURCE}
                                         in the container
                                       type: string
                                     devfileRegistry:
@@ -10742,6 +10893,7 @@ spec:
                                   description: Type of image
                                   enum:
                                   - Dockerfile
+                                  - AutoBuild
                                   type: string
                               type: object
                             kubernetes:
@@ -10755,9 +10907,19 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -10829,6 +10991,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -10866,9 +11029,19 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -10940,6 +11113,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -10998,7 +11172,9 @@ spec:
                                           has its `dedicatedPod` field set to `true`.
                                           \n When no `apply` command exist for a given
                                           component, it is assumed the component will
-                                          be applied at devworkspace start by default."
+                                          be applied at devworkspace start by default,
+                                          unless `deployByDefault` for that component
+                                          is set to false."
                                         properties:
                                           component:
                                             description: Describes component that
@@ -11207,6 +11383,24 @@ spec:
                                         description: Allows adding and configuring
                                           devworkspace-related containers
                                         properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
                                           args:
                                             description: "The arguments to supply
                                               to the command running the dockerimage
@@ -11241,6 +11435,13 @@ spec:
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -11325,6 +11526,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -11403,7 +11606,14 @@ spec:
                                         oneOf:
                                         - required:
                                           - dockerfile
+                                        - required:
+                                          - autoBuild
                                         properties:
+                                          autoBuild:
+                                            description: "Defines if the image should
+                                              be built during startup. \n Default
+                                              value is `false`"
+                                            type: boolean
                                           dockerfile:
                                             description: Allows specifying dockerfile
                                               type build
@@ -11424,7 +11634,7 @@ spec:
                                               buildContext:
                                                 description: Path of source directory
                                                   to establish build context. Defaults
-                                                  to ${PROJECT_ROOT} in the container
+                                                  to ${PROJECT_SOURCE} in the container
                                                 type: string
                                               devfileRegistry:
                                                 description: Dockerfile's Devfile
@@ -11519,6 +11729,7 @@ spec:
                                             description: Type of image
                                             enum:
                                             - Dockerfile
+                                            - AutoBuild
                                             type: string
                                         type: object
                                       kubernetes:
@@ -11533,9 +11744,21 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -11620,6 +11843,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -11660,9 +11885,21 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -11747,6 +11984,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -11816,6 +12055,16 @@ spec:
                                   description: URI Reference of a parent devfile YAML
                                     file. It can be a full URL or a relative URI with
                                     the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                                   type: string
                               type: object
                             volume:
@@ -12028,6 +12277,15 @@ spec:
                           devfile. Overriding is done according to K8S strategic merge
                           patch standard rules.
                         type: object
+                      version:
+                        description: Specific stack/sample version to pull the parent
+                          devfile from, when using id in the parent reference. To
+                          specify `version`, `id` must be defined and used as the
+                          import reference source. `version` can be either a specific
+                          stack version, or `latest`. If no `version` specified, default
+                          version will be used.
+                        pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                        type: string
                     type: object
                   projects:
                     description: Projects worked on in the devworkspace, containing
@@ -16245,7 +16503,8 @@ spec:
                         unless the component has its `dedicatedPod` field set to `true`.
                         \n When no `apply` command exist for a given component, it
                         is assumed the component will be applied at devworkspace start
-                        by default."
+                        by default, unless `deployByDefault` for that component is
+                        set to false."
                       properties:
                         component:
                           description: Describes component that will be applied
@@ -16491,6 +16750,21 @@ spec:
                       description: Allows adding and configuring devworkspace-related
                         containers
                       properties:
+                        annotation:
+                          description: Annotations that should be added to specific
+                            resources for this container
+                          properties:
+                            deployment:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to deployment
+                              type: object
+                            service:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to service
+                              type: object
+                          type: object
                         args:
                           description: "The arguments to supply to the command running
                             the dockerimage component. The arguments are supplied
@@ -16520,6 +16794,12 @@ spec:
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -16586,6 +16866,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -16682,6 +16963,10 @@ spec:
                       - required:
                         - dockerfile
                       properties:
+                        autoBuild:
+                          description: "Defines if the image should be built during
+                            startup. \n Default value is `false`"
+                          type: boolean
                         dockerfile:
                           description: Allows specifying dockerfile type build
                           oneOf:
@@ -16700,7 +16985,7 @@ spec:
                               type: array
                             buildContext:
                               description: Path of source directory to establish build
-                                context. Defaults to ${PROJECT_ROOT} in the container
+                                context. Defaults to ${PROJECT_SOURCE} in the container
                               type: string
                             devfileRegistry:
                               description: Dockerfile's Devfile Registry source
@@ -16799,9 +17084,19 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed
+                            during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -16868,6 +17163,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -16906,9 +17202,19 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed
+                            during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -16975,6 +17281,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -17031,7 +17338,9 @@ spec:
                                   unless the component has its `dedicatedPod` field
                                   set to `true`. \n When no `apply` command exist
                                   for a given component, it is assumed the component
-                                  will be applied at devworkspace start by default."
+                                  will be applied at devworkspace start by default,
+                                  unless `deployByDefault` for that component is set
+                                  to false."
                                 properties:
                                   component:
                                     description: Describes component that will be
@@ -17233,6 +17542,21 @@ spec:
                                 description: Allows adding and configuring devworkspace-related
                                   containers
                                 properties:
+                                  annotation:
+                                    description: Annotations that should be added
+                                      to specific resources for this container
+                                    properties:
+                                      deployment:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to deployment
+                                        type: object
+                                      service:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to service
+                                        type: object
+                                    type: object
                                   args:
                                     description: "The arguments to supply to the command
                                       running the dockerimage component. The arguments
@@ -17264,6 +17588,12 @@ spec:
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -17336,6 +17666,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -17410,7 +17741,13 @@ spec:
                                 oneOf:
                                 - required:
                                   - dockerfile
+                                - required:
+                                  - autoBuild
                                 properties:
+                                  autoBuild:
+                                    description: "Defines if the image should be built
+                                      during startup. \n Default value is `false`"
+                                    type: boolean
                                   dockerfile:
                                     description: Allows specifying dockerfile type
                                       build
@@ -17430,7 +17767,7 @@ spec:
                                         type: array
                                       buildContext:
                                         description: Path of source directory to establish
-                                          build context. Defaults to ${PROJECT_ROOT}
+                                          build context. Defaults to ${PROJECT_SOURCE}
                                           in the container
                                         type: string
                                       devfileRegistry:
@@ -17516,6 +17853,7 @@ spec:
                                     description: Type of image
                                     enum:
                                     - Dockerfile
+                                    - AutoBuild
                                     type: string
                                 type: object
                               kubernetes:
@@ -17529,9 +17867,20 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should
+                                      be deployed during startup. \n Default value
+                                      is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -17604,6 +17953,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -17642,9 +17992,20 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should
+                                      be deployed during startup. \n Default value
+                                      is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -17717,6 +18078,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -17785,6 +18147,15 @@ spec:
                           description: URI Reference of a parent devfile YAML file.
                             It can be a full URL or a relative URI with the current
                             devfile as the base URI.
+                          type: string
+                        version:
+                          description: Specific stack/sample version to pull the parent
+                            devfile from, when using id in the parent reference. To
+                            specify `version`, `id` must be defined and used as the
+                            import reference source. `version` can be either a specific
+                            stack version, or `latest`. If no `version` specified,
+                            default version will be used.
+                          pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                           type: string
                       type: object
                     volume:
@@ -17875,7 +18246,8 @@ spec:
                             the devworkspace POD, unless the component has its `dedicatedPod`
                             field set to `true`. \n When no `apply` command exist
                             for a given component, it is assumed the component will
-                            be applied at devworkspace start by default."
+                            be applied at devworkspace start by default, unless `deployByDefault`
+                            for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -18071,6 +18443,21 @@ spec:
                           description: Allows adding and configuring devworkspace-related
                             containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific
+                                resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command
                                 running the dockerimage component. The arguments are
@@ -18102,6 +18489,12 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -18170,6 +18563,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -18240,7 +18634,13 @@ spec:
                           oneOf:
                           - required:
                             - dockerfile
+                          - required:
+                            - autoBuild
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during
+                                startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -18259,7 +18659,7 @@ spec:
                                   type: array
                                 buildContext:
                                   description: Path of source directory to establish
-                                    build context. Defaults to ${PROJECT_ROOT} in
+                                    build context. Defaults to ${PROJECT_SOURCE} in
                                     the container
                                   type: string
                                 devfileRegistry:
@@ -18340,6 +18740,7 @@ spec:
                               description: Type of image
                               enum:
                               - Dockerfile
+                              - AutoBuild
                               type: string
                           type: object
                         kubernetes:
@@ -18353,9 +18754,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -18424,6 +18835,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -18461,9 +18873,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -18532,6 +18954,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -18588,7 +19011,9 @@ spec:
                                       has its `dedicatedPod` field set to `true`.
                                       \n When no `apply` command exist for a given
                                       component, it is assumed the component will
-                                      be applied at devworkspace start by default."
+                                      be applied at devworkspace start by default,
+                                      unless `deployByDefault` for that component
+                                      is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will
@@ -18792,6 +19217,23 @@ spec:
                                     description: Allows adding and configuring devworkspace-related
                                       containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added
+                                          to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the
                                           command running the dockerimage component.
@@ -18824,6 +19266,13 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -18902,6 +19351,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -18976,7 +19427,14 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should
+                                          be built during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile
                                           type build
@@ -18997,7 +19455,7 @@ spec:
                                           buildContext:
                                             description: Path of source directory
                                               to establish build context. Defaults
-                                              to ${PROJECT_ROOT} in the container
+                                              to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry
@@ -19088,6 +19546,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -19102,9 +19561,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -19183,6 +19654,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -19222,9 +19695,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -19303,6 +19788,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -19370,6 +19857,15 @@ spec:
                               description: URI Reference of a parent devfile YAML
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -19577,6 +20073,15 @@ spec:
                       Overriding is done according to K8S strategic merge patch standard
                       rules.
                     type: object
+                  version:
+                    description: Specific stack/sample version to pull the parent
+                      devfile from, when using id in the parent reference. To specify
+                      `version`, `id` must be defined and used as the import reference
+                      source. `version` can be either a specific stack version, or
+                      `latest`. If no `version` specified, default version will be
+                      used.
+                    pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                    type: string
                 type: object
               projects:
                 description: Projects worked on in the devworkspace, containing names

--- a/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -4179,7 +4179,8 @@ spec:
                             the devworkspace POD, unless the component has its `dedicatedPod`
                             field set to `true`. \n When no `apply` command exist
                             for a given component, it is assumed the component will
-                            be applied at devworkspace start by default."
+                            be applied at devworkspace start by default, unless `deployByDefault`
+                            for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -4435,6 +4436,21 @@ spec:
                           description: Allows adding and configuring devworkspace-related
                             containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific
+                                resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command
                                 running the dockerimage component. The arguments are
@@ -4466,6 +4482,12 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -4536,6 +4558,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -4633,6 +4656,10 @@ spec:
                           - required:
                             - dockerfile
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during
+                                startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -4651,7 +4678,7 @@ spec:
                                   type: array
                                 buildContext:
                                   description: Path of source directory to establish
-                                    build context. Defaults to ${PROJECT_ROOT} in
+                                    build context. Defaults to ${PROJECT_SOURCE} in
                                     the container
                                   type: string
                                 devfileRegistry:
@@ -4751,9 +4778,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -4824,6 +4861,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -4862,9 +4900,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -4935,6 +4983,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -4992,7 +5041,9 @@ spec:
                                       has its `dedicatedPod` field set to `true`.
                                       \n When no `apply` command exist for a given
                                       component, it is assumed the component will
-                                      be applied at devworkspace start by default."
+                                      be applied at devworkspace start by default,
+                                      unless `deployByDefault` for that component
+                                      is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will
@@ -5196,6 +5247,23 @@ spec:
                                     description: Allows adding and configuring devworkspace-related
                                       containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added
+                                          to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the
                                           command running the dockerimage component.
@@ -5228,6 +5296,13 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -5306,6 +5381,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -5380,7 +5457,14 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should
+                                          be built during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile
                                           type build
@@ -5401,7 +5485,7 @@ spec:
                                           buildContext:
                                             description: Path of source directory
                                               to establish build context. Defaults
-                                              to ${PROJECT_ROOT} in the container
+                                              to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry
@@ -5492,6 +5576,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -5506,9 +5591,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -5587,6 +5684,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -5626,9 +5725,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -5707,6 +5818,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -5776,6 +5889,15 @@ spec:
                               description: URI Reference of a parent devfile YAML
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -5868,7 +5990,8 @@ spec:
                                 its `dedicatedPod` field set to `true`. \n When no
                                 `apply` command exist for a given component, it is
                                 assumed the component will be applied at devworkspace
-                                start by default."
+                                start by default, unless `deployByDefault` for that
+                                component is set to false."
                               properties:
                                 component:
                                   description: Describes component that will be applied
@@ -6071,6 +6194,21 @@ spec:
                               description: Allows adding and configuring devworkspace-related
                                 containers
                               properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
                                 args:
                                   description: "The arguments to supply to the command
                                     running the dockerimage component. The arguments
@@ -6102,6 +6240,12 @@ spec:
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -6173,6 +6317,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -6246,7 +6391,13 @@ spec:
                               oneOf:
                               - required:
                                 - dockerfile
+                              - required:
+                                - autoBuild
                               properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built
+                                    during startup. \n Default value is `false`"
+                                  type: boolean
                                 dockerfile:
                                   description: Allows specifying dockerfile type build
                                   oneOf:
@@ -6265,7 +6416,7 @@ spec:
                                       type: array
                                     buildContext:
                                       description: Path of source directory to establish
-                                        build context. Defaults to ${PROJECT_ROOT}
+                                        build context. Defaults to ${PROJECT_SOURCE}
                                         in the container
                                       type: string
                                     devfileRegistry:
@@ -6350,6 +6501,7 @@ spec:
                                   description: Type of image
                                   enum:
                                   - Dockerfile
+                                  - AutoBuild
                                   type: string
                               type: object
                             kubernetes:
@@ -6363,9 +6515,19 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -6437,6 +6599,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -6474,9 +6637,19 @@ spec:
                               - required:
                                 - inlined
                               properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
                                 endpoints:
                                   items:
                                     properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
                                       attributes:
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
@@ -6548,6 +6721,7 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
+                                        description: The port number should be unique.
                                         type: integer
                                     required:
                                     - name
@@ -6606,7 +6780,9 @@ spec:
                                           has its `dedicatedPod` field set to `true`.
                                           \n When no `apply` command exist for a given
                                           component, it is assumed the component will
-                                          be applied at devworkspace start by default."
+                                          be applied at devworkspace start by default,
+                                          unless `deployByDefault` for that component
+                                          is set to false."
                                         properties:
                                           component:
                                             description: Describes component that
@@ -6815,6 +6991,24 @@ spec:
                                         description: Allows adding and configuring
                                           devworkspace-related containers
                                         properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
                                           args:
                                             description: "The arguments to supply
                                               to the command running the dockerimage
@@ -6849,6 +7043,13 @@ spec:
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -6933,6 +7134,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -7011,7 +7214,14 @@ spec:
                                         oneOf:
                                         - required:
                                           - dockerfile
+                                        - required:
+                                          - autoBuild
                                         properties:
+                                          autoBuild:
+                                            description: "Defines if the image should
+                                              be built during startup. \n Default
+                                              value is `false`"
+                                            type: boolean
                                           dockerfile:
                                             description: Allows specifying dockerfile
                                               type build
@@ -7032,7 +7242,7 @@ spec:
                                               buildContext:
                                                 description: Path of source directory
                                                   to establish build context. Defaults
-                                                  to ${PROJECT_ROOT} in the container
+                                                  to ${PROJECT_SOURCE} in the container
                                                 type: string
                                               devfileRegistry:
                                                 description: Dockerfile's Devfile
@@ -7127,6 +7337,7 @@ spec:
                                             description: Type of image
                                             enum:
                                             - Dockerfile
+                                            - AutoBuild
                                             type: string
                                         type: object
                                       kubernetes:
@@ -7141,9 +7352,21 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -7228,6 +7451,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -7268,9 +7493,21 @@ spec:
                                         - required:
                                           - inlined
                                         properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
                                           endpoints:
                                             items:
                                               properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
                                                 attributes:
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
@@ -7355,6 +7592,8 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
+                                                  description: The port number should
+                                                    be unique.
                                                   type: integer
                                               required:
                                               - name
@@ -7424,6 +7663,16 @@ spec:
                                   description: URI Reference of a parent devfile YAML
                                     file. It can be a full URL or a relative URI with
                                     the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                                   type: string
                               type: object
                             volume:
@@ -7636,6 +7885,15 @@ spec:
                           devfile. Overriding is done according to K8S strategic merge
                           patch standard rules.
                         type: object
+                      version:
+                        description: Specific stack/sample version to pull the parent
+                          devfile from, when using id in the parent reference. To
+                          specify `version`, `id` must be defined and used as the
+                          import reference source. `version` can be either a specific
+                          stack version, or `latest`. If no `version` specified, default
+                          version will be used.
+                        pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                        type: string
                     type: object
                   projects:
                     description: Projects worked on in the devworkspace, containing

--- a/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -3953,7 +3953,8 @@ spec:
                         unless the component has its `dedicatedPod` field set to `true`.
                         \n When no `apply` command exist for a given component, it
                         is assumed the component will be applied at devworkspace start
-                        by default."
+                        by default, unless `deployByDefault` for that component is
+                        set to false."
                       properties:
                         component:
                           description: Describes component that will be applied
@@ -4199,6 +4200,21 @@ spec:
                       description: Allows adding and configuring devworkspace-related
                         containers
                       properties:
+                        annotation:
+                          description: Annotations that should be added to specific
+                            resources for this container
+                          properties:
+                            deployment:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to deployment
+                              type: object
+                            service:
+                              additionalProperties:
+                                type: string
+                              description: Annotations to be added to service
+                              type: object
+                          type: object
                         args:
                           description: "The arguments to supply to the command running
                             the dockerimage component. The arguments are supplied
@@ -4228,6 +4244,12 @@ spec:
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -4294,6 +4316,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -4390,6 +4413,10 @@ spec:
                       - required:
                         - dockerfile
                       properties:
+                        autoBuild:
+                          description: "Defines if the image should be built during
+                            startup. \n Default value is `false`"
+                          type: boolean
                         dockerfile:
                           description: Allows specifying dockerfile type build
                           oneOf:
@@ -4408,7 +4435,7 @@ spec:
                               type: array
                             buildContext:
                               description: Path of source directory to establish build
-                                context. Defaults to ${PROJECT_ROOT} in the container
+                                context. Defaults to ${PROJECT_SOURCE} in the container
                               type: string
                             devfileRegistry:
                               description: Dockerfile's Devfile Registry source
@@ -4507,9 +4534,19 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed
+                            during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -4576,6 +4613,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -4614,9 +4652,19 @@ spec:
                       - required:
                         - inlined
                       properties:
+                        deployByDefault:
+                          description: "Defines if the component should be deployed
+                            during startup. \n Default value is `false`"
+                          type: boolean
                         endpoints:
                           items:
                             properties:
+                              annotation:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations to be added to Kubernetes
+                                  Ingress or Openshift Route
+                                type: object
                               attributes:
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
@@ -4683,6 +4731,7 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
+                                description: The port number should be unique.
                                 type: integer
                             required:
                             - name
@@ -4739,7 +4788,9 @@ spec:
                                   unless the component has its `dedicatedPod` field
                                   set to `true`. \n When no `apply` command exist
                                   for a given component, it is assumed the component
-                                  will be applied at devworkspace start by default."
+                                  will be applied at devworkspace start by default,
+                                  unless `deployByDefault` for that component is set
+                                  to false."
                                 properties:
                                   component:
                                     description: Describes component that will be
@@ -4941,6 +4992,21 @@ spec:
                                 description: Allows adding and configuring devworkspace-related
                                   containers
                                 properties:
+                                  annotation:
+                                    description: Annotations that should be added
+                                      to specific resources for this container
+                                    properties:
+                                      deployment:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to deployment
+                                        type: object
+                                      service:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to service
+                                        type: object
+                                    type: object
                                   args:
                                     description: "The arguments to supply to the command
                                       running the dockerimage component. The arguments
@@ -4972,6 +5038,12 @@ spec:
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -5044,6 +5116,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -5118,7 +5191,13 @@ spec:
                                 oneOf:
                                 - required:
                                   - dockerfile
+                                - required:
+                                  - autoBuild
                                 properties:
+                                  autoBuild:
+                                    description: "Defines if the image should be built
+                                      during startup. \n Default value is `false`"
+                                    type: boolean
                                   dockerfile:
                                     description: Allows specifying dockerfile type
                                       build
@@ -5138,7 +5217,7 @@ spec:
                                         type: array
                                       buildContext:
                                         description: Path of source directory to establish
-                                          build context. Defaults to ${PROJECT_ROOT}
+                                          build context. Defaults to ${PROJECT_SOURCE}
                                           in the container
                                         type: string
                                       devfileRegistry:
@@ -5224,6 +5303,7 @@ spec:
                                     description: Type of image
                                     enum:
                                     - Dockerfile
+                                    - AutoBuild
                                     type: string
                                 type: object
                               kubernetes:
@@ -5237,9 +5317,20 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should
+                                      be deployed during startup. \n Default value
+                                      is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -5312,6 +5403,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -5350,9 +5442,20 @@ spec:
                                 - required:
                                   - inlined
                                 properties:
+                                  deployByDefault:
+                                    description: "Defines if the component should
+                                      be deployed during startup. \n Default value
+                                      is `false`"
+                                    type: boolean
                                   endpoints:
                                     items:
                                       properties:
+                                        annotation:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations to be added to
+                                            Kubernetes Ingress or Openshift Route
+                                          type: object
                                         attributes:
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
@@ -5425,6 +5528,7 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
+                                          description: The port number should be unique.
                                           type: integer
                                       required:
                                       - name
@@ -5493,6 +5597,15 @@ spec:
                           description: URI Reference of a parent devfile YAML file.
                             It can be a full URL or a relative URI with the current
                             devfile as the base URI.
+                          type: string
+                        version:
+                          description: Specific stack/sample version to pull the parent
+                            devfile from, when using id in the parent reference. To
+                            specify `version`, `id` must be defined and used as the
+                            import reference source. `version` can be either a specific
+                            stack version, or `latest`. If no `version` specified,
+                            default version will be used.
+                          pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                           type: string
                       type: object
                     volume:
@@ -5583,7 +5696,8 @@ spec:
                             the devworkspace POD, unless the component has its `dedicatedPod`
                             field set to `true`. \n When no `apply` command exist
                             for a given component, it is assumed the component will
-                            be applied at devworkspace start by default."
+                            be applied at devworkspace start by default, unless `deployByDefault`
+                            for that component is set to false."
                           properties:
                             component:
                               description: Describes component that will be applied
@@ -5779,6 +5893,21 @@ spec:
                           description: Allows adding and configuring devworkspace-related
                             containers
                           properties:
+                            annotation:
+                              description: Annotations that should be added to specific
+                                resources for this container
+                              properties:
+                                deployment:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to deployment
+                                  type: object
+                                service:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations to be added to service
+                                  type: object
+                              type: object
                             args:
                               description: "The arguments to supply to the command
                                 running the dockerimage component. The arguments are
@@ -5810,6 +5939,12 @@ spec:
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -5878,6 +6013,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -5948,7 +6084,13 @@ spec:
                           oneOf:
                           - required:
                             - dockerfile
+                          - required:
+                            - autoBuild
                           properties:
+                            autoBuild:
+                              description: "Defines if the image should be built during
+                                startup. \n Default value is `false`"
+                              type: boolean
                             dockerfile:
                               description: Allows specifying dockerfile type build
                               oneOf:
@@ -5967,7 +6109,7 @@ spec:
                                   type: array
                                 buildContext:
                                   description: Path of source directory to establish
-                                    build context. Defaults to ${PROJECT_ROOT} in
+                                    build context. Defaults to ${PROJECT_SOURCE} in
                                     the container
                                   type: string
                                 devfileRegistry:
@@ -6048,6 +6190,7 @@ spec:
                               description: Type of image
                               enum:
                               - Dockerfile
+                              - AutoBuild
                               type: string
                           type: object
                         kubernetes:
@@ -6061,9 +6204,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -6132,6 +6285,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -6169,9 +6323,19 @@ spec:
                           - required:
                             - inlined
                           properties:
+                            deployByDefault:
+                              description: "Defines if the component should be deployed
+                                during startup. \n Default value is `false`"
+                              type: boolean
                             endpoints:
                               items:
                                 properties:
+                                  annotation:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to Kubernetes
+                                      Ingress or Openshift Route
+                                    type: object
                                   attributes:
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
@@ -6240,6 +6404,7 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
+                                    description: The port number should be unique.
                                     type: integer
                                 required:
                                 - name
@@ -6296,7 +6461,9 @@ spec:
                                       has its `dedicatedPod` field set to `true`.
                                       \n When no `apply` command exist for a given
                                       component, it is assumed the component will
-                                      be applied at devworkspace start by default."
+                                      be applied at devworkspace start by default,
+                                      unless `deployByDefault` for that component
+                                      is set to false."
                                     properties:
                                       component:
                                         description: Describes component that will
@@ -6500,6 +6667,23 @@ spec:
                                     description: Allows adding and configuring devworkspace-related
                                       containers
                                     properties:
+                                      annotation:
+                                        description: Annotations that should be added
+                                          to specific resources for this container
+                                        properties:
+                                          deployment:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              deployment
+                                            type: object
+                                          service:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations to be added to
+                                              service
+                                            type: object
+                                        type: object
                                       args:
                                         description: "The arguments to supply to the
                                           command running the dockerimage component.
@@ -6532,6 +6716,13 @@ spec:
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -6610,6 +6801,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -6684,7 +6877,14 @@ spec:
                                     oneOf:
                                     - required:
                                       - dockerfile
+                                    - required:
+                                      - autoBuild
                                     properties:
+                                      autoBuild:
+                                        description: "Defines if the image should
+                                          be built during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       dockerfile:
                                         description: Allows specifying dockerfile
                                           type build
@@ -6705,7 +6905,7 @@ spec:
                                           buildContext:
                                             description: Path of source directory
                                               to establish build context. Defaults
-                                              to ${PROJECT_ROOT} in the container
+                                              to ${PROJECT_SOURCE} in the container
                                             type: string
                                           devfileRegistry:
                                             description: Dockerfile's Devfile Registry
@@ -6796,6 +6996,7 @@ spec:
                                         description: Type of image
                                         enum:
                                         - Dockerfile
+                                        - AutoBuild
                                         type: string
                                     type: object
                                   kubernetes:
@@ -6810,9 +7011,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -6891,6 +7104,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -6930,9 +7145,21 @@ spec:
                                     - required:
                                       - inlined
                                     properties:
+                                      deployByDefault:
+                                        description: "Defines if the component should
+                                          be deployed during startup. \n Default value
+                                          is `false`"
+                                        type: boolean
                                       endpoints:
                                         items:
                                           properties:
+                                            annotation:
+                                              additionalProperties:
+                                                type: string
+                                              description: Annotations to be added
+                                                to Kubernetes Ingress or Openshift
+                                                Route
+                                              type: object
                                             attributes:
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
@@ -7011,6 +7238,8 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
+                                              description: The port number should
+                                                be unique.
                                               type: integer
                                           required:
                                           - name
@@ -7078,6 +7307,15 @@ spec:
                               description: URI Reference of a parent devfile YAML
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
+                              type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
                         volume:
@@ -7285,6 +7523,15 @@ spec:
                       Overriding is done according to K8S strategic merge patch standard
                       rules.
                     type: object
+                  version:
+                    description: Specific stack/sample version to pull the parent
+                      devfile from, when using id in the parent reference. To specify
+                      `version`, `id` must be defined and used as the import reference
+                      source. `version` can be either a specific stack version, or
+                      `latest`. If no `version` specified, default version will be
+                      used.
+                    pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                    type: string
                 type: object
               projects:
                 description: Projects worked on in the devworkspace, containing names

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -115,7 +115,7 @@ if $USE_DEFAULT_ENV; then
   export PROJECT_CLONE_IMG=${PROJECT_CLONE_IMG:-"quay.io/devfile/project-clone:next"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic
-  export DEVWORKSPACE_API_VERSION=089a48011460cbd9f06f200bad5452137a25f34b
+  export DEVWORKSPACE_API_VERSION=664e02df4202a8d4a9fdc30f25b445546e0c1acf
   export ROUTING_SUFFIX='""'
   export FORCE_DEVWORKSPACE_CRDS_UPDATE=true
 fi

--- a/docs/additional-configuration.md
+++ b/docs/additional-configuration.md
@@ -122,24 +122,6 @@ data:
 
 Note: As for automatically mounting secrets, it is necessary to apply the `controller.devfile.io/watch-secret` label to git credentials secrets
 
-## Applying labels and annotations to the workspace deployment
-In some cases, it is useful to apply additional labels or annotations to the deployment that is created for a DevWorkspace. This is supported by setting attributes `controller.devfile.io/deployment-labels` and `controller.devfile.io/deployment-annotations` in the DevWorkspace's attributes field. The value of these attributes should be specified as a string map, as it is for regular metadata labels and annotations. For example:
-```
-kind: DevWorkspace
-apiVersion: workspace.devfile.io/v1alpha2
-metadata:
-  name: my-workspace
-spec:
-  template:
-    attributes:
-      controller.devfile.io/deployment-labels:
-        my-label: foo
-        my-other-label: bar
-      controller.devfile.io/deployment-annotations:
-        my-attribute: foo
-        my-other-attribute: bar
-```
-
 ## Debugging a failing workspace
 Normally, when a workspace fails to start, the deployment will be scaled down and the workspace will be stopped in a `Failed` state. This can make it difficult to debug misconfiguration errors, so the annotation `controller.devfile.io/debug-start: "true"` can be applied to DevWorkspaces to leave resources for failed workspaces on the cluster. This allows viewing logs from workspace containers.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/devworkspace-operator
 go 1.16
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460
+	github.com/devfile/api/v2 v2.0.0-20220317194725-664e02df4202
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
-github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460 h1:cmd+3poyUwevcWchYdvE02YT1nQU4SJpA5/wrdLrpWE=
-github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460/go.mod h1:kLX/nW93gigOHXK3NLeJL2fSS/sgEe+OHu8bo3aoOi4=
+github.com/devfile/api/v2 v2.0.0-20220317194725-664e02df4202 h1:IbghWEZHOmoTnVp9J3AsVoOGheIxw9OVx6dg1FF2oQU=
+github.com/devfile/api/v2 v2.0.0-20220317194725-664e02df4202/go.mod h1:kLX/nW93gigOHXK3NLeJL2fSS/sgEe+OHu8bo3aoOi4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -65,14 +65,6 @@ const (
 	//               will not be cloned into the workspace on start.
 	ProjectCloneAttribute = "controller.devfile.io/project-clone"
 
-	// DeployLabelsAttribute is an DevWorkspace attribute used in .spec.attributes that defines additional labels
-	// that should be applied to the workspace deployment. Value should be a map[string]string
-	DeployLabelsAttribute = "controller.devfile.io/deployment-labels"
-
-	// DeployAnnotationsAttribute is an DevWorkspace attribute used in .spec.attributes that defines additional annotations
-	// that should be applied to the workspace deployment. Value should be a map[string]string
-	DeployAnnotationsAttribute = "controller.devfile.io/deployment-annotations"
-
 	// PluginSourceAttribute is an attribute added to components, commands, and projects in a flattened
 	// DevWorkspace representation to signify where the respective component came from (i.e. which plugin
 	// or parent imported it)


### PR DESCRIPTION
### What does this PR do?
* Updates the devfile/api dependency to match the current main branch of https://github.com/devfile/api. This is required as there are recent changes to devfile/api around Kubernetes/OpenShift component types that should be included in the PR for https://github.com/eclipse/che/issues/17894
* Removes changes from PR https://github.com/devfile/devworkspace-operator/pull/793 as some functionality (deployment annotations) is now duplicated in the regular Devfile API. 
    * This removes support for setting labels for now, but this can be re-added later if it is required.

A full diff between the previous and current devfile API dependencies is [here](https://github.com/devfile/api/compare/089a48011460cbd9f06f200bad5452137a25f34b..664e02df4202a8d4a9fdc30f25b445546e0c1acf).

### What issues does this PR fix or reference?
Required for https://github.com/eclipse/che/issues/17894

### Is it tested? How?
* Test setting `.spec.template.components[].container.annotations.deployment` in a DevWorkspace and check that annotations are propagated to the workspace Deployment
* DWO should be upgradeable in OLM to the new version with updated CRDs.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
