### PR TITLE
Update release GH action to set up Go correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ jobs:
       OPM_VERSION: v1.19.5
     runs-on: ubuntu-20.04
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.6
+
       - name: Clone source code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### What does this PR do?
The setup-go step is required in the release action to add Go to the path. Otherwise, installing goimports later will succeed but the binary will not be available.

### What issues does this PR fix or reference?
Remove the need to manually format files after running the prerelease job, e.g. https://github.com/devfile/devworkspace-operator/commit/4083e2926b6395a8977123b0a48d1da2b8738361

### Is it tested? How?
Hasn't actually been tested, but we'll find out if it does what it should on the next release. Worth noting that the PR check action does not have the formatting issue, so I assume it's fine.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
