### PR TITLE
configurable default Workspace Spec Template

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -16,6 +16,7 @@
 package v1alpha1
 
 import (
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,6 +128,10 @@ type WorkspaceConfig struct {
 	// configuration option is ignored. If set, the entire pod security context is overridden;
 	// values are not merged.
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	// DefaultTemplate defines an optional DevWorkspace Spec Template which gets applied to the workspace
+	// if the workspace's Template Spec Components are not defined. The DefaultTemplate will overwrite the existing
+	// Template Spec, with the exception of Projects (if any are defined).
+	DefaultTemplate *dw.DevWorkspaceTemplateSpecContent `json:"defaultTemplate,omitempty"`
 }
 
 // DevWorkspaceOperatorConfig is the Schema for the devworkspaceoperatorconfigs API

--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -20,6 +20,7 @@
 package v1alpha1
 
 import (
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -528,6 +529,11 @@ func (in *WorkspaceConfig) DeepCopyInto(out *WorkspaceConfig) {
 	if in.PodSecurityContext != nil {
 		in, out := &in.PodSecurityContext, &out.PodSecurityContext
 		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DefaultTemplate != nil {
+		in, out := &in.DefaultTemplate, &out.DefaultTemplate
+		*out = new(v1alpha2.DevWorkspaceTemplateSpecContent)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -59,6 +59,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	wsDefaults "github.com/devfile/devworkspace-operator/pkg/library/defaults"
 )
 
 const (
@@ -238,6 +239,10 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		Context:            ctx,
 		K8sClient:          r.Client,
 		HttpClient:         httpClient,
+	}
+
+	if wsDefaults.NeedsDefaultTemplate(workspace) {
+		wsDefaults.ApplyDefaultTemplate(workspace)
 	}
 
 	flattenedWorkspace, warnings, err := flatten.ResolveDevWorkspace(&workspace.Spec.Template, flattenHelpers)

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -80,6 +80,1278 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
+                  defaultTemplate:
+                    description: DefaultTemplate defines an optional DevWorkspace Spec Template which gets applied to the workspace if the workspace's Template Spec Components are not defined. The DefaultTemplate will overwrite the existing Template Spec, with the exception of Projects (if any are defined).
+                    properties:
+                      attributes:
+                        description: Map of implementation-dependant free-form YAML attributes.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      commands:
+                        description: Predefined, ready-to-use, devworkspace-related commands
+                        items:
+                          properties:
+                            apply:
+                              description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
+                              properties:
+                                component:
+                                  description: Describes component that will be applied
+                                  type: string
+                                group:
+                                  description: Defines the group this command is part of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                  type: string
+                              required:
+                              - component
+                              type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            commandType:
+                              description: Type of devworkspace command
+                              enum:
+                              - Exec
+                              - Apply
+                              - Composite
+                              - Custom
+                              type: string
+                            composite:
+                              description: Composite command that allows executing several sub-commands either sequentially or concurrently
+                              properties:
+                                commands:
+                                  description: The commands that comprise this composite command
+                                  items:
+                                    type: string
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                  type: string
+                                parallel:
+                                  description: Indicates if the sub-commands should be executed concurrently
+                                  type: boolean
+                              type: object
+                            custom:
+                              description: Custom command whose logic is implementation-dependant and should be provided by the user possibly through some dedicated plugin
+                              properties:
+                                commandClass:
+                                  description: Class of command that the associated implementation component should use to process this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration for this custom command that the implementation component will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                group:
+                                  description: Defines the group this command is part of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                  type: string
+                              required:
+                              - commandClass
+                              - embeddedResource
+                              type: object
+                            exec:
+                              description: CLI Command executed in an existing component container
+                              properties:
+                                commandLine:
+                                  description: "The actual command-line string \n Special variables that can be used: \n  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping. \n  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                                  type: string
+                                component:
+                                  description: Describes component to which given action relates
+                                  type: string
+                                env:
+                                  description: Optional list of environment variables that have to be set before running the command
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                hotReloadCapable:
+                                  description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                  type: boolean
+                                label:
+                                  description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                  type: string
+                                workingDir:
+                                  description: "Working directory where the command should be executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping. \n  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                                  type: string
+                              required:
+                              - commandLine
+                              - component
+                              type: object
+                            id:
+                              description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - id
+                          type: object
+                        type: array
+                      components:
+                        description: List of the devworkspace components, such as editor and plugins, user-provided containers, or other types of components
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            componentType:
+                              description: Type of component
+                              enum:
+                              - Container
+                              - Kubernetes
+                              - Openshift
+                              - Volume
+                              - Image
+                              - Plugin
+                              - Custom
+                              type: string
+                            container:
+                              description: Allows adding and configuring devworkspace-related containers
+                              properties:
+                                annotation:
+                                  description: Annotations that should be added to specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
+                                args:
+                                  description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  description: "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
+                                dedicatedPod:
+                                  description: "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address. \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within the container component. The same port cannot be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                env:
+                                  description: "Environment variables used in this container. \n The following variables are reserved and cannot be overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                memoryLimit:
+                                  type: string
+                                memoryRequest:
+                                  type: string
+                                mountSources:
+                                  description: "Toggles whether or not the project source code should be mounted in the component. \n Defaults to true for all component types except plugins and components that set `dedicatedPod` to true."
+                                  type: boolean
+                                sourceMapping:
+                                  default: /projects
+                                  description: Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.
+                                  type: string
+                                volumeMounts:
+                                  description: List of volumes mounts that should be mounted is this container.
+                                  items:
+                                    description: Volume that should be mounted to a component container
+                                    properties:
+                                      name:
+                                        description: The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                              required:
+                              - image
+                              type: object
+                            custom:
+                              description: Custom component whose logic is implementation-dependant and should be provided by the user possibly through some dedicated controller
+                              properties:
+                                componentClass:
+                                  description: Class of component that the associated implementation controller should use to process this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration for this custom component that the implementation controller will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - componentClass
+                              - embeddedResource
+                              type: object
+                            image:
+                              description: Allows specifying the definition of an image for outer loop builds
+                              properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built during startup. \n Default value is `false`"
+                                  type: boolean
+                                dockerfile:
+                                  description: Allows specifying dockerfile type build
+                                  properties:
+                                    args:
+                                      description: The arguments to supply to the dockerfile build.
+                                      items:
+                                        type: string
+                                      type: array
+                                    buildContext:
+                                      description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
+                                      type: string
+                                    devfileRegistry:
+                                      description: Dockerfile's Devfile Registry source
+                                      properties:
+                                        id:
+                                          description: Id in a devfile registry that contains a Dockerfile. The src in the OCI registry required for the Dockerfile build will be downloaded for building the image.
+                                          type: string
+                                        registryUrl:
+                                          description: Devfile Registry URL to pull the Dockerfile from when using the Devfile Registry as Dockerfile src. To ensure the Dockerfile gets resolved consistently in different environments, it is recommended to always specify the `devfileRegistryUrl` when `Id` is used.
+                                          type: string
+                                      required:
+                                      - id
+                                      type: object
+                                    git:
+                                      description: Dockerfile's Git source
+                                      properties:
+                                        checkoutFrom:
+                                          description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                                          properties:
+                                            remote:
+                                              description: The remote name should be used as init. Required if there are more than one remote configured
+                                              type: string
+                                            revision:
+                                              description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                                              type: string
+                                          type: object
+                                        fileLocation:
+                                          description: Location of the Dockerfile in the Git repository when using git as Dockerfile src. Defaults to Dockerfile.
+                                          type: string
+                                        remotes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                          type: object
+                                      required:
+                                      - remotes
+                                      type: object
+                                    rootRequired:
+                                      description: "Specify if a privileged builder pod is required. \n Default value is `false`"
+                                      type: boolean
+                                    srcType:
+                                      description: Type of Dockerfile src
+                                      enum:
+                                      - Uri
+                                      - DevfileRegistry
+                                      - Git
+                                      type: string
+                                    uri:
+                                      description: URI Reference of a Dockerfile. It can be a full URL or a relative URI from the current devfile as the base URI.
+                                      type: string
+                                  type: object
+                                imageName:
+                                  description: Name of the image for the resulting outerloop build
+                                  type: string
+                                imageType:
+                                  description: Type of image
+                                  enum:
+                                  - Dockerfile
+                                  type: string
+                              required:
+                              - imageName
+                              type: object
+                            kubernetes:
+                              description: Allows importing into the devworkspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address. \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within the container component. The same port cannot be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            name:
+                              description: Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            openshift:
+                              description: Allows importing into the devworkspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address. \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within the container component. The same port cannot be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            plugin:
+                              description: "Allows importing a plugin. \n Plugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources"
+                              properties:
+                                commands:
+                                  description: Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.
+                                  items:
+                                    properties:
+                                      apply:
+                                        description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
+                                        properties:
+                                          component:
+                                            description: Describes component that will be applied
+                                            type: string
+                                          group:
+                                            description: Defines the group this command is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                            type: string
+                                        type: object
+                                      attributes:
+                                        description: Map of implementation-dependant free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      commandType:
+                                        description: Type of devworkspace command
+                                        enum:
+                                        - Exec
+                                        - Apply
+                                        - Composite
+                                        type: string
+                                      composite:
+                                        description: Composite command that allows executing several sub-commands either sequentially or concurrently
+                                        properties:
+                                          commands:
+                                            description: The commands that comprise this composite command
+                                            items:
+                                              type: string
+                                            type: array
+                                          group:
+                                            description: Defines the group this command is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                            type: string
+                                          parallel:
+                                            description: Indicates if the sub-commands should be executed concurrently
+                                            type: boolean
+                                        type: object
+                                      exec:
+                                        description: CLI Command executed in an existing component container
+                                        properties:
+                                          commandLine:
+                                            description: "The actual command-line string \n Special variables that can be used: \n  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping. \n  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                                            type: string
+                                          component:
+                                            description: Describes component to which given action relates
+                                            type: string
+                                          env:
+                                            description: Optional list of environment variables that have to be set before running the command
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          group:
+                                            description: Defines the group this command is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          hotReloadCapable:
+                                            description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                            type: boolean
+                                          label:
+                                            description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                            type: string
+                                          workingDir:
+                                            description: "Working directory where the command should be executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping. \n  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                                            type: string
+                                        type: object
+                                      id:
+                                        description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                    required:
+                                    - id
+                                    type: object
+                                  type: array
+                                components:
+                                  description: Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.
+                                  items:
+                                    properties:
+                                      attributes:
+                                        description: Map of implementation-dependant free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      componentType:
+                                        description: Type of component
+                                        enum:
+                                        - Container
+                                        - Kubernetes
+                                        - Openshift
+                                        - Volume
+                                        - Image
+                                        type: string
+                                      container:
+                                        description: Allows adding and configuring devworkspace-related containers
+                                        properties:
+                                          annotation:
+                                            description: Annotations that should be added to specific resources for this container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added to service
+                                                type: object
+                                            type: object
+                                          args:
+                                            description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
+                                          dedicatedPod:
+                                            description: "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address. \n Default value is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used within the container component. The same port cannot be used by two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          env:
+                                            description: "Environment variables used in this container. \n The following variables are reserved and cannot be overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          memoryLimit:
+                                            type: string
+                                          memoryRequest:
+                                            type: string
+                                          mountSources:
+                                            description: "Toggles whether or not the project source code should be mounted in the component. \n Defaults to true for all component types except plugins and components that set `dedicatedPod` to true."
+                                            type: boolean
+                                          sourceMapping:
+                                            description: Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.
+                                            type: string
+                                          volumeMounts:
+                                            description: List of volumes mounts that should be mounted is this container.
+                                            items:
+                                              description: Volume that should be mounted to a component container
+                                              properties:
+                                                name:
+                                                  description: The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                        type: object
+                                      image:
+                                        description: Allows specifying the definition of an image for outer loop builds
+                                        properties:
+                                          autoBuild:
+                                            description: "Defines if the image should be built during startup. \n Default value is `false`"
+                                            type: boolean
+                                          dockerfile:
+                                            description: Allows specifying dockerfile type build
+                                            properties:
+                                              args:
+                                                description: The arguments to supply to the dockerfile build.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              buildContext:
+                                                description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
+                                                type: string
+                                              devfileRegistry:
+                                                description: Dockerfile's Devfile Registry source
+                                                properties:
+                                                  id:
+                                                    description: Id in a devfile registry that contains a Dockerfile. The src in the OCI registry required for the Dockerfile build will be downloaded for building the image.
+                                                    type: string
+                                                  registryUrl:
+                                                    description: Devfile Registry URL to pull the Dockerfile from when using the Devfile Registry as Dockerfile src. To ensure the Dockerfile gets resolved consistently in different environments, it is recommended to always specify the `devfileRegistryUrl` when `Id` is used.
+                                                    type: string
+                                                type: object
+                                              git:
+                                                description: Dockerfile's Git source
+                                                properties:
+                                                  checkoutFrom:
+                                                    description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                                                    properties:
+                                                      remote:
+                                                        description: The remote name should be used as init. Required if there are more than one remote configured
+                                                        type: string
+                                                      revision:
+                                                        description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                                                        type: string
+                                                    type: object
+                                                  fileLocation:
+                                                    description: Location of the Dockerfile in the Git repository when using git as Dockerfile src. Defaults to Dockerfile.
+                                                    type: string
+                                                  remotes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                                    type: object
+                                                type: object
+                                              rootRequired:
+                                                description: "Specify if a privileged builder pod is required. \n Default value is `false`"
+                                                type: boolean
+                                              srcType:
+                                                description: Type of Dockerfile src
+                                                enum:
+                                                - Uri
+                                                - DevfileRegistry
+                                                - Git
+                                                type: string
+                                              uri:
+                                                description: URI Reference of a Dockerfile. It can be a full URL or a relative URI from the current devfile as the base URI.
+                                                type: string
+                                            type: object
+                                          imageName:
+                                            description: Name of the image for the resulting outerloop build
+                                            type: string
+                                          imageType:
+                                            description: Type of image
+                                            enum:
+                                            - Dockerfile
+                                            - AutoBuild
+                                            type: string
+                                        type: object
+                                      kubernetes:
+                                        description: Allows importing into the devworkspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address. \n Default value is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used within the container component. The same port cannot be used by two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched from a uri.
+                                            type: string
+                                        type: object
+                                      name:
+                                        description: Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      openshift:
+                                        description: Allows importing into the devworkspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address. \n Default value is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used within the container component. The same port cannot be used by two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched from a uri.
+                                            type: string
+                                        type: object
+                                      volume:
+                                        description: Allows specifying the definition of a volume shared by several other components
+                                        properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not stored persistently across restarts. Defaults to false
+                                            type: boolean
+                                          size:
+                                            description: Size of the volume
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                id:
+                                  description: Id in a registry that contains a Devfile yaml file
+                                  type: string
+                                importReferenceType:
+                                  description: type of location from where the referenced template structure should be retrieved
+                                  enum:
+                                  - Uri
+                                  - Id
+                                  - Kubernetes
+                                  type: string
+                                kubernetes:
+                                  description: Reference to a Kubernetes CRD of type DevWorkspaceTemplate
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                registryUrl:
+                                  description: Registry URL to pull the parent devfile from when using id in the parent reference. To ensure the parent devfile gets resolved consistently in different environments, it is recommended to always specify the `registryUrl` when `id` is used.
+                                  type: string
+                                uri:
+                                  description: URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                                  type: string
+                              type: object
+                            volume:
+                              description: Allows specifying the definition of a volume shared by several other components
+                              properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently across restarts. Defaults to false
+                                  type: boolean
+                                size:
+                                  description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      events:
+                        description: Bindings of commands to events. Each command is referred-to by its name.
+                        properties:
+                          postStart:
+                            description: IDs of commands that should be executed after the devworkspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser.
+                            items:
+                              type: string
+                            type: array
+                          postStop:
+                            description: IDs of commands that should be executed after stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                          preStart:
+                            description: IDs of commands that should be executed before the devworkspace start. Kubernetes-wise, these commands would typically be executed in init containers of the devworkspace POD.
+                            items:
+                              type: string
+                            type: array
+                          preStop:
+                            description: IDs of commands that should be executed before stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      projects:
+                        description: Projects worked on in the devworkspace, containing names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used as init. Required if there are more than one remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      starterProjects:
+                        description: StarterProjects is a project that can be used as a starting point when bootstrapping new projects
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            description:
+                              description: Description of a starter project
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used as init. Required if there are more than one remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            subDir:
+                              description: Sub-directory from a starter project to be used as root for starter project.
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      variables:
+                        additionalProperties:
+                          type: string
+                        description: "Map of key-value variables used for string replacement in the devfile. Values can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for \n  - schemaVersion, metadata, parent source \n  - element identifiers, e.g. command id, component name, endpoint name, project name \n  - references to identifiers, e.g. in events, a command's component, container's volume mount name \n  - string enums, e.g. command group kind, endpoint exposure"
+                        type: object
+                    type: object
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should sit idle before being automatically scaled down. Proper functionality of this configuration property requires support in the workspace being started. If not specified, the default value of "15m" is used.
                     type: string

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -123,6 +123,1988 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
+                  defaultTemplate:
+                    description: DefaultTemplate defines an optional DevWorkspace
+                      Spec Template which gets applied to the workspace if the workspace's
+                      Template Spec Components are not defined. The DefaultTemplate
+                      will overwrite the existing Template Spec, with the exception
+                      of Projects (if any are defined).
+                    properties:
+                      attributes:
+                        description: Map of implementation-dependant free-form YAML
+                          attributes.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      commands:
+                        description: Predefined, ready-to-use, devworkspace-related
+                          commands
+                        items:
+                          properties:
+                            apply:
+                              description: "Command that consists in applying a given
+                                component definition, typically bound to a devworkspace
+                                event. \n For example, when an `apply` command is
+                                bound to a `preStart` event, and references a `container`
+                                component, it will start the container as a K8S initContainer
+                                in the devworkspace POD, unless the component has
+                                its `dedicatedPod` field set to `true`. \n When no
+                                `apply` command exist for a given component, it is
+                                assumed the component will be applied at devworkspace
+                                start by default, unless `deployByDefault` for that
+                                component is set to false."
+                              properties:
+                                component:
+                                  description: Describes component that will be applied
+                                  type: string
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - component
+                              type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            commandType:
+                              description: Type of devworkspace command
+                              enum:
+                              - Exec
+                              - Apply
+                              - Composite
+                              - Custom
+                              type: string
+                            composite:
+                              description: Composite command that allows executing
+                                several sub-commands either sequentially or concurrently
+                              properties:
+                                commands:
+                                  description: The commands that comprise this composite
+                                    command
+                                  items:
+                                    type: string
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                parallel:
+                                  description: Indicates if the sub-commands should
+                                    be executed concurrently
+                                  type: boolean
+                              type: object
+                            custom:
+                              description: Custom command whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated plugin
+                              properties:
+                                commandClass:
+                                  description: Class of command that the associated
+                                    implementation component should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom command that the implementation
+                                    component will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - commandClass
+                              - embeddedResource
+                              type: object
+                            exec:
+                              description: CLI Command executed in an existing component
+                                container
+                              properties:
+                                commandLine:
+                                  description: "The actual command-line string \n
+                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                    A path where projects sources are mounted as defined
+                                    by container component's sourceMapping. \n  -
+                                    `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>). If there are
+                                    multiple projects, this will point to the directory
+                                    of the first one."
+                                  type: string
+                                component:
+                                  description: Describes component to which given
+                                    action relates
+                                  type: string
+                                env:
+                                  description: Optional list of environment variables
+                                    that have to be set before running the command
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                hotReloadCapable:
+                                  description: "Whether the command is capable to
+                                    reload itself when source code changes. If set
+                                    to `true` the command won't be restarted and it
+                                    is expected to handle file changes on its own.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                workingDir:
+                                  description: "Working directory where the command
+                                    should be executed \n Special variables that can
+                                    be used: \n  - `$PROJECTS_ROOT`: A path where
+                                    projects sources are mounted as defined by container
+                                    component's sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one."
+                                  type: string
+                              required:
+                              - commandLine
+                              - component
+                              type: object
+                            id:
+                              description: Mandatory identifier that allows referencing
+                                this command in composite commands, from a parent,
+                                or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - id
+                          type: object
+                        type: array
+                      components:
+                        description: List of the devworkspace components, such as
+                          editor and plugins, user-provided containers, or other types
+                          of components
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            componentType:
+                              description: Type of component
+                              enum:
+                              - Container
+                              - Kubernetes
+                              - Openshift
+                              - Volume
+                              - Image
+                              - Plugin
+                              - Custom
+                              type: string
+                            container:
+                              description: Allows adding and configuring devworkspace-related
+                                containers
+                              properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
+                                args:
+                                  description: "The arguments to supply to the command
+                                    running the dockerimage component. The arguments
+                                    are supplied either to the default command provided
+                                    in the image or to the overridden command. \n
+                                    Defaults to an empty array, meaning use whatever
+                                    is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  description: "The command to run in the dockerimage
+                                    component instead of the default one provided
+                                    in the image. \n Defaults to an empty array, meaning
+                                    use whatever is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
+                                dedicatedPod:
+                                  description: "Specify if a container should run
+                                    in its own separated pod, instead of running as
+                                    part of the main development environment pod.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                env:
+                                  description: "Environment variables used in this
+                                    container. \n The following variables are reserved
+                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
+                                    \n  - `$PROJECT_SOURCE`"
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                memoryLimit:
+                                  type: string
+                                memoryRequest:
+                                  type: string
+                                mountSources:
+                                  description: "Toggles whether or not the project
+                                    source code should be mounted in the component.
+                                    \n Defaults to true for all component types except
+                                    plugins and components that set `dedicatedPod`
+                                    to true."
+                                  type: boolean
+                                sourceMapping:
+                                  default: /projects
+                                  description: Optional specification of the path
+                                    in the container where project sources should
+                                    be transferred/mounted when `mountSources` is
+                                    `true`. When omitted, the default value of /projects
+                                    is used.
+                                  type: string
+                                volumeMounts:
+                                  description: List of volumes mounts that should
+                                    be mounted is this container.
+                                  items:
+                                    description: Volume that should be mounted to
+                                      a component container
+                                    properties:
+                                      name:
+                                        description: The volume mount name is the
+                                          name of an existing `Volume` component.
+                                          If several containers mount the same volume
+                                          name then they will reuse the same volume
+                                          and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: The path in the component container
+                                          where the volume should be mounted. If not
+                                          path is mentioned, default path is the is
+                                          `/<name>`.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                              required:
+                              - image
+                              type: object
+                            custom:
+                              description: Custom component whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated controller
+                              properties:
+                                componentClass:
+                                  description: Class of component that the associated
+                                    implementation controller should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom component that the implementation
+                                    controller will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - componentClass
+                              - embeddedResource
+                              type: object
+                            image:
+                              description: Allows specifying the definition of an
+                                image for outer loop builds
+                              properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built
+                                    during startup. \n Default value is `false`"
+                                  type: boolean
+                                dockerfile:
+                                  description: Allows specifying dockerfile type build
+                                  properties:
+                                    args:
+                                      description: The arguments to supply to the
+                                        dockerfile build.
+                                      items:
+                                        type: string
+                                      type: array
+                                    buildContext:
+                                      description: Path of source directory to establish
+                                        build context. Defaults to ${PROJECT_SOURCE}
+                                        in the container
+                                      type: string
+                                    devfileRegistry:
+                                      description: Dockerfile's Devfile Registry source
+                                      properties:
+                                        id:
+                                          description: Id in a devfile registry that
+                                            contains a Dockerfile. The src in the
+                                            OCI registry required for the Dockerfile
+                                            build will be downloaded for building
+                                            the image.
+                                          type: string
+                                        registryUrl:
+                                          description: Devfile Registry URL to pull
+                                            the Dockerfile from when using the Devfile
+                                            Registry as Dockerfile src. To ensure
+                                            the Dockerfile gets resolved consistently
+                                            in different environments, it is recommended
+                                            to always specify the `devfileRegistryUrl`
+                                            when `Id` is used.
+                                          type: string
+                                      required:
+                                      - id
+                                      type: object
+                                    git:
+                                      description: Dockerfile's Git source
+                                      properties:
+                                        checkoutFrom:
+                                          description: Defines from what the project
+                                            should be checked out. Required if there
+                                            are more than one remote configured
+                                          properties:
+                                            remote:
+                                              description: The remote name should
+                                                be used as init. Required if there
+                                                are more than one remote configured
+                                              type: string
+                                            revision:
+                                              description: The revision to checkout
+                                                from. Should be branch name, tag or
+                                                commit id. Default branch is used
+                                                if missing or specified revision is
+                                                not found.
+                                              type: string
+                                          type: object
+                                        fileLocation:
+                                          description: Location of the Dockerfile
+                                            in the Git repository when using git as
+                                            Dockerfile src. Defaults to Dockerfile.
+                                          type: string
+                                        remotes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The remotes map which should
+                                            be initialized in the git project. Projects
+                                            must have at least one remote configured
+                                            while StarterProjects & Image Component's
+                                            Git source can only have at most one remote
+                                            configured.
+                                          type: object
+                                      required:
+                                      - remotes
+                                      type: object
+                                    rootRequired:
+                                      description: "Specify if a privileged builder
+                                        pod is required. \n Default value is `false`"
+                                      type: boolean
+                                    srcType:
+                                      description: Type of Dockerfile src
+                                      enum:
+                                      - Uri
+                                      - DevfileRegistry
+                                      - Git
+                                      type: string
+                                    uri:
+                                      description: URI Reference of a Dockerfile.
+                                        It can be a full URL or a relative URI from
+                                        the current devfile as the base URI.
+                                      type: string
+                                  type: object
+                                imageName:
+                                  description: Name of the image for the resulting
+                                    outerloop build
+                                  type: string
+                                imageType:
+                                  description: Type of image
+                                  enum:
+                                  - Dockerfile
+                                  type: string
+                              required:
+                              - imageName
+                              type: object
+                            kubernetes:
+                              description: Allows importing into the devworkspace
+                                the Kubernetes resources defined in a given manifest.
+                                For example this allows reusing the Kubernetes definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            name:
+                              description: Mandatory name that allows referencing
+                                the component from other elements (such as commands)
+                                or from an external devfile that may reference this
+                                component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            openshift:
+                              description: Allows importing into the devworkspace
+                                the OpenShift resources defined in a given manifest.
+                                For example this allows reusing the OpenShift definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            plugin:
+                              description: "Allows importing a plugin. \n Plugins
+                                are mainly imported devfiles that contribute components,
+                                commands and events as a consistent single unit. They
+                                are defined in either YAML files following the devfile
+                                syntax, or as `DevWorkspaceTemplate` Kubernetes Custom
+                                Resources"
+                              properties:
+                                commands:
+                                  description: Overrides of commands encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      apply:
+                                        description: "Command that consists in applying
+                                          a given component definition, typically
+                                          bound to a devworkspace event. \n For example,
+                                          when an `apply` command is bound to a `preStart`
+                                          event, and references a `container` component,
+                                          it will start the container as a K8S initContainer
+                                          in the devworkspace POD, unless the component
+                                          has its `dedicatedPod` field set to `true`.
+                                          \n When no `apply` command exist for a given
+                                          component, it is assumed the component will
+                                          be applied at devworkspace start by default,
+                                          unless `deployByDefault` for that component
+                                          is set to false."
+                                        properties:
+                                          component:
+                                            description: Describes component that
+                                              will be applied
+                                            type: string
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                        type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      commandType:
+                                        description: Type of devworkspace command
+                                        enum:
+                                        - Exec
+                                        - Apply
+                                        - Composite
+                                        type: string
+                                      composite:
+                                        description: Composite command that allows
+                                          executing several sub-commands either sequentially
+                                          or concurrently
+                                        properties:
+                                          commands:
+                                            description: The commands that comprise
+                                              this composite command
+                                            items:
+                                              type: string
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          parallel:
+                                            description: Indicates if the sub-commands
+                                              should be executed concurrently
+                                            type: boolean
+                                        type: object
+                                      exec:
+                                        description: CLI Command executed in an existing
+                                          component container
+                                        properties:
+                                          commandLine:
+                                            description: "The actual command-line
+                                              string \n Special variables that can
+                                              be used: \n  - `$PROJECTS_ROOT`: A path
+                                              where projects sources are mounted as
+                                              defined by container component's sourceMapping.
+                                              \n  - `$PROJECT_SOURCE`: A path to a
+                                              project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                          component:
+                                            description: Describes component to which
+                                              given action relates
+                                            type: string
+                                          env:
+                                            description: Optional list of environment
+                                              variables that have to be set before
+                                              running the command
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          hotReloadCapable:
+                                            description: "Whether the command is capable
+                                              to reload itself when source code changes.
+                                              If set to `true` the command won't be
+                                              restarted and it is expected to handle
+                                              file changes on its own. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          workingDir:
+                                            description: "Working directory where
+                                              the command should be executed \n Special
+                                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                              A path where projects sources are mounted
+                                              as defined by container component's
+                                              sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                        type: object
+                                      id:
+                                        description: Mandatory identifier that allows
+                                          referencing this command in composite commands,
+                                          from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                    required:
+                                    - id
+                                    type: object
+                                  type: array
+                                components:
+                                  description: Overrides of components encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      componentType:
+                                        description: Type of component
+                                        enum:
+                                        - Container
+                                        - Kubernetes
+                                        - Openshift
+                                        - Volume
+                                        - Image
+                                        type: string
+                                      container:
+                                        description: Allows adding and configuring
+                                          devworkspace-related containers
+                                        properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
+                                          args:
+                                            description: "The arguments to supply
+                                              to the command running the dockerimage
+                                              component. The arguments are supplied
+                                              either to the default command provided
+                                              in the image or to the overridden command.
+                                              \n Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: "The command to run in the
+                                              dockerimage component instead of the
+                                              default one provided in the image. \n
+                                              Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
+                                          dedicatedPod:
+                                            description: "Specify if a container should
+                                              run in its own separated pod, instead
+                                              of running as part of the main development
+                                              environment pod. \n Default value is
+                                              `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          env:
+                                            description: "Environment variables used
+                                              in this container. \n The following
+                                              variables are reserved and cannot be
+                                              overridden via env: \n  - `$PROJECTS_ROOT`
+                                              \n  - `$PROJECT_SOURCE`"
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          memoryLimit:
+                                            type: string
+                                          memoryRequest:
+                                            type: string
+                                          mountSources:
+                                            description: "Toggles whether or not the
+                                              project source code should be mounted
+                                              in the component. \n Defaults to true
+                                              for all component types except plugins
+                                              and components that set `dedicatedPod`
+                                              to true."
+                                            type: boolean
+                                          sourceMapping:
+                                            description: Optional specification of
+                                              the path in the container where project
+                                              sources should be transferred/mounted
+                                              when `mountSources` is `true`. When
+                                              omitted, the default value of /projects
+                                              is used.
+                                            type: string
+                                          volumeMounts:
+                                            description: List of volumes mounts that
+                                              should be mounted is this container.
+                                            items:
+                                              description: Volume that should be mounted
+                                                to a component container
+                                              properties:
+                                                name:
+                                                  description: The volume mount name
+                                                    is the name of an existing `Volume`
+                                                    component. If several containers
+                                                    mount the same volume name then
+                                                    they will reuse the same volume
+                                                    and will be able to access to
+                                                    the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: The path in the component
+                                                    container where the volume should
+                                                    be mounted. If not path is mentioned,
+                                                    default path is the is `/<name>`.
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                        type: object
+                                      image:
+                                        description: Allows specifying the definition
+                                          of an image for outer loop builds
+                                        properties:
+                                          autoBuild:
+                                            description: "Defines if the image should
+                                              be built during startup. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          dockerfile:
+                                            description: Allows specifying dockerfile
+                                              type build
+                                            properties:
+                                              args:
+                                                description: The arguments to supply
+                                                  to the dockerfile build.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              buildContext:
+                                                description: Path of source directory
+                                                  to establish build context. Defaults
+                                                  to ${PROJECT_SOURCE} in the container
+                                                type: string
+                                              devfileRegistry:
+                                                description: Dockerfile's Devfile
+                                                  Registry source
+                                                properties:
+                                                  id:
+                                                    description: Id in a devfile registry
+                                                      that contains a Dockerfile.
+                                                      The src in the OCI registry
+                                                      required for the Dockerfile
+                                                      build will be downloaded for
+                                                      building the image.
+                                                    type: string
+                                                  registryUrl:
+                                                    description: Devfile Registry
+                                                      URL to pull the Dockerfile from
+                                                      when using the Devfile Registry
+                                                      as Dockerfile src. To ensure
+                                                      the Dockerfile gets resolved
+                                                      consistently in different environments,
+                                                      it is recommended to always
+                                                      specify the `devfileRegistryUrl`
+                                                      when `Id` is used.
+                                                    type: string
+                                                type: object
+                                              git:
+                                                description: Dockerfile's Git source
+                                                properties:
+                                                  checkoutFrom:
+                                                    description: Defines from what
+                                                      the project should be checked
+                                                      out. Required if there are more
+                                                      than one remote configured
+                                                    properties:
+                                                      remote:
+                                                        description: The remote name
+                                                          should be used as init.
+                                                          Required if there are more
+                                                          than one remote configured
+                                                        type: string
+                                                      revision:
+                                                        description: The revision
+                                                          to checkout from. Should
+                                                          be branch name, tag or commit
+                                                          id. Default branch is used
+                                                          if missing or specified
+                                                          revision is not found.
+                                                        type: string
+                                                    type: object
+                                                  fileLocation:
+                                                    description: Location of the Dockerfile
+                                                      in the Git repository when using
+                                                      git as Dockerfile src. Defaults
+                                                      to Dockerfile.
+                                                    type: string
+                                                  remotes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: The remotes map which
+                                                      should be initialized in the
+                                                      git project. Projects must have
+                                                      at least one remote configured
+                                                      while StarterProjects & Image
+                                                      Component's Git source can only
+                                                      have at most one remote configured.
+                                                    type: object
+                                                type: object
+                                              rootRequired:
+                                                description: "Specify if a privileged
+                                                  builder pod is required. \n Default
+                                                  value is `false`"
+                                                type: boolean
+                                              srcType:
+                                                description: Type of Dockerfile src
+                                                enum:
+                                                - Uri
+                                                - DevfileRegistry
+                                                - Git
+                                                type: string
+                                              uri:
+                                                description: URI Reference of a Dockerfile.
+                                                  It can be a full URL or a relative
+                                                  URI from the current devfile as
+                                                  the base URI.
+                                                type: string
+                                            type: object
+                                          imageName:
+                                            description: Name of the image for the
+                                              resulting outerloop build
+                                            type: string
+                                          imageType:
+                                            description: Type of image
+                                            enum:
+                                            - Dockerfile
+                                            - AutoBuild
+                                            type: string
+                                        type: object
+                                      kubernetes:
+                                        description: Allows importing into the devworkspace
+                                          the Kubernetes resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the Kubernetes definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      name:
+                                        description: Mandatory name that allows referencing
+                                          the component from other elements (such
+                                          as commands) or from an external devfile
+                                          that may reference this component through
+                                          a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      openshift:
+                                        description: Allows importing into the devworkspace
+                                          the OpenShift resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the OpenShift definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      volume:
+                                        description: Allows specifying the definition
+                                          of a volume shared by several other components
+                                        properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
+                                          size:
+                                            description: Size of the volume
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                id:
+                                  description: Id in a registry that contains a Devfile
+                                    yaml file
+                                  type: string
+                                importReferenceType:
+                                  description: type of location from where the referenced
+                                    template structure should be retrieved
+                                  enum:
+                                  - Uri
+                                  - Id
+                                  - Kubernetes
+                                  type: string
+                                kubernetes:
+                                  description: Reference to a Kubernetes CRD of type
+                                    DevWorkspaceTemplate
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                registryUrl:
+                                  description: Registry URL to pull the parent devfile
+                                    from when using id in the parent reference. To
+                                    ensure the parent devfile gets resolved consistently
+                                    in different environments, it is recommended to
+                                    always specify the `registryUrl` when `id` is
+                                    used.
+                                  type: string
+                                uri:
+                                  description: URI Reference of a parent devfile YAML
+                                    file. It can be a full URL or a relative URI with
+                                    the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                                  type: string
+                              type: object
+                            volume:
+                              description: Allows specifying the definition of a volume
+                                shared by several other components
+                              properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
+                                size:
+                                  description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      events:
+                        description: Bindings of commands to events. Each command
+                          is referred-to by its name.
+                        properties:
+                          postStart:
+                            description: IDs of commands that should be executed after
+                              the devworkspace is completely started. In the case
+                              of Che-Theia, these commands should be executed after
+                              all plugins and extensions have started, including project
+                              cloning. This means that those commands are not triggered
+                              until the user opens the IDE in his browser.
+                            items:
+                              type: string
+                            type: array
+                          postStop:
+                            description: IDs of commands that should be executed after
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                          preStart:
+                            description: IDs of commands that should be executed before
+                              the devworkspace start. Kubernetes-wise, these commands
+                              would typically be executed in init containers of the
+                              devworkspace POD.
+                            items:
+                              type: string
+                            type: array
+                          preStop:
+                            description: IDs of commands that should be executed before
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      projects:
+                        description: Projects worked on in the devworkspace, containing
+                          names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      starterProjects:
+                        description: StarterProjects is a project that can be used
+                          as a starting point when bootstrapping new projects
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            description:
+                              description: Description of a starter project
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            subDir:
+                              description: Sub-directory from a starter project to
+                                be used as root for starter project.
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      variables:
+                        additionalProperties:
+                          type: string
+                        description: "Map of key-value variables used for string replacement
+                          in the devfile. Values can be referenced via {{variable-key}}
+                          to replace the corresponding value in string fields in the
+                          devfile. Replacement cannot be used for \n  - schemaVersion,
+                          metadata, parent source \n  - element identifiers, e.g.
+                          command id, component name, endpoint name, project name
+                          \n  - references to identifiers, e.g. in events, a command's
+                          component, container's volume mount name \n  - string enums,
+                          e.g. command group kind, endpoint exposure"
+                        type: object
+                    type: object
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -123,6 +123,1988 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
+                  defaultTemplate:
+                    description: DefaultTemplate defines an optional DevWorkspace
+                      Spec Template which gets applied to the workspace if the workspace's
+                      Template Spec Components are not defined. The DefaultTemplate
+                      will overwrite the existing Template Spec, with the exception
+                      of Projects (if any are defined).
+                    properties:
+                      attributes:
+                        description: Map of implementation-dependant free-form YAML
+                          attributes.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      commands:
+                        description: Predefined, ready-to-use, devworkspace-related
+                          commands
+                        items:
+                          properties:
+                            apply:
+                              description: "Command that consists in applying a given
+                                component definition, typically bound to a devworkspace
+                                event. \n For example, when an `apply` command is
+                                bound to a `preStart` event, and references a `container`
+                                component, it will start the container as a K8S initContainer
+                                in the devworkspace POD, unless the component has
+                                its `dedicatedPod` field set to `true`. \n When no
+                                `apply` command exist for a given component, it is
+                                assumed the component will be applied at devworkspace
+                                start by default, unless `deployByDefault` for that
+                                component is set to false."
+                              properties:
+                                component:
+                                  description: Describes component that will be applied
+                                  type: string
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - component
+                              type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            commandType:
+                              description: Type of devworkspace command
+                              enum:
+                              - Exec
+                              - Apply
+                              - Composite
+                              - Custom
+                              type: string
+                            composite:
+                              description: Composite command that allows executing
+                                several sub-commands either sequentially or concurrently
+                              properties:
+                                commands:
+                                  description: The commands that comprise this composite
+                                    command
+                                  items:
+                                    type: string
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                parallel:
+                                  description: Indicates if the sub-commands should
+                                    be executed concurrently
+                                  type: boolean
+                              type: object
+                            custom:
+                              description: Custom command whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated plugin
+                              properties:
+                                commandClass:
+                                  description: Class of command that the associated
+                                    implementation component should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom command that the implementation
+                                    component will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - commandClass
+                              - embeddedResource
+                              type: object
+                            exec:
+                              description: CLI Command executed in an existing component
+                                container
+                              properties:
+                                commandLine:
+                                  description: "The actual command-line string \n
+                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                    A path where projects sources are mounted as defined
+                                    by container component's sourceMapping. \n  -
+                                    `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>). If there are
+                                    multiple projects, this will point to the directory
+                                    of the first one."
+                                  type: string
+                                component:
+                                  description: Describes component to which given
+                                    action relates
+                                  type: string
+                                env:
+                                  description: Optional list of environment variables
+                                    that have to be set before running the command
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                hotReloadCapable:
+                                  description: "Whether the command is capable to
+                                    reload itself when source code changes. If set
+                                    to `true` the command won't be restarted and it
+                                    is expected to handle file changes on its own.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                workingDir:
+                                  description: "Working directory where the command
+                                    should be executed \n Special variables that can
+                                    be used: \n  - `$PROJECTS_ROOT`: A path where
+                                    projects sources are mounted as defined by container
+                                    component's sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one."
+                                  type: string
+                              required:
+                              - commandLine
+                              - component
+                              type: object
+                            id:
+                              description: Mandatory identifier that allows referencing
+                                this command in composite commands, from a parent,
+                                or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - id
+                          type: object
+                        type: array
+                      components:
+                        description: List of the devworkspace components, such as
+                          editor and plugins, user-provided containers, or other types
+                          of components
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            componentType:
+                              description: Type of component
+                              enum:
+                              - Container
+                              - Kubernetes
+                              - Openshift
+                              - Volume
+                              - Image
+                              - Plugin
+                              - Custom
+                              type: string
+                            container:
+                              description: Allows adding and configuring devworkspace-related
+                                containers
+                              properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
+                                args:
+                                  description: "The arguments to supply to the command
+                                    running the dockerimage component. The arguments
+                                    are supplied either to the default command provided
+                                    in the image or to the overridden command. \n
+                                    Defaults to an empty array, meaning use whatever
+                                    is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  description: "The command to run in the dockerimage
+                                    component instead of the default one provided
+                                    in the image. \n Defaults to an empty array, meaning
+                                    use whatever is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
+                                dedicatedPod:
+                                  description: "Specify if a container should run
+                                    in its own separated pod, instead of running as
+                                    part of the main development environment pod.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                env:
+                                  description: "Environment variables used in this
+                                    container. \n The following variables are reserved
+                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
+                                    \n  - `$PROJECT_SOURCE`"
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                memoryLimit:
+                                  type: string
+                                memoryRequest:
+                                  type: string
+                                mountSources:
+                                  description: "Toggles whether or not the project
+                                    source code should be mounted in the component.
+                                    \n Defaults to true for all component types except
+                                    plugins and components that set `dedicatedPod`
+                                    to true."
+                                  type: boolean
+                                sourceMapping:
+                                  default: /projects
+                                  description: Optional specification of the path
+                                    in the container where project sources should
+                                    be transferred/mounted when `mountSources` is
+                                    `true`. When omitted, the default value of /projects
+                                    is used.
+                                  type: string
+                                volumeMounts:
+                                  description: List of volumes mounts that should
+                                    be mounted is this container.
+                                  items:
+                                    description: Volume that should be mounted to
+                                      a component container
+                                    properties:
+                                      name:
+                                        description: The volume mount name is the
+                                          name of an existing `Volume` component.
+                                          If several containers mount the same volume
+                                          name then they will reuse the same volume
+                                          and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: The path in the component container
+                                          where the volume should be mounted. If not
+                                          path is mentioned, default path is the is
+                                          `/<name>`.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                              required:
+                              - image
+                              type: object
+                            custom:
+                              description: Custom component whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated controller
+                              properties:
+                                componentClass:
+                                  description: Class of component that the associated
+                                    implementation controller should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom component that the implementation
+                                    controller will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - componentClass
+                              - embeddedResource
+                              type: object
+                            image:
+                              description: Allows specifying the definition of an
+                                image for outer loop builds
+                              properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built
+                                    during startup. \n Default value is `false`"
+                                  type: boolean
+                                dockerfile:
+                                  description: Allows specifying dockerfile type build
+                                  properties:
+                                    args:
+                                      description: The arguments to supply to the
+                                        dockerfile build.
+                                      items:
+                                        type: string
+                                      type: array
+                                    buildContext:
+                                      description: Path of source directory to establish
+                                        build context. Defaults to ${PROJECT_SOURCE}
+                                        in the container
+                                      type: string
+                                    devfileRegistry:
+                                      description: Dockerfile's Devfile Registry source
+                                      properties:
+                                        id:
+                                          description: Id in a devfile registry that
+                                            contains a Dockerfile. The src in the
+                                            OCI registry required for the Dockerfile
+                                            build will be downloaded for building
+                                            the image.
+                                          type: string
+                                        registryUrl:
+                                          description: Devfile Registry URL to pull
+                                            the Dockerfile from when using the Devfile
+                                            Registry as Dockerfile src. To ensure
+                                            the Dockerfile gets resolved consistently
+                                            in different environments, it is recommended
+                                            to always specify the `devfileRegistryUrl`
+                                            when `Id` is used.
+                                          type: string
+                                      required:
+                                      - id
+                                      type: object
+                                    git:
+                                      description: Dockerfile's Git source
+                                      properties:
+                                        checkoutFrom:
+                                          description: Defines from what the project
+                                            should be checked out. Required if there
+                                            are more than one remote configured
+                                          properties:
+                                            remote:
+                                              description: The remote name should
+                                                be used as init. Required if there
+                                                are more than one remote configured
+                                              type: string
+                                            revision:
+                                              description: The revision to checkout
+                                                from. Should be branch name, tag or
+                                                commit id. Default branch is used
+                                                if missing or specified revision is
+                                                not found.
+                                              type: string
+                                          type: object
+                                        fileLocation:
+                                          description: Location of the Dockerfile
+                                            in the Git repository when using git as
+                                            Dockerfile src. Defaults to Dockerfile.
+                                          type: string
+                                        remotes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The remotes map which should
+                                            be initialized in the git project. Projects
+                                            must have at least one remote configured
+                                            while StarterProjects & Image Component's
+                                            Git source can only have at most one remote
+                                            configured.
+                                          type: object
+                                      required:
+                                      - remotes
+                                      type: object
+                                    rootRequired:
+                                      description: "Specify if a privileged builder
+                                        pod is required. \n Default value is `false`"
+                                      type: boolean
+                                    srcType:
+                                      description: Type of Dockerfile src
+                                      enum:
+                                      - Uri
+                                      - DevfileRegistry
+                                      - Git
+                                      type: string
+                                    uri:
+                                      description: URI Reference of a Dockerfile.
+                                        It can be a full URL or a relative URI from
+                                        the current devfile as the base URI.
+                                      type: string
+                                  type: object
+                                imageName:
+                                  description: Name of the image for the resulting
+                                    outerloop build
+                                  type: string
+                                imageType:
+                                  description: Type of image
+                                  enum:
+                                  - Dockerfile
+                                  type: string
+                              required:
+                              - imageName
+                              type: object
+                            kubernetes:
+                              description: Allows importing into the devworkspace
+                                the Kubernetes resources defined in a given manifest.
+                                For example this allows reusing the Kubernetes definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            name:
+                              description: Mandatory name that allows referencing
+                                the component from other elements (such as commands)
+                                or from an external devfile that may reference this
+                                component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            openshift:
+                              description: Allows importing into the devworkspace
+                                the OpenShift resources defined in a given manifest.
+                                For example this allows reusing the OpenShift definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            plugin:
+                              description: "Allows importing a plugin. \n Plugins
+                                are mainly imported devfiles that contribute components,
+                                commands and events as a consistent single unit. They
+                                are defined in either YAML files following the devfile
+                                syntax, or as `DevWorkspaceTemplate` Kubernetes Custom
+                                Resources"
+                              properties:
+                                commands:
+                                  description: Overrides of commands encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      apply:
+                                        description: "Command that consists in applying
+                                          a given component definition, typically
+                                          bound to a devworkspace event. \n For example,
+                                          when an `apply` command is bound to a `preStart`
+                                          event, and references a `container` component,
+                                          it will start the container as a K8S initContainer
+                                          in the devworkspace POD, unless the component
+                                          has its `dedicatedPod` field set to `true`.
+                                          \n When no `apply` command exist for a given
+                                          component, it is assumed the component will
+                                          be applied at devworkspace start by default,
+                                          unless `deployByDefault` for that component
+                                          is set to false."
+                                        properties:
+                                          component:
+                                            description: Describes component that
+                                              will be applied
+                                            type: string
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                        type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      commandType:
+                                        description: Type of devworkspace command
+                                        enum:
+                                        - Exec
+                                        - Apply
+                                        - Composite
+                                        type: string
+                                      composite:
+                                        description: Composite command that allows
+                                          executing several sub-commands either sequentially
+                                          or concurrently
+                                        properties:
+                                          commands:
+                                            description: The commands that comprise
+                                              this composite command
+                                            items:
+                                              type: string
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          parallel:
+                                            description: Indicates if the sub-commands
+                                              should be executed concurrently
+                                            type: boolean
+                                        type: object
+                                      exec:
+                                        description: CLI Command executed in an existing
+                                          component container
+                                        properties:
+                                          commandLine:
+                                            description: "The actual command-line
+                                              string \n Special variables that can
+                                              be used: \n  - `$PROJECTS_ROOT`: A path
+                                              where projects sources are mounted as
+                                              defined by container component's sourceMapping.
+                                              \n  - `$PROJECT_SOURCE`: A path to a
+                                              project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                          component:
+                                            description: Describes component to which
+                                              given action relates
+                                            type: string
+                                          env:
+                                            description: Optional list of environment
+                                              variables that have to be set before
+                                              running the command
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          hotReloadCapable:
+                                            description: "Whether the command is capable
+                                              to reload itself when source code changes.
+                                              If set to `true` the command won't be
+                                              restarted and it is expected to handle
+                                              file changes on its own. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          workingDir:
+                                            description: "Working directory where
+                                              the command should be executed \n Special
+                                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                              A path where projects sources are mounted
+                                              as defined by container component's
+                                              sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                        type: object
+                                      id:
+                                        description: Mandatory identifier that allows
+                                          referencing this command in composite commands,
+                                          from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                    required:
+                                    - id
+                                    type: object
+                                  type: array
+                                components:
+                                  description: Overrides of components encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      componentType:
+                                        description: Type of component
+                                        enum:
+                                        - Container
+                                        - Kubernetes
+                                        - Openshift
+                                        - Volume
+                                        - Image
+                                        type: string
+                                      container:
+                                        description: Allows adding and configuring
+                                          devworkspace-related containers
+                                        properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
+                                          args:
+                                            description: "The arguments to supply
+                                              to the command running the dockerimage
+                                              component. The arguments are supplied
+                                              either to the default command provided
+                                              in the image or to the overridden command.
+                                              \n Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: "The command to run in the
+                                              dockerimage component instead of the
+                                              default one provided in the image. \n
+                                              Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
+                                          dedicatedPod:
+                                            description: "Specify if a container should
+                                              run in its own separated pod, instead
+                                              of running as part of the main development
+                                              environment pod. \n Default value is
+                                              `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          env:
+                                            description: "Environment variables used
+                                              in this container. \n The following
+                                              variables are reserved and cannot be
+                                              overridden via env: \n  - `$PROJECTS_ROOT`
+                                              \n  - `$PROJECT_SOURCE`"
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          memoryLimit:
+                                            type: string
+                                          memoryRequest:
+                                            type: string
+                                          mountSources:
+                                            description: "Toggles whether or not the
+                                              project source code should be mounted
+                                              in the component. \n Defaults to true
+                                              for all component types except plugins
+                                              and components that set `dedicatedPod`
+                                              to true."
+                                            type: boolean
+                                          sourceMapping:
+                                            description: Optional specification of
+                                              the path in the container where project
+                                              sources should be transferred/mounted
+                                              when `mountSources` is `true`. When
+                                              omitted, the default value of /projects
+                                              is used.
+                                            type: string
+                                          volumeMounts:
+                                            description: List of volumes mounts that
+                                              should be mounted is this container.
+                                            items:
+                                              description: Volume that should be mounted
+                                                to a component container
+                                              properties:
+                                                name:
+                                                  description: The volume mount name
+                                                    is the name of an existing `Volume`
+                                                    component. If several containers
+                                                    mount the same volume name then
+                                                    they will reuse the same volume
+                                                    and will be able to access to
+                                                    the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: The path in the component
+                                                    container where the volume should
+                                                    be mounted. If not path is mentioned,
+                                                    default path is the is `/<name>`.
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                        type: object
+                                      image:
+                                        description: Allows specifying the definition
+                                          of an image for outer loop builds
+                                        properties:
+                                          autoBuild:
+                                            description: "Defines if the image should
+                                              be built during startup. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          dockerfile:
+                                            description: Allows specifying dockerfile
+                                              type build
+                                            properties:
+                                              args:
+                                                description: The arguments to supply
+                                                  to the dockerfile build.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              buildContext:
+                                                description: Path of source directory
+                                                  to establish build context. Defaults
+                                                  to ${PROJECT_SOURCE} in the container
+                                                type: string
+                                              devfileRegistry:
+                                                description: Dockerfile's Devfile
+                                                  Registry source
+                                                properties:
+                                                  id:
+                                                    description: Id in a devfile registry
+                                                      that contains a Dockerfile.
+                                                      The src in the OCI registry
+                                                      required for the Dockerfile
+                                                      build will be downloaded for
+                                                      building the image.
+                                                    type: string
+                                                  registryUrl:
+                                                    description: Devfile Registry
+                                                      URL to pull the Dockerfile from
+                                                      when using the Devfile Registry
+                                                      as Dockerfile src. To ensure
+                                                      the Dockerfile gets resolved
+                                                      consistently in different environments,
+                                                      it is recommended to always
+                                                      specify the `devfileRegistryUrl`
+                                                      when `Id` is used.
+                                                    type: string
+                                                type: object
+                                              git:
+                                                description: Dockerfile's Git source
+                                                properties:
+                                                  checkoutFrom:
+                                                    description: Defines from what
+                                                      the project should be checked
+                                                      out. Required if there are more
+                                                      than one remote configured
+                                                    properties:
+                                                      remote:
+                                                        description: The remote name
+                                                          should be used as init.
+                                                          Required if there are more
+                                                          than one remote configured
+                                                        type: string
+                                                      revision:
+                                                        description: The revision
+                                                          to checkout from. Should
+                                                          be branch name, tag or commit
+                                                          id. Default branch is used
+                                                          if missing or specified
+                                                          revision is not found.
+                                                        type: string
+                                                    type: object
+                                                  fileLocation:
+                                                    description: Location of the Dockerfile
+                                                      in the Git repository when using
+                                                      git as Dockerfile src. Defaults
+                                                      to Dockerfile.
+                                                    type: string
+                                                  remotes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: The remotes map which
+                                                      should be initialized in the
+                                                      git project. Projects must have
+                                                      at least one remote configured
+                                                      while StarterProjects & Image
+                                                      Component's Git source can only
+                                                      have at most one remote configured.
+                                                    type: object
+                                                type: object
+                                              rootRequired:
+                                                description: "Specify if a privileged
+                                                  builder pod is required. \n Default
+                                                  value is `false`"
+                                                type: boolean
+                                              srcType:
+                                                description: Type of Dockerfile src
+                                                enum:
+                                                - Uri
+                                                - DevfileRegistry
+                                                - Git
+                                                type: string
+                                              uri:
+                                                description: URI Reference of a Dockerfile.
+                                                  It can be a full URL or a relative
+                                                  URI from the current devfile as
+                                                  the base URI.
+                                                type: string
+                                            type: object
+                                          imageName:
+                                            description: Name of the image for the
+                                              resulting outerloop build
+                                            type: string
+                                          imageType:
+                                            description: Type of image
+                                            enum:
+                                            - Dockerfile
+                                            - AutoBuild
+                                            type: string
+                                        type: object
+                                      kubernetes:
+                                        description: Allows importing into the devworkspace
+                                          the Kubernetes resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the Kubernetes definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      name:
+                                        description: Mandatory name that allows referencing
+                                          the component from other elements (such
+                                          as commands) or from an external devfile
+                                          that may reference this component through
+                                          a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      openshift:
+                                        description: Allows importing into the devworkspace
+                                          the OpenShift resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the OpenShift definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      volume:
+                                        description: Allows specifying the definition
+                                          of a volume shared by several other components
+                                        properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
+                                          size:
+                                            description: Size of the volume
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                id:
+                                  description: Id in a registry that contains a Devfile
+                                    yaml file
+                                  type: string
+                                importReferenceType:
+                                  description: type of location from where the referenced
+                                    template structure should be retrieved
+                                  enum:
+                                  - Uri
+                                  - Id
+                                  - Kubernetes
+                                  type: string
+                                kubernetes:
+                                  description: Reference to a Kubernetes CRD of type
+                                    DevWorkspaceTemplate
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                registryUrl:
+                                  description: Registry URL to pull the parent devfile
+                                    from when using id in the parent reference. To
+                                    ensure the parent devfile gets resolved consistently
+                                    in different environments, it is recommended to
+                                    always specify the `registryUrl` when `id` is
+                                    used.
+                                  type: string
+                                uri:
+                                  description: URI Reference of a parent devfile YAML
+                                    file. It can be a full URL or a relative URI with
+                                    the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                                  type: string
+                              type: object
+                            volume:
+                              description: Allows specifying the definition of a volume
+                                shared by several other components
+                              properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
+                                size:
+                                  description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      events:
+                        description: Bindings of commands to events. Each command
+                          is referred-to by its name.
+                        properties:
+                          postStart:
+                            description: IDs of commands that should be executed after
+                              the devworkspace is completely started. In the case
+                              of Che-Theia, these commands should be executed after
+                              all plugins and extensions have started, including project
+                              cloning. This means that those commands are not triggered
+                              until the user opens the IDE in his browser.
+                            items:
+                              type: string
+                            type: array
+                          postStop:
+                            description: IDs of commands that should be executed after
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                          preStart:
+                            description: IDs of commands that should be executed before
+                              the devworkspace start. Kubernetes-wise, these commands
+                              would typically be executed in init containers of the
+                              devworkspace POD.
+                            items:
+                              type: string
+                            type: array
+                          preStop:
+                            description: IDs of commands that should be executed before
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      projects:
+                        description: Projects worked on in the devworkspace, containing
+                          names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      starterProjects:
+                        description: StarterProjects is a project that can be used
+                          as a starting point when bootstrapping new projects
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            description:
+                              description: Description of a starter project
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            subDir:
+                              description: Sub-directory from a starter project to
+                                be used as root for starter project.
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      variables:
+                        additionalProperties:
+                          type: string
+                        description: "Map of key-value variables used for string replacement
+                          in the devfile. Values can be referenced via {{variable-key}}
+                          to replace the corresponding value in string fields in the
+                          devfile. Replacement cannot be used for \n  - schemaVersion,
+                          metadata, parent source \n  - element identifiers, e.g.
+                          command id, component name, endpoint name, project name
+                          \n  - references to identifiers, e.g. in events, a command's
+                          component, container's volume mount name \n  - string enums,
+                          e.g. command group kind, endpoint exposure"
+                        type: object
+                    type: object
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -123,6 +123,1988 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
+                  defaultTemplate:
+                    description: DefaultTemplate defines an optional DevWorkspace
+                      Spec Template which gets applied to the workspace if the workspace's
+                      Template Spec Components are not defined. The DefaultTemplate
+                      will overwrite the existing Template Spec, with the exception
+                      of Projects (if any are defined).
+                    properties:
+                      attributes:
+                        description: Map of implementation-dependant free-form YAML
+                          attributes.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      commands:
+                        description: Predefined, ready-to-use, devworkspace-related
+                          commands
+                        items:
+                          properties:
+                            apply:
+                              description: "Command that consists in applying a given
+                                component definition, typically bound to a devworkspace
+                                event. \n For example, when an `apply` command is
+                                bound to a `preStart` event, and references a `container`
+                                component, it will start the container as a K8S initContainer
+                                in the devworkspace POD, unless the component has
+                                its `dedicatedPod` field set to `true`. \n When no
+                                `apply` command exist for a given component, it is
+                                assumed the component will be applied at devworkspace
+                                start by default, unless `deployByDefault` for that
+                                component is set to false."
+                              properties:
+                                component:
+                                  description: Describes component that will be applied
+                                  type: string
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - component
+                              type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            commandType:
+                              description: Type of devworkspace command
+                              enum:
+                              - Exec
+                              - Apply
+                              - Composite
+                              - Custom
+                              type: string
+                            composite:
+                              description: Composite command that allows executing
+                                several sub-commands either sequentially or concurrently
+                              properties:
+                                commands:
+                                  description: The commands that comprise this composite
+                                    command
+                                  items:
+                                    type: string
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                parallel:
+                                  description: Indicates if the sub-commands should
+                                    be executed concurrently
+                                  type: boolean
+                              type: object
+                            custom:
+                              description: Custom command whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated plugin
+                              properties:
+                                commandClass:
+                                  description: Class of command that the associated
+                                    implementation component should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom command that the implementation
+                                    component will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - commandClass
+                              - embeddedResource
+                              type: object
+                            exec:
+                              description: CLI Command executed in an existing component
+                                container
+                              properties:
+                                commandLine:
+                                  description: "The actual command-line string \n
+                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                    A path where projects sources are mounted as defined
+                                    by container component's sourceMapping. \n  -
+                                    `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>). If there are
+                                    multiple projects, this will point to the directory
+                                    of the first one."
+                                  type: string
+                                component:
+                                  description: Describes component to which given
+                                    action relates
+                                  type: string
+                                env:
+                                  description: Optional list of environment variables
+                                    that have to be set before running the command
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                hotReloadCapable:
+                                  description: "Whether the command is capable to
+                                    reload itself when source code changes. If set
+                                    to `true` the command won't be restarted and it
+                                    is expected to handle file changes on its own.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                workingDir:
+                                  description: "Working directory where the command
+                                    should be executed \n Special variables that can
+                                    be used: \n  - `$PROJECTS_ROOT`: A path where
+                                    projects sources are mounted as defined by container
+                                    component's sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one."
+                                  type: string
+                              required:
+                              - commandLine
+                              - component
+                              type: object
+                            id:
+                              description: Mandatory identifier that allows referencing
+                                this command in composite commands, from a parent,
+                                or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - id
+                          type: object
+                        type: array
+                      components:
+                        description: List of the devworkspace components, such as
+                          editor and plugins, user-provided containers, or other types
+                          of components
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            componentType:
+                              description: Type of component
+                              enum:
+                              - Container
+                              - Kubernetes
+                              - Openshift
+                              - Volume
+                              - Image
+                              - Plugin
+                              - Custom
+                              type: string
+                            container:
+                              description: Allows adding and configuring devworkspace-related
+                                containers
+                              properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
+                                args:
+                                  description: "The arguments to supply to the command
+                                    running the dockerimage component. The arguments
+                                    are supplied either to the default command provided
+                                    in the image or to the overridden command. \n
+                                    Defaults to an empty array, meaning use whatever
+                                    is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  description: "The command to run in the dockerimage
+                                    component instead of the default one provided
+                                    in the image. \n Defaults to an empty array, meaning
+                                    use whatever is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
+                                dedicatedPod:
+                                  description: "Specify if a container should run
+                                    in its own separated pod, instead of running as
+                                    part of the main development environment pod.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                env:
+                                  description: "Environment variables used in this
+                                    container. \n The following variables are reserved
+                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
+                                    \n  - `$PROJECT_SOURCE`"
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                memoryLimit:
+                                  type: string
+                                memoryRequest:
+                                  type: string
+                                mountSources:
+                                  description: "Toggles whether or not the project
+                                    source code should be mounted in the component.
+                                    \n Defaults to true for all component types except
+                                    plugins and components that set `dedicatedPod`
+                                    to true."
+                                  type: boolean
+                                sourceMapping:
+                                  default: /projects
+                                  description: Optional specification of the path
+                                    in the container where project sources should
+                                    be transferred/mounted when `mountSources` is
+                                    `true`. When omitted, the default value of /projects
+                                    is used.
+                                  type: string
+                                volumeMounts:
+                                  description: List of volumes mounts that should
+                                    be mounted is this container.
+                                  items:
+                                    description: Volume that should be mounted to
+                                      a component container
+                                    properties:
+                                      name:
+                                        description: The volume mount name is the
+                                          name of an existing `Volume` component.
+                                          If several containers mount the same volume
+                                          name then they will reuse the same volume
+                                          and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: The path in the component container
+                                          where the volume should be mounted. If not
+                                          path is mentioned, default path is the is
+                                          `/<name>`.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                              required:
+                              - image
+                              type: object
+                            custom:
+                              description: Custom component whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated controller
+                              properties:
+                                componentClass:
+                                  description: Class of component that the associated
+                                    implementation controller should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom component that the implementation
+                                    controller will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - componentClass
+                              - embeddedResource
+                              type: object
+                            image:
+                              description: Allows specifying the definition of an
+                                image for outer loop builds
+                              properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built
+                                    during startup. \n Default value is `false`"
+                                  type: boolean
+                                dockerfile:
+                                  description: Allows specifying dockerfile type build
+                                  properties:
+                                    args:
+                                      description: The arguments to supply to the
+                                        dockerfile build.
+                                      items:
+                                        type: string
+                                      type: array
+                                    buildContext:
+                                      description: Path of source directory to establish
+                                        build context. Defaults to ${PROJECT_SOURCE}
+                                        in the container
+                                      type: string
+                                    devfileRegistry:
+                                      description: Dockerfile's Devfile Registry source
+                                      properties:
+                                        id:
+                                          description: Id in a devfile registry that
+                                            contains a Dockerfile. The src in the
+                                            OCI registry required for the Dockerfile
+                                            build will be downloaded for building
+                                            the image.
+                                          type: string
+                                        registryUrl:
+                                          description: Devfile Registry URL to pull
+                                            the Dockerfile from when using the Devfile
+                                            Registry as Dockerfile src. To ensure
+                                            the Dockerfile gets resolved consistently
+                                            in different environments, it is recommended
+                                            to always specify the `devfileRegistryUrl`
+                                            when `Id` is used.
+                                          type: string
+                                      required:
+                                      - id
+                                      type: object
+                                    git:
+                                      description: Dockerfile's Git source
+                                      properties:
+                                        checkoutFrom:
+                                          description: Defines from what the project
+                                            should be checked out. Required if there
+                                            are more than one remote configured
+                                          properties:
+                                            remote:
+                                              description: The remote name should
+                                                be used as init. Required if there
+                                                are more than one remote configured
+                                              type: string
+                                            revision:
+                                              description: The revision to checkout
+                                                from. Should be branch name, tag or
+                                                commit id. Default branch is used
+                                                if missing or specified revision is
+                                                not found.
+                                              type: string
+                                          type: object
+                                        fileLocation:
+                                          description: Location of the Dockerfile
+                                            in the Git repository when using git as
+                                            Dockerfile src. Defaults to Dockerfile.
+                                          type: string
+                                        remotes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The remotes map which should
+                                            be initialized in the git project. Projects
+                                            must have at least one remote configured
+                                            while StarterProjects & Image Component's
+                                            Git source can only have at most one remote
+                                            configured.
+                                          type: object
+                                      required:
+                                      - remotes
+                                      type: object
+                                    rootRequired:
+                                      description: "Specify if a privileged builder
+                                        pod is required. \n Default value is `false`"
+                                      type: boolean
+                                    srcType:
+                                      description: Type of Dockerfile src
+                                      enum:
+                                      - Uri
+                                      - DevfileRegistry
+                                      - Git
+                                      type: string
+                                    uri:
+                                      description: URI Reference of a Dockerfile.
+                                        It can be a full URL or a relative URI from
+                                        the current devfile as the base URI.
+                                      type: string
+                                  type: object
+                                imageName:
+                                  description: Name of the image for the resulting
+                                    outerloop build
+                                  type: string
+                                imageType:
+                                  description: Type of image
+                                  enum:
+                                  - Dockerfile
+                                  type: string
+                              required:
+                              - imageName
+                              type: object
+                            kubernetes:
+                              description: Allows importing into the devworkspace
+                                the Kubernetes resources defined in a given manifest.
+                                For example this allows reusing the Kubernetes definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            name:
+                              description: Mandatory name that allows referencing
+                                the component from other elements (such as commands)
+                                or from an external devfile that may reference this
+                                component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            openshift:
+                              description: Allows importing into the devworkspace
+                                the OpenShift resources defined in a given manifest.
+                                For example this allows reusing the OpenShift definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            plugin:
+                              description: "Allows importing a plugin. \n Plugins
+                                are mainly imported devfiles that contribute components,
+                                commands and events as a consistent single unit. They
+                                are defined in either YAML files following the devfile
+                                syntax, or as `DevWorkspaceTemplate` Kubernetes Custom
+                                Resources"
+                              properties:
+                                commands:
+                                  description: Overrides of commands encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      apply:
+                                        description: "Command that consists in applying
+                                          a given component definition, typically
+                                          bound to a devworkspace event. \n For example,
+                                          when an `apply` command is bound to a `preStart`
+                                          event, and references a `container` component,
+                                          it will start the container as a K8S initContainer
+                                          in the devworkspace POD, unless the component
+                                          has its `dedicatedPod` field set to `true`.
+                                          \n When no `apply` command exist for a given
+                                          component, it is assumed the component will
+                                          be applied at devworkspace start by default,
+                                          unless `deployByDefault` for that component
+                                          is set to false."
+                                        properties:
+                                          component:
+                                            description: Describes component that
+                                              will be applied
+                                            type: string
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                        type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      commandType:
+                                        description: Type of devworkspace command
+                                        enum:
+                                        - Exec
+                                        - Apply
+                                        - Composite
+                                        type: string
+                                      composite:
+                                        description: Composite command that allows
+                                          executing several sub-commands either sequentially
+                                          or concurrently
+                                        properties:
+                                          commands:
+                                            description: The commands that comprise
+                                              this composite command
+                                            items:
+                                              type: string
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          parallel:
+                                            description: Indicates if the sub-commands
+                                              should be executed concurrently
+                                            type: boolean
+                                        type: object
+                                      exec:
+                                        description: CLI Command executed in an existing
+                                          component container
+                                        properties:
+                                          commandLine:
+                                            description: "The actual command-line
+                                              string \n Special variables that can
+                                              be used: \n  - `$PROJECTS_ROOT`: A path
+                                              where projects sources are mounted as
+                                              defined by container component's sourceMapping.
+                                              \n  - `$PROJECT_SOURCE`: A path to a
+                                              project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                          component:
+                                            description: Describes component to which
+                                              given action relates
+                                            type: string
+                                          env:
+                                            description: Optional list of environment
+                                              variables that have to be set before
+                                              running the command
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          hotReloadCapable:
+                                            description: "Whether the command is capable
+                                              to reload itself when source code changes.
+                                              If set to `true` the command won't be
+                                              restarted and it is expected to handle
+                                              file changes on its own. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          workingDir:
+                                            description: "Working directory where
+                                              the command should be executed \n Special
+                                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                              A path where projects sources are mounted
+                                              as defined by container component's
+                                              sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                        type: object
+                                      id:
+                                        description: Mandatory identifier that allows
+                                          referencing this command in composite commands,
+                                          from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                    required:
+                                    - id
+                                    type: object
+                                  type: array
+                                components:
+                                  description: Overrides of components encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      componentType:
+                                        description: Type of component
+                                        enum:
+                                        - Container
+                                        - Kubernetes
+                                        - Openshift
+                                        - Volume
+                                        - Image
+                                        type: string
+                                      container:
+                                        description: Allows adding and configuring
+                                          devworkspace-related containers
+                                        properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
+                                          args:
+                                            description: "The arguments to supply
+                                              to the command running the dockerimage
+                                              component. The arguments are supplied
+                                              either to the default command provided
+                                              in the image or to the overridden command.
+                                              \n Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: "The command to run in the
+                                              dockerimage component instead of the
+                                              default one provided in the image. \n
+                                              Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
+                                          dedicatedPod:
+                                            description: "Specify if a container should
+                                              run in its own separated pod, instead
+                                              of running as part of the main development
+                                              environment pod. \n Default value is
+                                              `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          env:
+                                            description: "Environment variables used
+                                              in this container. \n The following
+                                              variables are reserved and cannot be
+                                              overridden via env: \n  - `$PROJECTS_ROOT`
+                                              \n  - `$PROJECT_SOURCE`"
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          memoryLimit:
+                                            type: string
+                                          memoryRequest:
+                                            type: string
+                                          mountSources:
+                                            description: "Toggles whether or not the
+                                              project source code should be mounted
+                                              in the component. \n Defaults to true
+                                              for all component types except plugins
+                                              and components that set `dedicatedPod`
+                                              to true."
+                                            type: boolean
+                                          sourceMapping:
+                                            description: Optional specification of
+                                              the path in the container where project
+                                              sources should be transferred/mounted
+                                              when `mountSources` is `true`. When
+                                              omitted, the default value of /projects
+                                              is used.
+                                            type: string
+                                          volumeMounts:
+                                            description: List of volumes mounts that
+                                              should be mounted is this container.
+                                            items:
+                                              description: Volume that should be mounted
+                                                to a component container
+                                              properties:
+                                                name:
+                                                  description: The volume mount name
+                                                    is the name of an existing `Volume`
+                                                    component. If several containers
+                                                    mount the same volume name then
+                                                    they will reuse the same volume
+                                                    and will be able to access to
+                                                    the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: The path in the component
+                                                    container where the volume should
+                                                    be mounted. If not path is mentioned,
+                                                    default path is the is `/<name>`.
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                        type: object
+                                      image:
+                                        description: Allows specifying the definition
+                                          of an image for outer loop builds
+                                        properties:
+                                          autoBuild:
+                                            description: "Defines if the image should
+                                              be built during startup. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          dockerfile:
+                                            description: Allows specifying dockerfile
+                                              type build
+                                            properties:
+                                              args:
+                                                description: The arguments to supply
+                                                  to the dockerfile build.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              buildContext:
+                                                description: Path of source directory
+                                                  to establish build context. Defaults
+                                                  to ${PROJECT_SOURCE} in the container
+                                                type: string
+                                              devfileRegistry:
+                                                description: Dockerfile's Devfile
+                                                  Registry source
+                                                properties:
+                                                  id:
+                                                    description: Id in a devfile registry
+                                                      that contains a Dockerfile.
+                                                      The src in the OCI registry
+                                                      required for the Dockerfile
+                                                      build will be downloaded for
+                                                      building the image.
+                                                    type: string
+                                                  registryUrl:
+                                                    description: Devfile Registry
+                                                      URL to pull the Dockerfile from
+                                                      when using the Devfile Registry
+                                                      as Dockerfile src. To ensure
+                                                      the Dockerfile gets resolved
+                                                      consistently in different environments,
+                                                      it is recommended to always
+                                                      specify the `devfileRegistryUrl`
+                                                      when `Id` is used.
+                                                    type: string
+                                                type: object
+                                              git:
+                                                description: Dockerfile's Git source
+                                                properties:
+                                                  checkoutFrom:
+                                                    description: Defines from what
+                                                      the project should be checked
+                                                      out. Required if there are more
+                                                      than one remote configured
+                                                    properties:
+                                                      remote:
+                                                        description: The remote name
+                                                          should be used as init.
+                                                          Required if there are more
+                                                          than one remote configured
+                                                        type: string
+                                                      revision:
+                                                        description: The revision
+                                                          to checkout from. Should
+                                                          be branch name, tag or commit
+                                                          id. Default branch is used
+                                                          if missing or specified
+                                                          revision is not found.
+                                                        type: string
+                                                    type: object
+                                                  fileLocation:
+                                                    description: Location of the Dockerfile
+                                                      in the Git repository when using
+                                                      git as Dockerfile src. Defaults
+                                                      to Dockerfile.
+                                                    type: string
+                                                  remotes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: The remotes map which
+                                                      should be initialized in the
+                                                      git project. Projects must have
+                                                      at least one remote configured
+                                                      while StarterProjects & Image
+                                                      Component's Git source can only
+                                                      have at most one remote configured.
+                                                    type: object
+                                                type: object
+                                              rootRequired:
+                                                description: "Specify if a privileged
+                                                  builder pod is required. \n Default
+                                                  value is `false`"
+                                                type: boolean
+                                              srcType:
+                                                description: Type of Dockerfile src
+                                                enum:
+                                                - Uri
+                                                - DevfileRegistry
+                                                - Git
+                                                type: string
+                                              uri:
+                                                description: URI Reference of a Dockerfile.
+                                                  It can be a full URL or a relative
+                                                  URI from the current devfile as
+                                                  the base URI.
+                                                type: string
+                                            type: object
+                                          imageName:
+                                            description: Name of the image for the
+                                              resulting outerloop build
+                                            type: string
+                                          imageType:
+                                            description: Type of image
+                                            enum:
+                                            - Dockerfile
+                                            - AutoBuild
+                                            type: string
+                                        type: object
+                                      kubernetes:
+                                        description: Allows importing into the devworkspace
+                                          the Kubernetes resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the Kubernetes definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      name:
+                                        description: Mandatory name that allows referencing
+                                          the component from other elements (such
+                                          as commands) or from an external devfile
+                                          that may reference this component through
+                                          a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      openshift:
+                                        description: Allows importing into the devworkspace
+                                          the OpenShift resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the OpenShift definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      volume:
+                                        description: Allows specifying the definition
+                                          of a volume shared by several other components
+                                        properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
+                                          size:
+                                            description: Size of the volume
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                id:
+                                  description: Id in a registry that contains a Devfile
+                                    yaml file
+                                  type: string
+                                importReferenceType:
+                                  description: type of location from where the referenced
+                                    template structure should be retrieved
+                                  enum:
+                                  - Uri
+                                  - Id
+                                  - Kubernetes
+                                  type: string
+                                kubernetes:
+                                  description: Reference to a Kubernetes CRD of type
+                                    DevWorkspaceTemplate
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                registryUrl:
+                                  description: Registry URL to pull the parent devfile
+                                    from when using id in the parent reference. To
+                                    ensure the parent devfile gets resolved consistently
+                                    in different environments, it is recommended to
+                                    always specify the `registryUrl` when `id` is
+                                    used.
+                                  type: string
+                                uri:
+                                  description: URI Reference of a parent devfile YAML
+                                    file. It can be a full URL or a relative URI with
+                                    the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                                  type: string
+                              type: object
+                            volume:
+                              description: Allows specifying the definition of a volume
+                                shared by several other components
+                              properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
+                                size:
+                                  description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      events:
+                        description: Bindings of commands to events. Each command
+                          is referred-to by its name.
+                        properties:
+                          postStart:
+                            description: IDs of commands that should be executed after
+                              the devworkspace is completely started. In the case
+                              of Che-Theia, these commands should be executed after
+                              all plugins and extensions have started, including project
+                              cloning. This means that those commands are not triggered
+                              until the user opens the IDE in his browser.
+                            items:
+                              type: string
+                            type: array
+                          postStop:
+                            description: IDs of commands that should be executed after
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                          preStart:
+                            description: IDs of commands that should be executed before
+                              the devworkspace start. Kubernetes-wise, these commands
+                              would typically be executed in init containers of the
+                              devworkspace POD.
+                            items:
+                              type: string
+                            type: array
+                          preStop:
+                            description: IDs of commands that should be executed before
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      projects:
+                        description: Projects worked on in the devworkspace, containing
+                          names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      starterProjects:
+                        description: StarterProjects is a project that can be used
+                          as a starting point when bootstrapping new projects
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            description:
+                              description: Description of a starter project
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            subDir:
+                              description: Sub-directory from a starter project to
+                                be used as root for starter project.
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      variables:
+                        additionalProperties:
+                          type: string
+                        description: "Map of key-value variables used for string replacement
+                          in the devfile. Values can be referenced via {{variable-key}}
+                          to replace the corresponding value in string fields in the
+                          devfile. Replacement cannot be used for \n  - schemaVersion,
+                          metadata, parent source \n  - element identifiers, e.g.
+                          command id, component name, endpoint name, project name
+                          \n  - references to identifiers, e.g. in events, a command's
+                          component, container's volume mount name \n  - string enums,
+                          e.g. command group kind, endpoint exposure"
+                        type: object
+                    type: object
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -123,6 +123,1988 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
+                  defaultTemplate:
+                    description: DefaultTemplate defines an optional DevWorkspace
+                      Spec Template which gets applied to the workspace if the workspace's
+                      Template Spec Components are not defined. The DefaultTemplate
+                      will overwrite the existing Template Spec, with the exception
+                      of Projects (if any are defined).
+                    properties:
+                      attributes:
+                        description: Map of implementation-dependant free-form YAML
+                          attributes.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      commands:
+                        description: Predefined, ready-to-use, devworkspace-related
+                          commands
+                        items:
+                          properties:
+                            apply:
+                              description: "Command that consists in applying a given
+                                component definition, typically bound to a devworkspace
+                                event. \n For example, when an `apply` command is
+                                bound to a `preStart` event, and references a `container`
+                                component, it will start the container as a K8S initContainer
+                                in the devworkspace POD, unless the component has
+                                its `dedicatedPod` field set to `true`. \n When no
+                                `apply` command exist for a given component, it is
+                                assumed the component will be applied at devworkspace
+                                start by default, unless `deployByDefault` for that
+                                component is set to false."
+                              properties:
+                                component:
+                                  description: Describes component that will be applied
+                                  type: string
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - component
+                              type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            commandType:
+                              description: Type of devworkspace command
+                              enum:
+                              - Exec
+                              - Apply
+                              - Composite
+                              - Custom
+                              type: string
+                            composite:
+                              description: Composite command that allows executing
+                                several sub-commands either sequentially or concurrently
+                              properties:
+                                commands:
+                                  description: The commands that comprise this composite
+                                    command
+                                  items:
+                                    type: string
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                parallel:
+                                  description: Indicates if the sub-commands should
+                                    be executed concurrently
+                                  type: boolean
+                              type: object
+                            custom:
+                              description: Custom command whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated plugin
+                              properties:
+                                commandClass:
+                                  description: Class of command that the associated
+                                    implementation component should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom command that the implementation
+                                    component will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - commandClass
+                              - embeddedResource
+                              type: object
+                            exec:
+                              description: CLI Command executed in an existing component
+                                container
+                              properties:
+                                commandLine:
+                                  description: "The actual command-line string \n
+                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                    A path where projects sources are mounted as defined
+                                    by container component's sourceMapping. \n  -
+                                    `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>). If there are
+                                    multiple projects, this will point to the directory
+                                    of the first one."
+                                  type: string
+                                component:
+                                  description: Describes component to which given
+                                    action relates
+                                  type: string
+                                env:
+                                  description: Optional list of environment variables
+                                    that have to be set before running the command
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                hotReloadCapable:
+                                  description: "Whether the command is capable to
+                                    reload itself when source code changes. If set
+                                    to `true` the command won't be restarted and it
+                                    is expected to handle file changes on its own.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                workingDir:
+                                  description: "Working directory where the command
+                                    should be executed \n Special variables that can
+                                    be used: \n  - `$PROJECTS_ROOT`: A path where
+                                    projects sources are mounted as defined by container
+                                    component's sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one."
+                                  type: string
+                              required:
+                              - commandLine
+                              - component
+                              type: object
+                            id:
+                              description: Mandatory identifier that allows referencing
+                                this command in composite commands, from a parent,
+                                or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - id
+                          type: object
+                        type: array
+                      components:
+                        description: List of the devworkspace components, such as
+                          editor and plugins, user-provided containers, or other types
+                          of components
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            componentType:
+                              description: Type of component
+                              enum:
+                              - Container
+                              - Kubernetes
+                              - Openshift
+                              - Volume
+                              - Image
+                              - Plugin
+                              - Custom
+                              type: string
+                            container:
+                              description: Allows adding and configuring devworkspace-related
+                                containers
+                              properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
+                                args:
+                                  description: "The arguments to supply to the command
+                                    running the dockerimage component. The arguments
+                                    are supplied either to the default command provided
+                                    in the image or to the overridden command. \n
+                                    Defaults to an empty array, meaning use whatever
+                                    is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  description: "The command to run in the dockerimage
+                                    component instead of the default one provided
+                                    in the image. \n Defaults to an empty array, meaning
+                                    use whatever is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
+                                dedicatedPod:
+                                  description: "Specify if a container should run
+                                    in its own separated pod, instead of running as
+                                    part of the main development environment pod.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                env:
+                                  description: "Environment variables used in this
+                                    container. \n The following variables are reserved
+                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
+                                    \n  - `$PROJECT_SOURCE`"
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                memoryLimit:
+                                  type: string
+                                memoryRequest:
+                                  type: string
+                                mountSources:
+                                  description: "Toggles whether or not the project
+                                    source code should be mounted in the component.
+                                    \n Defaults to true for all component types except
+                                    plugins and components that set `dedicatedPod`
+                                    to true."
+                                  type: boolean
+                                sourceMapping:
+                                  default: /projects
+                                  description: Optional specification of the path
+                                    in the container where project sources should
+                                    be transferred/mounted when `mountSources` is
+                                    `true`. When omitted, the default value of /projects
+                                    is used.
+                                  type: string
+                                volumeMounts:
+                                  description: List of volumes mounts that should
+                                    be mounted is this container.
+                                  items:
+                                    description: Volume that should be mounted to
+                                      a component container
+                                    properties:
+                                      name:
+                                        description: The volume mount name is the
+                                          name of an existing `Volume` component.
+                                          If several containers mount the same volume
+                                          name then they will reuse the same volume
+                                          and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: The path in the component container
+                                          where the volume should be mounted. If not
+                                          path is mentioned, default path is the is
+                                          `/<name>`.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                              required:
+                              - image
+                              type: object
+                            custom:
+                              description: Custom component whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated controller
+                              properties:
+                                componentClass:
+                                  description: Class of component that the associated
+                                    implementation controller should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom component that the implementation
+                                    controller will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - componentClass
+                              - embeddedResource
+                              type: object
+                            image:
+                              description: Allows specifying the definition of an
+                                image for outer loop builds
+                              properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built
+                                    during startup. \n Default value is `false`"
+                                  type: boolean
+                                dockerfile:
+                                  description: Allows specifying dockerfile type build
+                                  properties:
+                                    args:
+                                      description: The arguments to supply to the
+                                        dockerfile build.
+                                      items:
+                                        type: string
+                                      type: array
+                                    buildContext:
+                                      description: Path of source directory to establish
+                                        build context. Defaults to ${PROJECT_SOURCE}
+                                        in the container
+                                      type: string
+                                    devfileRegistry:
+                                      description: Dockerfile's Devfile Registry source
+                                      properties:
+                                        id:
+                                          description: Id in a devfile registry that
+                                            contains a Dockerfile. The src in the
+                                            OCI registry required for the Dockerfile
+                                            build will be downloaded for building
+                                            the image.
+                                          type: string
+                                        registryUrl:
+                                          description: Devfile Registry URL to pull
+                                            the Dockerfile from when using the Devfile
+                                            Registry as Dockerfile src. To ensure
+                                            the Dockerfile gets resolved consistently
+                                            in different environments, it is recommended
+                                            to always specify the `devfileRegistryUrl`
+                                            when `Id` is used.
+                                          type: string
+                                      required:
+                                      - id
+                                      type: object
+                                    git:
+                                      description: Dockerfile's Git source
+                                      properties:
+                                        checkoutFrom:
+                                          description: Defines from what the project
+                                            should be checked out. Required if there
+                                            are more than one remote configured
+                                          properties:
+                                            remote:
+                                              description: The remote name should
+                                                be used as init. Required if there
+                                                are more than one remote configured
+                                              type: string
+                                            revision:
+                                              description: The revision to checkout
+                                                from. Should be branch name, tag or
+                                                commit id. Default branch is used
+                                                if missing or specified revision is
+                                                not found.
+                                              type: string
+                                          type: object
+                                        fileLocation:
+                                          description: Location of the Dockerfile
+                                            in the Git repository when using git as
+                                            Dockerfile src. Defaults to Dockerfile.
+                                          type: string
+                                        remotes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The remotes map which should
+                                            be initialized in the git project. Projects
+                                            must have at least one remote configured
+                                            while StarterProjects & Image Component's
+                                            Git source can only have at most one remote
+                                            configured.
+                                          type: object
+                                      required:
+                                      - remotes
+                                      type: object
+                                    rootRequired:
+                                      description: "Specify if a privileged builder
+                                        pod is required. \n Default value is `false`"
+                                      type: boolean
+                                    srcType:
+                                      description: Type of Dockerfile src
+                                      enum:
+                                      - Uri
+                                      - DevfileRegistry
+                                      - Git
+                                      type: string
+                                    uri:
+                                      description: URI Reference of a Dockerfile.
+                                        It can be a full URL or a relative URI from
+                                        the current devfile as the base URI.
+                                      type: string
+                                  type: object
+                                imageName:
+                                  description: Name of the image for the resulting
+                                    outerloop build
+                                  type: string
+                                imageType:
+                                  description: Type of image
+                                  enum:
+                                  - Dockerfile
+                                  type: string
+                              required:
+                              - imageName
+                              type: object
+                            kubernetes:
+                              description: Allows importing into the devworkspace
+                                the Kubernetes resources defined in a given manifest.
+                                For example this allows reusing the Kubernetes definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            name:
+                              description: Mandatory name that allows referencing
+                                the component from other elements (such as commands)
+                                or from an external devfile that may reference this
+                                component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            openshift:
+                              description: Allows importing into the devworkspace
+                                the OpenShift resources defined in a given manifest.
+                                For example this allows reusing the OpenShift definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            plugin:
+                              description: "Allows importing a plugin. \n Plugins
+                                are mainly imported devfiles that contribute components,
+                                commands and events as a consistent single unit. They
+                                are defined in either YAML files following the devfile
+                                syntax, or as `DevWorkspaceTemplate` Kubernetes Custom
+                                Resources"
+                              properties:
+                                commands:
+                                  description: Overrides of commands encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      apply:
+                                        description: "Command that consists in applying
+                                          a given component definition, typically
+                                          bound to a devworkspace event. \n For example,
+                                          when an `apply` command is bound to a `preStart`
+                                          event, and references a `container` component,
+                                          it will start the container as a K8S initContainer
+                                          in the devworkspace POD, unless the component
+                                          has its `dedicatedPod` field set to `true`.
+                                          \n When no `apply` command exist for a given
+                                          component, it is assumed the component will
+                                          be applied at devworkspace start by default,
+                                          unless `deployByDefault` for that component
+                                          is set to false."
+                                        properties:
+                                          component:
+                                            description: Describes component that
+                                              will be applied
+                                            type: string
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                        type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      commandType:
+                                        description: Type of devworkspace command
+                                        enum:
+                                        - Exec
+                                        - Apply
+                                        - Composite
+                                        type: string
+                                      composite:
+                                        description: Composite command that allows
+                                          executing several sub-commands either sequentially
+                                          or concurrently
+                                        properties:
+                                          commands:
+                                            description: The commands that comprise
+                                              this composite command
+                                            items:
+                                              type: string
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          parallel:
+                                            description: Indicates if the sub-commands
+                                              should be executed concurrently
+                                            type: boolean
+                                        type: object
+                                      exec:
+                                        description: CLI Command executed in an existing
+                                          component container
+                                        properties:
+                                          commandLine:
+                                            description: "The actual command-line
+                                              string \n Special variables that can
+                                              be used: \n  - `$PROJECTS_ROOT`: A path
+                                              where projects sources are mounted as
+                                              defined by container component's sourceMapping.
+                                              \n  - `$PROJECT_SOURCE`: A path to a
+                                              project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                          component:
+                                            description: Describes component to which
+                                              given action relates
+                                            type: string
+                                          env:
+                                            description: Optional list of environment
+                                              variables that have to be set before
+                                              running the command
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          hotReloadCapable:
+                                            description: "Whether the command is capable
+                                              to reload itself when source code changes.
+                                              If set to `true` the command won't be
+                                              restarted and it is expected to handle
+                                              file changes on its own. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          workingDir:
+                                            description: "Working directory where
+                                              the command should be executed \n Special
+                                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                              A path where projects sources are mounted
+                                              as defined by container component's
+                                              sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                        type: object
+                                      id:
+                                        description: Mandatory identifier that allows
+                                          referencing this command in composite commands,
+                                          from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                    required:
+                                    - id
+                                    type: object
+                                  type: array
+                                components:
+                                  description: Overrides of components encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      componentType:
+                                        description: Type of component
+                                        enum:
+                                        - Container
+                                        - Kubernetes
+                                        - Openshift
+                                        - Volume
+                                        - Image
+                                        type: string
+                                      container:
+                                        description: Allows adding and configuring
+                                          devworkspace-related containers
+                                        properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
+                                          args:
+                                            description: "The arguments to supply
+                                              to the command running the dockerimage
+                                              component. The arguments are supplied
+                                              either to the default command provided
+                                              in the image or to the overridden command.
+                                              \n Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: "The command to run in the
+                                              dockerimage component instead of the
+                                              default one provided in the image. \n
+                                              Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
+                                          dedicatedPod:
+                                            description: "Specify if a container should
+                                              run in its own separated pod, instead
+                                              of running as part of the main development
+                                              environment pod. \n Default value is
+                                              `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          env:
+                                            description: "Environment variables used
+                                              in this container. \n The following
+                                              variables are reserved and cannot be
+                                              overridden via env: \n  - `$PROJECTS_ROOT`
+                                              \n  - `$PROJECT_SOURCE`"
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          memoryLimit:
+                                            type: string
+                                          memoryRequest:
+                                            type: string
+                                          mountSources:
+                                            description: "Toggles whether or not the
+                                              project source code should be mounted
+                                              in the component. \n Defaults to true
+                                              for all component types except plugins
+                                              and components that set `dedicatedPod`
+                                              to true."
+                                            type: boolean
+                                          sourceMapping:
+                                            description: Optional specification of
+                                              the path in the container where project
+                                              sources should be transferred/mounted
+                                              when `mountSources` is `true`. When
+                                              omitted, the default value of /projects
+                                              is used.
+                                            type: string
+                                          volumeMounts:
+                                            description: List of volumes mounts that
+                                              should be mounted is this container.
+                                            items:
+                                              description: Volume that should be mounted
+                                                to a component container
+                                              properties:
+                                                name:
+                                                  description: The volume mount name
+                                                    is the name of an existing `Volume`
+                                                    component. If several containers
+                                                    mount the same volume name then
+                                                    they will reuse the same volume
+                                                    and will be able to access to
+                                                    the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: The path in the component
+                                                    container where the volume should
+                                                    be mounted. If not path is mentioned,
+                                                    default path is the is `/<name>`.
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                        type: object
+                                      image:
+                                        description: Allows specifying the definition
+                                          of an image for outer loop builds
+                                        properties:
+                                          autoBuild:
+                                            description: "Defines if the image should
+                                              be built during startup. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          dockerfile:
+                                            description: Allows specifying dockerfile
+                                              type build
+                                            properties:
+                                              args:
+                                                description: The arguments to supply
+                                                  to the dockerfile build.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              buildContext:
+                                                description: Path of source directory
+                                                  to establish build context. Defaults
+                                                  to ${PROJECT_SOURCE} in the container
+                                                type: string
+                                              devfileRegistry:
+                                                description: Dockerfile's Devfile
+                                                  Registry source
+                                                properties:
+                                                  id:
+                                                    description: Id in a devfile registry
+                                                      that contains a Dockerfile.
+                                                      The src in the OCI registry
+                                                      required for the Dockerfile
+                                                      build will be downloaded for
+                                                      building the image.
+                                                    type: string
+                                                  registryUrl:
+                                                    description: Devfile Registry
+                                                      URL to pull the Dockerfile from
+                                                      when using the Devfile Registry
+                                                      as Dockerfile src. To ensure
+                                                      the Dockerfile gets resolved
+                                                      consistently in different environments,
+                                                      it is recommended to always
+                                                      specify the `devfileRegistryUrl`
+                                                      when `Id` is used.
+                                                    type: string
+                                                type: object
+                                              git:
+                                                description: Dockerfile's Git source
+                                                properties:
+                                                  checkoutFrom:
+                                                    description: Defines from what
+                                                      the project should be checked
+                                                      out. Required if there are more
+                                                      than one remote configured
+                                                    properties:
+                                                      remote:
+                                                        description: The remote name
+                                                          should be used as init.
+                                                          Required if there are more
+                                                          than one remote configured
+                                                        type: string
+                                                      revision:
+                                                        description: The revision
+                                                          to checkout from. Should
+                                                          be branch name, tag or commit
+                                                          id. Default branch is used
+                                                          if missing or specified
+                                                          revision is not found.
+                                                        type: string
+                                                    type: object
+                                                  fileLocation:
+                                                    description: Location of the Dockerfile
+                                                      in the Git repository when using
+                                                      git as Dockerfile src. Defaults
+                                                      to Dockerfile.
+                                                    type: string
+                                                  remotes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: The remotes map which
+                                                      should be initialized in the
+                                                      git project. Projects must have
+                                                      at least one remote configured
+                                                      while StarterProjects & Image
+                                                      Component's Git source can only
+                                                      have at most one remote configured.
+                                                    type: object
+                                                type: object
+                                              rootRequired:
+                                                description: "Specify if a privileged
+                                                  builder pod is required. \n Default
+                                                  value is `false`"
+                                                type: boolean
+                                              srcType:
+                                                description: Type of Dockerfile src
+                                                enum:
+                                                - Uri
+                                                - DevfileRegistry
+                                                - Git
+                                                type: string
+                                              uri:
+                                                description: URI Reference of a Dockerfile.
+                                                  It can be a full URL or a relative
+                                                  URI from the current devfile as
+                                                  the base URI.
+                                                type: string
+                                            type: object
+                                          imageName:
+                                            description: Name of the image for the
+                                              resulting outerloop build
+                                            type: string
+                                          imageType:
+                                            description: Type of image
+                                            enum:
+                                            - Dockerfile
+                                            - AutoBuild
+                                            type: string
+                                        type: object
+                                      kubernetes:
+                                        description: Allows importing into the devworkspace
+                                          the Kubernetes resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the Kubernetes definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      name:
+                                        description: Mandatory name that allows referencing
+                                          the component from other elements (such
+                                          as commands) or from an external devfile
+                                          that may reference this component through
+                                          a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      openshift:
+                                        description: Allows importing into the devworkspace
+                                          the OpenShift resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the OpenShift definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      volume:
+                                        description: Allows specifying the definition
+                                          of a volume shared by several other components
+                                        properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
+                                          size:
+                                            description: Size of the volume
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                id:
+                                  description: Id in a registry that contains a Devfile
+                                    yaml file
+                                  type: string
+                                importReferenceType:
+                                  description: type of location from where the referenced
+                                    template structure should be retrieved
+                                  enum:
+                                  - Uri
+                                  - Id
+                                  - Kubernetes
+                                  type: string
+                                kubernetes:
+                                  description: Reference to a Kubernetes CRD of type
+                                    DevWorkspaceTemplate
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                registryUrl:
+                                  description: Registry URL to pull the parent devfile
+                                    from when using id in the parent reference. To
+                                    ensure the parent devfile gets resolved consistently
+                                    in different environments, it is recommended to
+                                    always specify the `registryUrl` when `id` is
+                                    used.
+                                  type: string
+                                uri:
+                                  description: URI Reference of a parent devfile YAML
+                                    file. It can be a full URL or a relative URI with
+                                    the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                                  type: string
+                              type: object
+                            volume:
+                              description: Allows specifying the definition of a volume
+                                shared by several other components
+                              properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
+                                size:
+                                  description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      events:
+                        description: Bindings of commands to events. Each command
+                          is referred-to by its name.
+                        properties:
+                          postStart:
+                            description: IDs of commands that should be executed after
+                              the devworkspace is completely started. In the case
+                              of Che-Theia, these commands should be executed after
+                              all plugins and extensions have started, including project
+                              cloning. This means that those commands are not triggered
+                              until the user opens the IDE in his browser.
+                            items:
+                              type: string
+                            type: array
+                          postStop:
+                            description: IDs of commands that should be executed after
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                          preStart:
+                            description: IDs of commands that should be executed before
+                              the devworkspace start. Kubernetes-wise, these commands
+                              would typically be executed in init containers of the
+                              devworkspace POD.
+                            items:
+                              type: string
+                            type: array
+                          preStop:
+                            description: IDs of commands that should be executed before
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      projects:
+                        description: Projects worked on in the devworkspace, containing
+                          names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      starterProjects:
+                        description: StarterProjects is a project that can be used
+                          as a starting point when bootstrapping new projects
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            description:
+                              description: Description of a starter project
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            subDir:
+                              description: Sub-directory from a starter project to
+                                be used as root for starter project.
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      variables:
+                        additionalProperties:
+                          type: string
+                        description: "Map of key-value variables used for string replacement
+                          in the devfile. Values can be referenced via {{variable-key}}
+                          to replace the corresponding value in string fields in the
+                          devfile. Replacement cannot be used for \n  - schemaVersion,
+                          metadata, parent source \n  - element identifiers, e.g.
+                          command id, component name, endpoint name, project name
+                          \n  - references to identifiers, e.g. in events, a command's
+                          component, container's volume mount name \n  - string enums,
+                          e.g. command group kind, endpoint exposure"
+                        type: object
+                    type: object
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -122,6 +122,1988 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
+                  defaultTemplate:
+                    description: DefaultTemplate defines an optional DevWorkspace
+                      Spec Template which gets applied to the workspace if the workspace's
+                      Template Spec Components are not defined. The DefaultTemplate
+                      will overwrite the existing Template Spec, with the exception
+                      of Projects (if any are defined).
+                    properties:
+                      attributes:
+                        description: Map of implementation-dependant free-form YAML
+                          attributes.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      commands:
+                        description: Predefined, ready-to-use, devworkspace-related
+                          commands
+                        items:
+                          properties:
+                            apply:
+                              description: "Command that consists in applying a given
+                                component definition, typically bound to a devworkspace
+                                event. \n For example, when an `apply` command is
+                                bound to a `preStart` event, and references a `container`
+                                component, it will start the container as a K8S initContainer
+                                in the devworkspace POD, unless the component has
+                                its `dedicatedPod` field set to `true`. \n When no
+                                `apply` command exist for a given component, it is
+                                assumed the component will be applied at devworkspace
+                                start by default, unless `deployByDefault` for that
+                                component is set to false."
+                              properties:
+                                component:
+                                  description: Describes component that will be applied
+                                  type: string
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - component
+                              type: object
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            commandType:
+                              description: Type of devworkspace command
+                              enum:
+                              - Exec
+                              - Apply
+                              - Composite
+                              - Custom
+                              type: string
+                            composite:
+                              description: Composite command that allows executing
+                                several sub-commands either sequentially or concurrently
+                              properties:
+                                commands:
+                                  description: The commands that comprise this composite
+                                    command
+                                  items:
+                                    type: string
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                parallel:
+                                  description: Indicates if the sub-commands should
+                                    be executed concurrently
+                                  type: boolean
+                              type: object
+                            custom:
+                              description: Custom command whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated plugin
+                              properties:
+                                commandClass:
+                                  description: Class of command that the associated
+                                    implementation component should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom command that the implementation
+                                    component will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                              required:
+                              - commandClass
+                              - embeddedResource
+                              type: object
+                            exec:
+                              description: CLI Command executed in an existing component
+                                container
+                              properties:
+                                commandLine:
+                                  description: "The actual command-line string \n
+                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                    A path where projects sources are mounted as defined
+                                    by container component's sourceMapping. \n  -
+                                    `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>). If there are
+                                    multiple projects, this will point to the directory
+                                    of the first one."
+                                  type: string
+                                component:
+                                  description: Describes component to which given
+                                    action relates
+                                  type: string
+                                env:
+                                  description: Optional list of environment variables
+                                    that have to be set before running the command
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                group:
+                                  description: Defines the group this command is part
+                                    of
+                                  properties:
+                                    isDefault:
+                                      description: Identifies the default command
+                                        for a given group kind
+                                      type: boolean
+                                    kind:
+                                      description: Kind of group the command is part
+                                        of
+                                      enum:
+                                      - build
+                                      - run
+                                      - test
+                                      - debug
+                                      - deploy
+                                      type: string
+                                  required:
+                                  - kind
+                                  type: object
+                                hotReloadCapable:
+                                  description: "Whether the command is capable to
+                                    reload itself when source code changes. If set
+                                    to `true` the command won't be restarted and it
+                                    is expected to handle file changes on its own.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                label:
+                                  description: Optional label that provides a label
+                                    for this command to be used in Editor UI menus
+                                    for example
+                                  type: string
+                                workingDir:
+                                  description: "Working directory where the command
+                                    should be executed \n Special variables that can
+                                    be used: \n  - `$PROJECTS_ROOT`: A path where
+                                    projects sources are mounted as defined by container
+                                    component's sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one."
+                                  type: string
+                              required:
+                              - commandLine
+                              - component
+                              type: object
+                            id:
+                              description: Mandatory identifier that allows referencing
+                                this command in composite commands, from a parent,
+                                or in events.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - id
+                          type: object
+                        type: array
+                      components:
+                        description: List of the devworkspace components, such as
+                          editor and plugins, user-provided containers, or other types
+                          of components
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            componentType:
+                              description: Type of component
+                              enum:
+                              - Container
+                              - Kubernetes
+                              - Openshift
+                              - Volume
+                              - Image
+                              - Plugin
+                              - Custom
+                              type: string
+                            container:
+                              description: Allows adding and configuring devworkspace-related
+                                containers
+                              properties:
+                                annotation:
+                                  description: Annotations that should be added to
+                                    specific resources for this container
+                                  properties:
+                                    deployment:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to deployment
+                                      type: object
+                                    service:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to service
+                                      type: object
+                                  type: object
+                                args:
+                                  description: "The arguments to supply to the command
+                                    running the dockerimage component. The arguments
+                                    are supplied either to the default command provided
+                                    in the image or to the overridden command. \n
+                                    Defaults to an empty array, meaning use whatever
+                                    is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  description: "The command to run in the dockerimage
+                                    component instead of the default one provided
+                                    in the image. \n Defaults to an empty array, meaning
+                                    use whatever is defined in the image."
+                                  items:
+                                    type: string
+                                  type: array
+                                cpuLimit:
+                                  type: string
+                                cpuRequest:
+                                  type: string
+                                dedicatedPod:
+                                  description: "Specify if a container should run
+                                    in its own separated pod, instead of running as
+                                    part of the main development environment pod.
+                                    \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                env:
+                                  description: "Environment variables used in this
+                                    container. \n The following variables are reserved
+                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
+                                    \n  - `$PROJECT_SOURCE`"
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                memoryLimit:
+                                  type: string
+                                memoryRequest:
+                                  type: string
+                                mountSources:
+                                  description: "Toggles whether or not the project
+                                    source code should be mounted in the component.
+                                    \n Defaults to true for all component types except
+                                    plugins and components that set `dedicatedPod`
+                                    to true."
+                                  type: boolean
+                                sourceMapping:
+                                  default: /projects
+                                  description: Optional specification of the path
+                                    in the container where project sources should
+                                    be transferred/mounted when `mountSources` is
+                                    `true`. When omitted, the default value of /projects
+                                    is used.
+                                  type: string
+                                volumeMounts:
+                                  description: List of volumes mounts that should
+                                    be mounted is this container.
+                                  items:
+                                    description: Volume that should be mounted to
+                                      a component container
+                                    properties:
+                                      name:
+                                        description: The volume mount name is the
+                                          name of an existing `Volume` component.
+                                          If several containers mount the same volume
+                                          name then they will reuse the same volume
+                                          and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: The path in the component container
+                                          where the volume should be mounted. If not
+                                          path is mentioned, default path is the is
+                                          `/<name>`.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                              required:
+                              - image
+                              type: object
+                            custom:
+                              description: Custom component whose logic is implementation-dependant
+                                and should be provided by the user possibly through
+                                some dedicated controller
+                              properties:
+                                componentClass:
+                                  description: Class of component that the associated
+                                    implementation controller should use to process
+                                    this command with the appropriate logic
+                                  type: string
+                                embeddedResource:
+                                  description: Additional free-form configuration
+                                    for this custom component that the implementation
+                                    controller will know how to use
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - componentClass
+                              - embeddedResource
+                              type: object
+                            image:
+                              description: Allows specifying the definition of an
+                                image for outer loop builds
+                              properties:
+                                autoBuild:
+                                  description: "Defines if the image should be built
+                                    during startup. \n Default value is `false`"
+                                  type: boolean
+                                dockerfile:
+                                  description: Allows specifying dockerfile type build
+                                  properties:
+                                    args:
+                                      description: The arguments to supply to the
+                                        dockerfile build.
+                                      items:
+                                        type: string
+                                      type: array
+                                    buildContext:
+                                      description: Path of source directory to establish
+                                        build context. Defaults to ${PROJECT_SOURCE}
+                                        in the container
+                                      type: string
+                                    devfileRegistry:
+                                      description: Dockerfile's Devfile Registry source
+                                      properties:
+                                        id:
+                                          description: Id in a devfile registry that
+                                            contains a Dockerfile. The src in the
+                                            OCI registry required for the Dockerfile
+                                            build will be downloaded for building
+                                            the image.
+                                          type: string
+                                        registryUrl:
+                                          description: Devfile Registry URL to pull
+                                            the Dockerfile from when using the Devfile
+                                            Registry as Dockerfile src. To ensure
+                                            the Dockerfile gets resolved consistently
+                                            in different environments, it is recommended
+                                            to always specify the `devfileRegistryUrl`
+                                            when `Id` is used.
+                                          type: string
+                                      required:
+                                      - id
+                                      type: object
+                                    git:
+                                      description: Dockerfile's Git source
+                                      properties:
+                                        checkoutFrom:
+                                          description: Defines from what the project
+                                            should be checked out. Required if there
+                                            are more than one remote configured
+                                          properties:
+                                            remote:
+                                              description: The remote name should
+                                                be used as init. Required if there
+                                                are more than one remote configured
+                                              type: string
+                                            revision:
+                                              description: The revision to checkout
+                                                from. Should be branch name, tag or
+                                                commit id. Default branch is used
+                                                if missing or specified revision is
+                                                not found.
+                                              type: string
+                                          type: object
+                                        fileLocation:
+                                          description: Location of the Dockerfile
+                                            in the Git repository when using git as
+                                            Dockerfile src. Defaults to Dockerfile.
+                                          type: string
+                                        remotes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The remotes map which should
+                                            be initialized in the git project. Projects
+                                            must have at least one remote configured
+                                            while StarterProjects & Image Component's
+                                            Git source can only have at most one remote
+                                            configured.
+                                          type: object
+                                      required:
+                                      - remotes
+                                      type: object
+                                    rootRequired:
+                                      description: "Specify if a privileged builder
+                                        pod is required. \n Default value is `false`"
+                                      type: boolean
+                                    srcType:
+                                      description: Type of Dockerfile src
+                                      enum:
+                                      - Uri
+                                      - DevfileRegistry
+                                      - Git
+                                      type: string
+                                    uri:
+                                      description: URI Reference of a Dockerfile.
+                                        It can be a full URL or a relative URI from
+                                        the current devfile as the base URI.
+                                      type: string
+                                  type: object
+                                imageName:
+                                  description: Name of the image for the resulting
+                                    outerloop build
+                                  type: string
+                                imageType:
+                                  description: Type of image
+                                  enum:
+                                  - Dockerfile
+                                  type: string
+                              required:
+                              - imageName
+                              type: object
+                            kubernetes:
+                              description: Allows importing into the devworkspace
+                                the Kubernetes resources defined in a given manifest.
+                                For example this allows reusing the Kubernetes definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            name:
+                              description: Mandatory name that allows referencing
+                                the component from other elements (such as commands)
+                                or from an external devfile that may reference this
+                                component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            openshift:
+                              description: Allows importing into the devworkspace
+                                the OpenShift resources defined in a given manifest.
+                                For example this allows reusing the OpenShift definitions
+                                used to deploy some runtime components in production.
+                              properties:
+                                deployByDefault:
+                                  description: "Defines if the component should be
+                                    deployed during startup. \n Default value is `false`"
+                                  type: boolean
+                                endpoints:
+                                  items:
+                                    properties:
+                                      annotation:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations to be added to Kubernetes
+                                          Ingress or Openshift Route
+                                        type: object
+                                      attributes:
+                                        description: "Map of implementation-dependant
+                                          string-based free-form attributes. \n Examples
+                                          of Che-specific attributes: \n - cookiesAuthEnabled:
+                                          \"true\" / \"false\", \n - type: \"terminal\"
+                                          / \"ide\" / \"ide-dev\","
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      exposure:
+                                        default: public
+                                        description: "Describes how the endpoint should
+                                          be exposed on the network. \n - `public`
+                                          means that the endpoint will be exposed
+                                          on the public network, typically through
+                                          a K8S ingress or an OpenShift route. \n
+                                          - `internal` means that the endpoint will
+                                          be exposed internally outside of the main
+                                          devworkspace POD, typically by K8S services,
+                                          to be consumed by other elements running
+                                          on the same cloud internal network. \n -
+                                          `none` means that the endpoint will not
+                                          be exposed and will only be accessible inside
+                                          the main devworkspace POD, on a local address.
+                                          \n Default value is `public`"
+                                        enum:
+                                        - public
+                                        - internal
+                                        - none
+                                        type: string
+                                      name:
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      path:
+                                        description: Path of the endpoint URL
+                                        type: string
+                                      protocol:
+                                        default: http
+                                        description: "Describes the application and
+                                          transport protocols of the traffic that
+                                          will go through this endpoint. \n - `http`:
+                                          Endpoint will have `http` traffic, typically
+                                          on a TCP connection. It will be automaticaly
+                                          promoted to `https` when the `secure` field
+                                          is set to `true`. \n - `https`: Endpoint
+                                          will have `https` traffic, typically on
+                                          a TCP connection. \n - `ws`: Endpoint will
+                                          have `ws` traffic, typically on a TCP connection.
+                                          It will be automaticaly promoted to `wss`
+                                          when the `secure` field is set to `true`.
+                                          \n - `wss`: Endpoint will have `wss` traffic,
+                                          typically on a TCP connection. \n - `tcp`:
+                                          Endpoint will have traffic on a TCP connection,
+                                          without specifying an application protocol.
+                                          \n - `udp`: Endpoint will have traffic on
+                                          an UDP connection, without specifying an
+                                          application protocol. \n Default value is
+                                          `http`"
+                                        enum:
+                                        - http
+                                        - https
+                                        - ws
+                                        - wss
+                                        - tcp
+                                        - udp
+                                        type: string
+                                      secure:
+                                        description: Describes whether the endpoint
+                                          should be secured and protected by some
+                                          authentication process. This requires a
+                                          protocol of `https` or `wss`.
+                                        type: boolean
+                                      targetPort:
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
+                                        type: integer
+                                    required:
+                                    - name
+                                    - targetPort
+                                    type: object
+                                  type: array
+                                inlined:
+                                  description: Inlined manifest
+                                  type: string
+                                locationType:
+                                  description: Type of Kubernetes-like location
+                                  enum:
+                                  - Uri
+                                  - Inlined
+                                  type: string
+                                uri:
+                                  description: Location in a file fetched from a uri.
+                                  type: string
+                              type: object
+                            plugin:
+                              description: "Allows importing a plugin. \n Plugins
+                                are mainly imported devfiles that contribute components,
+                                commands and events as a consistent single unit. They
+                                are defined in either YAML files following the devfile
+                                syntax, or as `DevWorkspaceTemplate` Kubernetes Custom
+                                Resources"
+                              properties:
+                                commands:
+                                  description: Overrides of commands encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      apply:
+                                        description: "Command that consists in applying
+                                          a given component definition, typically
+                                          bound to a devworkspace event. \n For example,
+                                          when an `apply` command is bound to a `preStart`
+                                          event, and references a `container` component,
+                                          it will start the container as a K8S initContainer
+                                          in the devworkspace POD, unless the component
+                                          has its `dedicatedPod` field set to `true`.
+                                          \n When no `apply` command exist for a given
+                                          component, it is assumed the component will
+                                          be applied at devworkspace start by default,
+                                          unless `deployByDefault` for that component
+                                          is set to false."
+                                        properties:
+                                          component:
+                                            description: Describes component that
+                                              will be applied
+                                            type: string
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                        type: object
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      commandType:
+                                        description: Type of devworkspace command
+                                        enum:
+                                        - Exec
+                                        - Apply
+                                        - Composite
+                                        type: string
+                                      composite:
+                                        description: Composite command that allows
+                                          executing several sub-commands either sequentially
+                                          or concurrently
+                                        properties:
+                                          commands:
+                                            description: The commands that comprise
+                                              this composite command
+                                            items:
+                                              type: string
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          parallel:
+                                            description: Indicates if the sub-commands
+                                              should be executed concurrently
+                                            type: boolean
+                                        type: object
+                                      exec:
+                                        description: CLI Command executed in an existing
+                                          component container
+                                        properties:
+                                          commandLine:
+                                            description: "The actual command-line
+                                              string \n Special variables that can
+                                              be used: \n  - `$PROJECTS_ROOT`: A path
+                                              where projects sources are mounted as
+                                              defined by container component's sourceMapping.
+                                              \n  - `$PROJECT_SOURCE`: A path to a
+                                              project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                          component:
+                                            description: Describes component to which
+                                              given action relates
+                                            type: string
+                                          env:
+                                            description: Optional list of environment
+                                              variables that have to be set before
+                                              running the command
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          group:
+                                            description: Defines the group this command
+                                              is part of
+                                            properties:
+                                              isDefault:
+                                                description: Identifies the default
+                                                  command for a given group kind
+                                                type: boolean
+                                              kind:
+                                                description: Kind of group the command
+                                                  is part of
+                                                enum:
+                                                - build
+                                                - run
+                                                - test
+                                                - debug
+                                                - deploy
+                                                type: string
+                                            type: object
+                                          hotReloadCapable:
+                                            description: "Whether the command is capable
+                                              to reload itself when source code changes.
+                                              If set to `true` the command won't be
+                                              restarted and it is expected to handle
+                                              file changes on its own. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          label:
+                                            description: Optional label that provides
+                                              a label for this command to be used
+                                              in Editor UI menus for example
+                                            type: string
+                                          workingDir:
+                                            description: "Working directory where
+                                              the command should be executed \n Special
+                                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                              A path where projects sources are mounted
+                                              as defined by container component's
+                                              sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                              If there are multiple projects, this
+                                              will point to the directory of the first
+                                              one."
+                                            type: string
+                                        type: object
+                                      id:
+                                        description: Mandatory identifier that allows
+                                          referencing this command in composite commands,
+                                          from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                    required:
+                                    - id
+                                    type: object
+                                  type: array
+                                components:
+                                  description: Overrides of components encapsulated
+                                    in a parent devfile or a plugin. Overriding is
+                                    done according to K8S strategic merge patch standard
+                                    rules.
+                                  items:
+                                    properties:
+                                      attributes:
+                                        description: Map of implementation-dependant
+                                          free-form YAML attributes.
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      componentType:
+                                        description: Type of component
+                                        enum:
+                                        - Container
+                                        - Kubernetes
+                                        - Openshift
+                                        - Volume
+                                        - Image
+                                        type: string
+                                      container:
+                                        description: Allows adding and configuring
+                                          devworkspace-related containers
+                                        properties:
+                                          annotation:
+                                            description: Annotations that should be
+                                              added to specific resources for this
+                                              container
+                                            properties:
+                                              deployment:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to deployment
+                                                type: object
+                                              service:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Annotations to be added
+                                                  to service
+                                                type: object
+                                            type: object
+                                          args:
+                                            description: "The arguments to supply
+                                              to the command running the dockerimage
+                                              component. The arguments are supplied
+                                              either to the default command provided
+                                              in the image or to the overridden command.
+                                              \n Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: "The command to run in the
+                                              dockerimage component instead of the
+                                              default one provided in the image. \n
+                                              Defaults to an empty array, meaning
+                                              use whatever is defined in the image."
+                                            items:
+                                              type: string
+                                            type: array
+                                          cpuLimit:
+                                            type: string
+                                          cpuRequest:
+                                            type: string
+                                          dedicatedPod:
+                                            description: "Specify if a container should
+                                              run in its own separated pod, instead
+                                              of running as part of the main development
+                                              environment pod. \n Default value is
+                                              `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          env:
+                                            description: "Environment variables used
+                                              in this container. \n The following
+                                              variables are reserved and cannot be
+                                              overridden via env: \n  - `$PROJECTS_ROOT`
+                                              \n  - `$PROJECT_SOURCE`"
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          image:
+                                            type: string
+                                          memoryLimit:
+                                            type: string
+                                          memoryRequest:
+                                            type: string
+                                          mountSources:
+                                            description: "Toggles whether or not the
+                                              project source code should be mounted
+                                              in the component. \n Defaults to true
+                                              for all component types except plugins
+                                              and components that set `dedicatedPod`
+                                              to true."
+                                            type: boolean
+                                          sourceMapping:
+                                            description: Optional specification of
+                                              the path in the container where project
+                                              sources should be transferred/mounted
+                                              when `mountSources` is `true`. When
+                                              omitted, the default value of /projects
+                                              is used.
+                                            type: string
+                                          volumeMounts:
+                                            description: List of volumes mounts that
+                                              should be mounted is this container.
+                                            items:
+                                              description: Volume that should be mounted
+                                                to a component container
+                                              properties:
+                                                name:
+                                                  description: The volume mount name
+                                                    is the name of an existing `Volume`
+                                                    component. If several containers
+                                                    mount the same volume name then
+                                                    they will reuse the same volume
+                                                    and will be able to access to
+                                                    the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: The path in the component
+                                                    container where the volume should
+                                                    be mounted. If not path is mentioned,
+                                                    default path is the is `/<name>`.
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                        type: object
+                                      image:
+                                        description: Allows specifying the definition
+                                          of an image for outer loop builds
+                                        properties:
+                                          autoBuild:
+                                            description: "Defines if the image should
+                                              be built during startup. \n Default
+                                              value is `false`"
+                                            type: boolean
+                                          dockerfile:
+                                            description: Allows specifying dockerfile
+                                              type build
+                                            properties:
+                                              args:
+                                                description: The arguments to supply
+                                                  to the dockerfile build.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              buildContext:
+                                                description: Path of source directory
+                                                  to establish build context. Defaults
+                                                  to ${PROJECT_SOURCE} in the container
+                                                type: string
+                                              devfileRegistry:
+                                                description: Dockerfile's Devfile
+                                                  Registry source
+                                                properties:
+                                                  id:
+                                                    description: Id in a devfile registry
+                                                      that contains a Dockerfile.
+                                                      The src in the OCI registry
+                                                      required for the Dockerfile
+                                                      build will be downloaded for
+                                                      building the image.
+                                                    type: string
+                                                  registryUrl:
+                                                    description: Devfile Registry
+                                                      URL to pull the Dockerfile from
+                                                      when using the Devfile Registry
+                                                      as Dockerfile src. To ensure
+                                                      the Dockerfile gets resolved
+                                                      consistently in different environments,
+                                                      it is recommended to always
+                                                      specify the `devfileRegistryUrl`
+                                                      when `Id` is used.
+                                                    type: string
+                                                type: object
+                                              git:
+                                                description: Dockerfile's Git source
+                                                properties:
+                                                  checkoutFrom:
+                                                    description: Defines from what
+                                                      the project should be checked
+                                                      out. Required if there are more
+                                                      than one remote configured
+                                                    properties:
+                                                      remote:
+                                                        description: The remote name
+                                                          should be used as init.
+                                                          Required if there are more
+                                                          than one remote configured
+                                                        type: string
+                                                      revision:
+                                                        description: The revision
+                                                          to checkout from. Should
+                                                          be branch name, tag or commit
+                                                          id. Default branch is used
+                                                          if missing or specified
+                                                          revision is not found.
+                                                        type: string
+                                                    type: object
+                                                  fileLocation:
+                                                    description: Location of the Dockerfile
+                                                      in the Git repository when using
+                                                      git as Dockerfile src. Defaults
+                                                      to Dockerfile.
+                                                    type: string
+                                                  remotes:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: The remotes map which
+                                                      should be initialized in the
+                                                      git project. Projects must have
+                                                      at least one remote configured
+                                                      while StarterProjects & Image
+                                                      Component's Git source can only
+                                                      have at most one remote configured.
+                                                    type: object
+                                                type: object
+                                              rootRequired:
+                                                description: "Specify if a privileged
+                                                  builder pod is required. \n Default
+                                                  value is `false`"
+                                                type: boolean
+                                              srcType:
+                                                description: Type of Dockerfile src
+                                                enum:
+                                                - Uri
+                                                - DevfileRegistry
+                                                - Git
+                                                type: string
+                                              uri:
+                                                description: URI Reference of a Dockerfile.
+                                                  It can be a full URL or a relative
+                                                  URI from the current devfile as
+                                                  the base URI.
+                                                type: string
+                                            type: object
+                                          imageName:
+                                            description: Name of the image for the
+                                              resulting outerloop build
+                                            type: string
+                                          imageType:
+                                            description: Type of image
+                                            enum:
+                                            - Dockerfile
+                                            - AutoBuild
+                                            type: string
+                                        type: object
+                                      kubernetes:
+                                        description: Allows importing into the devworkspace
+                                          the Kubernetes resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the Kubernetes definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      name:
+                                        description: Mandatory name that allows referencing
+                                          the component from other elements (such
+                                          as commands) or from an external devfile
+                                          that may reference this component through
+                                          a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                      openshift:
+                                        description: Allows importing into the devworkspace
+                                          the OpenShift resources defined in a given
+                                          manifest. For example this allows reusing
+                                          the OpenShift definitions used to deploy
+                                          some runtime components in production.
+                                        properties:
+                                          deployByDefault:
+                                            description: "Defines if the component
+                                              should be deployed during startup. \n
+                                              Default value is `false`"
+                                            type: boolean
+                                          endpoints:
+                                            items:
+                                              properties:
+                                                annotation:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: Annotations to be added
+                                                    to Kubernetes Ingress or Openshift
+                                                    Route
+                                                  type: object
+                                                attributes:
+                                                  description: "Map of implementation-dependant
+                                                    string-based free-form attributes.
+                                                    \n Examples of Che-specific attributes:
+                                                    \n - cookiesAuthEnabled: \"true\"
+                                                    / \"false\", \n - type: \"terminal\"
+                                                    / \"ide\" / \"ide-dev\","
+                                                  type: object
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                exposure:
+                                                  description: "Describes how the
+                                                    endpoint should be exposed on
+                                                    the network. \n - `public` means
+                                                    that the endpoint will be exposed
+                                                    on the public network, typically
+                                                    through a K8S ingress or an OpenShift
+                                                    route. \n - `internal` means that
+                                                    the endpoint will be exposed internally
+                                                    outside of the main devworkspace
+                                                    POD, typically by K8S services,
+                                                    to be consumed by other elements
+                                                    running on the same cloud internal
+                                                    network. \n - `none` means that
+                                                    the endpoint will not be exposed
+                                                    and will only be accessible inside
+                                                    the main devworkspace POD, on
+                                                    a local address. \n Default value
+                                                    is `public`"
+                                                  enum:
+                                                  - public
+                                                  - internal
+                                                  - none
+                                                  type: string
+                                                name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                  type: string
+                                                path:
+                                                  description: Path of the endpoint
+                                                    URL
+                                                  type: string
+                                                protocol:
+                                                  description: "Describes the application
+                                                    and transport protocols of the
+                                                    traffic that will go through this
+                                                    endpoint. \n - `http`: Endpoint
+                                                    will have `http` traffic, typically
+                                                    on a TCP connection. It will be
+                                                    automaticaly promoted to `https`
+                                                    when the `secure` field is set
+                                                    to `true`. \n - `https`: Endpoint
+                                                    will have `https` traffic, typically
+                                                    on a TCP connection. \n - `ws`:
+                                                    Endpoint will have `ws` traffic,
+                                                    typically on a TCP connection.
+                                                    It will be automaticaly promoted
+                                                    to `wss` when the `secure` field
+                                                    is set to `true`. \n - `wss`:
+                                                    Endpoint will have `wss` traffic,
+                                                    typically on a TCP connection.
+                                                    \n - `tcp`: Endpoint will have
+                                                    traffic on a TCP connection, without
+                                                    specifying an application protocol.
+                                                    \n - `udp`: Endpoint will have
+                                                    traffic on an UDP connection,
+                                                    without specifying an application
+                                                    protocol. \n Default value is
+                                                    `http`"
+                                                  enum:
+                                                  - http
+                                                  - https
+                                                  - ws
+                                                  - wss
+                                                  - tcp
+                                                  - udp
+                                                  type: string
+                                                secure:
+                                                  description: Describes whether the
+                                                    endpoint should be secured and
+                                                    protected by some authentication
+                                                    process. This requires a protocol
+                                                    of `https` or `wss`.
+                                                  type: boolean
+                                                targetPort:
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
+                                                  type: integer
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          inlined:
+                                            description: Inlined manifest
+                                            type: string
+                                          locationType:
+                                            description: Type of Kubernetes-like location
+                                            enum:
+                                            - Uri
+                                            - Inlined
+                                            type: string
+                                          uri:
+                                            description: Location in a file fetched
+                                              from a uri.
+                                            type: string
+                                        type: object
+                                      volume:
+                                        description: Allows specifying the definition
+                                          of a volume shared by several other components
+                                        properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
+                                          size:
+                                            description: Size of the volume
+                                            type: string
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                id:
+                                  description: Id in a registry that contains a Devfile
+                                    yaml file
+                                  type: string
+                                importReferenceType:
+                                  description: type of location from where the referenced
+                                    template structure should be retrieved
+                                  enum:
+                                  - Uri
+                                  - Id
+                                  - Kubernetes
+                                  type: string
+                                kubernetes:
+                                  description: Reference to a Kubernetes CRD of type
+                                    DevWorkspaceTemplate
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                registryUrl:
+                                  description: Registry URL to pull the parent devfile
+                                    from when using id in the parent reference. To
+                                    ensure the parent devfile gets resolved consistently
+                                    in different environments, it is recommended to
+                                    always specify the `registryUrl` when `id` is
+                                    used.
+                                  type: string
+                                uri:
+                                  description: URI Reference of a parent devfile YAML
+                                    file. It can be a full URL or a relative URI with
+                                    the current devfile as the base URI.
+                                  type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                                  type: string
+                              type: object
+                            volume:
+                              description: Allows specifying the definition of a volume
+                                shared by several other components
+                              properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
+                                size:
+                                  description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      events:
+                        description: Bindings of commands to events. Each command
+                          is referred-to by its name.
+                        properties:
+                          postStart:
+                            description: IDs of commands that should be executed after
+                              the devworkspace is completely started. In the case
+                              of Che-Theia, these commands should be executed after
+                              all plugins and extensions have started, including project
+                              cloning. This means that those commands are not triggered
+                              until the user opens the IDE in his browser.
+                            items:
+                              type: string
+                            type: array
+                          postStop:
+                            description: IDs of commands that should be executed after
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                          preStart:
+                            description: IDs of commands that should be executed before
+                              the devworkspace start. Kubernetes-wise, these commands
+                              would typically be executed in init containers of the
+                              devworkspace POD.
+                            items:
+                              type: string
+                            type: array
+                          preStop:
+                            description: IDs of commands that should be executed before
+                              stopping the devworkspace.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      projects:
+                        description: Projects worked on in the devworkspace, containing
+                          names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      starterProjects:
+                        description: StarterProjects is a project that can be used
+                          as a starting point when bootstrapping new projects
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            description:
+                              description: Description of a starter project
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            subDir:
+                              description: Sub-directory from a starter project to
+                                be used as root for starter project.
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      variables:
+                        additionalProperties:
+                          type: string
+                        description: "Map of key-value variables used for string replacement
+                          in the devfile. Values can be referenced via {{variable-key}}
+                          to replace the corresponding value in string fields in the
+                          devfile. Replacement cannot be used for \n  - schemaVersion,
+                          metadata, parent source \n  - element identifiers, e.g.
+                          command id, component name, endpoint name, project name
+                          \n  - references to identifiers, e.g. in events, a command's
+                          component, container's volume mount name \n  - string enums,
+                          e.g. command group kind, endpoint exposure"
+                        type: object
+                    type: object
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -43,6 +43,7 @@ var defaultConfig = &v1alpha1.OperatorConfiguration{
 			RunAsNonRoot: &boolTrue,
 			FSGroup:      &int64UID,
 		},
+		DefaultTemplate: nil,
 	},
 }
 

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -253,6 +253,10 @@ func mergeConfig(from, to *controller.OperatorConfiguration) {
 				to.Workspace.DefaultStorageSize.PerWorkspace = &perWorkspaceSizeCopy
 			}
 		}
+		if from.Workspace.DefaultTemplate != nil {
+			templateSpecContentCopy := from.Workspace.DefaultTemplate.DeepCopy()
+			to.Workspace.DefaultTemplate = templateSpecContentCopy
+		}
 	}
 }
 
