### PR TITLE
Add support for containerContributions

### DIFF
--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -89,4 +89,14 @@ const (
 	// EndpointURLAttribute is an attribute added to endpoints to denote the endpoint on the cluster that
 	// was created to route to this endpoint
 	EndpointURLAttribute = "controller.devfile.io/endpoint-url"
+
+	// ContainerContributionAttribute defines a container component as a container contribution that should be merged
+	// into an existing container in the devfile if possible. If no suitable container exists, this component
+	// is treated as a regular container component
+	ContainerContributionAttribute = "controller.devfile.io/container-contribution"
+
+	// MergeContributionAttribute defines a container component as a target for merging a container contribution. If
+	// present on a container component, any container contributions will be merged into that container. If multiple
+	// container components have the merge-contribution attribute, the first one will be used and all others ignored.
+	MergeContributionAttribute = "controller.devfile.io/merge-contribution"
 )

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -99,4 +99,8 @@ const (
 	// present on a container component, any container contributions will be merged into that container. If multiple
 	// container components have the merge-contribution attribute, the first one will be used and all others ignored.
 	MergeContributionAttribute = "controller.devfile.io/merge-contribution"
+
+	// MergedContributionsAttribute is applied as an attribute onto a component to list the components from the unflattened
+	// DevWorkspace that have been merged into the current component. The contributions are listed in a comma-separated list.
+	MergedContributionsAttribute = "controller.devfile.io/merged-contributions"
 )

--- a/pkg/library/flatten/flatten.go
+++ b/pkg/library/flatten/flatten.go
@@ -64,10 +64,12 @@ func ResolveDevWorkspace(workspace *dw.DevWorkspaceTemplateSpec, tooling Resolve
 		return resolvedDW, &warnings, nil
 	}
 
-	if needsContainerContributionMerge(resolvedDW) {
+	if needsMerge, err := needsContainerContributionMerge(resolvedDW); needsMerge {
 		if err := mergeContainerContributions(resolvedDW); err != nil {
 			return nil, nil, err
 		}
+	} else if err != nil {
+		return nil, nil, err
 	}
 
 	return resolvedDW, nil, nil

--- a/pkg/library/flatten/flatten.go
+++ b/pkg/library/flatten/flatten.go
@@ -64,6 +64,12 @@ func ResolveDevWorkspace(workspace *dw.DevWorkspaceTemplateSpec, tooling Resolve
 		return resolvedDW, &warnings, nil
 	}
 
+	if needsContainerContributionMerge(resolvedDW) {
+		if err := mergeContainerContributions(resolvedDW); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	return resolvedDW, nil, nil
 }
 

--- a/pkg/library/flatten/flatten_test.go
+++ b/pkg/library/flatten/flatten_test.go
@@ -211,6 +211,29 @@ func TestMergesDuplicateVolumeComponents(t *testing.T) {
 	}
 }
 
