### PR TITLE
fix: Treat Forbidden error as unrecoverable sync error

### DIFF
--- a/pkg/provision/sync/sync.go
+++ b/pkg/provision/sync/sync.go
@@ -82,9 +82,7 @@ func createObjectGeneric(specObj crclient.Object, api ClusterAPI) error {
 		// Need to try to update the object to address an edge case where removing a labelselector
 		// results in the object not being tracked by the controller's cache.
 		return updateObjectGeneric(specObj, nil, api)
-	case k8sErrors.IsForbidden(err):
-		fallthrough
-	case k8sErrors.IsInvalid(err):
+	case k8sErrors.IsInvalid(err), k8sErrors.IsForbidden(err):
 		return &UnrecoverableSyncError{err}
 	default:
 		return err
@@ -110,9 +108,7 @@ func updateObjectGeneric(specObj, clusterObj crclient.Object, api ClusterAPI) er
 	case k8sErrors.IsConflict(err), k8sErrors.IsNotFound(err):
 		// Need to catch IsNotFound here because we attempt to update when creation fails with AlreadyExists
 		return NewNotInSync(specObj, NeedRetryReason)
-	case k8sErrors.IsForbidden(err):
-		fallthrough
-	case k8sErrors.IsInvalid(err):
+	case k8sErrors.IsInvalid(err), k8sErrors.IsForbidden(err):
 		return &UnrecoverableSyncError{err}
 	default:
 		return err

--- a/pkg/provision/sync/sync.go
+++ b/pkg/provision/sync/sync.go
@@ -82,6 +82,8 @@ func createObjectGeneric(specObj crclient.Object, api ClusterAPI) error {
 		// Need to try to update the object to address an edge case where removing a labelselector
 		// results in the object not being tracked by the controller's cache.
 		return updateObjectGeneric(specObj, nil, api)
+	case k8sErrors.IsForbidden(err):
+		fallthrough
 	case k8sErrors.IsInvalid(err):
 		return &UnrecoverableSyncError{err}
 	default:
@@ -108,6 +110,8 @@ func updateObjectGeneric(specObj, clusterObj crclient.Object, api ClusterAPI) er
 	case k8sErrors.IsConflict(err), k8sErrors.IsNotFound(err):
 		// Need to catch IsNotFound here because we attempt to update when creation fails with AlreadyExists
 		return NewNotInSync(specObj, NeedRetryReason)
+	case k8sErrors.IsForbidden(err):
+		fallthrough
 	case k8sErrors.IsInvalid(err):
 		return &UnrecoverableSyncError{err}
 	default:


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

### What does this PR do?
Treat `Forbidden` error as unrecoverable sync error

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21599

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Create an ResourceQuota in a user namespace
```yaml
kind: ResourceQuota
apiVersion: v1
metadata:
  name: resourequota
spec:
  hard:
    count/deployments.apps: '1'
```
2. Try to create a second workspace. Creation immediately fails, dashboard prints an error.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
