### PR TITLE
Allow changing workspace storage type in some cases

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -269,7 +269,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Set finalizer on DevWorkspace if necessary
 	// Note: we need to check the flattened workspace to see if a finalizer is needed, as plugins could require storage
 	if storageProvisioner.NeedsStorage(&workspace.Spec.Template) {
-		coputil.AddFinalizer(clusterWorkspace, storageCleanupFinalizer)
+		coputil.AddFinalizer(clusterWorkspace, constants.StorageCleanupFinalizer)
 		if err := r.Update(ctx, clusterWorkspace); err != nil {
 			return reconcile.Result{}, err
 		}
@@ -399,7 +399,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return reconcile.Result{Requeue: serviceAcctStatus.Requeue}, serviceAcctStatus.Err
 	}
 	if wsprovision.NeedsServiceAccountFinalizer(&workspace.Spec.Template) {
-		coputil.AddFinalizer(clusterWorkspace, serviceAccountCleanupFinalizer)
+		coputil.AddFinalizer(clusterWorkspace, constants.ServiceAccountCleanupFinalizer)
 		if err := r.Update(ctx, clusterWorkspace); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -18,6 +18,8 @@ package controllers
 import (
 	"context"
 
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 
@@ -32,17 +34,12 @@ import (
 	wsprovision "github.com/devfile/devworkspace-operator/pkg/provision/workspace"
 )
 
-const (
-	storageCleanupFinalizer        = "storage.controller.devfile.io"
-	serviceAccountCleanupFinalizer = "serviceaccount.controller.devfile.io"
-)
-
 func (r *DevWorkspaceReconciler) workspaceNeedsFinalize(workspace *dw.DevWorkspace) bool {
 	for _, finalizer := range workspace.Finalizers {
-		if finalizer == storageCleanupFinalizer {
+		if finalizer == constants.StorageCleanupFinalizer {
 			return true
 		}
-		if finalizer == serviceAccountCleanupFinalizer {
+		if finalizer == constants.ServiceAccountCleanupFinalizer {
 			return true
 		}
 	}
@@ -60,9 +57,9 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 
 		for _, finalizer := range workspace.Finalizers {
 			switch finalizer {
-			case storageCleanupFinalizer:
+			case constants.StorageCleanupFinalizer:
 				return r.finalizeStorage(ctx, log, workspace)
-			case serviceAccountCleanupFinalizer:
+			case constants.ServiceAccountCleanupFinalizer:
 				return r.finalizeServiceAccount(ctx, log, workspace)
 			}
 		}
@@ -86,7 +83,7 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 	} else if terminating {
 		// Namespace is terminating, it's redundant to clean PVC files since it's going to be removed
 		log.Info("Namespace is terminating; clearing storage finalizer")
-		coputil.RemoveFinalizer(workspace, storageCleanupFinalizer)
+		coputil.RemoveFinalizer(workspace, constants.StorageCleanupFinalizer)
 		return reconcile.Result{}, r.Update(ctx, workspace)
 	}
 
@@ -118,7 +115,7 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 		}
 	}
 	log.Info("PVC clean up successful; clearing finalizer")
-	coputil.RemoveFinalizer(workspace, storageCleanupFinalizer)
+	coputil.RemoveFinalizer(workspace, constants.StorageCleanupFinalizer)
 	return reconcile.Result{}, r.Update(ctx, workspace)
 }
 
@@ -134,7 +131,7 @@ func (r *DevWorkspaceReconciler) finalizeServiceAccount(ctx context.Context, log
 		return reconcile.Result{Requeue: true}, nil
 	}
 	log.Info("ServiceAccount clean up successful; clearing finalizer")
-	coputil.RemoveFinalizer(workspace, serviceAccountCleanupFinalizer)
+	coputil.RemoveFinalizer(workspace, constants.ServiceAccountCleanupFinalizer)
 	return reconcile.Result{}, r.Update(ctx, workspace)
 }
 

--- a/pkg/constants/finalizers.go
+++ b/pkg/constants/finalizers.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const (
+	// StorageCleanupFinalizer is used to block DevWorkspace deletion when it is necessary
+	// to clean up persistent storage used for the workspace.
+	StorageCleanupFinalizer = "storage.controller.devfile.io"
+	// ServiceAccountCleanupFinalizer is used to block DevWorkspace deletion when it is
+	// necessary to clean up additional non-workspace roles added to the workspace
+	// serviceaccount
+	ServiceAccountCleanupFinalizer = "serviceaccount.controller.devfile.io"
+)


### PR DESCRIPTION
### What does this PR do?
This PR is a follow-up to https://github.com/devfile/devworkspace-operator/pull/833 that allows some storage-type modification after creation. It allows workspace storage type to be changed if:

* The original storage type is ephemeral, or
* If the workspace does not yet have a storage finalizer applied

In these cases, there is no data stored in any PVC, and so the storage class can be safely switched. This change allows

* Creating workspaces a ephemeral, and then adding storage after the fact if it is necessary
* Creating workspaces with `started: false` as a placeholder, and then changing the storage class before the first start.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
To test:
1. Create an ephemeral workspace -- e.g.
    ```yaml
    apiVersion: workspace.devfile.io/v1alpha2
    kind: DevWorkspace
    metadata:
      name: test-ephemeral
    spec:
      routingClass: basic
      started: true
      template:
        attributes:
          controller.devfile.io/storage-type: ephemeral
        components:
        - name: web-terminal
          container:
            command: ["tail", "-f", "/dev/null"]
            image: quay.io/amisevsk/web-terminal-tooling:dev
            memoryLimit: 512Mi
            mountSources: true
    ```
    and update the storage type to e.g. `common`

2. Create a workspace with `started: false` and update its storage type before starting it the first time:
    ```
    yq '.spec.started=false' samples/theia-next.yaml | oc apply -f -
    ```

In both cases, changes should be permitted. Of course, for regular workspaces, the change should still be blocked.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
