### PR TITLE
Fix command to install goimports in Go 1.16

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,9 +72,8 @@ jobs:
     -
       name: Check format
       run: |
-        go get -u github.com/google/addlicense
-        go get -u golang.org/x/tools/cmd/goimports
-        git reset HEAD --hard
+        go install github.com/google/addlicense@latest
+        go install golang.org/x/tools/cmd/goimports@latest
 
         make check_fmt
         if [[ $? != 0 ]]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,8 +110,7 @@ jobs:
         run: |
           # Need to grab goimports otherwise formatting after this step will fail
           # PR checks.
-          go get -u golang.org/x/tools/cmd/goimports
-          git reset HEAD --hard
+          go install golang.org/x/tools/cmd/goimports
 
           git config --global user.name "Angel Misevski"
           git config --global user.email "amisevsk@redhat.com"


### PR DESCRIPTION
### What does this PR do?
Fixes GH action steps that require `goimports`. These started failing for unclear reasons with the error message
```
${GOPATH}/pkg/mod/golang.org/x/tools@v0.1.10/cmd/goimports/goimports.go:14:2: //go:build comment without // +build comment
```

### What issues does this PR fix or reference?
See e.g. https://github.com/devfile/devworkspace-operator/runs/6262730928?check_suite_focus=true

### Is it tested? How?
Tested in Go 1.16 container locally; `go install` works and using `go get` for this purpose is [deprecated](https://go.dev/doc/go-get-install-deprecation)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
