### PR TITLE
docs: Convert additional documenation to adoc and add Table of Contents

### DIFF
--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -1,43 +1,58 @@
 # Additional configuration for DevWorkspaces
+:toc:
 
+## How DevWorkspaces are configured
 DevWorkspaces allow for additional configuration through the use Devfile attributes and Kubernetes labels and annotations. There are three fields in the DevWorkspace that are used to configure functionality:
-* Devfile attributes defined within the DevWorkspace spec, either at the *top-level* (`.spec.template.attributes`) or on *individual components*. For example:
-    ```yaml
-    kind: DevWorkspace
-    apiVersion: workspace.devfile.io/v1alpha2
-    metadata:
-      name: my-workspace
-    spec:
-      template:
-        attributes:
-          my-attribute: my-attribute-value
-    ```
+
+* Devfile attributes defined within the DevWorkspace spec, either at the _top-level_ (`.spec.template.attributes`) or on _individual components_. For example:
++
+[source,yaml]
+----
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-workspace
+spec:
+  template:
+    attributes:
+      my-attribute: my-attribute-value
+----
+
 * Kubernetes metadata labels (`.metadata.labels`):
-    ```yaml
-        kind: DevWorkspace
-        apiVersion: workspace.devfile.io/v1alpha2
-        metadata:
-          name: my-workspace
-          labels:
-            my-label: my-label-value
-    ```
++
+[source,yaml]
+----
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-workspace
+  labels:
+    my-label: my-label-value
+----
+
 * Kubernetes metadata annotations (`.metadata.annotations`):
-    ```yaml
-        kind: DevWorkspace
-        apiVersion: workspace.devfile.io/v1alpha2
-        metadata:
-          name: my-workspace
-          labels:
-            my-annotation: my-annotation-value
-    ```
++
+[source,yaml]
+----
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-workspace
+  labels:
+    my-annotation: my-annotation-value
+----
 
 ## Restricting access to DevWorkspaces
 Applying the
-```yaml
+[source,yaml]
+----
 controller.devfile.io/restricted-access: "true"
-```
+----
+
 annotation to a DevWorkspace enables additional access control for the workspace. When this annotation is applied to a DevWorkspace:
+
 * Only the user that created the DevWorkspace can access a terminal in the workspace via `pods/exec`
+
 * Only the DevWorkspace Operator serviceaccount or the user that created the DevWorkspace can modify fields in the DevWorkspace custom resource.
 
 This is useful in case a DevWorkspace is expected to contain sensitive information.
@@ -45,7 +60,8 @@ This is useful in case a DevWorkspace is expected to contain sensitive informati
 
 ## Configuring persistent storage used for a DevWorkspace
 The top-level Devfile attribute `controller.devfile.io/storage-type` can be used to configure persistent storage for DevWorkspaces:
-```yaml
+[source,yaml]
+----
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
@@ -54,15 +70,18 @@ spec:
   template:
     attributes:
       controller.devfile.io/storage-type: <storage-type>
-```
+----
+
 where `<storage-type>` is one of
-- `common`: Use one PVC for all workspace volumes, mounting Devfile volumes in subpaths within the common PVC
-- `ephemeral`: Replace all volumes with `emptyDir` volumes. This storage type is non-persistent; any local changes will be lost when the workspace is stopped. This is the equivalent of marking all volumes in the Devfile as `ephemeral: true`
-- `async`: Use `emptyDir` volumes for workspace volumes, but include a sidecar that synchronises local changes to a persistent volume as in the `common` strategy. This can potentially avoid issues where mounting volumes to a workspace on startup takes a long time.
+
+* `common`: Use one PVC for all workspace volumes, mounting Devfile volumes in subpaths within the common PVC
+* `ephemeral`: Replace all volumes with `emptyDir` volumes. This storage type is non-persistent; any local changes will be lost when the workspace is stopped. This is the equivalent of marking all volumes in the Devfile as `ephemeral: true`
+* `async`: Use `emptyDir` volumes for workspace volumes, but include a sidecar that synchronises local changes to a persistent volume as in the `common` strategy. This can potentially avoid issues where mounting volumes to a workspace on startup takes a long time.
 
 ## Configuring project cloning
 The top-level Devfile attribute `controller.devfile.io/project-clone` can be used to configure how storage is mounted to workspaces. By default, the DevWorkspace Operator will add an init container to the workspace deployment that will clone any projects to the workspace before start. This can be disabled by setting `controller.devfile.io/project-clone: disable` in the attributes field:
-```yaml
+[source,yaml]
+----
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
@@ -71,32 +90,43 @@ spec:
   template:
     attributes:
       controller.devfile.io/project-clone: disable
-```
+----
 
 ## Automatically mounting volumes, configmaps, and secrets
 Existing configmaps, secrets, and persistent volume claims on the cluster can be configured by applying the appropriate labels. To mark a resource for mounting to workspaces, apply the **label**
-```yaml
+[source,yaml]
+----
 metadata:
   labels:
     controller.devfile.io/mount-to-devworkspace: "true"
-```
+----
+
 to the resource. For secrets and configmaps, it's also necessary to apply an additional **label**:
+
 * `controller.devfile.io/watch-configmap` must be applied to configmaps to enable the DevWorkspace Operator to find them on the cluster
 * `controller.devfile.io/watch-secret` must be applied to secrets to enable the DevWorksapce Operator to find them on the cluster.
 
 By default, resources will be mounted based on the resource name:
