### PR TITLE
Fix goimports install command in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           # Need to grab goimports otherwise formatting after this step will fail
           # PR checks.
-          go install golang.org/x/tools/cmd/goimports
+          go install golang.org/x/tools/cmd/goimports@latest
 
           git config --global user.name "Angel Misevski"
           git config --global user.email "amisevsk@redhat.com"


### PR DESCRIPTION
### What does this PR do?
Fixes the goimports install command in the release GitHub action

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
