### PR TITLE
Improve handling of errors during PVC cleanup

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -658,6 +658,22 @@ func dwRelatedPodsHandler(obj client.Object) []reconcile.Request {
 }
 
 func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Request {
+	// Check if PVC is owned by a DevWorkspace (per-workspace storage case)
+	for _, ownerref := range obj.GetOwnerReferences() {
+		if ownerref.Kind != "DevWorkspace" {
+			continue
+		}
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Name:      ownerref.Name,
+					Namespace: obj.GetNamespace(),
+				},
+			},
+		}
+	}
+
+	// Otherwise, check if common PVC is deleted to make sure all DevWorkspaces see it happen
 	if obj.GetName() != config.Workspace.PVCName || obj.GetDeletionTimestamp() == nil {
 		// We're looking for a deleted common PVC
 		return []reconcile.Request{}

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -113,7 +113,10 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 			log.Info(storageErr.Message)
 			return reconcile.Result{RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
-			log.Error(storageErr, "Failed to clean up DevWorkspace storage")
+			if workspace.Status.Phase != dw.DevWorkspaceStatusError {
+				// Avoid repeatedly logging error unless it's relevant
+				log.Error(storageErr, "Failed to clean up DevWorkspace storage")
+			}
 			finalizeStatus.phase = dw.DevWorkspaceStatusError
 			finalizeStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
 			return reconcile.Result{}, nil

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -56,14 +56,12 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 		return r.updateWorkspaceStatus(workspace, log, finalizeStatus, finalizeResult, finalizeErr)
 	}()
 
-	if workspace.Status.Phase != dw.DevWorkspaceStatusError {
-		for _, finalizer := range workspace.Finalizers {
-			switch finalizer {
-			case constants.StorageCleanupFinalizer:
-				return r.finalizeStorage(ctx, log, workspace, finalizeStatus)
-			case constants.ServiceAccountCleanupFinalizer:
-				return r.finalizeServiceAccount(ctx, log, workspace, finalizeStatus)
-			}
+	for _, finalizer := range workspace.Finalizers {
+		switch finalizer {
+		case constants.StorageCleanupFinalizer:
+			return r.finalizeStorage(ctx, log, workspace, finalizeStatus)
+		case constants.ServiceAccountCleanupFinalizer:
+			return r.finalizeServiceAccount(ctx, log, workspace, finalizeStatus)
 		}
 	}
 	return reconcile.Result{}, nil

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -18,6 +18,7 @@ package controllers
 import (
 	"context"
 
+	"github.com/devfile/devworkspace-operator/pkg/conditions"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -26,7 +27,6 @@ import (
 	"github.com/go-logr/logr"
 	coputil "github.com/redhat-cop/operator-utils/pkg/util"
 	corev1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -46,28 +46,30 @@ func (r *DevWorkspaceReconciler) workspaceNeedsFinalize(workspace *dw.DevWorkspa
 	return false
 }
 
-func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace) (reconcile.Result, error) {
-	if workspace.Status.Phase != dw.DevWorkspaceStatusError {
-		workspace.Status.Message = "Cleaning up resources for deletion"
-		workspace.Status.Phase = devworkspacePhaseTerminating
-		err := r.Client.Status().Update(ctx, workspace)
-		if err != nil && !k8sErrors.IsConflict(err) {
-			return reconcile.Result{}, err
-		}
+func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace) (finalizeResult reconcile.Result, finalizeErr error) {
+	// Tracked state for the finalize process; we update the workspace status in a deferred function (and pass the
+	// named return value for finalize()) to update the workspace's status with whatever is in finalizeStatus
+	// when this function returns.
+	finalizeStatus := &currentStatus{phase: devworkspacePhaseTerminating}
+	finalizeStatus.setConditionTrue(conditions.Started, "Cleaning up resources for deletion")
+	defer func() (reconcile.Result, error) {
+		return r.updateWorkspaceStatus(workspace, log, finalizeStatus, finalizeResult, finalizeErr)
+	}()
 
+	if workspace.Status.Phase != dw.DevWorkspaceStatusError {
 		for _, finalizer := range workspace.Finalizers {
 			switch finalizer {
 			case constants.StorageCleanupFinalizer:
-				return r.finalizeStorage(ctx, log, workspace)
+				return r.finalizeStorage(ctx, log, workspace, finalizeStatus)
 			case constants.ServiceAccountCleanupFinalizer:
-				return r.finalizeServiceAccount(ctx, log, workspace)
+				return r.finalizeServiceAccount(ctx, log, workspace, finalizeStatus)
 			}
 		}
 	}
 	return reconcile.Result{}, nil
 }
 
-func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace) (reconcile.Result, error) {
+func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace, finalizeStatus *currentStatus) (reconcile.Result, error) {
 	// Need to make sure Deployment is cleaned up before starting job to avoid mounting issues for RWO PVCs
 	wait, err := wsprovision.DeleteWorkspaceDeployment(ctx, workspace, r.Client)
 	if err != nil {
@@ -90,9 +92,9 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {
 		log.Error(err, "Failed to clean up DevWorkspace storage")
-		failedStatus := currentStatus{phase: dw.DevWorkspaceStatusError}
-		failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
-		return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
+		finalizeStatus.phase = dw.DevWorkspaceStatusError
+		finalizeStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
+		return reconcile.Result{}, nil
 	}
 	err = storageProvisioner.CleanupWorkspaceStorage(workspace, sync.ClusterAPI{
 		Ctx:    ctx,
@@ -107,9 +109,9 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 			return reconcile.Result{RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
 			log.Error(storageErr, "Failed to clean up DevWorkspace storage")
-			failedStatus := currentStatus{phase: dw.DevWorkspaceStatusError}
-			failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
-			return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
+			finalizeStatus.phase = dw.DevWorkspaceStatusError
+			finalizeStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
+			return reconcile.Result{}, nil
 		default:
 			return reconcile.Result{}, storageErr
 		}
@@ -119,13 +121,13 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 	return reconcile.Result{}, r.Update(ctx, workspace)
 }
 
-func (r *DevWorkspaceReconciler) finalizeServiceAccount(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace) (reconcile.Result, error) {
+func (r *DevWorkspaceReconciler) finalizeServiceAccount(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace, finalizeStatus *currentStatus) (reconcile.Result, error) {
 	retry, err := wsprovision.FinalizeServiceAccount(workspace, ctx, r.NonCachingClient)
 	if err != nil {
 		log.Error(err, "Failed to finalize workspace ServiceAccount")
-		failedStatus := currentStatus{phase: dw.DevWorkspaceStatusError}
-		failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
-		return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
+		finalizeStatus.phase = dw.DevWorkspaceStatusError
+		finalizeStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
+		return reconcile.Result{}, nil
 	}
 	if retry {
 		return reconcile.Result{Requeue: true}, nil

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -63,6 +63,13 @@ func (p *PerWorkspaceStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1
 	}
 	pvcName := perWorkspacePVC.Name
 
+	// If PVC is being deleted, we need to fail workspace startup as a running pod will block deletion.
+	if perWorkspacePVC.DeletionTimestamp != nil {
+		return &ProvisioningError{
+			Message: "DevWorkspace PVC is being deleted",
+		}
+	}
+
 	// Rewrite container volume mounts
 	if err := p.rewriteContainerVolumeMounts(workspace.Status.DevWorkspaceId, pvcName, podAdditions, &workspace.Spec.Template); err != nil {
 		return &ProvisioningError{


### PR DESCRIPTION
### What does this PR do?
While working on a fix for #877, I began by attempting to unify how workspace status is managed in the finalize function (rather than having multiple places where it may be updated). In doing so, I came across a bug where every time finalize was called, it would first set the on-cluster workspace's status to `Terminating`, then potentially update it to `Errored` if PVC cleanup encountered an error. This turns out to be the underlying cause of https://github.com/devfile/devworkspace-operator/issues/845.

See commits messages in this PR for more information, but this PR:
1. Reuses the same trick from the `reconcile` function in handling workspace status -- we defer a function that sets the workspace's status so that there is only one call per finalize to update the status. This resolves https://github.com/devfile/devworkspace-operator/issues/877 and avoids reintroducing https://github.com/devfile/devworkspace-operator/issues/845 as we are no longer updating the workspace constantly
2. Changes the finalize function to continue attempting to finalize terminating workspaces even if they are in an errored state (partially undoing the fix for https://github.com/devfile/devworkspace-operator/issues/845) in order to resolve https://github.com/devfile/devworkspace-operator/issues/877
3. A minor fix to attempt to avoid logging a strange error that I've been seeing lately where we attempt to update the status of a workspace after it has been garbage collected (need to verify this works fully) -- see https://github.com/devfile/devworkspace-operator/issues/878

I think this PR may also incidentally resolve the main piece of https://github.com/devfile/devworkspace-operator/issues/873 but this needs more verification. In my brief testing, I've found:
* The errored workspace in #873 is still not removed as no reconcile is triggered, but it _will_ be removed the next time it is reconciled (you can trigger a reconcile by e.g. adding an annotation to the workspace)
* However, in one case the cluster was still not left in a clean state as the errored pods were still present even after the job was removed (not sure why).

### What issues does this PR fix or reference?
Closes: https://github.com/devfile/devworkspace-operator/issues/877
Needs verification: https://github.com/devfile/devworkspace-operator/issues/873

### Is it tested? How?
1. Verify that https://github.com/devfile/devworkspace-operator/issues/845 is _not_ re-introduced (via the reproducer in that issue)
2. Test that https://github.com/devfile/devworkspace-operator/issues/877 is resolved by:
    * Reaching the errored state in https://github.com/devfile/devworkspace-operator/issues/845 (your namespace has two workspaces, one in an errored terminating state and the other one started/stopped)
    * Undoing the patch from the #845 reproducer and updating the controller in order to run the correct job
    * Verify that the workspace is eventually cleaned up once that job succeeds
  
    this isn't a perfect test but approximates the situation that causes #877
3. Check if this PR also resolves https://github.com/devfile/devworkspace-operator/issues/873 by running the reproducing process there.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
