### PR TITLE
Cherry picks for 0.15.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ jobs:
       OPM_VERSION: v1.19.5
     runs-on: ubuntu-20.04
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.6
+
       - name: Clone source code
         uses: actions/checkout@v2
         with:

--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -477,6 +477,9 @@ func (r *DevWorkspaceReconciler) stopWorkspace(ctx context.Context, workspace *d
 			status.setConditionFalse(conditions.Started, "Workspace is stopped")
 		}
 	}
+	if stoppedBy, ok := workspace.Annotations[constants.DevWorkspaceStopReasonAnnotation]; ok {
+		logger.Info("Workspace stopped with reason", "stopped-by", stoppedBy)
+	}
 	return r.updateWorkspaceStatus(workspace, logger, &status, reconcile.Result{}, nil)
 }
 

--- a/webhook/main.go
+++ b/webhook/main.go
@@ -26,6 +26,7 @@ import (
 
 	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
 	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/cache"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/devfile/devworkspace-operator/version"
@@ -89,6 +90,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	cacheFunc, err := cache.GetWebhooksCacheFunc()
+	if err != nil {
+		log.Error(err, "failed to set up objects cache")
+		os.Exit(1)
+	}
+
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Namespace:              namespace,
@@ -96,6 +103,7 @@ func main() {
 		MetricsBindAddress:     metricsAddr,
 		HealthProbeBindAddress: ":6789",
 		CertDir:                server.WebhookServerCertDir,
+		NewCache:               cacheFunc,
 	})
 	if err != nil {
 		log.Error(err, "Failed to create manager")

--- a/webhook/workspace/handler/pod.go
+++ b/webhook/workspace/handler/pod.go
@@ -48,8 +48,11 @@ func (h *WebhookHandler) MutatePodOnUpdate(_ context.Context, req admission.Requ
 		return admission.Denied(err.Error())
 	}
 
-	ok, msg := h.handleImmutableObj(oldP, newP, req.UserInfo.UID)
-	if !ok {
+	if ok, msg := h.handleImmutableObj(oldP, newP, req.UserInfo.UID); !ok {
+		return admission.Denied(msg)
+	}
+
+	if ok, msg := h.handleImmutablePod(oldP, newP, req.UserInfo.UID); !ok {
 		return admission.Denied(msg)
 	}
 


### PR DESCRIPTION
### What does this PR do?
Cherry-pick changes for 0.15.2:

* https://github.com/devfile/devworkspace-operator/pull/864 to avoid needing to reformat files after a release
* https://github.com/devfile/devworkspace-operator/pull/886
* https://github.com/devfile/devworkspace-operator/pull/889 

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
