### PR TITLE
Report error when common PVC cleanup job hangs

### DIFF
--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	check "github.com/devfile/devworkspace-operator/pkg/library/status"
+	"github.com/devfile/devworkspace-operator/pkg/library/status"
 	nsconfig "github.com/devfile/devworkspace-operator/pkg/provision/config"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 
@@ -97,7 +97,7 @@ func SyncDeploymentToCluster(
 	}
 	clusterDeployment := clusterObj.(*appsv1.Deployment)
 
-	deploymentReady := check.CheckDeploymentStatus(clusterDeployment)
+	deploymentReady := status.CheckDeploymentStatus(clusterDeployment)
 	if deploymentReady {
 		return DeploymentProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{
@@ -106,7 +106,7 @@ func SyncDeploymentToCluster(
 		}
 	}
 
-	deploymentHealthy, deploymentErrMsg := check.CheckDeploymentConditions(clusterDeployment)
+	deploymentHealthy, deploymentErrMsg := status.CheckDeploymentConditions(clusterDeployment)
 	if !deploymentHealthy {
 		return DeploymentProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{
@@ -116,7 +116,7 @@ func SyncDeploymentToCluster(
 		}
 	}
 
-	failureMsg, checkErr := check.CheckPodsState(workspace, workspace.Namespace, k8sclient.MatchingLabels{
+	failureMsg, checkErr := status.CheckPodsState(workspace.Status.DevWorkspaceId, workspace.Namespace, k8sclient.MatchingLabels{
 		constants.DevWorkspaceIDLabel: workspace.Status.DevWorkspaceId,
 	}, clusterAPI)
 	if checkErr != nil {


### PR DESCRIPTION
### What does this PR do?
This PR reuses the logic for checking failed workspace deployments to check the status and events of the common PVC cleanup job pods. This allows detecting for pod failure events and status, which can determine whether the cleanup pod was unable to be scheduled. 
### What issues does this PR fix or reference?
Fix #551

### Is it tested? How?
In the PR's current state, the common PVC cleanup job spec has been modified so that the created cleanup pods fail:
```diff
	Args: []string{
		"-c",
- 		fmt.Sprintf(cleanupCommandFmt, path.Join(pvcClaimMountPath, workspaceId)),
+		 "exit 1",
	},
```

Though this isn't creating a case where the cleanup jobs pods aren't able to schedule, it will test the `cleanup.go `code that this PR adds.

To test this PR:
1. Start up DWO
2. Create 2 workspaces that use the common PVC storage-class strategy
3. Delete one of the workspaces so that the common PVC cleanup job will be run
4. Ensure an error related to the cleanup job's status is logged by DWO, something similar to the following (though the state will vary depending on the pod's state):
```
"level":"error","ts":1653943385.0445013,"logger":"controllers.DevWorkspace","msg":"Failed to clean up DevWorkspace storage","Request.Namespace":"devworkspace-controller","Request.Name":"theia-next-3","devworkspace_id":"workspace0192d636bd3f4b98","error":"DevWorkspace PVC cleanup job failed: see logs for job \"cleanup-workspace0192d636bd3f4b98\" for details. Additional information: Common PVC Cleanup related container cleanup-workspace0192d636bd3f4b98 has state ContainerCreating."
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
