### PR TITLE
feat: configmap option for perWorkspace PVC size

### DIFF
--- a/pkg/provision/config/config.go
+++ b/pkg/provision/config/config.go
@@ -30,11 +30,13 @@ import (
 )
 
 const (
-	commonPVCSizeKey = "commonPVCSize"
+	commonPVCSizeKey       = "commonPVCSize"
+	perWorkspacePVCSizeKey = "perWorkspacePVCSize"
 )
 
 type NamespacedConfig struct {
-	CommonPVCSize string
+	CommonPVCSize       string
+	PerWorkspacePVCSize string
 }
 
 // ReadNamespacedConfig reads the per-namespace DevWorkspace configmap and returns it as a struct. If there are
@@ -71,7 +73,8 @@ func ReadNamespacedConfig(namespace string, api sync.ClusterAPI) (*NamespacedCon
 	}
 
 	return &NamespacedConfig{
-		CommonPVCSize: cm.Data[commonPVCSizeKey],
+		CommonPVCSize:       cm.Data[commonPVCSizeKey],
+		PerWorkspacePVCSize: cm.Data[perWorkspacePVCSizeKey],
 	}, nil
 }
 

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -158,8 +158,8 @@ func syncPerWorkspacePVC(workspace *dw.DevWorkspace, clusterAPI sync.ClusterAPI)
 	// TODO: Determine the storage size that is needed by iterating through workspace volumes,
 	// adding the sizes specified and figuring out overrides/defaults
 	pvcSize := constants.PVCStorageSize
-	if namespacedConfig != nil && namespacedConfig.CommonPVCSize != "" {
-		pvcSize = namespacedConfig.CommonPVCSize
+	if namespacedConfig != nil && namespacedConfig.PerWorkspacePVCSize != "" {
+		pvcSize = namespacedConfig.PerWorkspacePVCSize
 	}
 
 	pvc, err := getPVCSpec(common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId), workspace.Namespace, pvcSize)


### PR DESCRIPTION
### What does this PR do?
Add a configmap configuration option to specify the perWorkspace PVC size, similar to how it is done for the common PVC size.

### What issues does this PR fix or reference?
Fix #836

### Is it tested? How?
- Start up DWO in the appropriate namespace (eg. `export NAMESPACE="devworkspace-controller"`)
- Apply a config map specifying the perWorkspace PVC size in the appropriate namespace:
```bash
cat <<EOF | kubectl apply -n $NAMESPACE -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-nsconfig
  labels:
    controller.devfile.io/namespaced-config: "true"
    controller.devfile.io/watch-configmap: "true"
data:
  perWorkspacePVCSize: 7Gi
EOF
```
- Apply a devfile that uses the perWorkspace storage class attribute to the same namespace, eg. `kubectl apply -f ./samples/theia-next_per-workspaceStorage.yaml -n $NAMESPACE`
- Verify in Kubernetes (eg. the dashboard) that the newly created PVC has the expected size (`7Gi`)
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
