### PR TITLE
fix: broken additional-configuration README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Dev Workspace operator repository that contains the controller for the DevWorksp
 
 ### Additional configuration
 
-DevWorkspaces can be configured through DevWorkspace attributes and Kubernetes labels/annotations. For a list of all options available, see [additional documentation](docs/additional-configuration.md).
+DevWorkspaces can be configured through DevWorkspace attributes and Kubernetes labels/annotations. For a list of all options available, see [additional documentation](docs/additional-configuration.adoc).
 
 #### Restricted Access
 


### PR DESCRIPTION
### What does this PR do?
Fixes the 'additional configuration' link in the README.

### What issues does this PR fix or reference?
Fix #819

### Is it tested? How?
Checkout the README and click on the 'see additional documentation' link and verify it links to `/docs/additional-configuration.adoc`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
