### PR TITLE
Log reason for stopping a workspace if stopped-by annotation is present

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -482,6 +482,9 @@ func (r *DevWorkspaceReconciler) stopWorkspace(ctx context.Context, workspace *d
 			status.setConditionFalse(conditions.Started, "Workspace is stopped")
 		}
 	}
+	if stoppedBy, ok := workspace.Annotations[constants.DevWorkspaceStopReasonAnnotation]; ok {
+		logger.Info("Workspace stopped with reason", "stopped-by", stoppedBy)
+	}
 	return r.updateWorkspaceStatus(workspace, logger, &status, reconcile.Result{}, nil)
 }
 


### PR DESCRIPTION
### What does this PR do?
If a workspace is stopped and has the `controller.devfile.io/stopped-by` annotation, log the value of that annotation when stopping workspaces in order to make it clearer when e.g. workspaces are being idled.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Start theia workspace (or any workspace that supports idling) and wait for it to idle. Verify that stop reason is logged.

Alternatively: Patch a running workspace to have `.spec.started: false` and add the `stopped-by` annotation at the same time.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
