### PR TITLE
fix: Allow switching to per-user or common strategy if the storage type is not defined

### DIFF
--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -116,6 +116,9 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnUpdate(ctx context.Context, re
 		case oldStorageType == constants.EphemeralStorageClassType:
 			// Allow switching from ephemeral to a persistent storage type
 			break
+		case oldStorageType == "" && (newStorageType == constants.CommonStorageClassType || newStorageType == constants.PerUserStorageClassType):
+			// Allow switching to per-user or common persistent storage type if the oldStorageType is empty (if empty, the common PVC strategy is used by design)
+			break
 		case (oldStorageType == constants.CommonStorageClassType && newStorageType == constants.PerUserStorageClassType) || (oldStorageType == constants.PerUserStorageClassType && newStorageType == constants.CommonStorageClassType):
 			// Allow switching between common and per-user persistent storage type for legacy compatibility
 			break

--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -117,7 +117,10 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnUpdate(ctx context.Context, re
 			// Allow switching from ephemeral to a persistent storage type
 			break
 		case oldStorageType == "" && (newStorageType == constants.CommonStorageClassType || newStorageType == constants.PerUserStorageClassType):
-			// Allow switching to per-user or common persistent storage type if the oldStorageType is empty (if empty, the common PVC strategy is used by design)
+			// Allow switching to per-user or common persistent storage type if the oldStorageType is empty (if empty, the common / per-user PVC strategy is used by design)
+			break
+		case newStorageType == "" && (oldStorageType == constants.CommonStorageClassType || oldStorageType == constants.PerUserStorageClassType):
+			// Allow removing storage type attribute if the oldStorageType is per-user or common (if empty, the common / per-user PVC strategy is used by design)
 			break
 		case (oldStorageType == constants.CommonStorageClassType && newStorageType == constants.PerUserStorageClassType) || (oldStorageType == constants.PerUserStorageClassType && newStorageType == constants.CommonStorageClassType):
 			// Allow switching between common and per-user persistent storage type for legacy compatibility


### PR DESCRIPTION
…
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Allow switching to per-user or common strategy if the storage type is not defined

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21707

### Is it tested? How?

Tested via `oc apply -f ./samples/git-clone-sample.yaml -n <namespace>` on dogfodding and the cluster with the fix.

On Dogfooding after patching the DevWorkspace ^ which does not contain attributes with:

```
  template:
    attributes:
      controller.devfile.io/devworkspace-config:
        name: devworkspace-config
        namespace: dogfooding
      controller.devfile.io/storage-type: per-user
``` 

The webhook error is shown `admission webhook "mutate.devworkspace-controller.svc" denied the request: DevWorkspace storage-type attribute cannot be changed once the workspace has been created.`

On a cluster, with a fix, it is possible to patch the DevWorkspace with the storage attributes, and no error is shown



### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
