### PR TITLE
Fix issue where deleting a workspace deletes the PVC incorrectly

### DIFF
--- a/pkg/provision/storage/commonStorage.go
+++ b/pkg/provision/storage/commonStorage.go
@@ -94,7 +94,7 @@ func (p *CommonStorageProvisioner) CleanupWorkspaceStorage(workspace *dw.DevWork
 
 	// If the number of common + async workspaces that exist (started or stopped) is zero,
 	// delete common PVC instead of running cleanup job
-	if totalWorkspaces > 1 {
+	if totalWorkspaces > 0 {
 		return runCommonPVCCleanupJob(workspace, clusterAPI)
 	} else {
 		sharedPVC := &corev1.PersistentVolumeClaim{}


### PR DESCRIPTION
### What does this PR do?
Fix a regression caused by commit cbd3fd11. When deleting workspaces, if
there are no non-terminating workspaces left in the namespace, we delete
the common PVC rather than running cleanup jobs. However, the way the
check was written assumed that we were counting _all_ workspaces, and
would delete the common PVC if there were two workspaces in a namespace
and one was deleted.

### What issues does this PR fix or reference?
Mentioned in review for https://github.com/devfile/devworkspace-operator/pull/846#pullrequestreview-1007392255 -- I'm not sure how I didn't catch it in the original PR; test case was likely missed by me testing
* delete a single workspace
* delete 3-5 workspaces at once

Closes https://github.com/devfile/devworkspace-operator/pull/871

### Is it tested? How?
```bash
kubectl apply -f samples/theia-next.yaml
yq '.metadata.name="theia-next-2"' samples/theia-next.yaml | kubectl apply -f -
# wait for workspaces to enter running state
kubectl delete dw theia-next
kubectl get pvc # should not be terminating.
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
