### PR TITLE
Cherry pick for 0.15.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7-13 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.10-4 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /devworkspace-operator
@@ -34,7 +34,7 @@ RUN make compile-devworkspace-controller
 RUN make compile-webhook-server
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.6-751
+FROM registry.access.redhat.com/ubi8-minimal:8.6-854
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /devworkspace-operator/_output/bin/devworkspace-controller /usr/local/bin/devworkspace-controller

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -631,28 +631,49 @@ func (r *DevWorkspaceReconciler) getWorkspaceId(ctx context.Context, workspace *
 }
 
 // Mapping the pod to the devworkspace
-func dwRelatedPodsHandler() handler.EventHandler {
-	podToDW := func(obj client.Object) []reconcile.Request {
-		labels := obj.GetLabels()
-		if _, ok := labels[constants.DevWorkspaceNameLabel]; !ok {
-			return nil
-		}
+func dwRelatedPodsHandler(obj client.Object) []reconcile.Request {
+	labels := obj.GetLabels()
+	if _, ok := labels[constants.DevWorkspaceNameLabel]; !ok {
+		return []reconcile.Request{}
+	}
 
-		//If the dewworkspace label does not exist, do no reconcile
-		if _, ok := labels[constants.DevWorkspaceIDLabel]; !ok {
-			return nil
-		}
+	//If the dewworkspace label does not exist, do no reconcile
+	if _, ok := labels[constants.DevWorkspaceIDLabel]; !ok {
+		return []reconcile.Request{}
+	}
 
-		return []reconcile.Request{
-			{
-				NamespacedName: types.NamespacedName{
-					Name:      labels[constants.DevWorkspaceNameLabel],
-					Namespace: obj.GetNamespace(),
-				},
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      labels[constants.DevWorkspaceNameLabel],
+				Namespace: obj.GetNamespace(),
 			},
+		},
+	}
+}
+
+func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Request {
+	if obj.GetName() != config.Workspace.PVCName || obj.GetDeletionTimestamp() == nil {
+		// We're looking for a deleted common PVC
+		return []reconcile.Request{}
+	}
+	dwList := &dw.DevWorkspaceList{}
+	if err := r.Client.List(context.Background(), dwList); err != nil {
+		return []reconcile.Request{}
+	}
+	var reconciles []reconcile.Request
+	for _, workspace := range dwList.Items {
+		storageType := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
+		if storageType == constants.CommonStorageClassType || storageType == "" {
+			reconciles = append(reconciles, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      workspace.GetName(),
+					Namespace: workspace.GetNamespace(),
+				},
+			})
 		}
 	}
-	return handler.EnqueueRequestsFromMapFunc(podToDW)
+	return reconciles
 }
 
 func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -683,7 +704,8 @@ func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ServiceAccount{}).
-		Watches(&source.Kind{Type: &corev1.Pod{}}, dwRelatedPodsHandler()).
+		Watches(&source.Kind{Type: &corev1.Pod{}}, handler.EnqueueRequestsFromMapFunc(dwRelatedPodsHandler)).
+		Watches(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, handler.EnqueueRequestsFromMapFunc(r.dwPVCHandler)).
 		Watches(&source.Kind{Type: &controllerv1alpha1.DevWorkspaceOperatorConfig{}}, handler.EnqueueRequestsFromMapFunc(emptyMapper), configWatcher).
 		WithEventFilter(predicates).
 		WithEventFilter(podPredicates).

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -113,7 +113,10 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 			log.Info(storageErr.Message)
 			return reconcile.Result{RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
-			log.Error(storageErr, "Failed to clean up DevWorkspace storage")
+			if workspace.Status.Phase != dw.DevWorkspaceStatusError {
+				// Avoid repeatedly logging error unless it's relevant
+				log.Error(storageErr, "Failed to clean up DevWorkspace storage")
+			}
 			finalizeStatus.phase = dw.DevWorkspaceStatusError
 			finalizeStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
 			return reconcile.Result{}, nil

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -56,14 +56,12 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 		return r.updateWorkspaceStatus(workspace, log, finalizeStatus, finalizeResult, finalizeErr)
 	}()
 
