### PR TITLE
feat: 'one PVC per-workspace' storage class

### DIFF
--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -75,6 +75,7 @@ spec:
 where `<storage-type>` is one of
 
 * `common`: Use one PVC for all workspace volumes, mounting Devfile volumes in subpaths within the common PVC
+* `per-workspace`: Every workspace is given its own PVC. Each Devfile volume is mounted as a subpath within the workspace PVC.
 * `ephemeral`: Replace all volumes with `emptyDir` volumes. This storage type is non-persistent; any local changes will be lost when the workspace is stopped. This is the equivalent of marking all volumes in the Devfile as `ephemeral: true`
 * `async`: Use `emptyDir` volumes for workspace volumes, but include a sidecar that synchronises local changes to a persistent volume as in the `common` strategy. This can potentially avoid issues where mounting volumes to a workspace on startup takes a long time.
 

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -90,6 +90,10 @@ func PVCCleanupJobName(workspaceId string) string {
 	return fmt.Sprintf("cleanup-%s", workspaceId)
 }
 
+func PerWorkspacePVCName(workspaceId string) string {
+	return fmt.Sprintf("storage-%s", workspaceId)
+}
+
 func MetadataConfigMapName(workspaceId string) string {
 	return fmt.Sprintf("%s-metadata", workspaceId)
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -73,6 +73,9 @@ const (
 	// EphemeralStorageClassType defines the 'ephemeral' storage policy: all volumes are allocated as emptyDir volumes and
 	// so do not require cleanup. When a DevWorkspace is stopped, all local changes are lost.
 	EphemeralStorageClassType = "ephemeral"
+	// PerWorkspaceStorageClassType defines the 'per-workspace' storage policy: a PVC is provisioned for each workspace within the namespace.
+	// All of the workspace's storage (volume mounts) are mounted on subpaths within the workspace's PVC.
+	PerWorkspaceStorageClassType = "per-workspace"
 
 	// CheCommonPVCName is the name of the common PVC equivalent used by Che. If present in the namespace, this PVC is mounted instead
 	// of the default PVC when the 'common' or 'async' storage classes are used.

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -106,7 +106,7 @@ func TestRewriteContainerVolumeMountsForCommonStorageClass(t *testing.T) {
 	tests := loadAllTestCasesOrPanic(t, "testdata/common-storage")
 	setupControllerCfg()
 	commonStorage := CommonStorageProvisioner{}
-	commonPVC, err := getCommonPVCSpec("test-namespace", "10Gi")
+	commonPVC, err := getPVCSpec("claim-devworkspace", "test-namespace", "10Gi")
 	if err != nil {
 		t.Fatalf("Failure during setup: %s", err)
 	}

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -1,0 +1,197 @@
+//
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	devfileConstants "github.com/devfile/devworkspace-operator/pkg/library/constants"
+	nsconfig "github.com/devfile/devworkspace-operator/pkg/provision/config"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// The PerWorkspaceStorageProvisioner provisions one PVC per workspace and configures all volumes in the workspace
+// to mount on subpaths within that PVC.
+type PerWorkspaceStorageProvisioner struct{}
+
+var _ Provisioner = (*PerWorkspaceStorageProvisioner)(nil)
+
+// This function is used to determine whether a finalizer should be applied to the DevWorkspace.
+// Since the per-workspace PVC are cleaned up/deleted via Owner References when the workspace is deleted,
+// no finalizer needs to be applied
+func (*PerWorkspaceStorageProvisioner) NeedsStorage(workspace *dw.DevWorkspaceTemplateSpec) bool {
+	return false
+}
+
+func (p *PerWorkspaceStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspace *dw.DevWorkspace, clusterAPI sync.ClusterAPI) error {
+	// Add ephemeral volumes
+	if err := addEphemeralVolumesFromWorkspace(workspace, podAdditions); err != nil {
+		return err
+	}
+
+	// If persistent storage is not needed, we're done
+	if !needsStorage(&workspace.Spec.Template) {
+		return nil
+	}
+
+	// Get perWorkspace PVC spec and sync it with cluster
+	perWorkspacePVC, err := syncPerWorkspacePVC(workspace, clusterAPI)
+	if err != nil {
+		return err
+	}
+	pvcName := perWorkspacePVC.Name
+
+	// Rewrite container volume mounts
+	if err := p.rewriteContainerVolumeMounts(workspace.Status.DevWorkspaceId, pvcName, podAdditions, &workspace.Spec.Template); err != nil {
+		return &ProvisioningError{
+			Err:     err,
+			Message: "Could not rewrite container volume mounts",
+		}
+	}
+
+	return nil
+}
+
+// We rely on Kubernetes to use the owner reference to automatically delete the PVC once the workspace is set for deletion.
+func (*PerWorkspaceStorageProvisioner) CleanupWorkspaceStorage(workspace *dw.DevWorkspace, clusterAPI sync.ClusterAPI) error {
+	return nil
+}
+
+// rewriteContainerVolumeMounts rewrites the VolumeMounts in a set of PodAdditions according to the 'per-workspace' PVC strategy
+// (i.e. all volume mounts are subpaths into a PVC used by a single workspace in the namespace).
+//
+// Also adds appropriate k8s Volumes to PodAdditions to accomodate the rewritten VolumeMounts.
+func (p *PerWorkspaceStorageProvisioner) rewriteContainerVolumeMounts(workspaceId, pvcName string, podAdditions *v1alpha1.PodAdditions, workspace *dw.DevWorkspaceTemplateSpec) error {
+	devfileVolumes := map[string]dw.VolumeComponent{}
+
+	// Construct map of volume name -> volume Component
+	for _, component := range workspace.Components {
+		if component.Volume != nil {
+			if _, exists := devfileVolumes[component.Name]; exists {
+				return fmt.Errorf("volume component '%s' is defined multiple times", component.Name)
+			}
+			devfileVolumes[component.Name] = *component.Volume
+		}
+	}
+
+	// Containers in podAdditions may reference e.g. automounted volumes in their volumeMounts, and this is not an error
+	additionalVolumes := map[string]bool{}
+	for _, additionalVolume := range podAdditions.Volumes {
+		additionalVolumes[additionalVolume.Name] = true
+	}
+
+	// Add implicit projects volume to support mountSources, if needed
+	if _, exists := devfileVolumes[devfileConstants.ProjectsVolumeName]; !exists {
+		projectsVolume := dw.VolumeComponent{}
+		projectsVolume.Size = constants.PVCStorageSize
+		devfileVolumes[devfileConstants.ProjectsVolumeName] = projectsVolume
+	}
+
+	// TODO: What should we do when a volume isn't explicitly defined?
+	rewriteVolumeMounts := func(containers []corev1.Container) error {
+		for cIdx, container := range containers {
+			for vmIdx, vm := range container.VolumeMounts {
+				volume, ok := devfileVolumes[vm.Name]
+				if !ok {
+					// Volume is defined outside of the devfile
+					if additionalVolumes[vm.Name] {
+						continue
+					}
+					// Should never happen as flattened Devfile is validated.
+					return fmt.Errorf("container '%s' references undefined volume '%s'", container.Name, vm.Name)
+				}
+				if !isEphemeral(&volume) {
+					containers[cIdx].VolumeMounts[vmIdx].SubPath = vm.Name
+					containers[cIdx].VolumeMounts[vmIdx].Name = pvcName
+				}
+			}
+		}
+		return nil
+	}
+	if err := rewriteVolumeMounts(podAdditions.Containers); err != nil {
+		return err
+	}
+	if err := rewriteVolumeMounts(podAdditions.InitContainers); err != nil {
+		return err
+	}
+
+	podAdditions.Volumes = append(podAdditions.Volumes, corev1.Volume{
+		Name: pvcName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcName,
+			},
+		},
+	})
+
+	return nil
+}
+
+func syncPerWorkspacePVC(workspace *dw.DevWorkspace, clusterAPI sync.ClusterAPI) (*corev1.PersistentVolumeClaim, error) {
+	namespace := workspace.Namespace
+
+	namespacedConfig, err := nsconfig.ReadNamespacedConfig(namespace, clusterAPI)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read namespace-specific configuration: %w", err)
+	}
+
+	// TODO: Determine the storage size that is needed by iterating through workspace volumes,
+	// adding the sizes specified and figuring out overrides/defaults
+	pvcSize := constants.PVCStorageSize
+	if namespacedConfig != nil && namespacedConfig.CommonPVCSize != "" {
+		pvcSize = namespacedConfig.CommonPVCSize
+	}
+
+	pvc, err := getPVCSpec(common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId), workspace.Namespace, pvcSize)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := controllerutil.SetControllerReference(workspace, pvc, clusterAPI.Scheme); err != nil {
+		return nil, err
+	}
+
+	currObject, err := sync.SyncObjectWithCluster(pvc, clusterAPI)
+	switch t := err.(type) {
+	case nil:
+		break
+	case *sync.NotInSyncError:
+		return nil, &NotReadyError{
+			Message: fmt.Sprintf("Updated %s PVC on cluster", pvc.Name),
+		}
+	case *sync.UnrecoverableSyncError:
+		return nil, &ProvisioningError{
+			Message: fmt.Sprintf("Failed to sync %s PVC to cluster", pvc.Name),
+			Err:     t.Cause,
+		}
+	default:
+		return nil, err
+	}
+
+	currPVC, ok := currObject.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return nil, errors.New("tried to sync per-workspace PVC to cluster but did not get a PVC back")
+	}
+
+	return currPVC, nil
+}

