### PR TITLE
feat: Allow external DWOC to be merged with internal DWOC on a per-workspace basis

### DIFF
--- a/controllers/controller/devworkspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/basic_solver.go
@@ -56,12 +56,7 @@ func (s *BasicSolver) Finalize(*controllerv1alpha1.DevWorkspaceRouting) error {
 func (s *BasicSolver) GetSpecObjects(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) (RoutingObjects, error) {
 	routingObjects := RoutingObjects{}
 
-	routingAnnotationPrefix := string(routing.Spec.RoutingClass) + constants.RoutingAnnotationInfix
-	if _, set := routing.Annotations[routingAnnotationPrefix+constants.ClusterHostSuffixAnnotationSuffix]; !set {
-		return routingObjects, &RoutingInvalid{"basic routing requires .config.routing.clusterHostSuffix to be set in operator config"}
-	}
-
-	routingSuffix := routing.Annotations[routingAnnotationPrefix+constants.ClusterHostSuffixAnnotationSuffix]
+	routingSuffix := routing.Annotations[constants.ClusterHostSuffixAnnotation]
 	if routingSuffix == "" {
 		return routingObjects, &RoutingInvalid{"basic routing requires .config.routing.clusterHostSuffix to be set in operator config"}
 	}

--- a/controllers/controller/devworkspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/basic_solver.go
@@ -17,10 +17,8 @@ package solvers
 
 import (
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var routeAnnotations = func(endpointName string) map[string]string {
@@ -58,7 +56,12 @@ func (s *BasicSolver) Finalize(*controllerv1alpha1.DevWorkspaceRouting) error {
 func (s *BasicSolver) GetSpecObjects(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) (RoutingObjects, error) {
 	routingObjects := RoutingObjects{}
 
-	routingSuffix := config.Routing.ClusterHostSuffix
+	routingAnnotationPrefix := string(routing.Spec.RoutingClass) + constants.RoutingAnnotationInfix
+	if _, set := routing.Annotations[routingAnnotationPrefix+constants.ClusterHostSuffixAnnotationSuffix]; !set {
+		return routingObjects, &RoutingInvalid{"basic routing requires .config.routing.clusterHostSuffix to be set in operator config"}
+	}
+
+	routingSuffix := routing.Annotations[routingAnnotationPrefix+constants.ClusterHostSuffixAnnotationSuffix]
 	if routingSuffix == "" {
 		return routingObjects, &RoutingInvalid{"basic routing requires .config.routing.clusterHostSuffix to be set in operator config"}
 	}

--- a/controllers/controller/devworkspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/basic_solver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var routeAnnotations = func(endpointName string) map[string]string {

--- a/controllers/controller/devworkspacerouting/solvers/common.go
+++ b/controllers/controller/devworkspacerouting/solvers/common.go
@@ -138,6 +138,16 @@ func GetServiceForEndpoints(endpoints map[string]controllerv1alpha1.EndpointList
 	}
 }
 
+func AddDWOCRoutingAnnotations(workspaceWithConfig common.DevWorkspaceWithConfig) {
+	routingClass := workspaceWithConfig.Spec.RoutingClass
+	if routingClass == "" {
+		routingClass = workspaceWithConfig.Config.Routing.DefaultRoutingClass
+	}
+	routingAnnotationPrefix := routingClass + constants.RoutingAnnotationInfix
+	// TODO: We could also just pass the entire Routing config
+	workspaceWithConfig.Annotations[routingAnnotationPrefix+constants.ClusterHostSuffixAnnotationSuffix] = workspaceWithConfig.Config.Routing.ClusterHostSuffix
+}
+
 func getServicesForEndpoints(endpoints map[string]controllerv1alpha1.EndpointList, meta DevWorkspaceMetadata) []corev1.Service {
 	if len(endpoints) == 0 {
 		return nil

--- a/controllers/controller/devworkspacerouting/solvers/common.go
+++ b/controllers/controller/devworkspacerouting/solvers/common.go
@@ -138,16 +138,6 @@ func GetServiceForEndpoints(endpoints map[string]controllerv1alpha1.EndpointList
 	}
 }
 
-func AddDWOCRoutingAnnotations(workspaceWithConfig common.DevWorkspaceWithConfig) {
-	routingClass := workspaceWithConfig.Spec.RoutingClass
-	if routingClass == "" {
-		routingClass = workspaceWithConfig.Config.Routing.DefaultRoutingClass
-	}
-	routingAnnotationPrefix := routingClass + constants.RoutingAnnotationInfix
-	// TODO: We could also just pass the entire Routing config
-	workspaceWithConfig.Annotations[routingAnnotationPrefix+constants.ClusterHostSuffixAnnotationSuffix] = workspaceWithConfig.Config.Routing.ClusterHostSuffix
-}
-
 func getServicesForEndpoints(endpoints map[string]controllerv1alpha1.EndpointList, meta DevWorkspaceMetadata) []corev1.Service {
 	if len(endpoints) == 0 {
 		return nil

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -694,7 +694,7 @@ func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Req
 
 	// TODO: Address this usage of global config. It'd be better to check if the PVC had a DWO-specific annotation that we can use to filter for
 	// Otherwise, check if common PVC is deleted to make sure all DevWorkspaces see it happen
-	if obj.GetName() != config.Workspace.PVCName || obj.GetDeletionTimestamp() == nil {
+	if obj.GetName() != config.GetGlobalConfig().Workspace.PVCName || obj.GetDeletionTimestamp() == nil {
 		// We're looking for a deleted common PVC
 		return []reconcile.Request{}
 	}

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -24,7 +24,6 @@ import (
 
 	devfilevalidation "github.com/devfile/api/v2/pkg/validation"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	"github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting/solvers"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/conditions"
@@ -257,9 +256,6 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if wsDefaults.NeedsDefaultTemplate(workspaceWithConfig) {
 		wsDefaults.ApplyDefaultTemplate(workspaceWithConfig)
 	}
-
-	// Apply devworkspace routing annotation(s) to pass DWOC routing settings to DWR
-	solvers.AddDWOCRoutingAnnotations(*workspaceWithConfig)
 
 	flattenedWorkspace, warnings, err := flatten.ResolveDevWorkspace(&workspaceWithConfig.Spec.Template, flattenHelpers)
 	if err != nil {

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -692,7 +692,7 @@ func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Req
 		}
 	}
 
-	// TODO: Address this usage of global config?
+	// TODO: Address this usage of global config. It'd be better to check if the PVC had a DWO-specific annotation that we can use to filter for
 	// Otherwise, check if common PVC is deleted to make sure all DevWorkspaces see it happen
 	if obj.GetName() != config.Workspace.PVCName || obj.GetDeletionTimestamp() == nil {
 		// We're looking for a deleted common PVC

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -60,7 +60,7 @@ func (r *DevWorkspaceReconciler) finalize(ctx context.Context, log logr.Logger, 
 			// client.Update() call that removes the last finalizer.
 			return finalizeResult, finalizeErr
 		}
-		return r.updateWorkspaceStatus(&workspace.DevWorkspace, log, finalizeStatus, finalizeResult, finalizeErr)
+		return r.updateWorkspaceStatus(workspace, log, finalizeStatus, finalizeResult, finalizeErr)
 	}()
 
 	for _, finalizer := range workspace.Finalizers {

--- a/controllers/workspace/finalize.go
+++ b/controllers/workspace/finalize.go
@@ -91,7 +91,7 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 		// Namespace is terminating, it's redundant to clean PVC files since it's going to be removed
 		log.Info("Namespace is terminating; clearing storage finalizer")
 		coputil.RemoveFinalizer(workspace, constants.StorageCleanupFinalizer)
-		return reconcile.Result{}, r.Update(ctx, workspace)
+		return reconcile.Result{}, r.Update(ctx, &workspace.DevWorkspace)
 	}
 
 	storageProvisioner, err := storage.GetProvisioner(&workspace.DevWorkspace)
@@ -126,7 +126,7 @@ func (r *DevWorkspaceReconciler) finalizeStorage(ctx context.Context, log logr.L
 	}
 	log.Info("PVC clean up successful; clearing finalizer")
 	coputil.RemoveFinalizer(workspace, constants.StorageCleanupFinalizer)
-	return reconcile.Result{}, r.Update(ctx, workspace)
+	return reconcile.Result{}, r.Update(ctx, &workspace.DevWorkspace)
 }
 
 func (r *DevWorkspaceReconciler) finalizeServiceAccount(ctx context.Context, log logr.Logger, workspace *dw.DevWorkspace, finalizeStatus *currentStatus) (reconcile.Result, error) {

--- a/controllers/workspace/http.go
+++ b/controllers/workspace/http.go
@@ -34,13 +34,15 @@ func setupHttpClients() {
 		InsecureSkipVerify: true,
 	}
 
+	routingConfig := config.GetGlobalConfig().Routing
+
 	// Note: per-workspace routing settings (that have been set with an external DWOC)
 	// are ignored for the HTTP Clients
-	if config.Routing != nil && config.Routing.ProxyConfig != nil {
+	if routingConfig != nil && routingConfig.ProxyConfig != nil {
 		proxyConf := httpproxy.Config{
-			HTTPProxy:  config.Routing.ProxyConfig.HttpProxy,
-			HTTPSProxy: config.Routing.ProxyConfig.HttpsProxy,
-			NoProxy:    config.Routing.ProxyConfig.NoProxy,
+			HTTPProxy:  routingConfig.ProxyConfig.HttpProxy,
+			HTTPSProxy: routingConfig.ProxyConfig.HttpsProxy,
+			NoProxy:    routingConfig.ProxyConfig.NoProxy,
 		}
 		proxyFunc := func(req *http.Request) (*url.URL, error) {
 			return proxyConf.ProxyFunc()(req.URL)

--- a/controllers/workspace/http.go
+++ b/controllers/workspace/http.go
@@ -34,6 +34,8 @@ func setupHttpClients() {
 		InsecureSkipVerify: true,
 	}
 
+	// Note: per-workspace routing settings (that have been set with an external DWOC)
+	// are ignored for the HTTP Clients
 	if config.Routing != nil && config.Routing.ProxyConfig != nil {
 		proxyConf := httpproxy.Config{
 			HTTPProxy:  config.Routing.ProxyConfig.HttpProxy,

--- a/controllers/workspace/metrics/update.go
+++ b/controllers/workspace/metrics/update.go
@@ -20,28 +20,28 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/conditions"
-	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 )
 
 // WorkspaceStarted updates metrics for workspaces entering the 'Starting' phase, given a workspace. If an error is
 // encountered, the provided logger is used to log the error.
-func WorkspaceStarted(wksp *dw.DevWorkspace, log logr.Logger) {
-	_, ok := wksp.GetAnnotations()[constants.DevWorkspaceStartedAtAnnotation]
+func WorkspaceStarted(workspaceWithConfig *common.DevWorkspaceWithConfig, log logr.Logger) {
+	_, ok := workspaceWithConfig.GetAnnotations()[constants.DevWorkspaceStartedAtAnnotation]
 	if !ok {
-		incrementMetricForWorkspace(workspaceTotal, wksp, log)
+		incrementMetricForWorkspace(workspaceTotal, workspaceWithConfig, log)
 	}
 }
 
 // WorkspaceRunning updates metrics for workspaces entering the 'Running' phase, given a workspace. If an error is
 // encountered, the provided logger is used to log the error. This function assumes the provided workspace has
 // fully-synced conditions (i.e. the WorkspaceReady condition is present).
-func WorkspaceRunning(wksp *dw.DevWorkspace, log logr.Logger) {
-	_, ok := wksp.GetAnnotations()[constants.DevWorkspaceStartedAtAnnotation]
+func WorkspaceRunning(workspaceWithConfig *common.DevWorkspaceWithConfig, log logr.Logger) {
+	_, ok := workspaceWithConfig.GetAnnotations()[constants.DevWorkspaceStartedAtAnnotation]
 	if !ok {
-		incrementMetricForWorkspace(workspaceStarts, wksp, log)
-		incrementStartTimeBucketForWorkspace(wksp, log)
+		incrementMetricForWorkspace(workspaceStarts, workspaceWithConfig, log)
+		incrementStartTimeBucketForWorkspace(workspaceWithConfig, log)
 	}
 }
 
@@ -51,14 +51,14 @@ func WorkspaceFailed(wksp *dw.DevWorkspace, log logr.Logger) {
 	incrementMetricForWorkspaceFailure(workspaceFailures, wksp, log)
 }
 
-func incrementMetricForWorkspace(metric *prometheus.CounterVec, wksp *dw.DevWorkspace, log logr.Logger) {
-	sourceLabel := wksp.Labels[workspaceSourceLabel]
+func incrementMetricForWorkspace(metric *prometheus.CounterVec, workspaceWithConfig *common.DevWorkspaceWithConfig, log logr.Logger) {
+	sourceLabel := workspaceWithConfig.Labels[workspaceSourceLabel]
 	if sourceLabel == "" {
 		sourceLabel = "unknown"
 	}
-	routingClass := wksp.Spec.RoutingClass
+	routingClass := workspaceWithConfig.Spec.RoutingClass
 	if routingClass == "" {
-		routingClass = config.Routing.DefaultRoutingClass
+		routingClass = workspaceWithConfig.Config.Routing.DefaultRoutingClass
 	}
 	ctr, err := metric.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel, metricsRoutingClassLabel: routingClass})
 	if err != nil {
@@ -80,24 +80,24 @@ func incrementMetricForWorkspaceFailure(metric *prometheus.CounterVec, wksp *dw.
 	ctr.Inc()
 }
 
-func incrementStartTimeBucketForWorkspace(wksp *dw.DevWorkspace, log logr.Logger) {
-	sourceLabel := wksp.Labels[workspaceSourceLabel]
+func incrementStartTimeBucketForWorkspace(workspaceWithConfig *common.DevWorkspaceWithConfig, log logr.Logger) {
+	sourceLabel := workspaceWithConfig.Labels[workspaceSourceLabel]
 	if sourceLabel == "" {
 		sourceLabel = "unknown"
 	}
-	routingClass := wksp.Spec.RoutingClass
+	routingClass := workspaceWithConfig.Spec.RoutingClass
 	if routingClass == "" {
-		routingClass = config.Routing.DefaultRoutingClass
+		routingClass = workspaceWithConfig.Config.Routing.DefaultRoutingClass
 	}
 	hist, err := workspaceStartupTimesHist.GetMetricWith(map[string]string{metricSourceLabel: sourceLabel, metricsRoutingClassLabel: routingClass})
 	if err != nil {
 		log.Error(err, "Failed to update metric")
 	}
-	readyCondition := conditions.GetConditionByType(wksp.Status.Conditions, dw.DevWorkspaceReady)
+	readyCondition := conditions.GetConditionByType(workspaceWithConfig.Status.Conditions, dw.DevWorkspaceReady)
 	if readyCondition == nil {
 		return
 	}
-	startedCondition := conditions.GetConditionByType(wksp.Status.Conditions, conditions.Started)
+	startedCondition := conditions.GetConditionByType(workspaceWithConfig.Status.Conditions, conditions.Started)
 	if startedCondition == nil {
 		return
 	}

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	"github.com/devfile/devworkspace-operator/pkg/conditions"
 )
@@ -241,7 +240,7 @@ func updateMetricsForPhase(workspaceWithConfig *common.DevWorkspaceWithConfig, o
 // startup timeout. This is determined by checking to see if the last condition transition time is more
 // than [timeout] duration ago. Workspaces that are not in the "Starting" phase cannot timeout. Returns
 // an error with message when timeout is reached.
-func checkForStartTimeout(workspace *dw.DevWorkspace, config controllerv1alpha1.OperatorConfiguration) error {
+func checkForStartTimeout(workspace *dw.DevWorkspace, config v1alpha1.OperatorConfiguration) error {
 	if workspace.Status.Phase != dw.DevWorkspaceStatusStarting {
 		return nil
 	}

--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -77,7 +77,7 @@ func (r *DevWorkspaceReconciler) updateWorkspaceStatus(workspace *dw.DevWorkspac
 		workspace.Status.Message = infoMessage
 	}
 
-	err := r.Status().Update(context.TODO(), workspace)
+	err := r.Status().Update(context.TODO(), &workspaceWithConfig.DevWorkspace)
 	if err != nil {
 		if k8sErrors.IsConflict(err) {
 			logger.Info("Failed to update workspace status due to conflict; retrying")

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+)
+
+//TODO: Rename?
+// TODO: Move
+type DevWorkspaceWithConfig struct {
+	dw.DevWorkspace `json:",inline"`
+	Config          controllerv1alpha1.OperatorConfiguration
+}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -14,9 +14,8 @@
 package common
 
 import (
-	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 )
 
 //TODO: Rename?

--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -54,7 +54,7 @@ func setupForTest(t *testing.T) {
 	configNamespace = testNamespace
 	originalDefaultConfig := defaultConfig.DeepCopy()
 	t.Cleanup(func() {
-		internalConfig = nil
+		InternalConfig = nil
 		defaultConfig = originalDefaultConfig
 	})
 }

--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -68,3 +68,13 @@ func buildConfig(config *v1alpha1.OperatorConfiguration) *v1alpha1.DevWorkspaceO
 		Config: config,
 	}
 }
+
+func buildExternalConfig(config *v1alpha1.OperatorConfiguration) *v1alpha1.DevWorkspaceOperatorConfig {
+	return &v1alpha1.DevWorkspaceOperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ExternalConfigName,
+			Namespace: ExternalConfigNamespace,
+		},
+		Config: config,
+	}
+}

--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -54,7 +54,7 @@ func setupForTest(t *testing.T) {
 	configNamespace = testNamespace
 	originalDefaultConfig := defaultConfig.DeepCopy()
 	t.Cleanup(func() {
-		InternalConfig = nil
+		internalConfig = nil
 		defaultConfig = originalDefaultConfig
 	})
 }

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -42,8 +42,8 @@ const (
 )
 
 var (
-	Routing         *controller.RoutingConfig
-	Workspace       *controller.WorkspaceConfig
+	routing         *controller.RoutingConfig
+	workspace       *controller.WorkspaceConfig
 	internalConfig  *controller.OperatorConfiguration
 	configMutex     sync.Mutex
 	configNamespace string
@@ -145,6 +145,11 @@ func ExperimentalFeaturesEnabled() bool {
 	return *internalConfig.EnableExperimentalFeatures
 }
 
+func GetGlobalConfig() *controller.OperatorConfiguration {
+	// TODO: Could make this return a deepcopy to prevent modifying the global config when we only intend for reads
+	return internalConfig
+}
+
 func getClusterConfig(namespace string, client crclient.Client) (*controller.DevWorkspaceOperatorConfig, error) {
 	clusterConfig := &controller.DevWorkspaceOperatorConfig{}
 	if err := client.Get(context.Background(), types.NamespacedName{Name: OperatorConfigName, Namespace: namespace}, clusterConfig); err != nil {
@@ -183,8 +188,8 @@ func restoreDefaultConfig() {
 }
 
 func updatePublicConfig() {
-	Routing = internalConfig.Routing.DeepCopy()
-	Workspace = internalConfig.Workspace.DeepCopy()
+	routing = internalConfig.Routing.DeepCopy()
+	workspace = internalConfig.Workspace.DeepCopy()
 	logCurrentConfig()
 }
 
@@ -311,40 +316,40 @@ func logCurrentConfig() {
 		return
 	}
 	var config []string
-	if Routing != nil {
-		if Routing.ClusterHostSuffix != "" && Routing.ClusterHostSuffix != defaultConfig.Routing.ClusterHostSuffix {
-			config = append(config, fmt.Sprintf("routing.clusterHostSuffix=%s", Routing.ClusterHostSuffix))
+	if routing != nil {
+		if routing.ClusterHostSuffix != "" && routing.ClusterHostSuffix != defaultConfig.Routing.ClusterHostSuffix {
+			config = append(config, fmt.Sprintf("routing.clusterHostSuffix=%s", routing.ClusterHostSuffix))
 		}
-		if Routing.DefaultRoutingClass != defaultConfig.Routing.DefaultRoutingClass {
-			config = append(config, fmt.Sprintf("routing.defaultRoutingClass=%s", Routing.DefaultRoutingClass))
+		if routing.DefaultRoutingClass != defaultConfig.Routing.DefaultRoutingClass {
+			config = append(config, fmt.Sprintf("routing.defaultRoutingClass=%s", routing.DefaultRoutingClass))
 		}
 	}
-	if Workspace != nil {
-		if Workspace.ImagePullPolicy != defaultConfig.Workspace.ImagePullPolicy {
-			config = append(config, fmt.Sprintf("workspace.imagePullPolicy=%s", Workspace.ImagePullPolicy))
+	if workspace != nil {
+		if workspace.ImagePullPolicy != defaultConfig.Workspace.ImagePullPolicy {
+			config = append(config, fmt.Sprintf("workspace.imagePullPolicy=%s", workspace.ImagePullPolicy))
 		}
-		if Workspace.PVCName != defaultConfig.Workspace.PVCName {
-			config = append(config, fmt.Sprintf("workspace.pvcName=%s", Workspace.PVCName))
+		if workspace.PVCName != defaultConfig.Workspace.PVCName {
+			config = append(config, fmt.Sprintf("workspace.pvcName=%s", workspace.PVCName))
 		}
-		if Workspace.StorageClassName != nil && Workspace.StorageClassName != defaultConfig.Workspace.StorageClassName {
-			config = append(config, fmt.Sprintf("workspace.storageClassName=%s", *Workspace.StorageClassName))
+		if workspace.StorageClassName != nil && workspace.StorageClassName != defaultConfig.Workspace.StorageClassName {
+			config = append(config, fmt.Sprintf("workspace.storageClassName=%s", *workspace.StorageClassName))
 		}
-		if Workspace.IdleTimeout != defaultConfig.Workspace.IdleTimeout {
-			config = append(config, fmt.Sprintf("workspace.idleTimeout=%s", Workspace.IdleTimeout))
+		if workspace.IdleTimeout != defaultConfig.Workspace.IdleTimeout {
+			config = append(config, fmt.Sprintf("workspace.idleTimeout=%s", workspace.IdleTimeout))
 		}
-		if Workspace.IgnoredUnrecoverableEvents != nil {
+		if workspace.IgnoredUnrecoverableEvents != nil {
 			config = append(config, fmt.Sprintf("workspace.ignoredUnrecoverableEvents=%s",
-				strings.Join(Workspace.IgnoredUnrecoverableEvents, ";")))
+				strings.Join(workspace.IgnoredUnrecoverableEvents, ";")))
 		}
-		if Workspace.DefaultStorageSize != nil {
-			if Workspace.DefaultStorageSize.Common != nil {
-				config = append(config, fmt.Sprintf("workspace.defaultStorageSize.common=%s", Workspace.DefaultStorageSize.Common.String()))
+		if workspace.DefaultStorageSize != nil {
+			if workspace.DefaultStorageSize.Common != nil {
+				config = append(config, fmt.Sprintf("workspace.defaultStorageSize.common=%s", workspace.DefaultStorageSize.Common.String()))
 			}
-			if Workspace.DefaultStorageSize.PerWorkspace != nil {
-				config = append(config, fmt.Sprintf("workspace.defaultStorageSize.perWorkspace=%s", Workspace.DefaultStorageSize.PerWorkspace.String()))
+			if workspace.DefaultStorageSize.PerWorkspace != nil {
+				config = append(config, fmt.Sprintf("workspace.defaultStorageSize.perWorkspace=%s", workspace.DefaultStorageSize.PerWorkspace.String()))
 			}
 		}
-		if Workspace.DefaultTemplate != nil {
+		if workspace.DefaultTemplate != nil {
 			config = append(config, fmt.Sprintf("workspace.defaultTemplate is set"))
 		}
 	}

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -85,7 +85,7 @@ func ResolveConfigForWorkspace(workspace *dw.DevWorkspace, client crclient.Clien
 		if err != nil {
 			return internalConfigCopy, fmt.Errorf("could not fetch external DWOC with name '%s' in namespace '%s': %w", namespacedName.Name, namespacedName.Namespace, err)
 		}
-		// TODO: Do we need to lock the internal config?
+
 		return getMergedConfig(externalDWOC.Config, internalConfig), nil
 	}
 
@@ -168,10 +168,10 @@ func syncConfigFrom(newConfig *controller.DevWorkspaceOperatorConfig) {
 }
 
 func getMergedConfig(from, to *controller.OperatorConfiguration) *controller.OperatorConfiguration {
-	configMutex.Lock()
-	defer configMutex.Unlock()
 	mergedConfig := to.DeepCopy()
-	mergeConfig(from, mergedConfig)
+	// TODO: Remove this comment: technically we don't need to deepCopy 'from', but we may use this function elsewhere in the future, so just incase..
+	fromCopy := from.DeepCopy()
+	mergeConfig(fromCopy, mergedConfig)
 	return mergedConfig
 }
 

--- a/pkg/config/sync_test.go
+++ b/pkg/config/sync_test.go
@@ -38,7 +38,7 @@ func TestSetupControllerConfigUsesDefault(t *testing.T) {
 	if !assert.NoError(t, err, "Should not return error") {
 		return
 	}
-	assert.Equal(t, defaultConfig, internalConfig, "Config used should be the default")
+	assert.Equal(t, defaultConfig, InternalConfig, "Config used should be the default")
 }
 
 func TestSetupControllerDefaultsAreExported(t *testing.T) {
@@ -63,7 +63,7 @@ func TestSetupControllerConfigFailsWhenAlreadySetup(t *testing.T) {
 	if !assert.Error(t, err, "Should return error when config is already setup") {
 		return
 	}
-	assert.Equal(t, defaultConfig, internalConfig, "Config used should be the default")
+	assert.Equal(t, defaultConfig, InternalConfig, "Config used should be the default")
 }
 
 func TestSetupControllerMergesClusterConfig(t *testing.T) {
@@ -91,9 +91,9 @@ func TestSetupControllerMergesClusterConfig(t *testing.T) {
 	if !assert.NoError(t, err, "Should not return error") {
 		return
 	}
-	assert.Equal(t, expectedConfig, internalConfig, fmt.Sprintf("Processed config should merge settings from cluster: %s", cmp.Diff(internalConfig, expectedConfig)))
-	assert.Equal(t, internalConfig.Routing, Routing, fmt.Sprintf("Changes to config should be propagated to exported fields"))
-	assert.Equal(t, internalConfig.Workspace, Workspace, fmt.Sprintf("Changes to config should be propagated to exported fields"))
+	assert.Equal(t, expectedConfig, InternalConfig, fmt.Sprintf("Processed config should merge settings from cluster: %s", cmp.Diff(InternalConfig, expectedConfig)))
+	assert.Equal(t, InternalConfig.Routing, Routing, fmt.Sprintf("Changes to config should be propagated to exported fields"))
+	assert.Equal(t, InternalConfig.Workspace, Workspace, fmt.Sprintf("Changes to config should be propagated to exported fields"))
 }
 
 func TestSetupControllerAlwaysSetsDefaultClusterRoutingSuffix(t *testing.T) {
@@ -139,12 +139,12 @@ func TestDetectsOpenShiftRouteSuffix(t *testing.T) {
 	if !assert.NoError(t, err, "Should not return error") {
 		return
 	}
-	assert.Equal(t, "test-host", internalConfig.Routing.ClusterHostSuffix, "Should determine host suffix with route on OpenShift")
+	assert.Equal(t, "test-host", InternalConfig.Routing.ClusterHostSuffix, "Should determine host suffix with route on OpenShift")
 }
 
 func TestSyncConfigFromIgnoresOtherConfigInOtherNamespaces(t *testing.T) {
 	setupForTest(t)
-	internalConfig = defaultConfig.DeepCopy()
+	InternalConfig = defaultConfig.DeepCopy()
 	config := buildConfig(&v1alpha1.OperatorConfiguration{
 		Workspace: &v1alpha1.WorkspaceConfig{
 			ImagePullPolicy: "IfNotPresent",
@@ -152,12 +152,12 @@ func TestSyncConfigFromIgnoresOtherConfigInOtherNamespaces(t *testing.T) {
 	})
 	config.Namespace = "not-test-namespace"
 	syncConfigFrom(config)
-	assert.Equal(t, defaultConfig, internalConfig)
+	assert.Equal(t, defaultConfig, InternalConfig)
 }
 
 func TestSyncConfigFromIgnoresOtherConfigWithOtherName(t *testing.T) {
 	setupForTest(t)
-	internalConfig = defaultConfig.DeepCopy()
+	InternalConfig = defaultConfig.DeepCopy()
 	config := buildConfig(&v1alpha1.OperatorConfiguration{
 		Workspace: &v1alpha1.WorkspaceConfig{
 			ImagePullPolicy: "IfNotPresent",
@@ -165,13 +165,13 @@ func TestSyncConfigFromIgnoresOtherConfigWithOtherName(t *testing.T) {
 	})
 	config.Name = "testing-name"
 	syncConfigFrom(config)
-	assert.Equal(t, defaultConfig, internalConfig)
+	assert.Equal(t, defaultConfig, InternalConfig)
 }
 
 func TestSyncConfigDoesNotChangeDefaults(t *testing.T) {
 	setupForTest(t)
 	oldDefaultConfig := defaultConfig.DeepCopy()
-	internalConfig = defaultConfig.DeepCopy()
+	InternalConfig = defaultConfig.DeepCopy()
 	config := buildConfig(&v1alpha1.OperatorConfiguration{
 		Routing: &v1alpha1.RoutingConfig{
 			DefaultRoutingClass: "test-routingClass",
@@ -183,7 +183,7 @@ func TestSyncConfigDoesNotChangeDefaults(t *testing.T) {
 		EnableExperimentalFeatures: &trueBool,
 	})
 	syncConfigFrom(config)
-	internalConfig.Routing.DefaultRoutingClass = "Changed after the fact"
+	InternalConfig.Routing.DefaultRoutingClass = "Changed after the fact"
 	assert.Equal(t, defaultConfig, oldDefaultConfig)
 }
 

--- a/pkg/config/sync_test.go
+++ b/pkg/config/sync_test.go
@@ -54,8 +54,8 @@ func TestSetupControllerDefaultsAreExported(t *testing.T) {
 	if !assert.NoError(t, err, "Should not return error") {
 		return
 	}
-	assert.Equal(t, defaultConfig.Routing, Routing, "Configuration should be exported")
-	assert.Equal(t, defaultConfig.Workspace, Workspace, "Configuration should be exported")
+	assert.Equal(t, defaultConfig.Routing, routing, "Configuration should be exported")
+	assert.Equal(t, defaultConfig.Workspace, workspace, "Configuration should be exported")
 }
 
 func TestSetupControllerConfigFailsWhenAlreadySetup(t *testing.T) {
@@ -98,8 +98,8 @@ func TestSetupControllerMergesClusterConfig(t *testing.T) {
 		return
 	}
 	assert.Equal(t, expectedConfig, internalConfig, fmt.Sprintf("Processed config should merge settings from cluster: %s", cmp.Diff(internalConfig, expectedConfig)))
-	assert.Equal(t, internalConfig.Routing, Routing, fmt.Sprintf("Changes to config should be propagated to exported fields"))
-	assert.Equal(t, internalConfig.Workspace, Workspace, fmt.Sprintf("Changes to config should be propagated to exported fields"))
+	assert.Equal(t, internalConfig.Routing, routing, fmt.Sprintf("Changes to config should be propagated to exported fields"))
+	assert.Equal(t, internalConfig.Workspace, workspace, fmt.Sprintf("Changes to config should be propagated to exported fields"))
 }
 
 func TestCatchesNonExistentExternalDWOC(t *testing.T) {
@@ -218,7 +218,7 @@ func TestSetupControllerAlwaysSetsDefaultClusterRoutingSuffix(t *testing.T) {
 		return
 	}
 	assert.Equal(t, "test-host", defaultConfig.Routing.ClusterHostSuffix, "Should set default clusterRoutingSuffix even if config overrides it initially")
-	assert.Equal(t, "192.168.0.1.nip.io", Routing.ClusterHostSuffix, "Should use value from config for clusterRoutingSuffix")
+	assert.Equal(t, "192.168.0.1.nip.io", routing.ClusterHostSuffix, "Should use value from config for clusterRoutingSuffix")
 }
 
 func TestDetectsOpenShiftRouteSuffix(t *testing.T) {
@@ -295,10 +295,10 @@ func TestSyncConfigRestoresClusterRoutingSuffix(t *testing.T) {
 		},
 	})
 	syncConfigFrom(config)
-	assert.Equal(t, "192.168.0.1.nip.io", Routing.ClusterHostSuffix, "Should update clusterRoutingSuffix from config")
+	assert.Equal(t, "192.168.0.1.nip.io", routing.ClusterHostSuffix, "Should update clusterRoutingSuffix from config")
 	config.Config.Routing.ClusterHostSuffix = ""
 	syncConfigFrom(config)
-	assert.Equal(t, "default.routing.suffix", Routing.ClusterHostSuffix, "Should restore default clusterRoutingSuffix if it is available")
+	assert.Equal(t, "default.routing.suffix", routing.ClusterHostSuffix, "Should restore default clusterRoutingSuffix if it is available")
 }
 
 func TestSyncConfigDoesNotEraseClusterRoutingSuffix(t *testing.T) {
@@ -318,7 +318,7 @@ func TestSyncConfigDoesNotEraseClusterRoutingSuffix(t *testing.T) {
 	if !assert.NoError(t, err, "Should not return error") {
 		return
 	}
-	assert.Equal(t, "test-host", Routing.ClusterHostSuffix, "Should get clusterHostSuffix from route on OpenShift")
+	assert.Equal(t, "test-host", routing.ClusterHostSuffix, "Should get clusterHostSuffix from route on OpenShift")
 	syncConfigFrom(buildConfig(&v1alpha1.OperatorConfiguration{
 		Routing: &v1alpha1.RoutingConfig{
 			DefaultRoutingClass: "test-routingClass",
@@ -330,7 +330,7 @@ func TestSyncConfigDoesNotEraseClusterRoutingSuffix(t *testing.T) {
 	if !assert.NoError(t, err, "Should not return error") {
 		return
 	}
-	assert.Equal(t, "test-host", Routing.ClusterHostSuffix, "clusterHostSuffix should persist after an update")
+	assert.Equal(t, "test-host", routing.ClusterHostSuffix, "clusterHostSuffix should persist after an update")
 }
 
 func TestMergeConfigLooksAtAllFields(t *testing.T) {

--- a/pkg/config/sync_test.go
+++ b/pkg/config/sync_test.go
@@ -16,18 +16,24 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 )
 
@@ -96,81 +102,86 @@ func TestSetupControllerMergesClusterConfig(t *testing.T) {
 	assert.Equal(t, internalConfig.Workspace, Workspace, fmt.Sprintf("Changes to config should be propagated to exported fields"))
 }
 
-/* func TestCatchesNonExistentExternalDWOC(t *testing.T) {
+func TestCatchesNonExistentExternalDWOC(t *testing.T) {
 	setupForTest(t)
 
 	workspace := &dw.DevWorkspace{}
 	attributes := attributes.Attributes{}
-	externalDWOCMeta := v1alpha1.ExternalConfig{}
-	externalDWOCMeta.Name = "external-config-name"
-	externalDWOCMeta.Namespace = "external-config-namespace"
-
-	attributes.Put(constants.ExternalDevWorkspaceConfiguration, externalDWOCMeta, nil)
+	namespacedName := types.NamespacedName{
+		Name:      "external-config-name",
+		Namespace: "external-config-namespace",
+	}
+	attributes.Put(constants.ExternalDevWorkspaceConfiguration, namespacedName, nil)
 	workspace.Spec.Template.DevWorkspaceTemplateSpecContent = dw.DevWorkspaceTemplateSpecContent{
 		Attributes: attributes,
 	}
-
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	err := ApplyExternalDWOCConfig(workspace, client)
+	resolvedConfig, err := ResolveConfigForWorkspace(workspace, client)
 	if !assert.Error(t, err, "Error should be given if external DWOC specified in workspace spec does not exist") {
 		return
 	}
+	assert.Equal(t, resolvedConfig, internalConfig, "Internal/Global DWOC should be used as fallback if external DWOC could not be resolved")
 }
 
-func TestConfigUpdatedAfterMerge(t *testing.T) {
+func TestMergeExternalConfig(t *testing.T) {
 	setupForTest(t)
 
 	workspace := &dw.DevWorkspace{}
 	attributes := attributes.Attributes{}
-	externalDWOCMeta := v1alpha1.ExternalConfig{}
-	externalDWOCMeta.Name = "external-config-name"
-	externalDWOCMeta.Namespace = "external-config-namespace"
+	namespacedName := types.NamespacedName{
+		Name:      ExternalConfigName,
+		Namespace: ExternalConfigNamespace,
+	}
 
-	attributes.Put(constants.ExternalDevWorkspaceConfiguration, externalDWOCMeta, nil)
+	attributes.Put(constants.ExternalDevWorkspaceConfiguration, namespacedName, nil)
 	workspace.Spec.Template.DevWorkspaceTemplateSpecContent = dw.DevWorkspaceTemplateSpecContent{
 		Attributes: attributes,
 	}
 
-	clusterConfig := buildConfig(&v1alpha1.OperatorConfiguration{
-		Routing: &v1alpha1.RoutingConfig{
-			DefaultRoutingClass: "test-routingClass",
-			ClusterHostSuffix:   "192.168.0.1.nip.io",
-		},
-		Workspace: &v1alpha1.WorkspaceConfig{
-			ImagePullPolicy: "IfNotPresent",
-		},
-		EnableExperimentalFeatures: &trueBool,
-	})
+	clusterConfig := buildConfig(defaultConfig.DeepCopy())
+	originalInternalConfig := clusterConfig.Config.DeepCopy()
 
-	internalConfig = clusterConfig.Config.DeepCopy()
-
-	externalConfig := buildExternalConfig(&v1alpha1.OperatorConfiguration{
-		Routing: &v1alpha1.RoutingConfig{
-			DefaultRoutingClass: "test-routingClass",
-			ClusterHostSuffix:   "192.168.0.1.nip.io",
-		},
-		Workspace: &v1alpha1.WorkspaceConfig{
-			ImagePullPolicy: "Always",
-		},
-		EnableExperimentalFeatures: &trueBool,
-	})
+	// External config is based off of the default/internal config, with just a few changes made
+	// So when the internal config is merged with the external one, they will become identical
+	externalConfig := buildExternalConfig(defaultConfig.DeepCopy())
+	externalConfig.Config.Workspace.ImagePullPolicy = "Always"
+	externalConfig.Config.Workspace.PVCName = "test-PVC-name"
+	storageSize := resource.MustParse("15Gi")
+	externalConfig.Config.Workspace.DefaultStorageSize = &v1alpha1.StorageSizes{
+		Common:       &storageSize,
+		PerWorkspace: &storageSize,
+	}
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(clusterConfig).WithObjects(externalConfig).Build()
-
-	err := ApplyExternalDWOCConfig(workspace, client)
+	err := SetupControllerConfig(client)
 	if !assert.NoError(t, err, "Should not return error") {
 		return
 	}
 
-	// Compare the internal config and external config
-	if !cmp.Equal(internalConfig, externalConfig.Config) {
-		t.Error("Internal config and external config should match after merge")
+	// Sanity check
+	if !cmp.Equal(clusterConfig.Config, internalConfig) {
+		t.Error("Internal config should be same as cluster config before starting:", cmp.Diff(clusterConfig.Config, internalConfig))
+	}
+
+	resolvedConfig, err := ResolveConfigForWorkspace(workspace, client)
+	if !assert.NoError(t, err, "Should not return error") {
+		return
+	}
+
+	// Compare the resolved config and external config
+	if !cmp.Equal(resolvedConfig, externalConfig.Config) {
+		t.Error("Resolved config and external config should match after merge:", cmp.Diff(resolvedConfig, externalConfig.Config))
+	}
+
+	// Ensure the internal config was not affected by merge
+	if !cmp.Equal(originalInternalConfig, internalConfig) {
+		t.Error("Internal config should remain the same after merge")
 	}
 
 	// Get the global config off cluster and ensure it hasn't changed
 	retrievedClusterConfig := &v1alpha1.DevWorkspaceOperatorConfig{}
-	namespacedName := types.NamespacedName{
+	namespacedName = types.NamespacedName{
 		Name:      OperatorConfigName,
 		Namespace: testNamespace,
 	}
@@ -180,10 +191,10 @@ func TestConfigUpdatedAfterMerge(t *testing.T) {
 	}
 
 	if !cmp.Equal(retrievedClusterConfig.Config, clusterConfig.Config) {
-		t.Error("Config on cluster and global config should match after merge; global config should not have been modified from merge")
+		t.Error("Config on cluster and global config should match after merge; global config should not have been modified from merge:", cmp.Diff(retrievedClusterConfig, clusterConfig.Config))
 	}
 }
-*/
+
 func TestSetupControllerAlwaysSetsDefaultClusterRoutingSuffix(t *testing.T) {
 	setupForTest(t)
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -28,6 +28,21 @@ const (
 	//                    stopped.
 	DevWorkspaceStorageTypeAttribute = "controller.devfile.io/storage-type"
 
+	// ExternalDevWorkspaceConfiguration is an attribute that allows for specifying an (optional) external DevWorkspace-Operator configuration (DWOC)
+	// which will merged with the internal/global DevWorkspace-Operator configuration. The DWOC resulting from the merge will be used for the workspace.
+	// The fields which are set in the external DevWorkspace-Operator configuration will overwrite those existing in the
+	// internal/global DevWorkspace-Operator configuration
+	// The structure of the attribute value should contain two strings: name and namespace.
+	// 'name' specifies the metadata.name of the external DevWorkspace-Operator configuration
+	// 'namespace' specifies the metadata.namespace of the external DevWorkspace-Operator configuration
+	// For example:
+	//
+	//   attributes:
+	//     controller.devfile.io/devworkspace-config:
+	//         name: external-dwoc-name
+	//         namespace: some-namespace
+	ExternalDevWorkspaceConfiguration = "controller.devfile.io/devworkspace-config"
+
 	// RuntimeClassNameAttribute is an attribute added to a DevWorkspace to specify a runtimeClassName for container
 	// components in the DevWorkspace (pod.spec.runtimeClassName). If empty, no runtimeClassName is added.
 	RuntimeClassNameAttribute = "controller.devfile.io/runtime-class"

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -117,10 +117,8 @@ const (
 	// The full annotation name is supposed to be "<routingClass>.routing.controller.devfile.io/<anything>"
 	RoutingAnnotationInfix = ".routing.controller.devfile.io/"
 
-	// ClusterHostSuffixAnnotationSuffix is an annotation suffix used in conjunction with RoutingAnnotationInfix.
-	// It is applied as an annotation to DevWorkspaceRouting objects to pass them the cluster host suffix from the DevWorkspace-Operator configuration.
-	// The suffix is intended to be used in the following manner: <routingClass>.routing.controller.devfile.io/cluster-host-suffix = <cluster-host-suffix>
-	ClusterHostSuffixAnnotationSuffix = "cluster-host-suffix"
+	// ClusterHostSuffixAnnotation is an annotation key for storing the value of the cluster host suffix to be used by the Basic DevWorkspace Routing Class.
+	ClusterHostSuffixAnnotation = "basic.routing.controller.devfile.io/cluster-host-suffix"
 
 	// DevWorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
 	DevWorkspaceEndpointNameAnnotation = "controller.devfile.io/endpoint_name"

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -117,6 +117,11 @@ const (
 	// The full annotation name is supposed to be "<routingClass>.routing.controller.devfile.io/<anything>"
 	RoutingAnnotationInfix = ".routing.controller.devfile.io/"
 
+	// ClusterHostSuffixAnnotationSuffix is an annotation suffix used in conjunction with RoutingAnnotationInfix.
+	// It is applied as an annotation to DevWorkspaceRouting objects to pass them the cluster host suffix from the DevWorkspace-Operator configuration.
+	// The suffix is intended to be used in the following manner: <routingClass>.routing.controller.devfile.io/cluster-host-suffix = <cluster-host-suffix>
+	ClusterHostSuffixAnnotationSuffix = "cluster-host-suffix"
+
 	// DevWorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
 	DevWorkspaceEndpointNameAnnotation = "controller.devfile.io/endpoint_name"
 
@@ -140,8 +145,4 @@ const (
 	// NamespaceNodeSelectorAnnotation is an annotation applied to a namespace to configure the node selector for all workspaces
 	// in that namespace. Value should be json-encoded map[string]string
 	NamespaceNodeSelectorAnnotation = "controller.devfile.io/node-selector"
-
-	// TODO: Document these
-	ExternalDWOCNameAnnotationSuffix      = "external-config-name"
-	ExternalDWOCNamespaceAnnotationSuffix = "external-config-namespace"
 )

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -140,4 +140,8 @@ const (
 	// NamespaceNodeSelectorAnnotation is an annotation applied to a namespace to configure the node selector for all workspaces
 	// in that namespace. Value should be json-encoded map[string]string
 	NamespaceNodeSelectorAnnotation = "controller.devfile.io/node-selector"
+
+	// TODO: Document these
+	ExternalDWOCNameAnnotationSuffix      = "external-config-name"
+	ExternalDWOCNamespaceAnnotationSuffix = "external-config-namespace"
 )

--- a/pkg/library/container/container.go
+++ b/pkg/library/container/container.go
@@ -43,7 +43,7 @@ import (
 // rewritten as Volumes are added to PodAdditions, in order to support e.g. using one PVC to hold all volumes
 //
 // Note: Requires DevWorkspace to be flattened (i.e. the DevWorkspace contains no Parent or Components of type Plugin)
-func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec) (*v1alpha1.PodAdditions, error) {
+func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, config v1alpha1.OperatorConfiguration) (*v1alpha1.PodAdditions, error) {
 	if !flatten.DevWorkspaceIsFlattened(workspace) {
 		return nil, fmt.Errorf("devfile is not flattened")
 	}
@@ -58,7 +58,7 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec) (*v1al
 		if component.Container == nil {
 			continue
 		}
-		k8sContainer, err := convertContainerToK8s(component)
+		k8sContainer, err := convertContainerToK8s(component, config)
 		if err != nil {
 			return nil, err
 		}
@@ -71,7 +71,7 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec) (*v1al
 	}
 
 	for _, container := range initContainers {
-		k8sContainer, err := convertContainerToK8s(container)
+		k8sContainer, err := convertContainerToK8s(container, config)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/library/container/container_test.go
+++ b/pkg/library/container/container_test.go
@@ -88,7 +88,7 @@ func TestGetKubeContainersFromDevfile(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check that file is read correctly.
 			assert.True(t, len(tt.Input.Components) > 0, "Input defines no components")
-			gotPodAdditions, err := GetKubeContainersFromDevfile(tt.Input)
+			gotPodAdditions, err := GetKubeContainersFromDevfile(tt.Input, *testControllerCfg)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {

--- a/pkg/library/container/conversion.go
+++ b/pkg/library/container/conversion.go
@@ -19,16 +19,16 @@ import (
 	"fmt"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 
-	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func convertContainerToK8s(devfileComponent dw.Component) (*v1.Container, error) {
+func convertContainerToK8s(devfileComponent dw.Component, config controllerv1alpha1.OperatorConfiguration) (*v1.Container, error) {
 	if devfileComponent.Container == nil {
 		return nil, fmt.Errorf("cannot get k8s container from non-container component")
 	}

--- a/pkg/library/defaults/helper.go
+++ b/pkg/library/defaults/helper.go
@@ -16,23 +16,22 @@
 package defaults
 
 import (
-	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"github.com/devfile/devworkspace-operator/pkg/config"
+	"github.com/devfile/devworkspace-operator/pkg/common"
 )
 
 // Overwrites the content of the workspace's Template Spec with the workspace config's Template Spec,
 // with the exception of the workspace's projects.
 // If the workspace's Template Spec defined any projects, they are preserved.
-func ApplyDefaultTemplate(workspace *dw.DevWorkspace) {
-	if config.Workspace.DefaultTemplate == nil {
+func ApplyDefaultTemplate(workspaceWithConfig *common.DevWorkspaceWithConfig) {
+	if workspaceWithConfig.Config.Workspace.DefaultTemplate == nil {
 		return
 	}
-	defaultCopy := config.Workspace.DefaultTemplate.DeepCopy()
-	originalProjects := workspace.Spec.Template.Projects
-	workspace.Spec.Template.DevWorkspaceTemplateSpecContent = *defaultCopy
-	workspace.Spec.Template.Projects = append(workspace.Spec.Template.Projects, originalProjects...)
+	defaultCopy := workspaceWithConfig.Config.Workspace.DefaultTemplate.DeepCopy()
+	originalProjects := workspaceWithConfig.Spec.Template.Projects
+	workspaceWithConfig.Spec.Template.DevWorkspaceTemplateSpecContent = *defaultCopy
+	workspaceWithConfig.Spec.Template.Projects = append(workspaceWithConfig.Spec.Template.Projects, originalProjects...)
 }
 
-func NeedsDefaultTemplate(workspace *dw.DevWorkspace) bool {
-	return len(workspace.Spec.Template.Components) == 0 && config.Workspace.DefaultTemplate != nil
+func NeedsDefaultTemplate(workspaceWithConfig *common.DevWorkspaceWithConfig) bool {
+	return len(workspaceWithConfig.Spec.Template.Components) == 0 && workspaceWithConfig.Config.Workspace.DefaultTemplate != nil
 }

--- a/pkg/library/defaults/helper.go
+++ b/pkg/library/defaults/helper.go
@@ -22,16 +22,16 @@ import (
 // Overwrites the content of the workspace's Template Spec with the workspace config's Template Spec,
 // with the exception of the workspace's projects.
 // If the workspace's Template Spec defined any projects, they are preserved.
-func ApplyDefaultTemplate(workspaceWithConfig *common.DevWorkspaceWithConfig) {
-	if workspaceWithConfig.Config.Workspace.DefaultTemplate == nil {
+func ApplyDefaultTemplate(workspace *common.DevWorkspaceWithConfig) {
+	if workspace.Config.Workspace.DefaultTemplate == nil {
 		return
 	}
-	defaultCopy := workspaceWithConfig.Config.Workspace.DefaultTemplate.DeepCopy()
-	originalProjects := workspaceWithConfig.Spec.Template.Projects
-	workspaceWithConfig.Spec.Template.DevWorkspaceTemplateSpecContent = *defaultCopy
-	workspaceWithConfig.Spec.Template.Projects = append(workspaceWithConfig.Spec.Template.Projects, originalProjects...)
+	defaultCopy := workspace.Config.Workspace.DefaultTemplate.DeepCopy()
+	originalProjects := workspace.Spec.Template.Projects
+	workspace.Spec.Template.DevWorkspaceTemplateSpecContent = *defaultCopy
+	workspace.Spec.Template.Projects = append(workspace.Spec.Template.Projects, originalProjects...)
 }
 
-func NeedsDefaultTemplate(workspaceWithConfig *common.DevWorkspaceWithConfig) bool {
-	return len(workspaceWithConfig.Spec.Template.Components) == 0 && workspaceWithConfig.Config.Workspace.DefaultTemplate != nil
+func NeedsDefaultTemplate(workspace *common.DevWorkspaceWithConfig) bool {
+	return len(workspace.Spec.Template.Components) == 0 && workspace.Config.Workspace.DefaultTemplate != nil
 }

--- a/pkg/library/env/workspaceenv.go
+++ b/pkg/library/env/workspaceenv.go
@@ -21,6 +21,7 @@ import (
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 
@@ -30,8 +31,8 @@ import (
 
 // AddCommonEnvironmentVariables adds environment variables to each container in podAdditions. Environment variables added include common
 // info environment variables and environment variables defined by a workspaceEnv attribute in the devfile itself
-func AddCommonEnvironmentVariables(podAdditions *v1alpha1.PodAdditions, clusterDW *dw.DevWorkspace, flattenedDW *dw.DevWorkspaceTemplateSpec) error {
-	commonEnv := commonEnvironmentVariables(clusterDW.Name, clusterDW.Status.DevWorkspaceId, clusterDW.Namespace, clusterDW.Labels[constants.DevWorkspaceCreatorLabel])
+func AddCommonEnvironmentVariables(podAdditions *v1alpha1.PodAdditions, clusterDW *dw.DevWorkspace, flattenedDW *dw.DevWorkspaceTemplateSpec, config controllerv1alpha1.OperatorConfiguration) error {
+	commonEnv := commonEnvironmentVariables(clusterDW.Name, clusterDW.Status.DevWorkspaceId, clusterDW.Namespace, clusterDW.Labels[constants.DevWorkspaceCreatorLabel], config)
 	workspaceEnv, err := collectWorkspaceEnv(flattenedDW)
 	if err != nil {
 		return err
@@ -47,7 +48,7 @@ func AddCommonEnvironmentVariables(podAdditions *v1alpha1.PodAdditions, clusterD
 	return nil
 }
 
-func commonEnvironmentVariables(workspaceName, workspaceId, namespace, creator string) []corev1.EnvVar {
+func commonEnvironmentVariables(workspaceName, workspaceId, namespace, creator string, config controllerv1alpha1.OperatorConfiguration) []corev1.EnvVar {
 	envvars := []corev1.EnvVar{
 		{
 			Name:  constants.DevWorkspaceNamespace,

--- a/pkg/library/env/workspaceenv.go
+++ b/pkg/library/env/workspaceenv.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 )
 
@@ -72,12 +71,12 @@ func commonEnvironmentVariables(workspaceName, workspaceId, namespace, creator s
 		},
 	}
 
-	envvars = append(envvars, getProxyEnvVars()...)
+	envvars = append(envvars, getProxyEnvVars(config)...)
 
 	return envvars
 }
 
-func getProxyEnvVars() []corev1.EnvVar {
+func getProxyEnvVars(config controllerv1alpha1.OperatorConfiguration) []corev1.EnvVar {
 	if config.Routing.ProxyConfig == nil {
 		return nil
 	}

--- a/pkg/library/projects/clone.go
+++ b/pkg/library/projects/clone.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"github.com/devfile/devworkspace-operator/pkg/config"
 	devfileConstants "github.com/devfile/devworkspace-operator/pkg/library/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/devfile/devworkspace-operator/internal/images"
+	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 )
 
@@ -32,14 +32,16 @@ const (
 	projectClonerContainerName = "project-clone"
 )
 
-func GetProjectCloneInitContainer(workspace *dw.DevWorkspaceTemplateSpec) (*corev1.Container, error) {
+func GetProjectCloneInitContainer(workspaceWithConfig *common.DevWorkspaceWithConfig) (*corev1.Container, error) {
+
+	workspace := workspaceWithConfig.Spec.Template
 	if len(workspace.Projects) == 0 {
 		return nil, nil
 	}
 	if workspace.Attributes.GetString(constants.ProjectCloneAttribute, nil) == constants.ProjectCloneDisable {
 		return nil, nil
 	}
-	if !hasContainerComponents(workspace) {
+	if !hasContainerComponents(&workspace) {
 		// Avoid adding project-clone init container when DevWorkspace does not define any containers
 		return nil, nil
 	}
@@ -92,7 +94,7 @@ func GetProjectCloneInitContainer(workspace *dw.DevWorkspaceTemplateSpec) (*core
 				MountPath: constants.DefaultProjectsSourcesRoot,
 			},
 		},
-		ImagePullPolicy: corev1.PullPolicy(config.Workspace.ImagePullPolicy),
+		ImagePullPolicy: corev1.PullPolicy(workspaceWithConfig.Config.Workspace.ImagePullPolicy),
 	}, nil
 }
 

--- a/pkg/library/projects/clone.go
+++ b/pkg/library/projects/clone.go
@@ -32,16 +32,15 @@ const (
 	projectClonerContainerName = "project-clone"
 )
 
-func GetProjectCloneInitContainer(workspaceWithConfig *common.DevWorkspaceWithConfig) (*corev1.Container, error) {
+func GetProjectCloneInitContainer(workspace *common.DevWorkspaceWithConfig) (*corev1.Container, error) {
 
-	workspace := workspaceWithConfig.Spec.Template
-	if len(workspace.Projects) == 0 {
+	if len(workspace.Spec.Template.Projects) == 0 {
 		return nil, nil
 	}
-	if workspace.Attributes.GetString(constants.ProjectCloneAttribute, nil) == constants.ProjectCloneDisable {
+	if workspace.Spec.Template.Attributes.GetString(constants.ProjectCloneAttribute, nil) == constants.ProjectCloneDisable {
 		return nil, nil
 	}
-	if !hasContainerComponents(&workspace) {
+	if !hasContainerComponents(&workspace.Spec.Template) {
 		// Avoid adding project-clone init container when DevWorkspace does not define any containers
 		return nil, nil
 	}
@@ -94,7 +93,7 @@ func GetProjectCloneInitContainer(workspaceWithConfig *common.DevWorkspaceWithCo
 				MountPath: constants.DefaultProjectsSourcesRoot,
 			},
 		},
-		ImagePullPolicy: corev1.PullPolicy(workspaceWithConfig.Config.Workspace.ImagePullPolicy),
+		ImagePullPolicy: corev1.PullPolicy(workspace.Config.Workspace.ImagePullPolicy),
 	}, nil
 }
 

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,7 +126,7 @@ func TestProvisionStorageForCommonStorageClass(t *testing.T) {
 	tests := loadAllTestCasesOrPanic(t, "testdata/common-storage")
 	setupControllerCfg()
 	commonStorage := CommonStorageProvisioner{}
-	commonPVC, err := getPVCSpec("claim-devworkspace", "test-namespace", resource.MustParse("10Gi"))
+	commonPVC, err := getPVCSpec("claim-devworkspace", "test-namespace", resource.MustParse("10Gi"), *testControllerCfg)
 	if err != nil {
 		t.Fatalf("Failure during setup: %s", err)
 	}
@@ -139,7 +140,8 @@ func TestProvisionStorageForCommonStorageClass(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check that file is read correctly.
 			assert.NotNil(t, tt.Input.Workspace, "Input does not define workspace")
-			workspace := &dw.DevWorkspace{}
+			workspace := &common.DevWorkspaceWithConfig{}
+			workspace.Config = *config.InternalConfig
 			workspace.Spec.Template = *tt.Input.Workspace
 			workspace.Status.DevWorkspaceId = tt.Input.DevWorkspaceID
 			workspace.Namespace = "test-namespace"
@@ -162,7 +164,7 @@ func TestProvisionStorageForCommonStorageClass(t *testing.T) {
 func TestTerminatingPVC(t *testing.T) {
 	setupControllerCfg()
 	commonStorage := CommonStorageProvisioner{}
-	commonPVC, err := getPVCSpec("claim-devworkspace", "test-namespace", resource.MustParse("10Gi"))
+	commonPVC, err := getPVCSpec("claim-devworkspace", "test-namespace", resource.MustParse("10Gi"), *testControllerCfg)
 	if err != nil {
 		t.Fatalf("Failure during setup: %s", err)
 	}
@@ -175,7 +177,8 @@ func TestTerminatingPVC(t *testing.T) {
 	}
 	testCase := loadTestCaseOrPanic(t, "testdata/common-storage/rewrites-volumes-for-common-pvc-strategy.yaml")
 	assert.NotNil(t, testCase.Input.Workspace, "Input does not define workspace")
-	workspace := &dw.DevWorkspace{}
+	workspace := &common.DevWorkspaceWithConfig{}
+	workspace.Config = *config.InternalConfig
 	workspace.Spec.Template = *testCase.Input.Workspace
 	workspace.Status.DevWorkspaceId = testCase.Input.DevWorkspaceID
 	workspace.Namespace = "test-namespace"

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -75,7 +75,7 @@ var testControllerCfg = &v1alpha1.OperatorConfiguration{
 }
 
 func setupControllerCfg() {
-	config.SetConfigForTesting(testControllerCfg)
+	testControllerCfg = config.SetConfigForTesting(testControllerCfg)
 }
 
 func loadTestCaseOrPanic(t *testing.T, testFilepath string) testCase {
@@ -141,7 +141,7 @@ func TestProvisionStorageForCommonStorageClass(t *testing.T) {
 			// sanity check that file is read correctly.
 			assert.NotNil(t, tt.Input.Workspace, "Input does not define workspace")
 			workspace := &common.DevWorkspaceWithConfig{}
-			workspace.Config = *config.InternalConfig
+			workspace.Config = *testControllerCfg
 			workspace.Spec.Template = *tt.Input.Workspace
 			workspace.Status.DevWorkspaceId = tt.Input.DevWorkspaceID
 			workspace.Namespace = "test-namespace"
@@ -178,7 +178,7 @@ func TestTerminatingPVC(t *testing.T) {
 	testCase := loadTestCaseOrPanic(t, "testdata/common-storage/rewrites-volumes-for-common-pvc-strategy.yaml")
 	assert.NotNil(t, testCase.Input.Workspace, "Input does not define workspace")
 	workspace := &common.DevWorkspaceWithConfig{}
-	workspace.Config = *config.InternalConfig
+	workspace.Config = *testControllerCfg
 	workspace.Spec.Template = *testCase.Input.Workspace
 	workspace.Status.DevWorkspaceId = testCase.Input.DevWorkspaceID
 	workspace.Namespace = "test-namespace"

--- a/pkg/provision/storage/ephemeralStorage.go
+++ b/pkg/provision/storage/ephemeralStorage.go
@@ -17,10 +17,10 @@ package storage
 
 import (
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
-
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/library/container"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 )
 
 // The EphemeralStorageProvisioner provisions all workspace storage as emptyDir volumes.
@@ -35,8 +35,8 @@ func (e EphemeralStorageProvisioner) NeedsStorage(_ *dw.DevWorkspaceTemplateSpec
 	return false
 }
 
-func (e EphemeralStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspace *dw.DevWorkspace, _ sync.ClusterAPI) error {
-	persistent, ephemeral, projects := getWorkspaceVolumes(workspace)
+func (e EphemeralStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspaceWithConfig *common.DevWorkspaceWithConfig, _ sync.ClusterAPI) error {
+	persistent, ephemeral, projects := getWorkspaceVolumes(&workspaceWithConfig.DevWorkspace)
 	if _, err := addEphemeralVolumesToPodAdditions(podAdditions, persistent); err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func (e EphemeralStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.Pod
 			return err
 		}
 	} else {
-		if container.AnyMountSources(workspace.Spec.Template.Components) {
+		if container.AnyMountSources(workspaceWithConfig.Spec.Template.Components) {
 			projectsComponent := dw.Component{Name: "projects"}
 			projectsComponent.Volume = &dw.VolumeComponent{}
 			if _, err := addEphemeralVolumesToPodAdditions(podAdditions, []dw.Component{projectsComponent}); err != nil {
@@ -59,6 +59,6 @@ func (e EphemeralStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.Pod
 	return nil
 }
 
-func (e EphemeralStorageProvisioner) CleanupWorkspaceStorage(_ *dw.DevWorkspace, _ sync.ClusterAPI) error {
+func (e EphemeralStorageProvisioner) CleanupWorkspaceStorage(_ *common.DevWorkspaceWithConfig, _ sync.ClusterAPI) error {
 	return nil
 }

--- a/pkg/provision/storage/ephemeralStorage.go
+++ b/pkg/provision/storage/ephemeralStorage.go
@@ -35,8 +35,8 @@ func (e EphemeralStorageProvisioner) NeedsStorage(_ *dw.DevWorkspaceTemplateSpec
 	return false
 }
 
-func (e EphemeralStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspaceWithConfig *common.DevWorkspaceWithConfig, _ sync.ClusterAPI) error {
-	persistent, ephemeral, projects := getWorkspaceVolumes(&workspaceWithConfig.DevWorkspace)
+func (e EphemeralStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspace *common.DevWorkspaceWithConfig, _ sync.ClusterAPI) error {
+	persistent, ephemeral, projects := getWorkspaceVolumes(&workspace.DevWorkspace)
 	if _, err := addEphemeralVolumesToPodAdditions(podAdditions, persistent); err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func (e EphemeralStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.Pod
 			return err
 		}
 	} else {
-		if container.AnyMountSources(workspaceWithConfig.Spec.Template.Components) {
+		if container.AnyMountSources(workspace.Spec.Template.Components) {
 			projectsComponent := dw.Component{Name: "projects"}
 			projectsComponent.Volume = &dw.VolumeComponent{}
 			if _, err := addEphemeralVolumesToPodAdditions(podAdditions, []dw.Component{projectsComponent}); err != nil {

--- a/pkg/provision/storage/ephemeralStorage_test.go
+++ b/pkg/provision/storage/ephemeralStorage_test.go
@@ -18,7 +18,7 @@ package storage
 import (
 	"testing"
 
-	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 	"github.com/stretchr/testify/assert"
 )
@@ -32,7 +32,8 @@ func TestRewriteContainerVolumeMountsForEphemeralStorageClass(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check that file is read correctly.
 			assert.NotNil(t, tt.Input.Workspace, "Input does not define workspace")
-			workspace := &dw.DevWorkspace{}
+			workspace := &common.DevWorkspaceWithConfig{}
+			workspace.Config = *testControllerCfg
 			workspace.Spec.Template = *tt.Input.Workspace
 			workspace.Status.DevWorkspaceId = tt.Input.DevWorkspaceID
 			workspace.Namespace = "test-namespace"

--- a/pkg/provision/storage/perWorkspaceStorage_test.go
+++ b/pkg/provision/storage/perWorkspaceStorage_test.go
@@ -52,7 +52,8 @@ func TestRewriteContainerVolumeMountsForPerWorkspaceStorageClass(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check that file is read correctly.
 			assert.NotNil(t, tt.Input.Workspace, "Input does not define workspace")
-			workspace := &dw.DevWorkspace{}
+			workspace := &common.DevWorkspaceWithConfig{}
+			workspace.Config = *config.InternalConfig
 			workspace.Spec.Template = *tt.Input.Workspace
 			workspace.Status.DevWorkspaceId = tt.Input.DevWorkspaceID
 			workspace.Namespace = "test-namespace"

--- a/pkg/provision/storage/perWorkspaceStorage_test.go
+++ b/pkg/provision/storage/perWorkspaceStorage_test.go
@@ -53,7 +53,7 @@ func TestRewriteContainerVolumeMountsForPerWorkspaceStorageClass(t *testing.T) {
 			// sanity check that file is read correctly.
 			assert.NotNil(t, tt.Input.Workspace, "Input does not define workspace")
 			workspace := &common.DevWorkspaceWithConfig{}
-			workspace.Config = *config.InternalConfig
+			workspace.Config = *testControllerCfg
 			workspace.Spec.Template = *tt.Input.Workspace
 			workspace.Status.DevWorkspaceId = tt.Input.DevWorkspaceID
 			workspace.Namespace = "test-namespace"

--- a/pkg/provision/storage/provisioner.go
+++ b/pkg/provision/storage/provisioner.go
@@ -17,10 +17,10 @@ package storage
 
 import (
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
-
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 )
 
 // Provisioner is an interface for rewriting volumeMounts in a pod according to a storage policy (e.g. common PVC for all mounts, etc.)
@@ -29,14 +29,14 @@ type Provisioner interface {
 	// out-of-pod required objects to the cluster.
 	// Returns NotReadyError to signify that storage is not ready, ProvisioningError when a fatal issue is encountered,
 	// and other error if there is an unexpected problem.
-	ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspace *dw.DevWorkspace, clusterAPI sync.ClusterAPI) error
+	ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspaceWithConfig *common.DevWorkspaceWithConfig, clusterAPI sync.ClusterAPI) error
 	// NeedsStorage returns whether the current workspace needs a PVC to be provisioned, given this storage strategy.
 	NeedsStorage(workspace *dw.DevWorkspaceTemplateSpec) bool
 	// CleanupWorkspaceStorage removes any objects provisioned by in the ProvisionStorage step that aren't automatically removed when a
 	// DevWorkspace is deleted (e.g. delete subfolders in a common PVC assigned to the workspace)
 	// Returns nil on success (DevWorkspace can be deleted), NotReadyError if additional reconciles are necessary, ProvisioningError when
 	// a fatal issue is encountered, and any other error if an unexpected problem arises.
-	CleanupWorkspaceStorage(workspace *dw.DevWorkspace, clusterAPI sync.ClusterAPI) error
+	CleanupWorkspaceStorage(workspaceWithConfig *common.DevWorkspaceWithConfig, clusterAPI sync.ClusterAPI) error
 }
 
 // GetProvisioner returns the storage provisioner that should be used for the current workspace

--- a/pkg/provision/storage/provisioner.go
+++ b/pkg/provision/storage/provisioner.go
@@ -29,14 +29,14 @@ type Provisioner interface {
 	// out-of-pod required objects to the cluster.
 	// Returns NotReadyError to signify that storage is not ready, ProvisioningError when a fatal issue is encountered,
 	// and other error if there is an unexpected problem.
-	ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspaceWithConfig *common.DevWorkspaceWithConfig, clusterAPI sync.ClusterAPI) error
+	ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspace *common.DevWorkspaceWithConfig, clusterAPI sync.ClusterAPI) error
 	// NeedsStorage returns whether the current workspace needs a PVC to be provisioned, given this storage strategy.
 	NeedsStorage(workspace *dw.DevWorkspaceTemplateSpec) bool
 	// CleanupWorkspaceStorage removes any objects provisioned by in the ProvisionStorage step that aren't automatically removed when a
 	// DevWorkspace is deleted (e.g. delete subfolders in a common PVC assigned to the workspace)
 	// Returns nil on success (DevWorkspace can be deleted), NotReadyError if additional reconciles are necessary, ProvisioningError when
 	// a fatal issue is encountered, and any other error if an unexpected problem arises.
-	CleanupWorkspaceStorage(workspaceWithConfig *common.DevWorkspaceWithConfig, clusterAPI sync.ClusterAPI) error
+	CleanupWorkspaceStorage(workspace *common.DevWorkspaceWithConfig, clusterAPI sync.ClusterAPI) error
 }
 
 // GetProvisioner returns the storage provisioner that should be used for the current workspace

--- a/pkg/provision/workspace/routing.go
+++ b/pkg/provision/workspace/routing.go
@@ -106,11 +106,8 @@ func getSpecRouting(
 	}
 	annotations = maputils.Append(annotations, constants.DevWorkspaceStartedStatusAnnotation, "true")
 
-	// TODO: Remove this comment
-	// I had to move this before the annotations get applied, as otherwise, if the routing class wasn't set in the spec, the annotation would start with a '.' which isin't allowed
 	routingClass := workspaceWithConfig.Spec.RoutingClass
 	if routingClass == "" {
-		// TODO: Just set workspace.Spec.RoutingClass = config.Routing.DefaultRoutingClass ?
 		routingClass = workspaceWithConfig.Config.Routing.DefaultRoutingClass
 	}
 
@@ -120,6 +117,10 @@ func getSpecRouting(
 		if strings.HasPrefix(k, expectedAnnotationPrefix) {
 			annotations = maputils.Append(annotations, k, v)
 		}
+	}
+
+	if v1alpha1.DevWorkspaceRoutingClass(routingClass) == v1alpha1.DevWorkspaceRoutingBasic {
+		annotations = maputils.Append(annotations, constants.ClusterHostSuffixAnnotation, workspaceWithConfig.Config.Routing.ClusterHostSuffix)
 	}
 
 	routing := &v1alpha1.DevWorkspaceRouting{


### PR DESCRIPTION
### What does this PR do?
This PR aims to make 2 changes to DWO:
1. Refactor (almost) all uses of the DWOC, so that, internally, each workspace instance has its own configuration. Currently, this per-workspace devworkspace-operator configuration is not visible to users, and was added only to support changed n.2
2. Allow for specifying an external DWOC (that exists on the cluster), which gets merged with the workspace's internal DWOC

The external DWOC's name and namespace are specified with the `controller.devfile.io/devworkspace-config` DevWorkspace attribute, which has the following structure:
    
```YAML
attributes:
  controller.devfile.io/devworkspace-config:
    name: <string>
    namespace: <string>
```


### What issues does this PR fix or reference?
Part of eclipse/che#21405

### Is it tested? How?
I added 2 automated tests.

For manual testing, perform the following steps:
1. Deploy DWO
2. Create a devfile with the `controller.devfile.io/devworkspace-config` attribute set, e.g.

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next-external-dwoc
spec:
  started: true
  template:
    attributes:
        controller.devfile.io/devworkspace-config:
          name: external-dwoc-test
          namespace: default
        controller.devfile.io/storage-type: per-workspace
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
          components:
            - name: theia-ide
              container:
                env:
                  - name: THEIA_HOST
                    value: 0.0.0.0
    commands:
      - id: say-hello
        exec:
          component: theia-ide
          commandLine: echo "Hello from $(pwd)"
          workingDir: ${PROJECTS_ROOT}/project/app
```
3. Create a DWOC file, for reference, we'll call it `test-external-dwoc.yaml`. Also, ensure its name field is set to the same value as the `controller.devfile.io/devworkspace-config-name` attribute in the devfile from step 2:
```YAML
apiVersion: controller.devfile.io/v1alpha1
config:
  enableExperimentalFeatures: true
  routing:
    clusterHostSuffix: 192.168.49.2.nip.io
    defaultRoutingClass: basic
  workspace:
    defaultStorageSize:
      common: 20Gi
      perWorkspace: 29Gi
    imagePullPolicy: Always
kind: DevWorkspaceOperatorConfig
metadata:
  name: external-dwoc-test
  namespace: default
```
4. Apply the (external) DWOC file you just created, ensuring it's in the namespace you specified in the `controller.devfile.io/devworkspace-config-namespace` (in my example, the default namespace is used): `kubectl apply -f test-external-dwoc.yaml`
5. Apply the devfile created in step 2. 
6. Verify that the internal DWOC has been modified. I recommend checking the size of the per-workspace PVC that is created and ensuring it is `29Gi` instead of the default `10Gi`
7. Afterwards, you can ensure that workspace's that do not have the `controller.devfile.io/devworkspace-config` attribute set are not affected by the external DWOC, and instead, they use the global/internal DWOC. For instance, start up the per-workspace example and ensure the PVC created for it is `10Gi` big: `kubectl apply -f per-workspace-storage.yaml -n $NAMESPACE`.

### Some notes and limitations:
1. The HTTP client / Proxy settings cannot be affected by the externally applied DWOC, as [the HTTP client is created and configured on DWO startup rather than workspace startup](https://github.com/devfile/devworkspace-operator/pull/711#issuecomment-995360107). 
2. There is [a handler](https://github.com/devfile/devworkspace-operator/blob/main/controllers/workspace/devworkspace_controller.go#L680) that checks if the common PVC was deleted. Currently, it filters for PVC's related to DWO by checking the PVC name against the global configs PVC name. In the future, this limitation can be worked around by applying a DWO-specific annotation to all PVC's created by DWO, and filtering by that annotation. 
3. This change could have weird implications for anything configurable that is shared across workspaces. Most notably, the common PVC. For example, if the common PVC does not yet exist on the cluster, and an external DWOC that has the common PVC size set to `20Gi` is applied for a specific workspace, then other (future) workspaces that use the common storage strategy will also be using a PVC of `20Gi`, even if they aren't using an external DWOC. 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
