### PR TITLE
Ignore mount path for git-credentials secrets and mount as file

### DIFF
--- a/pkg/provision/automount/templates.go
+++ b/pkg/provision/automount/templates.go
@@ -125,27 +125,3 @@ func mergeGitCredentials(namespace string, credentialSecrets []corev1.Secret) (*
 	}
 	return mergedCredentials, nil
 }
-
-// getCredentialsMountPath returns the mount path to be used by all git credentials secrets. If no secrets define a mountPath,
-// the root path ('/credentials') is used. If secrets define conflicting mountPaths, an error is returned and represents an invalid
-// configuration. If any secret defines a mountPath, that mountPath overrides the mountPath for all secrets that do not
-// define a mountPath. If there are no credentials secrets, the empty string is returned
-func getCredentialsMountPath(secrets []corev1.Secret) (string, error) {
-	if len(secrets) == 0 {
-		return "", nil
-	}
-	mountPath := ""
-	for _, secret := range secrets {
-		secretMountPath := secret.Annotations[constants.DevWorkspaceMountPathAnnotation]
-		if secretMountPath != "" {
-			if mountPath != "" && secretMountPath != mountPath {
-				return "", fmt.Errorf("auto-mounted git credentials have conflicting mountPaths: %s, %s", mountPath, secretMountPath)
-			}
-			mountPath = secretMountPath
-		}
-	}
-	if mountPath == "" {
-		mountPath = "/"
-	}
-	return mountPath, nil
-}


### PR DESCRIPTION
### What does this PR do?
Ignore any mount-path annotations on secrets labelled 'controller.devfile.io/git-credential'. Instead, always mount the merged git credentials secret to `/.git-credentials/`.

Additionally, mount the credentials file as files rather than using subpath mounts, in order to ensure changes to the on-cluster secret can be propagated to the running workspace without requiring a restart.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/915

### Is it tested? How?
1. Create a secret with git-credentials label:
    ```yaml
    kind: Secret
    apiVersion: v1
    metadata:
      name: git-credentials-test-secret
      labels:
        controller.devfile.io/git-credential: 'true'
        controller.devfile.io/watch-secret: 'true'
    data:
      credentials: aGVsbG8gd29ybGQK # "hello world"
    type: Opaque
    ```
2. Start a workspace and verify file `/.git-credentials/credentials` is mounted and contains text "hello world"
3. Edit the secret in the cluster, changing the value of the `credentials` key
4. Update the workspace in any way to trigger a reconcile (e.g. add an annotation)
5. Check that file `/.git-credentials/credentials` reflects the new value (this may take some time to propagate down)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
