### PR TITLE
Include git-lfs configuration in overridden gitconfig

### DIFF
--- a/pkg/provision/automount/templates.go
+++ b/pkg/provision/automount/templates.go
@@ -33,6 +33,16 @@ const gitCredentialsConfigMapName = "devworkspace-gitconfig"
 const gitCredentialsSecretKey = "credentials"
 const gitCredentialsSecretName = "devworkspace-merged-git-credentials"
 
+// gitLFSConfig is the default configuration that gets provisioned when git-lfs
+// is installed. It needs to be included in the overridden gitconfig to avoid
+// disabling git-lfs in repos that require a gitconfig.
+const gitLFSConfig = `[filter "lfs"]
+    clean = git-lfs clean -- %f
+    smudge = git-lfs smudge -- %f
+    process = git-lfs filter-process
+    required = true
+`
+
 const credentialTemplate = `[credential]
     helper = store --file %s
 `
@@ -47,6 +57,8 @@ const defaultGitServerTemplate = `[http]
 
 func constructGitConfig(namespace, credentialMountPath string, certificatesConfigMaps []corev1.ConfigMap, baseGitConfig *string) (*corev1.ConfigMap, error) {
 	var configSettings []string
+	configSettings = append(configSettings, gitLFSConfig)
+
 	if credentialMountPath != "" {
 		configSettings = append(configSettings, fmt.Sprintf(credentialTemplate, path.Join(credentialMountPath, gitCredentialsSecretKey)))
 	}


### PR DESCRIPTION
### What does this PR do?
Copies the git-lfs configuration block used by the project-clone container into the overridden gitconfig that gets mounted when git credentials or a custom gitconfig are used.

### What issues does this PR fix or reference?
#911 

### Is it tested? How?
1. Test using reproducer in #911
2. Test that git-lfs still works when git-credentials is used
3. Test that there is no issue if manually configured gitconfig contains an `lfs` section

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
