### PR TITLE
Ensure automounted volume names are shorter than 63 characters

### DIFF
--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -98,16 +98,19 @@ func MetadataConfigMapName(workspaceId string) string {
 	return fmt.Sprintf("%s-metadata", workspaceId)
 }
 
+// We can't add prefixes to automount volume names, as adding any characters
+// can potentially push the name over the 63 character limit (if the original
+// object has a long name)
 func AutoMountConfigMapVolumeName(volumeName string) string {
-	return fmt.Sprintf("automount-configmap-%s", volumeName)
+	return fmt.Sprintf("%s", volumeName)
 }
 
 func AutoMountSecretVolumeName(volumeName string) string {
-	return fmt.Sprintf("automount-secret-%s", volumeName)
+	return fmt.Sprintf("%s", volumeName)
 }
 
 func AutoMountPVCVolumeName(pvcName string) string {
-	return fmt.Sprintf("automount-pvc-%s", pvcName)
+	return fmt.Sprintf("%s", pvcName)
 }
 
 func WorkspaceRoleName() string {


### PR DESCRIPTION
### What does this PR do?
Remove prefix from automount volume names to avoid going over 63 characters and creating invalid deployments.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/828

### Is it tested? How?
```bash
cat <<EOF | oc apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-loooooooooooooooooooooooong-configmap-name
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: 'true'
  annotations:
    controller.devfile.io/mount-as: file
    controller.devfile.io/mount-path: /tmp/configmap/file
data:
  configmap-key: "hello"
EOF
oc apply -f samples/plain.yaml
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
