### PR TITLE
Temporarily disable validation of DevWorkspaces to workaround api issue

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	devfilevalidation "github.com/devfile/api/v2/pkg/validation"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	"github.com/devfile/devworkspace-operator/pkg/common"
@@ -253,13 +252,14 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	reconcileStatus.setConditionTrue(conditions.DevWorkspaceResolved, "Resolved plugins and parents from DevWorkspace")
 
 	// Verify that the devworkspace components are valid after flattening
-	components := workspace.Spec.Template.Components
-	if components != nil {
-		eventErrors := devfilevalidation.ValidateComponents(components)
-		if eventErrors != nil {
-			return r.failWorkspace(workspace, eventErrors.Error(), metrics.ReasonBadRequest, reqLogger, &reconcileStatus)
-		}
-	}
+	// TODO: Disable validation until https://github.com/devfile/api/issues/821 is resolved and pulled into this repo
+	// components := workspace.Spec.Template.Components
+	// if components != nil {
+	// 	eventErrors := devfilevalidation.ValidateComponents(components)
+	// 	if eventErrors != nil {
+	// 		return r.failWorkspace(workspace, eventErrors.Error(), metrics.ReasonBadRequest, reqLogger, &reconcileStatus)
+	// 	}
+	// }
 
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?
Temporarily disable validation of the flattened DevWorkspace to work around an issue in the devfile/api validation package where all endpoint targetPorts must be unique.

This PR should be reverted once https://github.com/devfile/api/pull/822 is merged and the updated dependency is pulled into the DWO repo. 

This is also an opportunity to test https://github.com/devfile/devworkspace-operator/pull/815 on the dogfooding instance if it is merged first :)

Validation generally does not catch many issues that are not caught by the schema, so including this change for now is low risk (worst case scenario is that the error message is perhaps less informative).

### What issues does this PR fix or reference?
Workaround for https://github.com/devfile/devworkspace-operator/issues/816

### Is it tested? How?
Tested by starting `samples/theia-next.yaml` DevWorkspace

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
