### PR TITLE
fix: Adding 'KUBERNETES_SERVICE_HOST' env var to the 'no_proxy / NO_PROXY' list

### DIFF
--- a/pkg/library/env/workspaceenv.go
+++ b/pkg/library/env/workspaceenv.go
@@ -17,6 +17,7 @@ package env
 
 import (
 	"fmt"
+	"os"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
@@ -96,8 +97,10 @@ func getProxyEnvVars() []corev1.EnvVar {
 		env = append(env, v1.EnvVar{Name: "HTTPS_PROXY", Value: config.Routing.ProxyConfig.HttpsProxy})
 	}
 	if config.Routing.ProxyConfig.NoProxy != "" {
-		env = append(env, v1.EnvVar{Name: "no_proxy", Value: config.Routing.ProxyConfig.NoProxy})
-		env = append(env, v1.EnvVar{Name: "NO_PROXY", Value: config.Routing.ProxyConfig.NoProxy})
+		// Adding 'KUBERNETES_SERVICE_HOST' env var to the 'no_proxy / NO_PROXY' list. Hot Fix for https://issues.redhat.com/browse/CRW-2820
+		kubernetesServiceHost := os.Getenv("KUBERNETES_SERVICE_HOST")
+		env = append(env, v1.EnvVar{Name: "no_proxy", Value: config.Routing.ProxyConfig.NoProxy + "," + kubernetesServiceHost})
+		env = append(env, v1.EnvVar{Name: "NO_PROXY", Value: config.Routing.ProxyConfig.NoProxy + "," + kubernetesServiceHost})
 	}
 
 	return env


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Adding 'KUBERNETES_SERVICE_HOST' env var to the 'no_proxy / NO_PROXY' list

### What issues does this PR fix or reference?
Hot Fix for https://issues.redhat.com/browse/CRW-2820 

since DWO is a standalone operator it has it is own mechanism for proxy config detection. DWO automatically reads values from cluster [proxies.config.openshift.io](http://proxies.config.openshift.io/) and propagates them as env vars to workspace
At the same time, Che Operator detects proxy configuration in a similar fashion as the DWO, and creates a cm with the right label so that DWO would be able to mount this cm to workspace deployment
the problem is that values from cm are overridden by the proxy env vars that are detected by DWO, e.g. this particular case when KUBERNETES_SERVICE_HOST value is added to the cm on the Che operator level but DWO during the workspace startup sets NO_PROXY env var that it detected

Initial fix on the che-operator end - https://github.com/eclipse-che/che-operator/pull/1387

### Is it tested? How?

 image `quay.io/ibuziuk/devworkspace-controller:crw-2820`

- setup a cluster using cluster bot `launch 4.10 aws,proxy`
- Run the DWO with a fix
  `export DWO_IMG=quay.io/ibuziuk/devworkspace-controller:crw-2820`
  `export NAMESPACE="devworkspace-controller"`
  `make install`
- Create a sample DW `kubectl apply -f ./samples/flattened_theia-next.yaml` - the workspace panel is shown

![image](https://user-images.githubusercontent.com/1461122/169349930-83d3d446-1d9f-45eb-9f49-53e863c63ffe.png)

![image](https://user-images.githubusercontent.com/1461122/169350200-7699a0e4-aaa8-4b91-bab0-2a766345d3c9.png)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
