### PR TITLE
fix: prevent storage class attribute modification

### DIFF
--- a/pkg/provision/storage/provisioner.go
+++ b/pkg/provision/storage/provisioner.go
@@ -41,9 +41,6 @@ type Provisioner interface {
 
 // GetProvisioner returns the storage provisioner that should be used for the current workspace
 func GetProvisioner(workspace *dw.DevWorkspace) (Provisioner, error) {
-	// TODO: Figure out what to do if a workspace changes the storage type after its been created
-	// e.g. common -> async so as to not leave files on PVCs after removal. Maybe block changes to
-	// this label via webhook?
 	storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
 	if storageClass == "" {
 		return &CommonStorageProvisioner{}, nil

--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -106,6 +106,13 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnUpdate(ctx context.Context, re
 		return admission.Denied("DevWorkspace ID cannot be changed once it is set")
 	}
 
+	oldStorageClass := oldWksp.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
+	newStorageClass := newWksp.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
+
+	if oldStorageClass != newStorageClass {
+		return admission.Denied("DevWorkspace storage-type attribute cannot be changed once the workspace has been created.")
+	}
+
 	allowed, msg := h.checkRestrictedAccessWorkspaceV1alpha2(oldWksp, newWksp, req.UserInfo.UID)
 	if !allowed {
 		return admission.Denied(msg)


### PR DESCRIPTION
### What does this PR do?
Add a webhook to prevent storage class attribute modification for V1alpha2 workspaces.

### What issues does this PR fix or reference?
Fix #825

### Is it tested? How?
- Start up a workspace
- If the devfile has it's storage-class attribute (`controller.devfile.io/storage-type`) set, change it with `kubectl edit` or `oc edit` (eg. from `common` to `ephemeral`)
- If the devfile does not have it's storage class attribute set, set it (eg. to `async`)
- After making the modification to the devfile, you should see that the change was denied, e.g.: `error: devworkspaces.workspace.devfile.io "theia-next" could not be patched: admission webhook "mutate.devworkspace-controller.svc" denied the request: DevWorkspace storage-type attribute cannot be changed once the workspace has been created.`

### Extra notes
Extra code could be added to validate that the storage class attribute given is actually valid. This could be done in a way that uses a generic helper function that could be extended for validating other attributes.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
