### PR TITLE
Cherry pick PR #898 to 0.15.x branch

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -677,7 +677,7 @@ func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Req
 		return []reconcile.Request{}
 	}
 	dwList := &dw.DevWorkspaceList{}
-	if err := r.Client.List(context.Background(), dwList); err != nil {
+	if err := r.Client.List(context.Background(), dwList, &client.ListOptions{Namespace: obj.GetNamespace()}); err != nil {
 		return []reconcile.Request{}
 	}
 	var reconciles []reconcile.Request

--- a/pkg/provision/workspace/pull_secret.go
+++ b/pkg/provision/workspace/pull_secret.go
@@ -18,6 +18,8 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
@@ -93,6 +95,10 @@ func PullSecrets(clusterAPI sync.ClusterAPI, serviceAccountName, namespace strin
 			dockerCfgs = append(dockerCfgs, corev1.LocalObjectReference{Name: s.Name})
 		}
 	}
+
+	sort.Slice(dockerCfgs, func(i, j int) bool {
+		return strings.Compare(dockerCfgs[i].Name, dockerCfgs[j].Name) < 0
+	})
 
 	return PullSecretsProvisioningStatus{
 		ProvisioningStatus: ProvisioningStatus{

--- a/pkg/provision/workspace/pull_secret.go
+++ b/pkg/provision/workspace/pull_secret.go
@@ -52,7 +52,10 @@ func PullSecrets(clusterAPI sync.ClusterAPI, serviceAccountName, namespace strin
 	}
 
 	secrets := corev1.SecretList{}
-	err = clusterAPI.Client.List(context.TODO(), &secrets, &client.ListOptions{LabelSelector: labelSelector})
+	err = clusterAPI.Client.List(context.TODO(), &secrets, &client.ListOptions{
+		Namespace:     namespace,
+		LabelSelector: labelSelector,
+	})
 	if err != nil {
 		return PullSecretsProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{


### PR DESCRIPTION
### What does this PR do?
Cherry-pick changes from https://github.com/devfile/devworkspace-operator/pull/898 to the 0.15.x branch

### What issues does this PR fix or reference?
Fixes #896 and #897 in the 0.15.x stream

### Is it tested? How?
Test as in #898 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