+func TestMergeContainerContributions(t *testing.T) {
+	tests := testutil.LoadAllTestsOrPanic(t, "testdata/container-contributions")
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			// sanity check: input defines components
+			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
+			testResolverTools := getTestingTools(tt.Input, "test-ignored")
+
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
+				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
+			} else {
+				if !assert.NoError(t, err, "Should not return error") {
+					return
+				}
+				assert.Truef(t, cmp.Equal(tt.Output.DevWorkspace, outputWorkspace, testutil.WorkspaceTemplateDiffOpts),
+					"DevWorkspace should match expected output:\n%s",
+					cmp.Diff(tt.Output.DevWorkspace, outputWorkspace, testutil.WorkspaceTemplateDiffOpts))
+			}
+		})
+	}
+}
+
 func getTestingTools(input testutil.TestInput, testNamespace string) ResolverTools {
 	testHttpGetter := &testutil.FakeHTTPGetter{
 		DevfileResources:      input.DevfileResources,

--- a/pkg/library/flatten/internal/testutil/common.go
+++ b/pkg/library/flatten/internal/testutil/common.go
@@ -37,6 +37,12 @@ var WorkspaceTemplateDiffOpts = cmp.Options{
 	cmpopts.SortSlices(func(a, b dw.EnvVar) bool {
 		return strings.Compare(a.Name, b.Name) > 0
 	}),
+	cmpopts.SortSlices(func(a, b dw.Endpoint) bool {
+		return strings.Compare(a.Name, b.Name) > 0
+	}),
+	cmpopts.SortSlices(func(a, b dw.VolumeMount) bool {
+		return strings.Compare(a.Name, b.Name) > 0
+	}),
 	// TODO: Devworkspace overriding results in empty []string instead of nil
 	cmpopts.IgnoreFields(dw.DevWorkspaceEvents{}, "PostStart", "PreStop", "PostStop"),
 }

--- a/pkg/library/flatten/testdata/container-contributions/adds-resources.yaml
+++ b/pkg/library/flatten/testdata/container-contributions/adds-resources.yaml
@@ -1,0 +1,46 @@
+name: "Adds attributes from contribution"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          memoryLimit: 1Gi
+          memoryRequest: 1000Mi
+          cpuLimit: 1500m
+          cpuRequest: "1"
+      - name: test-contribution
+        plugin:
+          uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          memoryLimit: 512Mi
+          memoryRequest: 1.5G
+          cpuLimit: "0.5"
+          cpuRequest: 500m
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "test-contribution"
+        container:
+          image: test-image
+          memoryLimit: 1536Mi
+          memoryRequest: "2548576000" # 1.5G + 1000Mi = 1.5*1000^3 + 1000*1024^2
+          cpuLimit: "2"
+          cpuRequest: 1500m

--- a/pkg/library/flatten/testdata/container-contributions/adds-unmerged-elements.yaml
+++ b/pkg/library/flatten/testdata/container-contributions/adds-unmerged-elements.yaml
@@ -1,0 +1,76 @@
+name: "Adds unmerged elements"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+
+      - name: test-contribution
+        plugin:
+          uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        volume: {}
+      commands:
+      - name: plugin-command
+        apply:
+          component: unmerged-container
+      events:
+        prestart:
+          - plugin-command
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "test-contribution"
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        volume: {}
+    commands:
+      - name: plugin-command
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        apply:
+          component: unmerged-container
+    events:
+        prestart:
+          - plugin-command

--- a/pkg/library/flatten/testdata/container-contributions/che-code-usecase.yaml
+++ b/pkg/library/flatten/testdata/container-contributions/che-code-usecase.yaml
@@ -1,0 +1,188 @@
+name: "Merges Che Code IDE contribution"
+
+input:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+          memoryLimit: 2Gi
+          mountSources: true
+      - name: che-code
+        plugin:
+          uri: che-code.yaml
+
+  devfileResources:
+    che-code.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: che-code
+      commands:
+        - id: init-container-command
+          apply:
+            component: che-code-injector
+      events:
+        preStart:
+          - init-container-command
+      components:
+        - name: che-code-runtime-description
+          attributes:
+            app.kubernetes.io/component: che-code-runtime
+            app.kubernetes.io/part-of: che-code.eclipse.org
+            controller.devfile.io/container-contribution: true
+          container:
+            image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+            command:
+              - /checode/entrypoint-volume.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 1024Mi
+            memoryRequest: 256Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+            endpoints:
+              - name: che-code
+                attributes:
+                  type: main
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                path: '?tkn=eclipse-che'
+                secure: false
+                protocol: https
+              - name: code-redirect-1
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13131
+                exposure: public
+                protocol: http
+              - name: code-redirect-2
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13132
+                exposure: public
+                protocol: http
+              - name: code-redirect-3
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13133
+                exposure: public
+                protocol: http
+        - name: checode
+          volume: {}
+        - name: che-code-injector
+          container:
+            image: quay.io/che-incubator/che-code:insiders
+            command:
+              - /entrypoint-init-container.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+
+output:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          app.kubernetes.io/component: che-code-runtime
+          app.kubernetes.io/part-of: che-code.eclipse.org
+          controller.devfile.io/merged-contributions: "che-code"
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          command:
+            - /checode/entrypoint-volume.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 3Gi
+          memoryRequest: 256Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+            - name: che-code
+              attributes:
+                type: main
+                cookiesAuthEnabled: true
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              path: '?tkn=eclipse-che'
+              secure: false
+              protocol: https
+            - name: code-redirect-1
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13131
+              exposure: public
+              protocol: http
+            - name: code-redirect-2
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13132
+              exposure: public
+              protocol: http
+            - name: code-redirect-3
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13133
+              exposure: public
+              protocol: http
+          mountSources: true
+      - name: checode
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        volume: {}
+      - name: che-code-injector
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        container:
+          image: quay.io/che-incubator/che-code:insiders
+          command:
+            - /entrypoint-init-container.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+    commands:
+      - id: init-container-command
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        apply:
+          component: che-code-injector
+    events:
+      preStart:
+          - init-container-command

--- a/pkg/library/flatten/testdata/container-contributions/merges-list-elements.yaml
+++ b/pkg/library/flatten/testdata/container-contributions/merges-list-elements.yaml
@@ -1,0 +1,89 @@
+name: "Merges list elements in contribution"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          volumeMounts:
+            - name: test-volume
+              path: test-volume-path
+          endpoints:
+            - name: test-endpoint-1
+              targetPort: 8888
+              exposure: internal
+              protocol: https
+            - name: test-endpoint-2
+              targetPort: 8889
+              exposure: internal
+              protocol: https
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+
+      - name: test-contribution
+        plugin:
+          uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          volumeMounts:
+            - name: contrib-volume
+              path: contrib-volume-path
+          endpoints:
+            - name: contrib-endpoint-1
+              targetPort: 9999
+              exposure: public
+              protocol: https
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+            - name: CONTRIB_ENVVAR_2
+              value: CONTRIB_VALUE_2
+
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "test-contribution"
+        container:
+          image: test-image
+          volumeMounts:
+            - name: test-volume
+              path: test-volume-path
+            - name: contrib-volume
+              path: contrib-volume-path
+          endpoints:
+            - name: test-endpoint-1
+              targetPort: 8888
+              exposure: internal
+              protocol: https
+            - name: test-endpoint-2
+              targetPort: 8889
+              exposure: internal
+              protocol: https
+            - name: contrib-endpoint-1
+              targetPort: 9999
+              exposure: public
+              protocol: https
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+            - name: CONTRIB_ENVVAR_2
+              value: CONTRIB_VALUE_2

--- a/pkg/library/flatten/testdata/container-contributions/no-op-if-no-contribution.yaml
+++ b/pkg/library/flatten/testdata/container-contributions/no-op-if-no-contribution.yaml
@@ -1,0 +1,82 @@
+name: "Adds unmerged elements"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+
+      - name: test-contribution
+        plugin:
+          uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        # attributes:
+        #   controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        volume: {}
+      commands:
+      - name: plugin-command
+        apply:
+          component: unmerged-container
+      events:
+        prestart:
+          - plugin-command
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        volume: {}
+    commands:
+      - name: plugin-command
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        apply:
+          component: unmerged-container
+    events:
+        prestart:
+          - plugin-command

--- a/pkg/library/flatten/testdata/container-contributions/no-op-if-no-target.yaml
+++ b/pkg/library/flatten/testdata/container-contributions/no-op-if-no-target.yaml
@@ -1,0 +1,81 @@
+name: "Adds unmerged elements"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        # attributes:
+        #   controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+
+      - name: test-contribution
+        plugin:
+          uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        volume: {}
+      commands:
+      - name: plugin-command
+        apply:
+          component: unmerged-container
+      events:
+        prestart:
+          - plugin-command
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        volume: {}
+    commands:
+      - name: plugin-command
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        apply:
+          component: unmerged-container
+    events:
+        prestart:
+          - plugin-command

--- a/pkg/library/flatten/testdata/container-contributions/theia-merge-usecase.yaml
+++ b/pkg/library/flatten/testdata/container-contributions/theia-merge-usecase.yaml
@@ -1,0 +1,386 @@
+name: "Merges Theia IDE contribution"
+
+input:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+          memoryLimit: 2Gi
+          mountSources: true
+      - name: theia-ide
+        plugin:
+          uri: theia-ide.yaml
+
+  devfileResources:
+    theia-ide.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: theia-ide
+      commands:
+        - id: init-container-command
+          apply:
+            component: remote-runtime-injector
+      events:
+        preStart:
+          - init-container-command
+      components:
+        - name: theia-ide-contributions
+          attributes:
+            controller.devfile.io/container-contribution: true
+          container:
+            args:
+              - sh
+              - '-c'
+              - '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}'
+            env:
+              - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+                value: /remote-endpoint/plugin-remote-endpoint
+              - name: THEIA_PLUGINS
+                value: local-dir:///plugins/sidecars/tools
+            memoryLimit: 512Mi
+            volumeMounts:
+              - name: plugins
+                path: /plugins
+              - name: remote-endpoint
+                path: /remote-endpoint
+            image: quay.io/devfile/universal-developer-image@sha256:53cec58dd190dd1e06100478ae879d7c28abd8fc883d5fdf5be3eb6e943fe5e7
+        - name: theia-ide
+          container:
+            image: quay.io/eclipse/che-theia:next
+            env:
+              - name: THEIA_PLUGINS
+                value: local-dir:///plugins
+              - name: HOSTED_PLUGIN_HOSTNAME
+                value: 0.0.0.0
+              - name: HOSTED_PLUGIN_PORT
+                value: '3130'
+              - name: THEIA_HOST
+                value: 127.0.0.1
+            volumeMounts:
+              - name: plugins
+                path: /plugins
+              - name: theia-local
+                path: /home/theia/.theia
+            mountSources: true
+            memoryLimit: 512M
+            cpuLimit: 1500m
+            cpuRequest: 100m
+            endpoints:
+              - name: theia
+                attributes:
+                  type: main
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                secure: false
+                protocol: https
+              - name: webviews
+                attributes:
+                  type: webview
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  unique: true
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                secure: false
+                protocol: https
+              - name: mini-browser
+                attributes:
+                  type: mini-browser
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  unique: true
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                secure: false
+                protocol: https
+              - name: theia-dev
+                attributes:
+                  type: ide-dev
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3130
+                exposure: public
+                protocol: http
+              - name: theia-redirect-1
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13131
+                exposure: public
+                protocol: http
+              - name: theia-redirect-2
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13132
+                exposure: public
+                protocol: http
+              - name: theia-redirect-3
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13133
+                exposure: public
+                protocol: http
+              - name: terminal
+                attributes:
+                  type: collocated-terminal
+                  discoverable: false
+                  cookiesAuthEnabled: true
+                  urlRewriteSupported: true
+                targetPort: 3333
+                exposure: public
+                secure: false
+                protocol: wss
+          attributes:
+            app.kubernetes.io/component: che-theia
+            app.kubernetes.io/part-of: che-theia.eclipse.org
+        - name: plugins
+          volume: {}
+        - name: theia-local
+          volume: {}
+        - name: che-machine-exec
+          container:
+            image: quay.io/eclipse/che-machine-exec:next
+            command:
+              - /go/bin/che-machine-exec
+              - '--url'
+              - 127.0.0.1:3333
+              - '--idle-timeout'
+              - 15m
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+          attributes:
+            app.kubernetes.io/component: machine-exec
+            app.kubernetes.io/part-of: che-theia.eclipse.org
+        - name: remote-runtime-injector
+          container:
+            image: quay.io/eclipse/che-theia-endpoint-runtime-binary:next
+            env:
+              - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+                value: /remote-endpoint/plugin-remote-endpoint
+              - name: REMOTE_ENDPOINT_VOLUME_NAME
+                value: remote-endpoint
+            volumeMounts:
+              - name: plugins
+                path: /plugins
+              - name: remote-endpoint
+                path: /remote-endpoint
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+          attributes:
+            app.kubernetes.io/component: remote-runtime-injector
+            app.kubernetes.io/part-of: che-theia.eclipse.org
+        - name: remote-endpoint
+          volume:
+            ephemeral: true
+
+
+output:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          controller.devfile.io/merged-contributions: "theia-ide"
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins/sidecars/tools
+          args:
+            - sh
+            - '-c'
+            - '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}'
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+          volumeMounts:
+            - name: plugins
+              path: /plugins
+            - name: remote-endpoint
+              path: /remote-endpoint
+          memoryLimit: 2560Mi # 2Gi = 2048Mi + 512Mi
+          mountSources: true
+      - name: theia-ide
+        attributes:
+          app.kubernetes.io/component: che-theia
+          app.kubernetes.io/part-of: che-theia.eclipse.org
+          controller.devfile.io/imported-by: theia-ide
+        container:
+          image: quay.io/eclipse/che-theia:next
+          env:
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins
+            - name: HOSTED_PLUGIN_HOSTNAME
+              value: 0.0.0.0
+            - name: HOSTED_PLUGIN_PORT
+              value: '3130'
+            - name: THEIA_HOST
+              value: 127.0.0.1
+          volumeMounts:
+            - name: plugins
+              path: /plugins
+            - name: theia-local
+              path: /home/theia/.theia
+          mountSources: true
+          memoryLimit: 512M
+          cpuLimit: 1500m
+          cpuRequest: 100m
+          endpoints:
+            - name: theia
+              attributes:
+                type: main
+                cookiesAuthEnabled: true
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              secure: false
+              protocol: https
+            - name: webviews
+              attributes:
+                type: webview
+                cookiesAuthEnabled: true
+                discoverable: false
+                unique: true
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              secure: false
+              protocol: https
+            - name: mini-browser
+              attributes:
+                type: mini-browser
+                cookiesAuthEnabled: true
+                discoverable: false
+                unique: true
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              secure: false
+              protocol: https
+            - name: theia-dev
+              attributes:
+                type: ide-dev
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3130
+              exposure: public
+              protocol: http
+            - name: theia-redirect-1
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13131
+              exposure: public
+              protocol: http
+            - name: theia-redirect-2
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13132
+              exposure: public
+              protocol: http
+            - name: theia-redirect-3
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13133
+              exposure: public
+              protocol: http
+            - name: terminal
+              attributes:
+                type: collocated-terminal
+                discoverable: false
+                cookiesAuthEnabled: true
+                urlRewriteSupported: true
+              targetPort: 3333
+              exposure: public
+              secure: false
+              protocol: wss
+      - name: plugins
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+        volume: {}
+      - name: theia-local
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+        volume: {}
+      - name: che-machine-exec
+        attributes:
+          app.kubernetes.io/component: machine-exec
+          app.kubernetes.io/part-of: che-theia.eclipse.org
+          controller.devfile.io/imported-by: theia-ide
+        container:
+          image: quay.io/eclipse/che-machine-exec:next
+          command:
+            - /go/bin/che-machine-exec
+            - '--url'
+            - 127.0.0.1:3333
+            - '--idle-timeout'
+            - 15m
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+      - name: remote-runtime-injector
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+          app.kubernetes.io/component: remote-runtime-injector
+          app.kubernetes.io/part-of: che-theia.eclipse.org
+        container:
+          image: quay.io/eclipse/che-theia-endpoint-runtime-binary:next
+          env:
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint
+            - name: REMOTE_ENDPOINT_VOLUME_NAME
+              value: remote-endpoint
+          volumeMounts:
+            - name: plugins
+              path: /plugins
+            - name: remote-endpoint
+              path: /remote-endpoint
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+      - name: remote-endpoint
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+        volume:
+          ephemeral: true
+    commands:
+      - id: init-container-command
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+        apply:
+          component: remote-runtime-injector
+    events:
+      preStart:
+        - init-container-command


### PR DESCRIPTION
**This PR is an early draft. Before merging:**
- [x] Decide on format for specifying container contributions cc: @l0rd, @benoitf
  - [x] Is the current design sufficient? Should we define contributions in another way?
  - [x] Does the mechanism need a way to specify which container to merge into, or is "merge into the first available target" sufficient? (This can be added later if necessary)
  - [x] Does this approach cover all use cases for Code-OSS and Theia?
- [x] Write tests to cover feature once design is settled
- [x] Clean up and polish

### What does this PR do?
Adds support for container contributions as described in https://github.com/devfile/devworkspace-operator/issues/656 without needing to add new component types.

This PR adds two new attributes to the operator:

* `controller.devfile.io/container-contribution: true` defines a container component as a "container contribution"
* `controller.devfile.io/merge-contribution: true` defines a container as a target for merging a "container contribution"

If a flattened DevWorkspace has a container component with the `merge-contribution` attribute, then any container contributions are merged into that container component according to

* Resource requirements (memory/cpu limits/requests) are summed
* The image from the contribution component is ignored
* Remaining fields are merged according to a Kubernetes strategic merge patch (e.g. env vars and endpoints are appended)

This approach has the additional benefit of failing safely if it's not obvious how to merge containers, defaulting to using the unmerged image to host the container components that cannot be merged.

If multiple components have the `merge-contribution` attribute, contributions are merged into the first one encountered.

### Background
Eclipse Che uses DWO to create workspaces from a basic devfile, injecting an editor into the Devfile before converting it to a DevWorkspace. However, since Che intends to run editors inside a devfile container component and not as sidecars, it's necessary to _modify_ existing container components to add endpoints, environment variables, and override the args. For example, to update a container component to run Eclipse Theia plugins, Che has to update the component to add the following fields:
```diff
 components:
   - name: tools
+    attributes:
+      app.kubernetes.io/name: tools
+      che-theia.eclipse.org/vscode-extensions:
+        - https://github.com/golang/vscode-go/releases/download/v0.23.0/go-0.23.0.vsix
     container:
+      args:
+        - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
+        - -c
+        - sh
       env:
         - name: GOCACHE
           value: /tmp/.cache
         - name: GOPATH
           value: /projects:/home/user/go
+        - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+          value: /remote-endpoint/plugin-remote-endpoint
+        - name: THEIA_PLUGINS
+          value: local-dir:///plugins/sidecars/tools
       image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       memoryLimit: 2Gi
       mountSources: true
+      sourceMapping: /projects
+      volumeMounts:
+        - name: plugins
+          path: /plugins
+        - name: remote-endpoint
+          path: /remote-endpoint
   # Theia is added as a plugin here
+  - name: theia-ide-golang-example
+    plugin:
+      kubernetes:
+        name: theia-ide-golang-example
```
The added fields are defined by the plugin (`theia-ide-golang-example` in this case), so it would be useful if plugins had a mechanism for automatically defining these additions. This would also mean that devfiles could be converted into DevWorkspaces by only adding plugin components, leaving original devfile components untouched (as the merging happens within the flatten process, leaving the DevWorkspace as-is).

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/656

### Is it tested? How?
There are two DevWorkspaces for testing this feature:

1. Che-Theia + Golang [[link]](https://gist.github.com/amisevsk/46da73704a126d2324e5c633ff077b8c#file-theia-golang-devworkspace-yaml)
    ```
    kubectl apply -f https://gist.githubusercontent.com/amisevsk/46da73704a126d2324e5c633ff077b8c/raw/41dee8cbe9531363ffd8975982bdc1113d7b58c4/theia-golang.devworkspace.yaml
    ```
    Creates a DevWorkspace that references plugin devfile [theia-next.yaml](https://gist.github.com/amisevsk/b342b9ae064b5a79e08945d04d02c208). The contributions in this plugin add fields as described above to allow Theia plugins to run inside the `tools` container component without having to update the `tools` component in the DevWorkspace itself (duplicating the process that Che does when creating a workspace from a devfile). The diff between the referenced plugin and the default plugin at https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml is
    ```diff
    @@ -9,6 +9,26 @@
       preStart:
         - init-container-command
     components:
    +  - name: theia-ide-contributions
    +    attributes:
    +      controller.devfile.io/container-contribution: true
    +    container:
    +      args:
    +        - sh
    +        - '-c'
    +        - '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}'
    +      env:
    +        - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
    +          value: /remote-endpoint/plugin-remote-endpoint
    +        - name: THEIA_PLUGINS
    +          value: local-dir:///plugins/sidecars/tools
    +      memoryLimit: 512Mi
    +      volumeMounts:
    +        - name: plugins
    +          path: /plugins
    +        - name: remote-endpoint
    +          path: /remote-endpoint
    +      image: quay.io/devfile/universal-developer-image@sha256:53cec58dd190dd1e06100478ae879d7c28abd8fc883d5fdf5be3eb6e943fe5e7
       - name: theia-ide
         container:
           image: quay.io/eclipse/che-theia:next
    ```

2. Che-Code + Golang [[link]](https://gist.github.com/amisevsk/46da73704a126d2324e5c633ff077b8c#file-code-golang-devfile-yaml)
    ```
    kubectl apply -f https://gist.githubusercontent.com/amisevsk/46da73704a126d2324e5c633ff077b8c/raw/9af5c2d5ffa2012e760acdcd6fa4427fb611af1c/code-golang.devfile.yaml
    ```
    Creates a DevWorkspace that references the plugin devfile [che-code.yaml](https://gist.github.com/amisevsk/53f4f8281c1339599a553f3be2d5c650). This plugin is a modified version of the current plugin hosted [here](https://che-plugin-registry-main.surge.sh/v3/plugins/che-incubator/che-code/insiders/devfile.yaml), which converts the `che-code-runtime-description` into a container contribution. This workspace results in a deployment with two init containers (`che-code-injector` and `project-clone`) and only one running container (`tools`). The changes to the plugin used here compared to the one in the registry are:
    ```diff
    @@ -13,8 +13,9 @@
         attributes:
           app.kubernetes.io/component: che-code-runtime
           app.kubernetes.io/part-of: che-code.eclipse.org
    +      controller.devfile.io/container-contribution: true
         container:
    -      image: quay.io/devfile/universal-developer-image@sha256:53cec58dd190dd1e06100478ae879d7c28abd8fc883d5fdf5be3eb6e943fe5e7
    +      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
           command:
             - /checode/entrypoint-volume.sh
           volumeMounts:
    ```
    (I updated the image to match the one from the devfile to avoid having to pull two separate UDI images)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
