### PR TITLE
feat: add WorkspaceStopped method to RoutingSolver

### DIFF
--- a/apis/controller/v1alpha1/devworkspacerouting_types.go
+++ b/apis/controller/v1alpha1/devworkspacerouting_types.go
@@ -16,6 +16,7 @@
 package v1alpha1
 
 import (
+	"github.com/devfile/devworkspace-operator/pkg/constants"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -204,4 +205,8 @@ type DevWorkspaceRoutingList struct {
 
 func init() {
 	SchemeBuilder.Register(&DevWorkspaceRouting{}, &DevWorkspaceRoutingList{})
+}
+
+func (d *DevWorkspaceRouting) IsWorkspaceStopped() bool {
+	return d.Annotations != nil && d.Annotations[constants.DevWorkspaceStartedStatusAnnotation] == "false"
 }

--- a/controllers/controller/devworkspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/basic_solver.go
@@ -80,3 +80,7 @@ func (s *BasicSolver) GetExposedEndpoints(
 	routingObj RoutingObjects) (exposedEndpoints map[string]controllerv1alpha1.ExposedEndpointList, ready bool, err error) {
 	return getExposedEndpoints(endpoints, routingObj)
 }
+
+func (s *BasicSolver) WorkspaceStopped(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) error {
+	return nil
+}

--- a/controllers/controller/devworkspacerouting/solvers/cluster_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/cluster_solver.go
@@ -126,3 +126,7 @@ func getHostnameFromService(service corev1.Service, port int32) string {
 	}
 	return fmt.Sprintf("%s://%s.%s.svc:%d", scheme, service.Name, service.Namespace, port)
 }
+
+func (s *ClusterSolver) WorkspaceStopped(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) error {
+	return nil
+}

--- a/controllers/controller/devworkspacerouting/solvers/solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/solver.go
@@ -59,6 +59,9 @@ type RoutingSolver interface {
 	// Return value "ready" specifies if all endpoints are resolved on the cluster; if false it is necessary to retry, as
 	// URLs will be undefined.
 	GetExposedEndpoints(endpoints map[string]controllerv1alpha1.EndpointList, routingObj RoutingObjects) (exposedEndpoints map[string]controllerv1alpha1.ExposedEndpointList, ready bool, err error)
+
+	// WorkspaceStopped is called when the DevWorkspace for the current routing has .spec.started set to false
+	WorkspaceStopped(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) error
 }
 
 type RoutingSolverGetter interface {


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

### What does this PR do?
Adds a `func (s *ClusterSolver) WorkspaceStopped(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) error` method to `RoutingSolver` interface. This function runs when the corresponding devworkspace has stopped. 

### What issues does this PR fix or reference?
This PR was created to help support https://github.com/eclipse-che/che-operator/pull/1386

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Check out this branch: https://github.com/dkwon17/devworkspace-operator/tree/workspacestoppedtesting
This branch contains the same commit as this current PR's branch, except that there is a [new commit](https://github.com/dkwon17/devworkspace-operator/commit/506e11e6ff354a97913af565070309c965e44ba2) on top of it with a print statement that can be used for testing.
2. After checking out the above branch, run the code locally by following these instructions: https://github.com/devfile/devworkspace-operator#run-controller-locally
3. Run the following to create a devworkspace in the `devworkspace-controller` namespace from the devworkspace samples:
```
kubectl apply -f samples/theia-latest.yaml -n devworkspace-controller
```
4. Stop the devworkspace by setting `spec.started` to false.

5. In the output from the terminal used to run DWO from step 2, verify that the we see the print statement:
![image](https://user-images.githubusercontent.com/83611742/168655396-665e3e59-89cb-4f86-ba07-cc1e8428ced1.png)


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
