### PR TITLE
WIP: feat: support PVC expansion based on DWOC

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -92,6 +92,7 @@ type DevWorkspaceReconciler struct {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create
 // +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get,resourceNames=cluster
 // +kubebuilder:rbac:groups=apps,resourceNames=devworkspace-controller,resources=deployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 /////// Required permissions for workspace ServiceAccount
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups=apps;extensions,resources=replicasets,verbs=get;list;watch

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -308,6 +308,14 @@ spec:
           verbs:
           - create
         - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - workspace.devfile.io
           resources:
           - '*'

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -23717,6 +23717,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - workspace.devfile.io
   resources:
   - '*'

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -232,6 +232,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - workspace.devfile.io
   resources:
   - '*'

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -23717,6 +23717,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - workspace.devfile.io
   resources:
   - '*'

--- a/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -232,6 +232,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - workspace.devfile.io
   resources:
   - '*'

--- a/deploy/templates/components/rbac/role.yaml
+++ b/deploy/templates/components/rbac/role.yaml
@@ -231,6 +231,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - workspace.devfile.io
   resources:
   - '*'

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/devfile/devworkspace-operator/pkg/webhook"
 	"github.com/devfile/devworkspace-operator/version"
+	storagev1 "k8s.io/api/storage/v1"
 
 	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
 	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -68,6 +69,7 @@ func init() {
 	}
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(storagev1.AddToScheme(scheme))
 
 	utilruntime.Must(controllerv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(dwv1.AddToScheme(scheme))

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -27,6 +27,7 @@ import (
 
 // defaultConfig represents the default configuration for the DevWorkspace Operator.
 var defaultConfig = &v1alpha1.OperatorConfiguration{
+	EnableExperimentalFeatures: pointer.BoolPtr(false),
 	Routing: &v1alpha1.RoutingConfig{
 		DefaultRoutingClass: "basic",
 		ClusterHostSuffix:   "", // is auto discovered when running on OpenShift. Must be defined by CR on Kubernetes.

--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -110,7 +110,7 @@ func (p *AsyncStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdd
 
 	if !usingAlternatePVC {
 		// Create common PVC if needed
-		clusterPVC, err := syncCommonPVC(workspace.Namespace, workspace.Config, clusterAPI)
+		clusterPVC, err := syncCommonPVC(workspace.Namespace, workspace, clusterAPI)
 		if err != nil {
 			return err
 		}

--- a/pkg/provision/storage/commonStorage.go
+++ b/pkg/provision/storage/commonStorage.go
@@ -72,7 +72,7 @@ func (p *CommonStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAd
 	}
 
 	if !usingAlternatePVC {
-		commonPVC, err := syncCommonPVC(workspace.Namespace, workspace.Config, clusterAPI)
+		commonPVC, err := syncCommonPVC(workspace.Namespace, workspace, clusterAPI)
 		if err != nil {
 			return err
 		}

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -173,8 +173,7 @@ func syncPerWorkspacePVC(workspace *common.DevWorkspaceWithConfig, clusterAPI sy
 		}
 	}
 
-	storageClass := workspace.Config.Workspace.StorageClassName
-	pvc := getPVCSpec(common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId), workspace.Namespace, storageClass, pvcSize)
+	pvc := getPVCSpec(common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId), workspace.Namespace, workspace.Config.Workspace.StorageClassName, pvcSize)
 
 	namespaceName := types.NamespacedName{
 		Name:      common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId),

--- a/pkg/provision/storage/storageExpansion_test.go
+++ b/pkg/provision/storage/storageExpansion_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(dw.AddToScheme(scheme))
+	utilruntime.Must(storagev1.AddToScheme(scheme))
+}
+
+func runExpansionTestCases(test testCase, t *testing.T, storageProvisioner Provisioner, PVC *corev1.PersistentVolumeClaim, volumeExpansionAllowed bool, expectedPVCSize resource.Quantity) {
+	workspace := dw.DevWorkspace{}
+	workspace.Spec.Template = *test.Input.Workspace
+	workspace.Status.DevWorkspaceId = test.Input.DevWorkspaceID
+	workspace.Namespace = "test-namespace"
+
+	workspaceWithConfig := &common.DevWorkspaceWithConfig{}
+	workspaceWithConfig.DevWorkspace = &workspace
+	workspaceWithConfig.Config = &test.Input.ControllerConfig
+
+	storageClass := &storagev1.StorageClass{}
+	storageClass.Name = *workspaceWithConfig.Config.Workspace.StorageClassName
+	storageClass.Namespace = PVC.Namespace
+	storageClass.AllowVolumeExpansion = &volumeExpansionAllowed
+
+	clusterAPI := sync.ClusterAPI{
+		Scheme: scheme,
+		// The PVC already exists in the cluster at the original size
+		Client: fake.NewFakeClientWithScheme(scheme, PVC),
+		Logger: zap.New(),
+	}
+
+	err := clusterAPI.Client.Create(context.TODO(), storageClass)
+	assert.NoError(t, err, "Unable to add storage class to testing cluster")
+
+	err = storageProvisioner.ProvisionStorage(&test.Input.PodAdditions, workspaceWithConfig, clusterAPI)
+
+	if !assert.NoError(t, err, "Should not return error") {
+		return
+	}
+
+	retrievedPVC := &corev1.PersistentVolumeClaim{}
+	namespacedName := types.NamespacedName{Name: PVC.Name, Namespace: workspace.Namespace}
+
+	err = clusterAPI.Client.Get(clusterAPI.Ctx, namespacedName, retrievedPVC)
+	assert.NoError(t, err, "Unable to retrieve modified PVC")
+
+	// TODO: Use cmp instead of assert.Equal?
+
+	// Case 1: Experimental Features enabled, volume expansion allowed, and final PVC size is not the desired PVC size
+	if *test.Input.ControllerConfig.EnableExperimentalFeatures && volumeExpansionAllowed && assert.Equal(t, retrievedPVC.Spec.Resources.Requests[corev1.ResourceStorage], expectedPVCSize, "PVC size should have increased") {
+		return
+	}
+
+	// Case 2: Experimental Features enabled, volume expansion not allowed, yet the PVC size still changed
+	// Note: On a real cluster, this is impossible to happen. This case only ensures there is a check for whether volume expansion is allowedvolume expansion not allowed
+	if *test.Input.ControllerConfig.EnableExperimentalFeatures && !volumeExpansionAllowed && assert.NotEqual(t, retrievedPVC.Spec.Resources.Requests[corev1.ResourceStorage], expectedPVCSize, "Volume expansion not allowed; PVC size should not have changed") {
+		return
+	}
+
+	// Case 3: Experimental Features disabled, yet the PVC size still changed
+	if !*test.Input.ControllerConfig.EnableExperimentalFeatures && assert.NotEqual(t, retrievedPVC.Spec.Resources.Requests[corev1.ResourceStorage], expectedPVCSize, "ExperimentalFeatures disabled; PVC size should not have changed") {
+		return
+	}
+}
+
+func TestExpandCommonStorage(t *testing.T) {
+	test := loadTestCaseOrPanic(t, "testdata/storage-expansion/do-expand-storage.yaml")
+
+	t.Run(test.Name, func(t *testing.T) {
+		// sanity check that file is read correctly.
+		assert.NotNil(t, test.Input.Workspace, "Input does not define workspace")
+		assert.NotNil(t, test.Input.ControllerConfig, "Input does not define an operator configuration")
+
+		storageProvisioner := CommonStorageProvisioner{}
+		PVC := getPVCSpec("claim-devworkspace", "test-namespace", test.Input.ControllerConfig.Workspace.StorageClassName, resource.MustParse("10Gi"))
+		PVC.Status.Phase = corev1.ClaimBound
+
+		runExpansionTestCases(test, t, &storageProvisioner, PVC, true, *test.Input.ControllerConfig.Workspace.DefaultStorageSize.Common)
+		runExpansionTestCases(test, t, &storageProvisioner, PVC, false, *test.Input.ControllerConfig.Workspace.DefaultStorageSize.Common)
+	})
+}
+
+func TestExpandCommonStorageExperimentalFeaturesDisabled(t *testing.T) {
+	test := loadTestCaseOrPanic(t, "testdata/storage-expansion/do-not-expand-storage.yaml")
+
+	t.Run(test.Name, func(t *testing.T) {
+		// sanity check that file is read correctly.
+		assert.NotNil(t, test.Input.Workspace, "Input does not define workspace")
+		assert.NotNil(t, test.Input.ControllerConfig, "Input does not define an operator configuration")
+
+		storageProvisioner := CommonStorageProvisioner{}
+		PVC := getPVCSpec("claim-devworkspace", "test-namespace", test.Input.ControllerConfig.Workspace.StorageClassName, resource.MustParse("10Gi"))
+		PVC.Status.Phase = corev1.ClaimBound
+
+		runExpansionTestCases(test, t, &storageProvisioner, PVC, true, *test.Input.ControllerConfig.Workspace.DefaultStorageSize.Common)
+		runExpansionTestCases(test, t, &storageProvisioner, PVC, false, *test.Input.ControllerConfig.Workspace.DefaultStorageSize.Common)
+	})
+}
+
+func TestExpandPerWorkspaceStorage(t *testing.T) {
+	test := loadTestCaseOrPanic(t, "testdata/storage-expansion/do-expand-storage.yaml")
+
+	t.Run(test.Name, func(t *testing.T) {
+		// sanity check that file is read correctly.
+		assert.NotNil(t, test.Input.Workspace, "Input does not define workspace")
+		assert.NotNil(t, test.Input.ControllerConfig, "Input does not define an operator configuration")
+
+		storageProvisioner := PerWorkspaceStorageProvisioner{}
+		PVC := getPVCSpec(common.PerWorkspacePVCName(test.Input.DevWorkspaceID), "test-namespace", test.Input.ControllerConfig.Workspace.StorageClassName, resource.MustParse("10Gi"))
+		PVC.Status.Phase = corev1.ClaimBound
+
+		runExpansionTestCases(test, t, &storageProvisioner, PVC, true, *test.Input.ControllerConfig.Workspace.DefaultStorageSize.PerWorkspace)
+		runExpansionTestCases(test, t, &storageProvisioner, PVC, false, *test.Input.ControllerConfig.Workspace.DefaultStorageSize.PerWorkspace)
+	})
+}
+
+func TestExpandPerWorkspaceStorageExperimentalFeaturesDisabled(t *testing.T) {
+	test := loadTestCaseOrPanic(t, "testdata/storage-expansion/do-not-expand-storage.yaml")
+
+	t.Run(test.Name, func(t *testing.T) {
+		// sanity check that file is read correctly.
+		assert.NotNil(t, test.Input.Workspace, "Input does not define workspace")
+		assert.NotNil(t, test.Input.ControllerConfig, "Input does not define an operator configuration")
+
+		storageProvisioner := PerWorkspaceStorageProvisioner{}
+		PVC := getPVCSpec(common.PerWorkspacePVCName(test.Input.DevWorkspaceID), "test-namespace", test.Input.ControllerConfig.Workspace.StorageClassName, resource.MustParse("10Gi"))
+		PVC.Status.Phase = corev1.ClaimBound
+
+		runExpansionTestCases(test, t, &storageProvisioner, PVC, true, *test.Input.ControllerConfig.Workspace.DefaultStorageSize.PerWorkspace)
+		runExpansionTestCases(test, t, &storageProvisioner, PVC, false, *test.Input.ControllerConfig.Workspace.DefaultStorageSize.PerWorkspace)
+	})
+}

--- a/pkg/provision/storage/testdata/storage-expansion/do-expand-storage.yaml
+++ b/pkg/provision/storage/testdata/storage-expansion/do-expand-storage.yaml
@@ -1,0 +1,21 @@
+name: "Storage expansion (experimental feature) enabled"
+
+input:
+  devworkspaceId: "test-workspaceid"
+
+  config:
+    enableExperimentalFeatures: true
+    workspace:
+      defaultStorageSize: 
+        common: 15Gi
+        perWorkspace: 15Gi
+      storageClassName: "test-storage-class"
+      pvcName: "claim-devworkspace"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true 

--- a/pkg/provision/storage/testdata/storage-expansion/do-not-expand-storage.yaml
+++ b/pkg/provision/storage/testdata/storage-expansion/do-not-expand-storage.yaml
@@ -1,0 +1,21 @@
+name: "Storage expansion (experimental feature) disabled"
+
+input:
+  devworkspaceId: "test-workspaceid"
+
+  config:
+    enableExperimentalFeatures: false
+    workspace:
+      defaultStorageSize: 
+        common: 15Gi
+        perWorkspace: 15Gi
+      storageClassName: "test-storage-class"
+      pvcName: "claim-devworkspace"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+          mountSources: true


### PR DESCRIPTION
### What does this PR do?
Allows PVC's provisioned using the `common` (or `per-user`) or `per-workspace` storage-type to be expanded to the size configured in the `workspace.DefaultStorageSize` field of the DWOC. This occurs during reconciliation, and requires `enableExperimentalFeatures` to be set to `true` in the DWOC.

The [Kubernetes storage-class](https://kubernetes.io/docs/concepts/storage/storage-classes/) must have it's `allowVolumeExpansion` field set to `true` for resizing to work. Furthermore, only certain volumes support expansion - according to the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims) these are:
```
- azureDisk
- azureFile
- awsElasticBlockStore
- cinder (deprecated)
- [csi](https://kubernetes.io/docs/concepts/storage/volumes/#csi)
- flexVolume (deprecated)
- gcePersistentDisk
- glusterfs
- rbd
- portworxVolume
```

Minikube does **not** support PVC expansion by default, even if its storage-class has the `allowVolumeExpansion` field set to `true`. 

This is an 'experimental' feature primarily for the following 2 reasons:
1. If the volume does not support expansion, then a warning stating that the PVC could not be expanded will be logged. In my testing, once the volume expansion request has been submitted, this warning will no longer be logged in the future for a given PVC, assuming `workspace.DefaultStorageSize` is not modified again (as the PVC spec already contains the requested size, causing `PVCExpansionRequired()` to return false).
2. If a `ResourceQuota` or `LimitRange` prevents the PVC expansion request, then an error will be returned and continuously logged by DWO. For example:
```json
{
   "level":"error",
   "ts":1660253077.8029618,
   "logger":"controller-runtime.manager.controller.devworkspace",
   "msg":"Reconciler error",
   "reconciler group":"workspace.devfile.io",
   "reconciler kind":"DevWorkspace",
   "name":"theia-next-2",
   "namespace":"devworkspace-controller",
   "error":"persistentvolumeclaims \"claim-devworkspace\" is forbidden: maximum storage usage per PersistentVolumeClaim is 17Gi, but request is 20Gi",
   "stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/aobuchow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/internal/controller/controller.go:253\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/aobuchow/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.5/pkg/internal/controller/controller.go:214"
}
```

### What issues does this PR fix or reference?
Fix #875

### Is it tested? How?
Some automated tests were added to test this feature.

There are two manual-testing scenario's: on Minikube and on OpenShift.
For both scenarios, the steps to follow are:
1. Deploy DWO onto the cluster. E.g for OpenShift `make docker install` (make sure `$DWO_IMG` is set to your quay repository)
2. **For Minikube only:** Edit the standard storage-class used by minikube to set the `allowVolumeExpansion` field to `true`.  If this is not set, then DWO will silently not attempt to resize the PVC. To do so: `kubectl edit storageClass standard`
```diff
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
 annotations:
   kubectl.kubernetes.io/last-applied-configuration: |
     {"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"},"labels":{"addonmanager.kub\
ernetes.io/mode":"EnsureExists"},"name":"standard"},"provisioner":"k8s.io/minikube-hostpath"}
   storageclass.kubernetes.io/is-default-class: "true"
 creationTimestamp: "2022-08-15T14:46:41Z"
 labels:
   addonmanager.kubernetes.io/mode: EnsureExists
 name: standard
 resourceVersion: "1507"
 uid: 7585ccfd-04fd-49f9-89e3-c551fb2e62ed
provisioner: k8s.io/minikube-hostpath
reclaimPolicy: Delete
volumeBindingMode: Immediate
+ allowVolumeExpansion: true
```


3. Apply a devfile that uses the common PVC strategy, as well as a devfile that uses the per-workspace PVC strategy, eg. `kubectl apply -f ./samples/theia-next.yaml -n $NAMESPACE && yq -i -y '.metadata.name |= "theia-next-per-workspace"' ./samples/per-workspace-storage.yaml && kubectl apply -f ./samples/per-workspace-storage.yaml -n $NAMESPACE`
4. Edit the DWOC to set `enableExperimentalFeatures` to `true`, as well as set the default storage sizes for per-workspace and common to something bigger than their defaults (which are 5Gi and 10Gi respectively): `kubectl edit dwoc -n $NAMESPACE`

```diff
apiVersion: controller.devfile.io/v1alpha1
config:
+  enableExperimentalFeatures: true
  routing:
    defaultRoutingClass: basic
  workspace:
+    defaultStorageSize:
+      common: 15Gi
+      perWorkspace: 15Gi
    imagePullPolicy: Always
kind: DevWorkspaceOperatorConfig
...
```
5. Trigger a reconcile in both workspaces to allow expansion to occur, eg. `edit dw theia-next-per-workspace -n $NAMESPACE` and toggle `spec.started` from false to true

In the **OpenShift scenario**, both the common PVC and per-workspace PVC will have their capacity expanded to the amount set in the DWOC (15Gi in the example given). This can be viewed on the Administrator view of the OpenShift console -> Storage -> Persistent Volume Claims.

In the **Minikube scenario**, both the common and per-workspace PVC will fail to have their capacity expanded, and a message similar to the following will be logged:
```json
{
   "level":"info",
   "ts":1660582376.9331381,
	"msg":"PVC expansion error: Unable to expand PVC. More information: Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC."
}
```

### PR Checklist
- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che