### PR TITLE
chore: Set version of 'next' bundle to always update and add build info

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -138,6 +138,36 @@ jobs:
           export DEFAULT_DWO_IMG="quay.io/devfile/devworkspace-controller:$TAG"
           export PROJECT_CLONE_IMG="quay.io/devfile/project-clone:$TAG"
 
+          # Next builds are not rolled out unless the version is incremented. We want to use semver
+          # prerelease tags to make sure each new build increments on the previous one, e.g.
+          # v0.15.0-dev.1, v0.15.0-dev.2, etc.
+          CURR_VERSION=$(yq -r '.spec.version' deploy/templates/components/csv/clusterserviceversion.yaml)
+          PREV_VERSION=$(opm render ${DWO_INDEX_IMG} |\
+            jq -r 'select(.schema == "olm.channel") | .entries[0].name | ltrimstr("devworkspace-operator.v")')
+          # Strip the static version number and build identifier to get the previous build number, e.g.
+          #   v0.15.0-dev.1+41e8ccb8 -> 1
+          # If previous version does not have build number/identifier, result is the full version (e.g. v0.15.0-dev)
+          PREV_ID=${PREV_VERSION##*-dev.}
+          PREV_ID=${PREV_ID%%+*}
+
+          if [ "$PREV_ID" == "$CURR_VERSION" ]; then
+            # no build number set, start at 0
+            NEXT_ID="0"
+          elif [ "${PREV_VERSION%%-*}" != "${CURR_VERSION%%-*}" ]; then
+            # minor version bump, moving from e.g. v0.14.0-dev.8 -> v0.15.0-dev.0
+            NEXT_ID="0"
+          else
+            NEXT_ID=$((PREV_ID+1))
+          fi
+
+          NEW_VERSION="${CURR_VERSION}.${NEXT_ID}+${{ needs.build-next-imgs.outputs.git-sha }}"
+          NEW_NAME="devworkspace-operator.v${CURR_VERSION}.${NEXT_ID}"
+          echo "Updating version for this build to $NEW_VERSION"
+          yq -Yi --arg NEW_VERSION "$NEW_VERSION" \
+            --arg NEW_NAME "$NEW_NAME" \
+            '.spec.version=$NEW_VERSION | .metadata.name=$NEW_NAME' \
+            deploy/templates/components/csv/clusterserviceversion.yaml
+
           ./build/scripts/build_index_image.sh \
             --bundle-repo ${DWO_BUNDLE_REPO} \
             --bundle-tag ${DWO_BUNDLE_TAG} \


### PR DESCRIPTION
### What does this PR do?
Configure the 'next' index image build to add incrementing prerelease identifiers and include the git-sha as the build identifier. E.g. for version v0.15.0-dev, build index images with versions

  v0.15.0-dev.0+59b2f40e
  v0.15.0-dev.1+ca15cf09
  v0.15.0-dev.2+bd17527a

To ensure clusters deploying the 'next' catalog will always update to
new builds.

Note the semantics for version comparison in SemVer are:
* Build identifiers are ignored (e.g. +59b2f40e)
* Each dot-separated segment of a prerelease identifier is compared:
  * if alphanumeric, lexically in ASCII sort order
  * if only digits, numerically
  * numeric identifiers < alphanumeric identifiers

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/814

### Is it tested? How?
Tested in my fork, see recent runs of the `test.ymll` workflow: https://github.com/amisevsk/devworkspace-operator/actions/workflows/test.yml

* logs from [run #13](https://github.com/amisevsk/devworkspace-operator/runs/5996997269?check_suite_focus=true)
    >  Updating version for this build to 0.15.0-dev.0+7c43dcc
* logs from [run #14](https://github.com/amisevsk/devworkspace-operator/runs/5997099243?check_suite_focus=true)
    >  Updating version for this build to 0.15.0-dev.1+ba74740

I've also tested 
* OLM behavior on `crc`: with the versioning scheme used here, new changes are automatically rolled out and new DWO images are pulled (technically each one is a new version of DWO)
* The script to determine the next version to ensure it correctly handles the cases where 1) the current index does not have a build number (i.e. the first run after merging this PR), 2) the actual version is incremented (i.e. a minor release) to ensure the counter resets to 0.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
