### PR TITLE
fix: specify updated makefile rules for install via OLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ In order to build a custom bundle, the following env vars should be set:
 
 To build the index image and register its catalogsource to the cluster, run
 ```
-make generate_olm_bundle_yaml build_bundle_image build_index_image register_catalogsource
+make generate_olm_bundle_yaml build_bundle_and_index register_catalogsource
 ```
 
 Note that setting `DEFAULT_DWO_IMG` while generating sources will result in local changes to the repo which should be `git restored` before committing. This can also be done by unsetting the `DEFAULT_DWO_IMG` env var and re-running `make generate_olm_bundle_yaml`


### PR DESCRIPTION
### What does this PR do?
Updates the OLM installation instructions to reference the updated makefile rule `build_bundle_and_index`

### What issues does this PR fix or reference?
Fix #906

### Is it tested? How?
Run `make generate_olm_bundle_yaml build_bundle_and_index register_catalogsource` with the `DWO_BUNDLE_IMG` and `DWO_INDEX_IMG` environment variables set, ensure this results in DWO being installed to an OpenShift cluster, and DWO is available in OperatorHub. 


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