--- a/pkg/provision/storage/perWorkspaceStorage_test.go
+++ b/pkg/provision/storage/perWorkspaceStorage_test.go
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/config"
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(dw.AddToScheme(scheme))
+	config.SetConfigForTesting(nil)
+}
+
+func TestRewriteContainerVolumeMountsForPerWorkspaceStorageClass(t *testing.T) {
+	tests := loadAllTestCasesOrPanic(t, "testdata/perWorkspace-storage")
+	setupControllerCfg()
+	perWorkspaceStorage := PerWorkspaceStorageProvisioner{}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			// sanity check that file is read correctly.
+			assert.NotNil(t, tt.Input.Workspace, "Input does not define workspace")
+			workspace := &dw.DevWorkspace{}
+			workspace.Spec.Template = *tt.Input.Workspace
+			workspace.Status.DevWorkspaceId = tt.Input.DevWorkspaceID
+			workspace.Namespace = "test-namespace"
+
+			clusterAPI := sync.ClusterAPI{
+				Scheme: scheme,
+				Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+				Logger: zap.New(),
+			}
+
+			if needsStorage(&workspace.Spec.Template) {
+				err := perWorkspaceStorage.ProvisionStorage(&tt.Input.PodAdditions, workspace, clusterAPI)
+				if !assert.Error(t, err, "Should get a NotReady error when creating PVC") {
+					return
+				}
+
+				assert.Regexp(t, err.Error(), fmt.Sprintf("Updated %s PVC on cluster", common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId)))
+
+				retrievedPVC := &corev1.PersistentVolumeClaim{}
+				namespacedName := types.NamespacedName{Name: common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId), Namespace: workspace.Namespace}
+
+				err = clusterAPI.Client.Get(clusterAPI.Ctx, namespacedName, retrievedPVC)
+
+				if !assert.NoError(t, err, "PVC should be created on cluster") {
+					return
+				}
+
+				if !assert.NotEmpty(t, retrievedPVC.ObjectMeta.OwnerReferences) {
+					return
+				}
+				assert.Len(t, retrievedPVC.ObjectMeta.OwnerReferences, 1)
+				assert.Equal(t, retrievedPVC.ObjectMeta.OwnerReferences[0].Kind, "DevWorkspace")
+			}
+
+			err := perWorkspaceStorage.ProvisionStorage(&tt.Input.PodAdditions, workspace, clusterAPI)
+
+			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
+				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
+			} else {
+				if !assert.NoError(t, err, "Should not return error") {
+					return
+				}
+
+				sortVolumesAndVolumeMounts(&tt.Output.PodAdditions)
+				sortVolumesAndVolumeMounts(&tt.Input.PodAdditions)
+				assert.Equal(t, tt.Output.PodAdditions, tt.Input.PodAdditions,
+					"PodAdditions should match expected output: Diff: %s", cmp.Diff(tt.Output.PodAdditions, tt.Input.PodAdditions))
+			}
+		})
+	}
+}

