### PR TITLE
fix: edge cases when using project clone

### DIFF
--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -135,10 +135,11 @@ func CheckoutReference(repo *git.Repository, project *dw.Project, projectPath st
 	}
 
 	log.Printf("No tag or branch named %s found on remote %s; attempting to resolve commit", checkoutFrom.Revision, defaultRemoteName)
-	if _, err := repo.ResolveRevision(plumbing.Revision(checkoutFrom.Revision)); err != nil {
-		return fmt.Errorf("failed to resolve commit %s: %s", checkoutFrom.Revision, err)
+	if _, err := repo.ResolveRevision(plumbing.Revision(checkoutFrom.Revision)); err == nil {
+		return checkoutCommit(projectPath, checkoutFrom.Revision)
 	}
-	return checkoutCommit(projectPath, checkoutFrom.Revision)
+	log.Printf("Could not find revision %s in repository, using default branch", checkoutFrom.Revision)
+	return nil
 }
 
 func checkoutLocalBranch(projectPath, branchName, remote string) error {

--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -96,7 +96,7 @@ func SetupRemotes(repo *git.Repository, project *dw.Project, projectPath string)
 // CheckoutReference sets the current HEAD in repo to point at the revision and remote referenced by checkoutFrom
 func CheckoutReference(repo *git.Repository, project *dw.Project, projectPath string) error {
 	checkoutFrom := project.Git.CheckoutFrom
-	if checkoutFrom == nil {
+	if checkoutFrom == nil || checkoutFrom.Revision == "" {
 		return nil
 	}
 	var defaultRemoteName string

--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -105,6 +105,40 @@ func GitCheckoutBranch(projectPath, branchName, remote string) error {
 	return executeCommand("git", "checkout", "-b", branchName, "--track", fmt.Sprintf("%s/%s", remote, branchName))
 }
 
+func GitCheckoutBranchLocal(projectPath, branchName string) error {
+	currDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %s", err)
+	}
+	defer func() {
+		if err := os.Chdir(currDir); err != nil {
+			log.Printf("failed to return to original working directory: %s", err)
+		}
+	}()
+	err = os.Chdir(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to move to project directory %s: %s", projectPath, err)
+	}
+	return executeCommand("git", "checkout", branchName)
+}
+
+func GitSetTrackingRemoteBranch(projectPath, branchName, remote string) error {
+	currDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %s", err)
+	}
+	defer func() {
+		if err := os.Chdir(currDir); err != nil {
+			log.Printf("failed to return to original working directory: %s", err)
+		}
+	}()
+	err = os.Chdir(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to move to project directory %s: %s", projectPath, err)
+	}
+	return executeCommand("git", "branch", "--set-upstream-to", fmt.Sprintf("%s/%s", remote, branchName), branchName)
+}
+
 func executeCommand(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
### What does this PR do?
Fix issues in project clone
* Project clone fails when project specifies `checkoutFrom` but leaves `checkoutFrom.revision` blank
* Project clone fails to checkout branch when `checkoutFrom.revision` specifies the default branch
* Project clone should not fail when `checkoutFrom.revision` cannot be resolved

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/806
Closes https://github.com/devfile/devworkspace-operator/issues/807
Brings project-clone functionality in line with `checkoutFrom.revision` Devfile spec:
>  revision: string
>
> The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.

### Is it tested? How?
The easiest way to test the project clone container is by running locally:
```bash
# Define flattened DevWorkspace's template as used in a running DevWorkspace:
cat <<EOF > /tmp/flattened-devworkspace.yaml
projects:
  - git:
      remotes:
        upstream: 'https://github.com/devfile/devworkspace-operator.git'
        origin: https://github.com/amisevsk/devworkspace-operator.git
      checkoutFrom:
        remote: upstream
        revision: main
    name: devworkspace-operator
EOF
FLATTENED_DEVWORKSPACE_PATH=/tmp/flattened-devworkspace.yaml

# Build project-clone container locally
podman build -t project-clone:test -f ./project-clone/Dockerfile .

# Run project-clone locally and sleep indefinitely
podman run -it --rm --name project-clone \
          -e DEVWORKSPACE_FLATTENED_DEVFILE=/tmp/dw.yaml \
          -e PROJECTS_ROOT=/projects \
          --mount type=bind,src="$FLATTENED_DEVWORKSPACE_PATH",dst=/tmp/dw.yaml,z \
          --mount type=tmpfs,tmpfs-size=500M,dst=/projects/ \
          project-clone:test -- /bin/bash -c "/usr/local/bin/project-clone && tail -f /dev/null"
```

Once project-clone is done, you can `podman exec -it project-clone /bin/bash` in another terminal to check the contents of `/projects/devworkspace-operator` to ensure branches/remotes are set up correctly. Once done, the project-clone container should be stopped via `podman kill project-clone`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