@@ -294,6 +298,9 @@ func logCurrentConfig() {
 			if Workspace.DefaultStorageSize.PerWorkspace != nil {
 				config = append(config, fmt.Sprintf("workspace.defaultStorageSize.perWorkspace=%s", Workspace.DefaultStorageSize.PerWorkspace.String()))
 			}
+		}
+		if Workspace.DefaultTemplate != nil {
+			config = append(config, fmt.Sprintf("workspace.defaultTemplate is set"))
 		}
 	}
 	if internalConfig.EnableExperimentalFeatures != nil && *internalConfig.EnableExperimentalFeatures {

--- a/pkg/config/sync_test.go
+++ b/pkg/config/sync_test.go
@@ -24,6 +24,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
@@ -234,7 +235,9 @@ func TestSyncConfigDoesNotEraseClusterRoutingSuffix(t *testing.T) {
 }
 
 func TestMergeConfigLooksAtAllFields(t *testing.T) {
-	f := fuzz.New().NilChance(0)
+	f := fuzz.New().NilChance(0).Funcs(
+		func(embeddedResource *runtime.RawExtension, c fuzz.Continue) {},
+	)
 	expectedConfig := &v1alpha1.OperatorConfiguration{}
 	actualConfig := &v1alpha1.OperatorConfiguration{}
 	f.Fuzz(expectedConfig)

--- a/pkg/library/defaults/helper.go
+++ b/pkg/library/defaults/helper.go
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package defaults
+
+import (
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/config"
+)
+
+// Overwrites the content of the workspace's Template Spec with the workspace config's Template Spec,
+// with the exception of the workspace's projects.
+// If the workspace's Template Spec defined any projects, they are preserved.
+func ApplyDefaultTemplate(workspace *dw.DevWorkspace) {
+	if config.Workspace.DefaultTemplate == nil {
+		return
+	}
+	defaultCopy := config.Workspace.DefaultTemplate.DeepCopy()
+	originalProjects := workspace.Spec.Template.Projects
+	workspace.Spec.Template.DevWorkspaceTemplateSpecContent = *defaultCopy
+	workspace.Spec.Template.Projects = append(workspace.Spec.Template.Projects, originalProjects...)
+}
+
+func NeedsDefaultTemplate(workspace *dw.DevWorkspace) bool {
+	return len(workspace.Spec.Template.Components) == 0 && config.Workspace.DefaultTemplate != nil
+}


### PR DESCRIPTION
This PR adds a new CRD configuration option `defaultTemplate` to DWO. The configuration option takes in a `DevWorkspaceTemplateSpecContent` which gets applied to the workspace's devfile if the devfile does not define any components. Currently, the `DevWorkspaceTemplateSpecContent` will overwrite the devfile's existing template spec but keep the existing projects (if they were defined).

### What issues does this PR fix or reference?
Fix #853

### Is it tested? How?
1. Create a minimal devfile, such as the following: 
```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: minimal
spec:
  started: true
```
2. Start up DWO
3. Edit the DWO config custom resource `kubectl edit dwoc -n $NAMESPACE`
4. Add the `defaultTemplate` to the workspace attribute:
```YAML
    defaultTemplate:
      commands:
      - exec:
          commandLine: echo "Hello from $(pwd)"
          component: theia-ide
          workingDir: ${PROJECTS_ROOT}/project/app
        id: say-hello
      components:
      - name: theia
        plugin:
          components:
          - container:
              env:
              - name: THEIA_HOST
                value: 0.0.0.0
            name: theia-ide
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
      projects:
      - git:
          remotes:
            origin: https://github.com/che-samples/web-nodejs-sample.git
        name: web-nodejs-sample
```

The resulting DWO configuration should ressemble something like the following:
```YAML
apiVersion: controller.devfile.io/v1alpha1
config:
  routing:
    clusterHostSuffix: 192.168.39.217.nip.io
    defaultRoutingClass: basic
  workspace:
    defaultTemplate:
      commands:
      - exec:
          commandLine: echo "Hello from $(pwd)"
          component: theia-ide
          workingDir: ${PROJECTS_ROOT}/project/app
        id: say-hello
      components:
      - name: theia
        plugin:
          components:
          - container:
              env:
              - name: THEIA_HOST
                value: 0.0.0.0
            name: theia-ide
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
      projects:
      - git:
          remotes:
            origin: https://github.com/che-samples/web-nodejs-sample.git
        name: web-nodejs-sample
    imagePullPolicy: Always
kind: DevWorkspaceOperatorConfig
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"controller.devfile.io/v1alpha1","config":{"routing":{"clusterHostSuffix":"192.168.39.217.nip.io","defaultRoutingClass":"basic"},"workspace":{"imagePu\
llPolicy":"Always"}},"kind":"DevWorkspaceOperatorConfig","metadata":{"annotations":{},"name":"devworkspace-operator-config","namespace":"devworkspace-controller"}}
  creationTimestamp: "2022-06-10T20:28:38Z"
  generation: 4
  name: devworkspace-operator-config
  namespace: devworkspace-controller
  resourceVersion: "42646"
  uid: 4f5198b5-1d0d-48d6-9f10-6d0955363934
```
 5. Apply the minimal devfile from step 1: `kubectl apply -f minimal_devfile.yaml -n $NAMESPACE `
 6. Wait for the workspace to startup and open it: 
```bash
$: kubectl get devworkspace -n $NAMESPACE 
NAME      DEVWORKSPACE ID             PHASE     INFO
minimal   workspace7dab320bcbd64672   Running   https://workspace7dab320bcbd64672-theia-3100.192.168.39.217.nip.io/
```
7. Once opened, the workspace should contain the `web-nodejs-sample` project 


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
