### PR TITLE
fix: ignore order of volumeMounts when comparing deployments

### DIFF
--- a/pkg/provision/sync/diffopts.go
+++ b/pkg/provision/sync/diffopts.go
@@ -48,7 +48,17 @@ var deploymentDiffOpts = cmp.Options{
 		return strings.Compare(a.Name, b.Name) > 0
 	}),
 	cmpopts.SortSlices(func(a, b corev1.VolumeMount) bool {
-		return strings.Compare(a.Name, b.Name) > 0
+		switch {
+		case a.Name != b.Name:
+			return strings.Compare(a.Name, b.Name) > 0
+		case a.MountPath != b.MountPath:
+			return strings.Compare(a.MountPath, b.MountPath) > 0
+		case a.SubPath != b.SubPath:
+			return strings.Compare(a.SubPath, b.SubPath) > 0
+		default:
+			// If mountPath + subPath match, the deployment is invalid, so this cannot happen.
+			return false
+		}
 	}),
 	cmpopts.SortSlices(func(a, b corev1.EnvFromSource) bool {
 		return strings.Compare(getNameFromEnvFrom(a), getNameFromEnvFrom(b)) > 0


### PR DESCRIPTION
### What does this PR do?
Since support for subpath automount volumes was added, the comparison function used to ignore the order of volumeMounts in a deployment is no  use the same volume. This can result in spurious changes to the deployment's spec, if the operator reads volumes in a random order.

To fix this, also compare mountPath and subPath. The comparison function for other slices is unchanged, as in those cases the name is a key in the list and must be unique.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/859

### Is it tested? How?
Test using reproducer in issue.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