-	if workspace.Status.Phase != dw.DevWorkspaceStatusError {
-		for _, finalizer := range workspace.Finalizers {
-			switch finalizer {
-			case constants.StorageCleanupFinalizer:
-				return r.finalizeStorage(ctx, log, workspace, finalizeStatus)
-			case constants.ServiceAccountCleanupFinalizer:
-				return r.finalizeServiceAccount(ctx, log, workspace, finalizeStatus)
-			}
+	for _, finalizer := range workspace.Finalizers {
+		switch finalizer {
+		case constants.StorageCleanupFinalizer:
+			return r.finalizeStorage(ctx, log, workspace, finalizeStatus)
+		case constants.ServiceAccountCleanupFinalizer:
+			return r.finalizeServiceAccount(ctx, log, workspace, finalizeStatus)
 		}
 	}
 	return reconcile.Result{}, nil

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -18,6 +18,7 @@ package controllers
 import (
 	"context"
 
+	"github.com/devfile/devworkspace-operator/pkg/conditions"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -26,7 +27,6 @@ import (
 	"github.com/go-logr/logr"
 	coputil "github.com/redhat-cop/operator-utils/pkg/util"
 	corev1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -46,28 +46,30 @@ func (r *DevWorkspaceReconciler) workspaceNeedsFinalize(workspace *dw.DevWorkspa
 	return false
 }
 
-func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace) (reconcile.Result, error) {
-	if workspace.Status.Phase != dw.DevWorkspaceStatusError {
-		workspace.Status.Message = "Cleaning up resources for deletion"
-		workspace.Status.Phase = devworkspacePhaseTerminating
-		err := r.Client.Status().Update(ctx, workspace)
-		if err != nil && !k8sErrors.IsConflict(err) {
-			return reconcile.Result{}, err
-		}
+func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace) (finalizeResult reconcile.Result, finalizeErr error) {
+	// Tracked state for the finalize process; we update the workspace status in a deferred function (and pass the
+	// named return value for finalize()) to update the workspace's status with whatever is in finalizeStatus
+	// when this function returns.
+	finalizeStatus := &currentStatus{phase: devworkspacePhaseTerminating}
+	finalizeStatus.setConditionTrue(conditions.Started, "Cleaning up resources for deletion")
+	defer func() (reconcile.Result, error) {
+		return r.updateWorkspaceStatus(workspace, log, finalizeStatus, finalizeResult, finalizeErr)
+	}()
 
+	if workspace.Status.Phase != dw.DevWorkspaceStatusError {
 		for _, finalizer := range workspace.Finalizers {
 			switch finalizer {
 			case constants.StorageCleanupFinalizer:
-				return r.finalizeStorage(ctx, log, workspace)
+				return r.finalizeStorage(ctx, log, workspace, finalizeStatus)
 			case constants.ServiceAccountCleanupFinalizer:
-				return r.finalizeServiceAccount(ctx, log, workspace)
+				return r.finalizeServiceAccount(ctx, log, workspace, finalizeStatus)
 			}
 		}
 	}
 	return reconcile.Result{}, nil
 }
 
-func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace) (reconcile.Result, error) {
+func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace, finalizeStatus *currentStatus) (reconcile.Result, error) {
 	// Need to make sure Deployment is cleaned up before starting job to avoid mounting issues for RWO PVCs
 	wait, err := wsprovision.DeleteWorkspaceDeployment(ctx, workspace, r.Client)
 	if err != nil {
@@ -90,9 +92,9 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 	storageProvisioner, err := storage.GetProvisioner(workspace)
 	if err != nil {
 		log.Error(err, "Failed to clean up DevWorkspace storage")
-		failedStatus := currentStatus{phase: dw.DevWorkspaceStatusError}
-		failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
-		return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
+		finalizeStatus.phase = dw.DevWorkspaceStatusError
+		finalizeStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
+		return reconcile.Result{}, nil
 	}
 	err = storageProvisioner.CleanupWorkspaceStorage(workspace, sync.ClusterAPI{
 		Ctx:    ctx,
@@ -107,9 +109,9 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 			return reconcile.Result{RequeueAfter: storageErr.RequeueAfter}, nil
 		case *storage.ProvisioningError:
 			log.Error(storageErr, "Failed to clean up DevWorkspace storage")
-			failedStatus := currentStatus{phase: dw.DevWorkspaceStatusError}
-			failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
-			return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
+			finalizeStatus.phase = dw.DevWorkspaceStatusError
+			finalizeStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
+			return reconcile.Result{}, nil
 		default:
 			return reconcile.Result{}, storageErr
 		}
@@ -119,13 +121,13 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 	return reconcile.Result{}, r.Update(ctx, workspace)
 }
 
-func (r *DevWorkspaceReconciler) finalizeServiceAccount(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace) (reconcile.Result, error) {
+func (r *DevWorkspaceReconciler) finalizeServiceAccount(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace, finalizeStatus *currentStatus) (reconcile.Result, error) {
 	retry, err := wsprovision.FinalizeServiceAccount(workspace, ctx, r.NonCachingClient)
 	if err != nil {
 		log.Error(err, "Failed to finalize workspace ServiceAccount")
-		failedStatus := currentStatus{phase: dw.DevWorkspaceStatusError}
-		failedStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
-		return r.updateWorkspaceStatus(workspace, r.Log, &failedStatus, reconcile.Result{}, nil)
+		finalizeStatus.phase = dw.DevWorkspaceStatusError
+		finalizeStatus.setConditionTrue(dw.DevWorkspaceError, err.Error())
+		return reconcile.Result{}, nil
 	}
 	if retry {
 		return reconcile.Result{Requeue: true}, nil

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -91,9 +91,7 @@ func SetupControllerConfig(client crclient.Client) error {
 		return err
 	}
 	defaultConfig.Routing.ProxyConfig = clusterProxy
-	if internalConfig.Routing.ProxyConfig == nil {
-		internalConfig.Routing.ProxyConfig = clusterProxy
-	}
+	internalConfig.Routing.ProxyConfig = proxy.MergeProxyConfigs(clusterProxy, internalConfig.Routing.ProxyConfig)
 
 	updatePublicConfig()
 	return nil

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -20,11 +20,12 @@ const (
 	// DevWorkspaceStorageTypeAttribute defines the strategy used for provisioning storage for the workspace.
 	// If empty, the common PVC strategy is used.
 	// Supported options:
-	// - "common":    Create one PVC per namespace, and store data for all workspaces in that namespace in that PVC
-	// - "async" :    Create one PVC per namespace, and create a remote server that syncs data from workspaces to the PVC.
-	//                All volumeMounts used for devworkspaces are emptyDir
-	// - "ephemeral": Use emptyDir volumes for all volumes in the DevWorkspace. All data is lost when the workspace is
-	//                stopped.
+	// - "common":        Create one PVC per namespace, and store data for all workspaces in that namespace in that PVC
+	// - "async" :        Create one PVC per namespace, and create a remote server that syncs data from workspaces to the PVC.
+	//                    All volumeMounts used for devworkspaces are emptyDir
+	// - "per-workspace": Create one PVC per workspace, delete that PVC when the workspace is deleted.
+	// - "ephemeral":     Use emptyDir volumes for all volumes in the DevWorkspace. All data is lost when the workspace is
+	//                    stopped.
 	DevWorkspaceStorageTypeAttribute = "controller.devfile.io/storage-type"
 
 	// RuntimeClassNameAttribute is an attribute added to a DevWorkspace to specify a runtimeClassName for container

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -63,6 +63,13 @@ func (p *PerWorkspaceStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1
 	}
 	pvcName := perWorkspacePVC.Name
 
+	// If PVC is being deleted, we need to fail workspace startup as a running pod will block deletion.
+	if perWorkspacePVC.DeletionTimestamp != nil {
+		return &ProvisioningError{
+			Message: "DevWorkspace PVC is being deleted",
+		}
+	}
+
 	// Rewrite container volume mounts
 	if err := p.rewriteContainerVolumeMounts(workspace.Status.DevWorkspaceId, pvcName, podAdditions, &workspace.Spec.Template); err != nil {
 		return &ProvisioningError{

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 
-	check "github.com/devfile/devworkspace-operator/pkg/library/status"
+	"github.com/devfile/devworkspace-operator/pkg/library/status"
 	nsconfig "github.com/devfile/devworkspace-operator/pkg/provision/config"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 
@@ -97,7 +97,7 @@ func SyncDeploymentToCluster(
 	}
 	clusterDeployment := clusterObj.(*appsv1.Deployment)
 
-	deploymentReady := check.CheckDeploymentStatus(clusterDeployment)
+	deploymentReady := status.CheckDeploymentStatus(clusterDeployment)
 	if deploymentReady {
 		return DeploymentProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{
@@ -106,7 +106,7 @@ func SyncDeploymentToCluster(
 		}
 	}
 
-	deploymentHealthy, deploymentErrMsg := check.CheckDeploymentConditions(clusterDeployment)
+	deploymentHealthy, deploymentErrMsg := status.CheckDeploymentConditions(clusterDeployment)
 	if !deploymentHealthy {
 		return DeploymentProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{
@@ -116,7 +116,7 @@ func SyncDeploymentToCluster(
 		}
 	}
 
-	failureMsg, checkErr := check.CheckPodsState(workspace, workspace.Namespace, k8sclient.MatchingLabels{
+	failureMsg, checkErr := status.CheckPodsState(workspace.Status.DevWorkspaceId, workspace.Namespace, k8sclient.MatchingLabels{
 		constants.DevWorkspaceIDLabel: workspace.Status.DevWorkspaceId,
 	}, clusterAPI)
 	if checkErr != nil {

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -15,7 +15,7 @@
 
 # Build the manager binary
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7-13 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.10-4 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /project-clone
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
   project-clone/main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.6-751
+FROM registry.access.redhat.com/ubi8-minimal:8.6-854
 RUN microdnf -y update && microdnf install -y time git git-lfs && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/project-clone


### PR DESCRIPTION
### What does this PR do?
Cherry-pick fixes from main branch into 0.15.x:
* https://github.com/devfile/devworkspace-operator/pull/866 (fixes issue https://github.com/devfile/devworkspace-operator/issues/865) - 1 commit
* https://github.com/devfile/devworkspace-operator/pull/846 (fixes issue https://github.com/devfile/devworkspace-operator/issues/551) - 2 commits
* https://github.com/devfile/devworkspace-operator/pull/880 (docs improvement) - 1 commit
* https://github.com/devfile/devworkspace-operator/pull/879 (fixes issues https://github.com/devfile/devworkspace-operator/issues/877, https://github.com/devfile/devworkspace-operator/issues/873, and https://github.com/devfile/devworkspace-operator/issues/881) - 6 commits
* Updates base container images to match main (ubi8-minimal and ubi8/go-toolset) - 1 commit

### What issues does this PR fix or reference?
See above

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
