### PR TITLE
codeblock indentation on uninstall instructions

### DIFF
--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -25,7 +25,7 @@ The DevWorkspace Operator makes use of finalizers on DevWorkspace resources and 
 
 	```
 	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
-  kubectl delete mutatingwebhookconfigurations controller.devfile.io
+	kubectl delete mutatingwebhookconfigurations controller.devfile.io
 	kubectl delete validatingwebhookconfigurations controller.devfile.io
 	```
 

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -5,36 +5,36 @@ The DevWorkspace Operator makes use of finalizers on DevWorkspace resources and 
 
 1. Ensure that all DevWorkspace Custom Resources are removed along with their related k8s objects, like deployments.
 
-	```
-	kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
-	kubectl delete devworkspaceroutings.controller.devfile.io --all-namespaces --all --wait
-	```
-	Note: This step must be done first, as otherwise the resources above may have finalizers that block automatic cleanup.
+    ```
+    kubectl delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
+    kubectl delete devworkspaceroutings.controller.devfile.io --all-namespaces --all --wait
+    ```
+    Note: This step must be done first, as otherwise the resources above may have finalizers that block automatic cleanup.
 
 2. Uninstall the Operator
 
 3. Remove the custom resource definitions installed by the operator
 
-	```
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaceroutings.controller.devfile.io
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
-	kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspacetemplates.workspace.devfile.io
-	```
+    ```
+    kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaceroutings.controller.devfile.io
+    kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
+    kubectl delete customresourcedefinitions.apiextensions.k8s.io devworkspacetemplates.workspace.devfile.io
+    ```
 
 4. Remove DevWorkspace Webhook Server deployment and mutating/validating webhook configurations
 
-	```
-	kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
-	kubectl delete mutatingwebhookconfigurations controller.devfile.io
-	kubectl delete validatingwebhookconfigurations controller.devfile.io
-	```
+    ```
+    kubectl delete deployment/devworkspace-webhook-server -n openshift-operators
+    kubectl delete mutatingwebhookconfigurations controller.devfile.io
+    kubectl delete validatingwebhookconfigurations controller.devfile.io
+    ```
 
 5. Remove lingering service, secrets, and configmaps
 
-	```
-	kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator
-	kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators
-	kubectl delete configmap devworkspace-controller -n openshift-operators
-	kubectl delete clusterrole devworkspace-webhook-server
-	kubectl delete clusterrolebinding devworkspace-webhook-server
-	```
+    ```
+    kubectl delete all --selector app.kubernetes.io/part-of=devworkspace-operator
+    kubectl delete serviceaccounts devworkspace-webhook-server -n openshift-operators
+    kubectl delete configmap devworkspace-controller -n openshift-operators
+    kubectl delete clusterrole devworkspace-webhook-server
+    kubectl delete clusterrolebinding devworkspace-webhook-server
+    ```


### PR DESCRIPTION
### What does this PR do?
Fixes some markdown rendering in uninstall instructions.  A missing indent (may have been tab/space issue) was causing problems with a code block rendered on the instruction page.  Anyone copying code directly from the code blocks would end up missing 2 terminal commands from step 4.

### What issues does this PR fix or reference?
NA

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
View rendering after fix here: https://github.com/lglussen/devworkspace-operator/blob/149a2bbca13049eccd51ea4e1758485b886e69a2/docs/uninstall.md
Look at the step 4 commands.

Compare against current rendering: https://github.com/devfile/devworkspace-operator/blob/main/docs/uninstall.md

### PR Checklist

NA - just a markdown tweak
