### PR TITLE
docs: Update permissions doc to mention granting role to all workspaces in ns

### DIFF
--- a/docs/workspace-capabilities.md
+++ b/docs/workspace-capabilities.md
@@ -94,6 +94,7 @@ Additional permissions can be bound to the DevWorkspace ServiceAccount as follow
     The service account created for the DevWorkspace will be named `${DEVWORKSPACE_ID}-sa`
 2. Create a rolebinding to attach a custom role to the workspace service account:
     ```yaml
+    NAMESPACE=<workspace namespace>
     cat << EOF | kubectl apply -f -
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
@@ -106,7 +107,29 @@ Additional permissions can be bound to the DevWorkspace ServiceAccount as follow
     subjects:
     - kind: ServiceAccount
       name: ${DEVWORKSPACE_ID}-sa
-      namespace: <current namespace>
+      namespace: $NAMESPACE
     EOF
     ```
     where `<current namespace>` is the namespace of the workspace, and `<custom role name>` is the name of role to be bound to the DevWorkspace.
+
+In order to grant permissions to all workspaces in a given namespace, the RoleBinding can instead bind to all ServiceAccounts in the namespace:
+```yaml
+NAMESPACE=<workspace namespace>
+cat << EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: devworkspace-custom-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: <custom role name>
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:$NAMESPACE
+EOF
+```
+Note however that this will bind the role to _all_ service accounts in that namespace, including the default serviceaccount used for pods.
+
+For more information on creating rolebindings, see [rolebinding and clusterrolebinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) in the Kubernetes documentation.


### PR DESCRIPTION
### What does this PR do?
Quick update to the workspace-capabilities doc to explain granting additional permissions to all workspaces in a namespace.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