--- a/pkg/provision/storage/provisioner.go
+++ b/pkg/provision/storage/provisioner.go
@@ -51,6 +51,8 @@ func GetProvisioner(workspace *dw.DevWorkspace) (Provisioner, error) {
 	switch storageClass {
 	case constants.CommonStorageClassType:
 		return &CommonStorageProvisioner{}, nil
+	case constants.PerWorkspaceStorageClassType:
+		return &PerWorkspaceStorageProvisioner{}, nil
 	case constants.AsyncStorageClassType:
 		return &AsyncStorageProvisioner{}, nil
 	case constants.EphemeralStorageClassType:

--- a/pkg/provision/storage/testdata/perWorkspace-storage/can-make-projects-ephemeral.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/can-make-projects-ephemeral.yaml
@@ -1,0 +1,35 @@
+name: "Can make projects volume ephemeral"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true
+      - name: projects
+        volume:
+          ephemeral: true
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: projects
+            mountPath: "/projects-mountpath"
+
+    volumes:
+      - name: projects
+        emptyDir: {}

--- a/pkg/provision/storage/testdata/perWorkspace-storage/can-set-ephemeral-volume-size.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/can-set-ephemeral-volume-size.yaml
@@ -1,0 +1,37 @@
+name: "Can set ephemeral volume size"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true
+      - name: projects
+        volume:
+          ephemeral: true
+          size: 512Mi
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: projects
+            mountPath: "/projects-mountpath"
+
+    volumes:
+      - name: projects
+        emptyDir:
+          sizeLimit: 512Mi

--- a/pkg/provision/storage/testdata/perWorkspace-storage/does-nothing-for-no-storage-needed.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/does-nothing-for-no-storage-needed.yaml
@@ -1,0 +1,22 @@
+name: "Does not modify PodAdditions when storage is not required"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image-1
+        imagePullPolicy: Always
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          mountSources: false
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image-1
+        imagePullPolicy: Always

--- a/pkg/provision/storage/testdata/perWorkspace-storage/error-duplicate-volumes.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/error-duplicate-volumes.yaml
@@ -1,0 +1,27 @@
+name: "Returns error when workspace defines duplicate volumes"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+          - name: "my-defined-volume"
+            mountPath: "/test-1"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+      - name: my-defined-volume
+        volume: {}
+      - name: my-defined-volume
+        volume: {}
+
+output:
+  errRegexp: "volume component 'my-defined-volume' is defined multiple times"

--- a/pkg/provision/storage/testdata/perWorkspace-storage/error-undefined-volume-init-container.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/error-undefined-volume-init-container.yaml
@@ -1,0 +1,24 @@
+name: "Returns error on undefined volume in init container"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    initContainers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+          - name: "my-defined-volume"
+            mountPath: "/test-1"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+
+
+output:
+  errRegexp: "container 'testing-container-1' references undefined volume 'my-defined-volume'"

--- a/pkg/provision/storage/testdata/perWorkspace-storage/error-undefined-volume.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/error-undefined-volume.yaml
@@ -1,0 +1,24 @@
+name: "Returns error on undefined volume in container"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+          - name: "my-defined-volume"
+            mountPath: "/test-1"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+
+
+output:
+  errRegexp: "container 'testing-container-1' references undefined volume 'my-defined-volume'"

--- a/pkg/provision/storage/testdata/perWorkspace-storage/error-unparseable-ephemeral-size.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/error-unparseable-ephemeral-size.yaml
@@ -1,0 +1,26 @@
+name: "Can make projects volume ephemeral"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true
+      - name: projects
+        volume:
+          ephemeral: true
+          size: 512XX
+
+output:
+  errRegexp: "failed to parse size for Volume projects.*"

--- a/pkg/provision/storage/testdata/perWorkspace-storage/handles-ephemeral-volumes.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/handles-ephemeral-volumes.yaml
@@ -1,0 +1,35 @@
+name: "Handles ephemeral volumes"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: testvol
+            mountPath: "/projects-mountpath"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          mountSources: false
+
+      - name: testvol
+        volume:
+          ephemeral: true
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: testvol
+            mountPath: "/projects-mountpath"
+
+    volumes:
+      - name: testvol
+        emptyDir: {}

--- a/pkg/provision/storage/testdata/perWorkspace-storage/handles-projects-volume-ordering.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/handles-projects-volume-ordering.yaml
@@ -1,0 +1,56 @@
+name: "Does not depend on component order in detecting projects volume"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image-1
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+      - name: testing-container-2
+        image: testing-image-2
+        volumeMounts:
+          - name: "projects"
+      - name: testing-container-3
+        image: testing-image-3
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true
+      - name: projects
+        volume:
+          ephemeral: true
+      - name: testing-container-2
+        container:
+          image: testing-image-2
+          mountSources: true
+      - name: testing-container-3
+        container:
+          image: testing-image-3
+          sourceMapping: "/plugins-mountpath"
+          mountSources: false
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image-1
+        volumeMounts:
+          - name: projects
+            mountPath: "/projects-mountpath"
+      - name: testing-container-2
+        image: testing-image-2
+        volumeMounts:
+          - name: "projects"
+      - name: testing-container-3
+        image: testing-image-3
+
+    volumes:
+      - name: projects
+        emptyDir: {}

--- a/pkg/provision/storage/testdata/perWorkspace-storage/projects-volume-overriding.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/projects-volume-overriding.yaml
@@ -1,0 +1,35 @@
+name: "User can specify a projects volume manually"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+      - name: projects
+        volume: {}
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "projects"
+            mountPath: "/projects-mountpath"
+
+    volumes:
+      - name: storage-test-workspaceid
+        persistentVolumeClaim:
+          claimName: storage-test-workspaceid

--- a/pkg/provision/storage/testdata/perWorkspace-storage/rewrites-volumes-for-perworkspace-pvc-strategy.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/rewrites-volumes-for-perworkspace-pvc-strategy.yaml
@@ -1,0 +1,59 @@
+name: "Rewrites volumeMounts according to perworkspace PVC strategy"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+          - name: "my-defined-volume"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: "plugins"
+            mountPath: "/plugins"
+          - name: "my-defined-volume"
+            mountPath: "/test-3"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+      - name: my-defined-volume
+        volume: {}
+      - name: plugins
+        volume: {}
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "projects"
+            mountPath: "/projects-mountpath"
+          - name: storage-test-workspaceid
+            subPath: "my-defined-volume"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "plugins"
+            mountPath: "/plugins"
+          - name: storage-test-workspaceid
+            subPath: "my-defined-volume"
+            mountPath: "/test-3"
+    volumes:
+      - name: storage-test-workspaceid
+        persistentVolumeClaim:
+          claimName: storage-test-workspaceid

--- a/samples/theia-next_per-workspaceStorage.yaml
+++ b/samples/theia-next_per-workspaceStorage.yaml
@@ -1,0 +1,30 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: theia-next
+spec:
+  started: true
+  template:
+    attributes:
+        controller.devfile.io/storage-type: per-workspace
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    components:
+      - name: theia
+        plugin:
+          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
+          components:
+            - name: theia-ide
+              container:
+                env:
+                  - name: THEIA_HOST
+                    value: 0.0.0.0
+    commands:
+      - id: say-hello
+        exec:
+          component: theia-ide
+          commandLine: echo "Hello from $(pwd)"
+          workingDir: ${PROJECTS_ROOT}/project/app


### PR DESCRIPTION
### What does this PR do?
This PR adds a new storage class called 'perWorkspace'. When in use in the devfile, every workspace gets its own PVC.


### What issues does this PR fix or reference?
Fix #792 

### Is it tested? How?
In order to enable the 'perWorkspace' storage class, the `controller.devfile.io/storage-type` devfile attribute must be set to `per-workspace`.

Eg.
```YAML
spec:
  template:
    attributes:
        controller.devfile.io/storage-type: per-workspace
```


**Manual testing:**
- Start up DWO (i.e. `make run`)
- Apply the sample devfile that uses the perWorkspace storage class: `kubectl apply -f ./samples/theia-next_per-workspaceStorage.yaml -n $NAMESPACE`
- Check K8s status (through terminal or dashboard) and ensure a PVC has been created for the workspace. The naming of the PVC should be of the form `storage-[workspaceID]`
- Delete the workspace: `kubectl delete dw theia-next -n $NAMESPACE`
- Ensure the PVC is also deleted shortly after (check K8s dashboard for PVC or use terminal commands)

**Automated testing:**
There is also a new test file, `pkg/provision/storage/perWorkspaceStorage_test.go`.
It is based off of `pkg/provision/storage/CommonStorage_test.go` with slight adaptions. It also ensures that the owner reference is set for the perWorkspace PVC, which is required for automatic PVC deletion with cluster garbage collection.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
