### PR TITLE
Log all non-default fields when updating config

### DIFF
--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -314,6 +314,7 @@ func GetCurrentConfigString(currConfig *controller.OperatorConfiguration) string
 	}
 	workspace := currConfig.Workspace
 	if workspace != nil {
+		// Don't include PodSecurityContext for now as it's less easy to compare
 		if workspace.ImagePullPolicy != defaultConfig.Workspace.ImagePullPolicy {
 			config = append(config, fmt.Sprintf("workspace.imagePullPolicy=%s", workspace.ImagePullPolicy))
 		}
@@ -326,9 +327,15 @@ func GetCurrentConfigString(currConfig *controller.OperatorConfiguration) string
 		if workspace.IdleTimeout != defaultConfig.Workspace.IdleTimeout {
 			config = append(config, fmt.Sprintf("workspace.idleTimeout=%s", workspace.IdleTimeout))
 		}
+		if workspace.ProgressTimeout != "" && workspace.ProgressTimeout != defaultConfig.Workspace.ProgressTimeout {
+			config = append(config, fmt.Sprintf("workspace.progressTimeout=%s", workspace.ProgressTimeout))
+		}
 		if workspace.IgnoredUnrecoverableEvents != nil {
 			config = append(config, fmt.Sprintf("workspace.ignoredUnrecoverableEvents=%s",
 				strings.Join(workspace.IgnoredUnrecoverableEvents, ";")))
+		}
+		if workspace.CleanupOnStop != nil && *workspace.CleanupOnStop != *defaultConfig.Workspace.CleanupOnStop {
+			config = append(config, fmt.Sprintf("workspace.cleanupOnStop=%t", *workspace.CleanupOnStop))
 		}
 		if workspace.DefaultStorageSize != nil {
 			if workspace.DefaultStorageSize.Common != nil && workspace.DefaultStorageSize.Common.String() != defaultConfig.Workspace.DefaultStorageSize.Common.String() {


### PR DESCRIPTION
### What does this PR do?
Log all non-default fields in config when updating config to avoid missing info. Previously, settings like cleanupOnStop and progressTimeout were ignored in the config log, which is confusing.

For now, we still don't log differences in `workspace.podSecurityContext` as it's not as simple to diff the structs.

This PR should probably not be merged before https://github.com/devfile/devworkspace-operator/pull/918 to avoid an annoying merge conflict.

### What issues does this PR fix or reference?
N/A, minor fixup

### Is it tested? How?
Start DWO and set custom values for `.config.workspace.cleanupOnStop` and `.config.workspace.progressTimeout`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
