### PR TITLE
Remove install_crds mention from README. Fix #800

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Some of the rules supported by the makefile:
 | docker | build and push docker image |
 | install | install controller to cluster |
 | restart | restart cluster controller deployment |
-| install_crds | update CRDs on cluster |
 | install_cert_manager | installs the cert-manager to the cluster (only required for Kubernetes) |
 | uninstall | delete controller namespace `devworkspace-controller` and remove CRDs from cluster |
 | help | print all rules and variables |


### PR DESCRIPTION
Signed-off-by: Andrew Obuchowicz <aobuchow@redhat.com>

### What does this PR do?
Removes the mention of the outdated makefile rule `install_crds` from README

### What issues does this PR fix or reference?
#800 

### Is it tested? How?
Check the README and ensure `install_crds` is no longer mentioned

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
