### PR TITLE
Ignore order of envFrom when comparing deployments

### DIFF
--- a/pkg/provision/sync/diffopts.go
+++ b/pkg/provision/sync/diffopts.go
@@ -50,6 +50,9 @@ var deploymentDiffOpts = cmp.Options{
 	cmpopts.SortSlices(func(a, b corev1.VolumeMount) bool {
 		return strings.Compare(a.Name, b.Name) > 0
 	}),
+	cmpopts.SortSlices(func(a, b corev1.EnvFromSource) bool {
+		return strings.Compare(getNameFromEnvFrom(a), getNameFromEnvFrom(b)) > 0
+	}),
 }
 
 var configmapDiffOpts = cmp.Options{
@@ -73,4 +76,15 @@ var routeDiffOpts = cmp.Options{
 var ingressDiffOpts = cmp.Options{
 	cmpopts.IgnoreFields(networkingv1.Ingress{}, "TypeMeta", "ObjectMeta", "Status"),
 	cmpopts.IgnoreFields(networkingv1.HTTPIngressPath{}, "PathType"),
+}
+
+func getNameFromEnvFrom(source corev1.EnvFromSource) string {
+	switch {
+	case source.ConfigMapRef != nil:
+		return source.ConfigMapRef.Name
+	case source.SecretRef != nil:
+		return source.SecretRef.Name
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
### What does this PR do?
When listing configmaps and secrets on the cluster, the API can return objects in a random order (for two configmaps, I see the reverse order almost exactly 1/8th of the time, at random)

This can result in the operator defining a Deployment spec for workspaces with the envFrom fields switched, if those configmaps are automounted as environment variables. To get around this, we ignore the order of envFrom entries when deciding if the deployment needs to be updated.

### What issues does this PR fix or reference?
Closes #849 

### Is it tested? How?
Create two `mount-as: env` configmaps in a namespace and attempt to start a workspace. Since the issue does not reproduce consistently, the only way to be 100% sure is to add debug logging in `pkg/provision/automount/configmap.go` to list the order of configmaps seen -- add the following to line 39 in that file
```go
	fmt.Printf("configmaps_found:")
	for _, configmap := range configmaps.Items {
		fmt.Printf("%s, ", configmap.Name)
	}
	fmt.Printf("\n")
```
and then grep the DWO logs for "configmaps_found". You should see different orders appear:

```
configmaps_found:che-proxy-settings, my-settings, 
configmaps_found:che-proxy-settings, my-settings, 
configmaps_found:che-proxy-settings, my-settings, 
configmaps_found:che-proxy-settings, my-settings, 
configmaps_found:che-proxy-settings, my-settings, 
configmaps_found:che-proxy-settings, my-settings, 
configmaps_found:my-settings, che-proxy-settings, 
configmaps_found:che-proxy-settings, my-settings,
```
You might have to repeatedly edit a workspace to get enough reconciles to see the bug:
```bash
for i in {1..100}; do
oc patch dw theia-next --type merge -p "
metadata:
  annotations:
    touch: \"$i\"
"
sleep 0.5
done
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
