### PR TITLE
fix: Set workspace warning if error occurs when resolving external DWOC

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/devfile/devworkspace-operator/controllers/workspace/metrics"
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/conditions"
-	"github.com/devfile/devworkspace-operator/pkg/config"
 	wkspConfig "github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/library/annotate"
@@ -691,7 +690,7 @@ func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Req
 
 	// TODO: Label PVCs used for workspace storage so that they can be cleaned up if non-default name is used.
 	// Otherwise, check if common PVC is deleted to make sure all DevWorkspaces see it happen
-	if obj.GetName() != config.GetGlobalConfig().Workspace.PVCName || obj.GetDeletionTimestamp() == nil {
+	if obj.GetName() != wkspConfig.GetGlobalConfig().Workspace.PVCName || obj.GetDeletionTimestamp() == nil {
 		// We're looking for a deleted common PVC
 		return []reconcile.Request{}
 	}
@@ -717,7 +716,7 @@ func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Req
 func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	setupHttpClients()
 
-	maxConcurrentReconciles, err := config.GetMaxConcurrentReconciles()
+	maxConcurrentReconciles, err := wkspConfig.GetMaxConcurrentReconciles()
 	if err != nil {
 		return err
 	}
@@ -726,7 +725,7 @@ func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return []reconcile.Request{}
 	}
 
-	var configWatcher builder.WatchesOption = builder.WithPredicates(config.Predicates())
+	var configWatcher builder.WatchesOption = builder.WithPredicates(wkspConfig.Predicates())
 
 	// TODO: Set up indexing https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html#setup
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
### What does this PR do?
Sets the workspace status to warning if an issue occurs while resolving the external DWOC (specified in the optional `controller.devfile.io/devworkspace-config` workspace attribute).

The warning will not appear if other active warnings exist for the workspace (eg. if there was an error during the flattening process of a workspace). This was an opinionated decision, as I think other warnings may have higher priority/urgency compared to not being able to resolve the external DWOC. I can change this if desired :)

### What issues does this PR fix or reference?
Fix #921

### Is it tested? How?
1. Deploy DWO
2. Apply the following workspace, which will reference a (currently non-existent on the cluster) DWOC
```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next-external-dwoc
spec:
  started: true
  template:
    attributes:
        controller.devfile.io/devworkspace-config:
          name: external-dwoc-test
          namespace: default
        controller.devfile.io/storage-type: per-workspace
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
          components:
            - name: theia-ide
              container:
                env:
                  - name: THEIA_HOST
                    value: 0.0.0.0
    commands:
      - id: say-hello
        exec:
          component: theia-ide
          commandLine: echo "Hello from $(pwd)"
          workingDir: ${PROJECTS_ROOT}/project/app
```
3. Get the workspaces for the `devworkspace-controller` namespace, you should see that warnings are present:
```bash
[aobuchow@fedora samples]$ kubectl get dw -n $NAMESPACE -w
NAME                       DEVWORKSPACE ID             PHASE     INFO
theia-next-external-dwoc   workspace7015525656304d3d   Running   [warnings present] https://workspace7015525656304d3d-theia-3100.192.168.49.2.nip.io/
```
A `kubectl describe` should list in the Status that the external DWOC was not found:
`kubectl describe dw theia-next-external-dwoc -n $NAMESPACE`
```YAML
Name:         theia-next-external-dwoc
Namespace:    devworkspace-controller
Labels:       controller.devfile.io/creator=
Annotations:  controller.devfile.io/started-at: 1663001600348
API Version:  workspace.devfile.io/v1alpha2
Kind:         DevWorkspace
(...)
Status:
  Conditions:
    Last Transition Time:  2022-09-12T16:58:49Z
    Message:               Error applying external DevWorkspace-Operator configuration: could not fetch external DWOC with name external-dwoc-test in namespace default: DevWorkspaceOperatorConfig.controller.devfile.io "external-dwoc-test" not found
    Status:                True
    Type:                  DevWorkspaceWarning
    Last Transition Time:  2022-09-12T16:53:07Z
    Message:               DevWorkspace is starting
    Status:                True
    Type:                  Started
    Last Transition Time:  2022-09-12T16:53:07Z
    Message:               Resolved plugins and parents from DevWorkspace
    Status:                True
    Type:                  DevWorkspaceResolved
    Last Transition Time:  2022-09-12T16:53:07Z
    Message:               Storage ready
    Status:                True
    Type:                  StorageReady
    Last Transition Time:  2022-09-12T16:53:08Z
    Message:               Networking ready
    Status:                True
    Type:                  RoutingReady
    Last Transition Time:  2022-09-12T16:53:08Z
    Message:               DevWorkspace serviceaccount ready
    Status:                True
    Type:                  ServiceAccountReady
    Last Transition Time:  2022-09-12T16:53:13Z
    Message:               DevWorkspace secrets ready
    Status:                True
    Type:                  PullSecretsReady
    Last Transition Time:  2022-09-12T16:53:20Z
    Message:               DevWorkspace deployment ready
    Status:                True
    Type:                  DeploymentReady
    Last Transition Time:  2022-09-12T16:53:20Z
    Status:                True
    Type:                  Ready
  Devworkspace Id:         workspace7015525656304d3d
  Main URL:                https://workspace7015525656304d3d-theia-3100.192.168.49.2.nip.io/
  Message:                 [warnings present] https://workspace7015525656304d3d-theia-3100.192.168.49.2.nip.io/
  Phase:                   Running
Events:                    <none>
```
4. Now apply the following external DWOC to the cluster in the `default` namespace:
```YAML
apiVersion: controller.devfile.io/v1alpha1
config:
  enableExperimentalFeatures: true
  routing:
    clusterHostSuffix: 192.168.49.2.nip.io
    defaultRoutingClass: basic
  workspace:
    defaultStorageSize:
      common: 20Gi
      perWorkspace: 29Gi
    imagePullPolicy: Always
kind: DevWorkspaceOperatorConfig
metadata:
  name: external-dwoc-test
  namespace: default
```
5. Ensure that there are no longer any active warnings are present for the workspace:
```bash
[aobuchow@fedora samples]$ kubectl get dw -n $NAMESPACE -w
NAME                       DEVWORKSPACE ID             PHASE     INFO
theia-next-external-dwoc   workspace7015525656304d3d   Running   https://workspace7015525656304d3d-theia-3100.192.168.49.2.nip.io/
```

`kubectl describe dw theia-next-external-dwoc -n $NAMESPACE`:

```YAML
Name:         theia-next-external-dwoc
Namespace:    devworkspace-controller
Labels:       controller.devfile.io/creator=
Annotations:  controller.devfile.io/started-at: 1663001600348
              test: testt
API Version:  workspace.devfile.io/v1alpha2
Kind:         DevWorkspace
(...)
Status:
  Conditions:
    Last Transition Time:  2022-09-12T17:01:51Z
    Message:               External DevWorkspaceOperatorConfig successfully resolved
    Status:                False
    Type:                  DevWorkspaceWarning
    Last Transition Time:  2022-09-12T16:53:07Z
...
```
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
