### PR TITLE
Merge proxy configs on start when running in OpenShift

### DIFF
--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -91,9 +91,7 @@ func SetupControllerConfig(client crclient.Client) error {
 		return err
 	}
 	defaultConfig.Routing.ProxyConfig = clusterProxy
-	if internalConfig.Routing.ProxyConfig == nil {
-		internalConfig.Routing.ProxyConfig = clusterProxy
-	}
+	internalConfig.Routing.ProxyConfig = proxy.MergeProxyConfigs(clusterProxy, internalConfig.Routing.ProxyConfig)
 
 	updatePublicConfig()
 	return nil


### PR DESCRIPTION
### What does this PR do?
Make sure we merge both the dwoc proxy config and the cluster proxy config on OpenShift to avoid an issue where we ignore the cluster proxy if the dwoc contains a proxy config on start.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/865

### Is it tested? How?
Use reproducer in issue.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