+
 * Secrets will be mounted to `/etc/secret/<secret-name>`
 * Configmaps will be mounted to `/etc/config/<configmap-name>`
 * Persistent volume claims will be mounted to `/tmp/<pvc-name>`
 
 Mounting resources can be additionally configured via **annotations**:
+
 * `controller.devfile.io/mount-path`: configure where the resource should be mounted
 * `controller.devfile.io/mount-as`: for secrets and configmaps only, configure how the resource should be mounted to the workspace
-    * If `controller.devfile.io/mount-as: file`, the configmap/secret will be mounted as files within the mount path. This is the default behavior.
-    * If `controller.devfile.io/mount-as: subpath`, the keys and values in the configmap/secret will be mounted as files within the mount path using subpath volume mounts.
-    * If `controller.devfile.io/mount-as: env`, the keys and values in the configmap/secret will be mounted as environment variables in all containers in the DevWorkspace.
++
+--
+  ** If `controller.devfile.io/mount-as: file`, the configmap/secret will be mounted as files within the mount path. This is the default behavior.
 
-  When "file" is used, the configmap is mounted as a directory within the workspace, erasing any files/directories already present. When "subpath" is used, each key in the configmap/secret is mounted as a subpath volume mount in the mount path, leaving existing files intact but preventing changes to the secret/configmap from propagating into the workspace without a restart.
+  ** If `controller.devfile.io/mount-as: subpath`, the keys and values in the configmap/secret will be mounted as files within the mount path using subpath volume mounts.
+
+  ** If `controller.devfile.io/mount-as: env`, the keys and values in the configmap/secret will be mounted as environment variables in all containers in the DevWorkspace.
+--
++
+When "file" is used, the configmap is mounted as a directory within the workspace, erasing any files/directories already present. When "subpath" is used, each key in the configmap/secret is mounted as a subpath volume mount in the mount path, leaving existing files intact but preventing changes to the secret/configmap from propagating into the workspace without a restart.
+
 * `controller.devfile.io/read-only`: for persistent volume claims, mount the resource as read-only
 
 ## Adding image pull secrets to workspaces
@@ -105,8 +135,9 @@ Labelling secrets with `controller.devfile.io/devworkspace_pullsecret: true` mar
 Note: As for automatically mounting secrets, it is necessary to apply the `controller.devfile.io/watch-secret` label to image pull secrets
 
 ## Adding git credentials to a workspace
-Labelling secrets with `controller.devfile.io/git-credential` marks the secret as containing git credentials. All git credential secrets will be merged into a single secret (leaving the original resources in-tact). See [git documentation](https://git-scm.com/docs/git-credential-store#_storage_format) for details on the file format for this configuration. For example
-```yaml
+Labelling secrets with `controller.devfile.io/git-credential` marks the secret as containing git credentials. All git credential secrets will be merged into a single secret (leaving the original resources in-tact). See https://git-scm.com/docs/git-credential-store#_storage_format[git documentation] for details on the file format for this configuration. For example
+[source,yaml]
+----
 kind: Secret
 apiVersion: v1
 metadata:
@@ -118,7 +149,7 @@ metadata:
 type: Opaque
 data:
   credentials: https://{USERNAME}:{PERSONAL_ACCESS_TOKEN}@{GIT_WEBSITE}
-```
+----
 
 Note: As for automatically mounting secrets, it is necessary to apply the `controller.devfile.io/watch-secret` label to git credentials secrets
 
@@ -126,8 +157,9 @@ Note: As for automatically mounting secrets, it is necessary to apply the `contr
 Normally, when a workspace fails to start, the deployment will be scaled down and the workspace will be stopped in a `Failed` state. This can make it difficult to debug misconfiguration errors, so the annotation `controller.devfile.io/debug-start: "true"` can be applied to DevWorkspaces to leave resources for failed workspaces on the cluster. This allows viewing logs from workspace containers.
 
 ## Setting RuntimeClass for workspace pods
-To run a DevWorkspace with a specific RuntimeClass, the attribute `controller.devfile.io/runtime-class` can be set on the DevWorkspace with the name of the RuntimeClass to be used. If the specified RuntimeClass does not exist, the workspace will fail to start. For example, to run a DevWorkspace using the [kata containers](https://github.com/kata-containers/kata-containers) runtime in clusters where this is enabled, the DevWorkspace can be specified:
-```yaml
+To run a DevWorkspace with a specific RuntimeClass, the attribute `controller.devfile.io/runtime-class` can be set on the DevWorkspace with the name of the RuntimeClass to be used. If the specified RuntimeClass does not exist, the workspace will fail to start. For example, to run a DevWorkspace using the https://github.com/kata-containers/kata-containers[kata containers] runtime in clusters where this is enabled, the DevWorkspace can be specified:
+[source,yaml]
+----
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
@@ -136,6 +168,6 @@ spec:
   template:
     attributes:
       controller.devfile.io/runtime-class: kata
-```
+----
 
 For documentation on Runtime Classes, see https://kubernetes.io/docs/concepts/containers/runtime-class/


### PR DESCRIPTION
### What does this PR do?
Convert additional-configuration.md to a asciidoc and add a table of contents.

### What issues does this PR fix or reference?
It has gotten long enough that a TOC is useful

### Is it tested? How?
Still need to verify nothing external links to the old file directly

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
