### PR TITLE
Add 'per-workspace' to storage-type attribute documentation

### DIFF
--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -20,11 +20,12 @@ const (
 	// DevWorkspaceStorageTypeAttribute defines the strategy used for provisioning storage for the workspace.
 	// If empty, the common PVC strategy is used.
 	// Supported options:
-	// - "common":    Create one PVC per namespace, and store data for all workspaces in that namespace in that PVC
-	// - "async" :    Create one PVC per namespace, and create a remote server that syncs data from workspaces to the PVC.
-	//                All volumeMounts used for devworkspaces are emptyDir
-	// - "ephemeral": Use emptyDir volumes for all volumes in the DevWorkspace. All data is lost when the workspace is
-	//                stopped.
+	// - "common":        Create one PVC per namespace, and store data for all workspaces in that namespace in that PVC
+	// - "async" :        Create one PVC per namespace, and create a remote server that syncs data from workspaces to the PVC.
+	//                    All volumeMounts used for devworkspaces are emptyDir
+	// - "per-workspace": Create one PVC per workspace, delete that PVC when the workspace is deleted.
+	// - "ephemeral":     Use emptyDir volumes for all volumes in the DevWorkspace. All data is lost when the workspace is
+	//                    stopped.
 	DevWorkspaceStorageTypeAttribute = "controller.devfile.io/storage-type"
 
 	// RuntimeClassNameAttribute is an attribute added to a DevWorkspace to specify a runtimeClassName for container


### PR DESCRIPTION
### What does this PR do?
Minor fixup to update doc on storage-type attribute constant.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
