### PR TITLE
Add per-user storage-class option

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -685,7 +685,7 @@ func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Req
 	var reconciles []reconcile.Request
 	for _, workspace := range dwList.Items {
 		storageType := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
-		if storageType == constants.CommonStorageClassType || storageType == "" {
+		if storageType == constants.CommonStorageClassType || storageType == constants.PerUserStorageClassType || storageType == "" {
 			reconciles = append(reconciles, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      workspace.GetName(),

--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -74,7 +74,8 @@ spec:
 
 where `<storage-type>` is one of
 
-* `common`: Use one PVC for all workspace volumes, mounting Devfile volumes in subpaths within the common PVC
+* `per-user`: Use one PVC for all workspace volumes, mounting Devfile volumes in subpaths within the shared PVC
+* `common`: An alias of the `per-user` storage-type, which behaves the same way as the `per-user` storage-type. Exists for legacy compatibility reasons.
 * `per-workspace`: Every workspace is given its own PVC. Each Devfile volume is mounted as a subpath within the workspace PVC.
 * `ephemeral`: Replace all volumes with `emptyDir` volumes. This storage type is non-persistent; any local changes will be lost when the workspace is stopped. This is the equivalent of marking all volumes in the Devfile as `ephemeral: true`
 * `async`: Use `emptyDir` volumes for workspace volumes, but include a sidecar that synchronises local changes to a persistent volume as in the `common` strategy. This can potentially avoid issues where mounting volumes to a workspace on startup takes a long time.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -64,9 +64,12 @@ const (
 
 	// Constants describing storage classes supported by the controller
 
-	// CommonStorageClassType defines the 'common' storage policy -- one PVC is provisioned per namespace and all devworkspace storage
-	// is mounted in it on subpaths according to devworkspace ID.
+	// CommonStorageClassType defines the 'common' storage policy, which is an alias of the 'per-user' storage policy, and operates in the same fashion as the 'per-user' storage policy.
+	// The 'common' storage policy exists only for legacy compatibility.
 	CommonStorageClassType = "common"
+	// PerUserStorageClassType defines the 'per-user' storage policy -- one PVC is provisioned per namespace and all devworkspace storage
+	// is mounted in it on subpaths according to devworkspace ID.
+	PerUserStorageClassType = "per-user"
 	// AsyncStorageClassType defines the 'asynchronous' storage policy. An rsync sidecar is added to devworkspaces that uses SSH to connect
 	// to a storage deployment that mounts a common PVC for the namespace.
 	AsyncStorageClassType = "async"

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -104,6 +104,23 @@ func loadAllTestCasesOrPanic(t *testing.T, fromDir string) []testCase {
 	return tests
 }
 
+func TestUseCommonStorageProvisionerForPerUserStorageClass(t *testing.T) {
+	test := loadTestCaseOrPanic(t, "testdata/common-storage/per-user-alias.yaml")
+
+	t.Run(test.Name, func(t *testing.T) {
+		// sanity check that file is read correctly.
+		assert.NotNil(t, test.Input.Workspace, "Input does not define workspace")
+		workspace := &dw.DevWorkspace{}
+		workspace.Spec.Template = *test.Input.Workspace
+		storageProvisioner, err := GetProvisioner(workspace)
+
+		if !assert.NoError(t, err, "Should not return error") {
+			return
+		}
+		assert.Equal(t, &CommonStorageProvisioner{}, storageProvisioner, "Per-user storage class should use the common storage provisioner")
+	})
+}
+
 func TestProvisionStorageForCommonStorageClass(t *testing.T) {
 	tests := loadAllTestCasesOrPanic(t, "testdata/common-storage")
 	setupControllerCfg()

--- a/pkg/provision/storage/provisioner.go
+++ b/pkg/provision/storage/provisioner.go
@@ -54,6 +54,8 @@ func GetProvisioner(workspace *dw.DevWorkspace) (Provisioner, error) {
 		return &AsyncStorageProvisioner{}, nil
 	case constants.EphemeralStorageClassType:
 		return &EphemeralStorageProvisioner{}, nil
+	case constants.PerUserStorageClassType:
+		return &CommonStorageProvisioner{}, nil
 	default:
 		return nil, UnsupportedStorageStrategy
 	}

--- a/pkg/provision/storage/shared.go
+++ b/pkg/provision/storage/shared.go
@@ -252,7 +252,7 @@ func getSharedPVCWorkspaceCount(namespace string, api sync.ClusterAPI) (total in
 		}
 		storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
 		// Note, if the storageClass attribute isn't set (ie. storageClass == ""), then the storage class being used is "common"
-		if storageClass == constants.AsyncStorageClassType || storageClass == constants.CommonStorageClassType || storageClass == "" {
+		if storageClass == constants.AsyncStorageClassType || storageClass == constants.CommonStorageClassType || storageClass == constants.PerUserStorageClassType || storageClass == "" {
 			total++
 		}
 	}

--- a/pkg/provision/storage/testdata/common-storage/per-user-alias.yaml
+++ b/pkg/provision/storage/testdata/common-storage/per-user-alias.yaml
@@ -1,0 +1,8 @@
+name: "per-user storage class can be used as an alias for common storage class"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  workspace:
+    attributes:
+      controller.devfile.io/storage-type: per-user
+

--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -116,6 +116,9 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnUpdate(ctx context.Context, re
 		case oldStorageType == constants.EphemeralStorageClassType:
 			// Allow switching from ephemeral to a persistent storage type
 			break
+		case (oldStorageType == constants.CommonStorageClassType && newStorageType == constants.PerUserStorageClassType) || (oldStorageType == constants.PerUserStorageClassType && newStorageType == constants.CommonStorageClassType):
+			// Allow switching between common and per-user persistent storage type for legacy compatibility
+			break
 		case !hasFinalizer(oldWksp, constants.StorageCleanupFinalizer) && !hasFinalizer(newWksp, constants.StorageCleanupFinalizer):
 			// If finalizer is not set, the workspace does not use storage yet and so can safely switch (e.g. a workspace was created
 			// with `started: false` and then edited)


### PR DESCRIPTION
The 'per-user' storage type is an alternate storage-type name for the 'common' storage class.
In other words, it is an alias for the 'common' storage-type and behaves in the same manner.

Note that in the PR's current state, the 'per-user' storage-type replaces the 'common' storage-type, and the 'common' storage-type is treated as an alias of the 'per-user' storage-type. It may be better to reverse things, i.e. document that the 'per-user' storage-type is an alias of the 'common' storage-type 

### What issues does this PR fix or reference?
Part of eclipse/che#21405

### Is it tested? How?
There are two parts of this PR to test.
**Ensuring that the 'per-user' storage type works the same as the 'common' storage type:**
1. Start up DWO
2. Create and apply a devfile that uses the 'per-user' storage type, e.g.
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next
spec:
  started: true
  template:
    attributes:
        controller.devfile.io/storage-type: per-user
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
          components:
            - name: theia-ide
              container:
                env:
                  - name: THEIA_HOST
                    value: 0.0.0.0
    commands:
      - id: say-hello
        exec:
          component: theia-ide
          commandLine: echo "Hello from $(pwd)"
          workingDir: ${PROJECTS_ROOT}/project/app
```
3. Ensure that the workspace starts up and that the `claim-devworkspace` PVC is created.
4. Delete the workspace and ensure that the `claim-devworkspace` PVC is deleted.

**Ensuring that you can switch between the 'per-user' and 'common' storage-type:**
1. Start up DWO
2. Create and apply 2 devfiles, one with the 'per-user' storage-type and the other with the 'common' storage-type
3. After the workspaces are started up, do a `kubectl edit` or `oc edit` and change their storage-type from `per-user` -> `common` and `common` -> `per-user` respectively
4. Ensure the edit is allowed by the webhook


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
