### PR TITLE
Shorten sample catalogsource registry polling interval to 5m

### DIFF
--- a/catalog-source.yaml
+++ b/catalog-source.yaml
@@ -10,4 +10,4 @@ spec:
   displayName: DevWorkspace Operator Catalog
   updateStrategy:
     registryPoll:
-      interval: 1d
+      interval: 5m


### PR DESCRIPTION
### What does this PR do?
Shortens the registry polling interval for the sample catalogsource to 5m.

### What issues does this PR fix or reference?
Hopefully avoids the issue of the catalogSource not becoming ready for a long time

### Is it tested? How?
Apply catalogSource and check OperatorHub to see if DWO `next` is available.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
