### PR TITLE
Add support for contributions through `.spec.contributions` field in DevWorkspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export PROJECT_CLONE_IMG ?= quay.io/devfile/project-clone:next
 export PULL_POLICY ?= Always
 export DEFAULT_ROUTING ?= basic
 export KUBECONFIG ?= ${HOME}/.kube/config
-export DEVWORKSPACE_API_VERSION ?= 32cae1f8e42c22035138ef6ee93080bc47d751c6
+export DEVWORKSPACE_API_VERSION ?= fe7c10eaa530b12b19cfb0e22e221e753391304c
 
 # Enable using Podman instead of Docker
 export DOCKER ?= docker

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -259,7 +259,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		wsDefaults.ApplyDefaultTemplate(workspace)
 	}
 
-	flattenedWorkspace, warnings, err := flatten.ResolveDevWorkspace(&workspace.Spec.Template, flattenHelpers)
+	flattenedWorkspace, warnings, err := flatten.ResolveDevWorkspace(&workspace.Spec.Template, workspace.Spec.Contributions, flattenHelpers)
 	if err != nil {
 		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus)
 	}

--- a/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
+++ b/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
@@ -2937,6 +2937,588 @@ spec:
           spec:
             description: DevWorkspaceSpec defines the desired state of DevWorkspace
             properties:
+              contributions:
+                items:
+                  oneOf:
+                  - required:
+                    - uri
+                  - required:
+                    - id
+                  - required:
+                    - kubernetes
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    commands:
+                      description: Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - exec
+                        - required:
+                          - apply
+                        - required:
+                          - composite
+                        properties:
+                          apply:
+                            description: "Command that consists in applying a given component definition, typically bound to a devworkspace event. \n For example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its `dedicatedPod` field set to `true`. \n When no `apply` command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless `deployByDefault` for that component is set to false."
+                            properties:
+                              component:
+                                description: Describes component that will be applied
+                                type: string
+                              group:
+                                description: Defines the group this command is part of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                type: string
+                            type: object
+                          attributes:
+                            description: Map of implementation-dependant free-form YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          commandType:
+                            description: Type of devworkspace command
+                            enum:
+                            - Exec
+                            - Apply
+                            - Composite
+                            type: string
+                          composite:
+                            description: Composite command that allows executing several sub-commands either sequentially or concurrently
+                            properties:
+                              commands:
+                                description: The commands that comprise this composite command
+                                items:
+                                  type: string
+                                type: array
+                              group:
+                                description: Defines the group this command is part of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                type: string
+                              parallel:
+                                description: Indicates if the sub-commands should be executed concurrently
+                                type: boolean
+                            type: object
+                          exec:
+                            description: CLI Command executed in an existing component container
+                            properties:
+                              commandLine:
+                                description: "The actual command-line string \n Special variables that can be used: \n  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping. \n  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                                type: string
+                              component:
+                                description: Describes component to which given action relates
+                                type: string
+                              env:
+                                description: Optional list of environment variables that have to be set before running the command
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              group:
+                                description: Defines the group this command is part of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              hotReloadCapable:
+                                description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                type: boolean
+                              label:
+                                description: Optional label that provides a label for this command to be used in Editor UI menus for example
+                                type: string
+                              workingDir:
+                                description: "Working directory where the command should be executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping. \n  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                                type: string
+                            type: object
+                          id:
+                            description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - id
+                        type: object
+                      type: array
+                    components:
+                      description: Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - container
+                        - required:
+                          - kubernetes
+                        - required:
+                          - openshift
+                        - required:
+                          - volume
+                        - required:
+                          - image
+                        properties:
+                          attributes:
+                            description: Map of implementation-dependant free-form YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          componentType:
+                            description: Type of component
+                            enum:
+                            - Container
+                            - Kubernetes
+                            - Openshift
+                            - Volume
+                            - Image
+                            type: string
+                          container:
+                            description: Allows adding and configuring devworkspace-related containers
+                            properties:
+                              annotation:
+                                description: Annotations that should be added to specific resources for this container
+                                properties:
+                                  deployment:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to deployment
+                                    type: object
+                                  service:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to service
+                                    type: object
+                                type: object
+                              args:
+                                description: "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command. \n Defaults to an empty array, meaning use whatever is defined in the image."
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                description: "The command to run in the dockerimage component instead of the default one provided in the image. \n Defaults to an empty array, meaning use whatever is defined in the image."
+                                items:
+                                  type: string
+                                type: array
+                              cpuLimit:
+                                type: string
+                              cpuRequest:
+                                type: string
+                              dedicatedPod:
+                                description: "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address. \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the container component. The same port cannot be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              env:
+                                description: "Environment variables used in this container. \n The following variables are reserved and cannot be overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              memoryLimit:
+                                type: string
+                              memoryRequest:
+                                type: string
+                              mountSources:
+                                description: "Toggles whether or not the project source code should be mounted in the component. \n Defaults to true for all component types except plugins and components that set `dedicatedPod` to true."
+                                type: boolean
+                              sourceMapping:
+                                description: Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.
+                                type: string
+                              volumeMounts:
+                                description: List of volumes mounts that should be mounted is this container.
+                                items:
+                                  description: Volume that should be mounted to a component container
+                                  properties:
+                                    name:
+                                      description: The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/<name>`.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          image:
+                            description: Allows specifying the definition of an image for outer loop builds
+                            oneOf:
+                            - required:
+                              - dockerfile
+                            - required:
+                              - autoBuild
+                            properties:
+                              autoBuild:
+                                description: "Defines if the image should be built during startup. \n Default value is `false`"
+                                type: boolean
+                              dockerfile:
+                                description: Allows specifying dockerfile type build
+                                oneOf:
+                                - required:
+                                  - uri
+                                - required:
+                                  - devfileRegistry
+                                - required:
+                                  - git
+                                properties:
+                                  args:
+                                    description: The arguments to supply to the dockerfile build.
+                                    items:
+                                      type: string
+                                    type: array
+                                  buildContext:
+                                    description: Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container
+                                    type: string
+                                  devfileRegistry:
+                                    description: Dockerfile's Devfile Registry source
+                                    properties:
+                                      id:
+                                        description: Id in a devfile registry that contains a Dockerfile. The src in the OCI registry required for the Dockerfile build will be downloaded for building the image.
+                                        type: string
+                                      registryUrl:
+                                        description: Devfile Registry URL to pull the Dockerfile from when using the Devfile Registry as Dockerfile src. To ensure the Dockerfile gets resolved consistently in different environments, it is recommended to always specify the `devfileRegistryUrl` when `Id` is used.
+                                        type: string
+                                    type: object
+                                  git:
+                                    description: Dockerfile's Git source
+                                    properties:
+                                      checkoutFrom:
+                                        description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                                        properties:
+                                          remote:
+                                            description: The remote name should be used as init. Required if there are more than one remote configured
+                                            type: string
+                                          revision:
+                                            description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                                            type: string
+                                        type: object
+                                      fileLocation:
+                                        description: Location of the Dockerfile in the Git repository when using git as Dockerfile src. Defaults to Dockerfile.
+                                        type: string
+                                      remotes:
+                                        additionalProperties:
+                                          type: string
+                                        description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                        type: object
+                                    type: object
+                                  rootRequired:
+                                    description: "Specify if a privileged builder pod is required. \n Default value is `false`"
+                                    type: boolean
+                                  srcType:
+                                    description: Type of Dockerfile src
+                                    enum:
+                                    - Uri
+                                    - DevfileRegistry
+                                    - Git
+                                    type: string
+                                  uri:
+                                    description: URI Reference of a Dockerfile. It can be a full URL or a relative URI from the current devfile as the base URI.
+                                    type: string
+                                type: object
+                              imageName:
+                                description: Name of the image for the resulting outerloop build
+                                type: string
+                              imageType:
+                                description: Type of image
+                                enum:
+                                - Dockerfile
+                                - AutoBuild
+                                type: string
+                            type: object
+                          kubernetes:
+                            description: Allows importing into the devworkspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address. \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the container component. The same port cannot be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          name:
+                            description: Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          openshift:
+                            description: Allows importing into the devworkspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant string-based free-form attributes. \n Examples of Che-specific attributes: \n - cookiesAuthEnabled: \"true\" / \"false\", \n - type: \"terminal\" / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should be exposed on the network. \n - `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route. \n - `internal` means that the endpoint will be exposed internally outside of the main devworkspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network. \n - `none` means that the endpoint will not be exposed and will only be accessible inside the main devworkspace POD, on a local address. \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and transport protocols of the traffic that will go through this endpoint. \n - `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`. \n - `https`: Endpoint will have `https` traffic, typically on a TCP connection. \n - `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`. \n - `wss`: Endpoint will have `wss` traffic, typically on a TCP connection. \n - `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol. \n - `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol. \n Default value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the container component. The same port cannot be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          volume:
+                            description: Allows specifying the definition of a volume shared by several other components
+                            properties:
+                              ephemeral:
+                                description: Ephemeral volumes are not stored persistently across restarts. Defaults to false
+                                type: boolean
+                              size:
+                                description: Size of the volume
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    id:
+                      description: Id in a registry that contains a Devfile yaml file
+                      type: string
+                    importReferenceType:
+                      description: type of location from where the referenced template structure should be retrieved
+                      enum:
+                      - Uri
+                      - Id
+                      - Kubernetes
+                      type: string
+                    kubernetes:
+                      description: Reference to a Kubernetes CRD of type DevWorkspaceTemplate
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    name:
+                      description: Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    registryUrl:
+                      description: Registry URL to pull the parent devfile from when using id in the parent reference. To ensure the parent devfile gets resolved consistently in different environments, it is recommended to always specify the `registryUrl` when `id` is used.
+                      type: string
+                    uri:
+                      description: URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.
+                      type: string
+                    version:
+                      description: Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.
+                      pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               routingClass:
                 type: string
               started:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -10545,6 +10545,857 @@ spec:
           spec:
             description: DevWorkspaceSpec defines the desired state of DevWorkspace
             properties:
+              contributions:
+                items:
+                  oneOf:
+                  - required:
+                    - uri
+                  - required:
+                    - id
+                  - required:
+                    - kubernetes
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML
+                        attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    commands:
+                      description: Overrides of commands encapsulated in a parent
+                        devfile or a plugin. Overriding is done according to K8S strategic
+                        merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - exec
+                        - required:
+                          - apply
+                        - required:
+                          - composite
+                        properties:
+                          apply:
+                            description: "Command that consists in applying a given
+                              component definition, typically bound to a devworkspace
+                              event. \n For example, when an `apply` command is bound
+                              to a `preStart` event, and references a `container`
+                              component, it will start the container as a K8S initContainer
+                              in the devworkspace POD, unless the component has its
+                              `dedicatedPod` field set to `true`. \n When no `apply`
+                              command exist for a given component, it is assumed the
+                              component will be applied at devworkspace start by default,
+                              unless `deployByDefault` for that component is set to
+                              false."
+                            properties:
+                              component:
+                                description: Describes component that will be applied
+                                type: string
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                            type: object
+                          attributes:
+                            description: Map of implementation-dependant free-form
+                              YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          commandType:
+                            description: Type of devworkspace command
+                            enum:
+                            - Exec
+                            - Apply
+                            - Composite
+                            type: string
+                          composite:
+                            description: Composite command that allows executing several
+                              sub-commands either sequentially or concurrently
+                            properties:
+                              commands:
+                                description: The commands that comprise this composite
+                                  command
+                                items:
+                                  type: string
+                                type: array
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                              parallel:
+                                description: Indicates if the sub-commands should
+                                  be executed concurrently
+                                type: boolean
+                            type: object
+                          exec:
+                            description: CLI Command executed in an existing component
+                              container
+                            properties:
+                              commandLine:
+                                description: "The actual command-line string \n Special
+                                  variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                  A path where projects sources are mounted as defined
+                                  by container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                  A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
+                                type: string
+                              component:
+                                description: Describes component to which given action
+                                  relates
+                                type: string
+                              env:
+                                description: Optional list of environment variables
+                                  that have to be set before running the command
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              hotReloadCapable:
+                                description: "Whether the command is capable to reload
+                                  itself when source code changes. If set to `true`
+                                  the command won't be restarted and it is expected
+                                  to handle file changes on its own. \n Default value
+                                  is `false`"
+                                type: boolean
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                              workingDir:
+                                description: "Working directory where the command
+                                  should be executed \n Special variables that can
+                                  be used: \n  - `$PROJECTS_ROOT`: A path where projects
+                                  sources are mounted as defined by container component's
+                                  sourceMapping. \n  - `$PROJECT_SOURCE`: A path to
+                                  a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
+                                type: string
+                            type: object
+                          id:
+                            description: Mandatory identifier that allows referencing
+                              this command in composite commands, from a parent, or
+                              in events.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - id
+                        type: object
+                      type: array
+                    components:
+                      description: Overrides of components encapsulated in a parent
+                        devfile or a plugin. Overriding is done according to K8S strategic
+                        merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - container
+                        - required:
+                          - kubernetes
+                        - required:
+                          - openshift
+                        - required:
+                          - volume
+                        - required:
+                          - image
+                        properties:
+                          attributes:
+                            description: Map of implementation-dependant free-form
+                              YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          componentType:
+                            description: Type of component
+                            enum:
+                            - Container
+                            - Kubernetes
+                            - Openshift
+                            - Volume
+                            - Image
+                            type: string
+                          container:
+                            description: Allows adding and configuring devworkspace-related
+                              containers
+                            properties:
+                              annotation:
+                                description: Annotations that should be added to specific
+                                  resources for this container
+                                properties:
+                                  deployment:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to deployment
+                                    type: object
+                                  service:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to service
+                                    type: object
+                                type: object
+                              args:
+                                description: "The arguments to supply to the command
+                                  running the dockerimage component. The arguments
+                                  are supplied either to the default command provided
+                                  in the image or to the overridden command. \n Defaults
+                                  to an empty array, meaning use whatever is defined
+                                  in the image."
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                description: "The command to run in the dockerimage
+                                  component instead of the default one provided in
+                                  the image. \n Defaults to an empty array, meaning
+                                  use whatever is defined in the image."
+                                items:
+                                  type: string
+                                type: array
+                              cpuLimit:
+                                type: string
+                              cpuRequest:
+                                type: string
+                              dedicatedPod:
+                                description: "Specify if a container should run in
+                                  its own separated pod, instead of running as part
+                                  of the main development environment pod. \n Default
+                                  value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              env:
+                                description: "Environment variables used in this container.
+                                  \n The following variables are reserved and cannot
+                                  be overridden via env: \n  - `$PROJECTS_ROOT` \n
+                                  \ - `$PROJECT_SOURCE`"
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              memoryLimit:
+                                type: string
+                              memoryRequest:
+                                type: string
+                              mountSources:
+                                description: "Toggles whether or not the project source
+                                  code should be mounted in the component. \n Defaults
+                                  to true for all component types except plugins and
+                                  components that set `dedicatedPod` to true."
+                                type: boolean
+                              sourceMapping:
+                                description: Optional specification of the path in
+                                  the container where project sources should be transferred/mounted
+                                  when `mountSources` is `true`. When omitted, the
+                                  default value of /projects is used.
+                                type: string
+                              volumeMounts:
+                                description: List of volumes mounts that should be
+                                  mounted is this container.
+                                items:
+                                  description: Volume that should be mounted to a
+                                    component container
+                                  properties:
+                                    name:
+                                      description: The volume mount name is the name
+                                        of an existing `Volume` component. If several
+                                        containers mount the same volume name then
+                                        they will reuse the same volume and will be
+                                        able to access to the same files.
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: The path in the component container
+                                        where the volume should be mounted. If not
+                                        path is mentioned, default path is the is
+                                        `/<name>`.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          image:
+                            description: Allows specifying the definition of an image
+                              for outer loop builds
+                            oneOf:
+                            - required:
+                              - dockerfile
+                            - required:
+                              - autoBuild
+                            properties:
+                              autoBuild:
+                                description: "Defines if the image should be built
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              dockerfile:
+                                description: Allows specifying dockerfile type build
+                                oneOf:
+                                - required:
+                                  - uri
+                                - required:
+                                  - devfileRegistry
+                                - required:
+                                  - git
+                                properties:
+                                  args:
+                                    description: The arguments to supply to the dockerfile
+                                      build.
+                                    items:
+                                      type: string
+                                    type: array
+                                  buildContext:
+                                    description: Path of source directory to establish
+                                      build context. Defaults to ${PROJECT_SOURCE}
+                                      in the container
+                                    type: string
+                                  devfileRegistry:
+                                    description: Dockerfile's Devfile Registry source
+                                    properties:
+                                      id:
+                                        description: Id in a devfile registry that
+                                          contains a Dockerfile. The src in the OCI
+                                          registry required for the Dockerfile build
+                                          will be downloaded for building the image.
+                                        type: string
+                                      registryUrl:
+                                        description: Devfile Registry URL to pull
+                                          the Dockerfile from when using the Devfile
+                                          Registry as Dockerfile src. To ensure the
+                                          Dockerfile gets resolved consistently in
+                                          different environments, it is recommended
+                                          to always specify the `devfileRegistryUrl`
+                                          when `Id` is used.
+                                        type: string
+                                    type: object
+                                  git:
+                                    description: Dockerfile's Git source
+                                    properties:
+                                      checkoutFrom:
+                                        description: Defines from what the project
+                                          should be checked out. Required if there
+                                          are more than one remote configured
+                                        properties:
+                                          remote:
+                                            description: The remote name should be
+                                              used as init. Required if there are
+                                              more than one remote configured
+                                            type: string
+                                          revision:
+                                            description: The revision to checkout
+                                              from. Should be branch name, tag or
+                                              commit id. Default branch is used if
+                                              missing or specified revision is not
+                                              found.
+                                            type: string
+                                        type: object
+                                      fileLocation:
+                                        description: Location of the Dockerfile in
+                                          the Git repository when using git as Dockerfile
+                                          src. Defaults to Dockerfile.
+                                        type: string
+                                      remotes:
+                                        additionalProperties:
+                                          type: string
+                                        description: The remotes map which should
+                                          be initialized in the git project. Projects
+                                          must have at least one remote configured
+                                          while StarterProjects & Image Component's
+                                          Git source can only have at most one remote
+                                          configured.
+                                        type: object
+                                    type: object
+                                  rootRequired:
+                                    description: "Specify if a privileged builder
+                                      pod is required. \n Default value is `false`"
+                                    type: boolean
+                                  srcType:
+                                    description: Type of Dockerfile src
+                                    enum:
+                                    - Uri
+                                    - DevfileRegistry
+                                    - Git
+                                    type: string
+                                  uri:
+                                    description: URI Reference of a Dockerfile. It
+                                      can be a full URL or a relative URI from the
+                                      current devfile as the base URI.
+                                    type: string
+                                type: object
+                              imageName:
+                                description: Name of the image for the resulting outerloop
+                                  build
+                                type: string
+                              imageType:
+                                description: Type of image
+                                enum:
+                                - Dockerfile
+                                - AutoBuild
+                                type: string
+                            type: object
+                          kubernetes:
+                            description: Allows importing into the devworkspace the
+                              Kubernetes resources defined in a given manifest. For
+                              example this allows reusing the Kubernetes definitions
+                              used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          name:
+                            description: Mandatory name that allows referencing the
+                              component from other elements (such as commands) or
+                              from an external devfile that may reference this component
+                              through a parent or a plugin.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          openshift:
+                            description: Allows importing into the devworkspace the
+                              OpenShift resources defined in a given manifest. For
+                              example this allows reusing the OpenShift definitions
+                              used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          volume:
+                            description: Allows specifying the definition of a volume
+                              shared by several other components
+                            properties:
+                              ephemeral:
+                                description: Ephemeral volumes are not stored persistently
+                                  across restarts. Defaults to false
+                                type: boolean
+                              size:
+                                description: Size of the volume
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    id:
+                      description: Id in a registry that contains a Devfile yaml file
+                      type: string
+                    importReferenceType:
+                      description: type of location from where the referenced template
+                        structure should be retrieved
+                      enum:
+                      - Uri
+                      - Id
+                      - Kubernetes
+                      type: string
+                    kubernetes:
+                      description: Reference to a Kubernetes CRD of type DevWorkspaceTemplate
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    name:
+                      description: Mandatory name that allows referencing the component
+                        from other elements (such as commands) or from an external
+                        devfile that may reference this component through a parent
+                        or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    registryUrl:
+                      description: Registry URL to pull the parent devfile from when
+                        using id in the parent reference. To ensure the parent devfile
+                        gets resolved consistently in different environments, it is
+                        recommended to always specify the `registryUrl` when `id`
+                        is used.
+                      type: string
+                    uri:
+                      description: URI Reference of a parent devfile YAML file. It
+                        can be a full URL or a relative URI with the current devfile
+                        as the base URI.
+                      type: string
+                    version:
+                      description: Specific stack/sample version to pull the parent
+                        devfile from, when using id in the parent reference. To specify
+                        `version`, `id` must be defined and used as the import reference
+                        source. `version` can be either a specific stack version,
+                        or `latest`. If no `version` specified, default version will
+                        be used.
+                      pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               routingClass:
                 type: string
               started:

--- a/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -4145,6 +4145,857 @@ spec:
           spec:
             description: DevWorkspaceSpec defines the desired state of DevWorkspace
             properties:
+              contributions:
+                items:
+                  oneOf:
+                  - required:
+                    - uri
+                  - required:
+                    - id
+                  - required:
+                    - kubernetes
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML
+                        attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    commands:
+                      description: Overrides of commands encapsulated in a parent
+                        devfile or a plugin. Overriding is done according to K8S strategic
+                        merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - exec
+                        - required:
+                          - apply
+                        - required:
+                          - composite
+                        properties:
+                          apply:
+                            description: "Command that consists in applying a given
+                              component definition, typically bound to a devworkspace
+                              event. \n For example, when an `apply` command is bound
+                              to a `preStart` event, and references a `container`
+                              component, it will start the container as a K8S initContainer
+                              in the devworkspace POD, unless the component has its
+                              `dedicatedPod` field set to `true`. \n When no `apply`
+                              command exist for a given component, it is assumed the
+                              component will be applied at devworkspace start by default,
+                              unless `deployByDefault` for that component is set to
+                              false."
+                            properties:
+                              component:
+                                description: Describes component that will be applied
+                                type: string
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                            type: object
+                          attributes:
+                            description: Map of implementation-dependant free-form
+                              YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          commandType:
+                            description: Type of devworkspace command
+                            enum:
+                            - Exec
+                            - Apply
+                            - Composite
+                            type: string
+                          composite:
+                            description: Composite command that allows executing several
+                              sub-commands either sequentially or concurrently
+                            properties:
+                              commands:
+                                description: The commands that comprise this composite
+                                  command
+                                items:
+                                  type: string
+                                type: array
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                              parallel:
+                                description: Indicates if the sub-commands should
+                                  be executed concurrently
+                                type: boolean
+                            type: object
+                          exec:
+                            description: CLI Command executed in an existing component
+                              container
+                            properties:
+                              commandLine:
+                                description: "The actual command-line string \n Special
+                                  variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                  A path where projects sources are mounted as defined
+                                  by container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                  A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
+                                type: string
+                              component:
+                                description: Describes component to which given action
+                                  relates
+                                type: string
+                              env:
+                                description: Optional list of environment variables
+                                  that have to be set before running the command
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              hotReloadCapable:
+                                description: "Whether the command is capable to reload
+                                  itself when source code changes. If set to `true`
+                                  the command won't be restarted and it is expected
+                                  to handle file changes on its own. \n Default value
+                                  is `false`"
+                                type: boolean
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                              workingDir:
+                                description: "Working directory where the command
+                                  should be executed \n Special variables that can
+                                  be used: \n  - `$PROJECTS_ROOT`: A path where projects
+                                  sources are mounted as defined by container component's
+                                  sourceMapping. \n  - `$PROJECT_SOURCE`: A path to
+                                  a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
+                                type: string
+                            type: object
+                          id:
+                            description: Mandatory identifier that allows referencing
+                              this command in composite commands, from a parent, or
+                              in events.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - id
+                        type: object
+                      type: array
+                    components:
+                      description: Overrides of components encapsulated in a parent
+                        devfile or a plugin. Overriding is done according to K8S strategic
+                        merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - container
+                        - required:
+                          - kubernetes
+                        - required:
+                          - openshift
+                        - required:
+                          - volume
+                        - required:
+                          - image
+                        properties:
+                          attributes:
+                            description: Map of implementation-dependant free-form
+                              YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          componentType:
+                            description: Type of component
+                            enum:
+                            - Container
+                            - Kubernetes
+                            - Openshift
+                            - Volume
+                            - Image
+                            type: string
+                          container:
+                            description: Allows adding and configuring devworkspace-related
+                              containers
+                            properties:
+                              annotation:
+                                description: Annotations that should be added to specific
+                                  resources for this container
+                                properties:
+                                  deployment:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to deployment
+                                    type: object
+                                  service:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to service
+                                    type: object
+                                type: object
+                              args:
+                                description: "The arguments to supply to the command
+                                  running the dockerimage component. The arguments
+                                  are supplied either to the default command provided
+                                  in the image or to the overridden command. \n Defaults
+                                  to an empty array, meaning use whatever is defined
+                                  in the image."
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                description: "The command to run in the dockerimage
+                                  component instead of the default one provided in
+                                  the image. \n Defaults to an empty array, meaning
+                                  use whatever is defined in the image."
+                                items:
+                                  type: string
+                                type: array
+                              cpuLimit:
+                                type: string
+                              cpuRequest:
+                                type: string
+                              dedicatedPod:
+                                description: "Specify if a container should run in
+                                  its own separated pod, instead of running as part
+                                  of the main development environment pod. \n Default
+                                  value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              env:
+                                description: "Environment variables used in this container.
+                                  \n The following variables are reserved and cannot
+                                  be overridden via env: \n  - `$PROJECTS_ROOT` \n
+                                  \ - `$PROJECT_SOURCE`"
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              memoryLimit:
+                                type: string
+                              memoryRequest:
+                                type: string
+                              mountSources:
+                                description: "Toggles whether or not the project source
+                                  code should be mounted in the component. \n Defaults
+                                  to true for all component types except plugins and
+                                  components that set `dedicatedPod` to true."
+                                type: boolean
+                              sourceMapping:
+                                description: Optional specification of the path in
+                                  the container where project sources should be transferred/mounted
+                                  when `mountSources` is `true`. When omitted, the
+                                  default value of /projects is used.
+                                type: string
+                              volumeMounts:
+                                description: List of volumes mounts that should be
+                                  mounted is this container.
+                                items:
+                                  description: Volume that should be mounted to a
+                                    component container
+                                  properties:
+                                    name:
+                                      description: The volume mount name is the name
+                                        of an existing `Volume` component. If several
+                                        containers mount the same volume name then
+                                        they will reuse the same volume and will be
+                                        able to access to the same files.
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: The path in the component container
+                                        where the volume should be mounted. If not
+                                        path is mentioned, default path is the is
+                                        `/<name>`.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          image:
+                            description: Allows specifying the definition of an image
+                              for outer loop builds
+                            oneOf:
+                            - required:
+                              - dockerfile
+                            - required:
+                              - autoBuild
+                            properties:
+                              autoBuild:
+                                description: "Defines if the image should be built
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              dockerfile:
+                                description: Allows specifying dockerfile type build
+                                oneOf:
+                                - required:
+                                  - uri
+                                - required:
+                                  - devfileRegistry
+                                - required:
+                                  - git
+                                properties:
+                                  args:
+                                    description: The arguments to supply to the dockerfile
+                                      build.
+                                    items:
+                                      type: string
+                                    type: array
+                                  buildContext:
+                                    description: Path of source directory to establish
+                                      build context. Defaults to ${PROJECT_SOURCE}
+                                      in the container
+                                    type: string
+                                  devfileRegistry:
+                                    description: Dockerfile's Devfile Registry source
+                                    properties:
+                                      id:
+                                        description: Id in a devfile registry that
+                                          contains a Dockerfile. The src in the OCI
+                                          registry required for the Dockerfile build
+                                          will be downloaded for building the image.
+                                        type: string
+                                      registryUrl:
+                                        description: Devfile Registry URL to pull
+                                          the Dockerfile from when using the Devfile
+                                          Registry as Dockerfile src. To ensure the
+                                          Dockerfile gets resolved consistently in
+                                          different environments, it is recommended
+                                          to always specify the `devfileRegistryUrl`
+                                          when `Id` is used.
+                                        type: string
+                                    type: object
+                                  git:
+                                    description: Dockerfile's Git source
+                                    properties:
+                                      checkoutFrom:
+                                        description: Defines from what the project
+                                          should be checked out. Required if there
+                                          are more than one remote configured
+                                        properties:
+                                          remote:
+                                            description: The remote name should be
+                                              used as init. Required if there are
+                                              more than one remote configured
+                                            type: string
+                                          revision:
+                                            description: The revision to checkout
+                                              from. Should be branch name, tag or
+                                              commit id. Default branch is used if
+                                              missing or specified revision is not
+                                              found.
+                                            type: string
+                                        type: object
+                                      fileLocation:
+                                        description: Location of the Dockerfile in
+                                          the Git repository when using git as Dockerfile
+                                          src. Defaults to Dockerfile.
+                                        type: string
+                                      remotes:
+                                        additionalProperties:
+                                          type: string
+                                        description: The remotes map which should
+                                          be initialized in the git project. Projects
+                                          must have at least one remote configured
+                                          while StarterProjects & Image Component's
+                                          Git source can only have at most one remote
+                                          configured.
+                                        type: object
+                                    type: object
+                                  rootRequired:
+                                    description: "Specify if a privileged builder
+                                      pod is required. \n Default value is `false`"
+                                    type: boolean
+                                  srcType:
+                                    description: Type of Dockerfile src
+                                    enum:
+                                    - Uri
+                                    - DevfileRegistry
+                                    - Git
+                                    type: string
+                                  uri:
+                                    description: URI Reference of a Dockerfile. It
+                                      can be a full URL or a relative URI from the
+                                      current devfile as the base URI.
+                                    type: string
+                                type: object
+                              imageName:
+                                description: Name of the image for the resulting outerloop
+                                  build
+                                type: string
+                              imageType:
+                                description: Type of image
+                                enum:
+                                - Dockerfile
+                                - AutoBuild
+                                type: string
+                            type: object
+                          kubernetes:
+                            description: Allows importing into the devworkspace the
+                              Kubernetes resources defined in a given manifest. For
+                              example this allows reusing the Kubernetes definitions
+                              used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          name:
+                            description: Mandatory name that allows referencing the
+                              component from other elements (such as commands) or
+                              from an external devfile that may reference this component
+                              through a parent or a plugin.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          openshift:
+                            description: Allows importing into the devworkspace the
+                              OpenShift resources defined in a given manifest. For
+                              example this allows reusing the OpenShift definitions
+                              used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          volume:
+                            description: Allows specifying the definition of a volume
+                              shared by several other components
+                            properties:
+                              ephemeral:
+                                description: Ephemeral volumes are not stored persistently
+                                  across restarts. Defaults to false
+                                type: boolean
+                              size:
+                                description: Size of the volume
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    id:
+                      description: Id in a registry that contains a Devfile yaml file
+                      type: string
+                    importReferenceType:
+                      description: type of location from where the referenced template
+                        structure should be retrieved
+                      enum:
+                      - Uri
+                      - Id
+                      - Kubernetes
+                      type: string
+                    kubernetes:
+                      description: Reference to a Kubernetes CRD of type DevWorkspaceTemplate
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    name:
+                      description: Mandatory name that allows referencing the component
+                        from other elements (such as commands) or from an external
+                        devfile that may reference this component through a parent
+                        or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    registryUrl:
+                      description: Registry URL to pull the parent devfile from when
+                        using id in the parent reference. To ensure the parent devfile
+                        gets resolved consistently in different environments, it is
+                        recommended to always specify the `registryUrl` when `id`
+                        is used.
+                      type: string
+                    uri:
+                      description: URI Reference of a parent devfile YAML file. It
+                        can be a full URL or a relative URI with the current devfile
+                        as the base URI.
+                      type: string
+                    version:
+                      description: Specific stack/sample version to pull the parent
+                        devfile from, when using id in the parent reference. To specify
+                        `version`, `id` must be defined and used as the import reference
+                        source. `version` can be either a specific stack version,
+                        or `latest`. If no `version` specified, default version will
+                        be used.
+                      pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               routingClass:
                 type: string
               started:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -10545,6 +10545,857 @@ spec:
           spec:
             description: DevWorkspaceSpec defines the desired state of DevWorkspace
             properties:
+              contributions:
+                items:
+                  oneOf:
+                  - required:
+                    - uri
+                  - required:
+                    - id
+                  - required:
+                    - kubernetes
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML
+                        attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    commands:
+                      description: Overrides of commands encapsulated in a parent
+                        devfile or a plugin. Overriding is done according to K8S strategic
+                        merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - exec
+                        - required:
+                          - apply
+                        - required:
+                          - composite
+                        properties:
+                          apply:
+                            description: "Command that consists in applying a given
+                              component definition, typically bound to a devworkspace
+                              event. \n For example, when an `apply` command is bound
+                              to a `preStart` event, and references a `container`
+                              component, it will start the container as a K8S initContainer
+                              in the devworkspace POD, unless the component has its
+                              `dedicatedPod` field set to `true`. \n When no `apply`
+                              command exist for a given component, it is assumed the
+                              component will be applied at devworkspace start by default,
+                              unless `deployByDefault` for that component is set to
+                              false."
+                            properties:
+                              component:
+                                description: Describes component that will be applied
+                                type: string
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                            type: object
+                          attributes:
+                            description: Map of implementation-dependant free-form
+                              YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          commandType:
+                            description: Type of devworkspace command
+                            enum:
+                            - Exec
+                            - Apply
+                            - Composite
+                            type: string
+                          composite:
+                            description: Composite command that allows executing several
+                              sub-commands either sequentially or concurrently
+                            properties:
+                              commands:
+                                description: The commands that comprise this composite
+                                  command
+                                items:
+                                  type: string
+                                type: array
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                              parallel:
+                                description: Indicates if the sub-commands should
+                                  be executed concurrently
+                                type: boolean
+                            type: object
+                          exec:
+                            description: CLI Command executed in an existing component
+                              container
+                            properties:
+                              commandLine:
+                                description: "The actual command-line string \n Special
+                                  variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                  A path where projects sources are mounted as defined
+                                  by container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                  A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
+                                type: string
+                              component:
+                                description: Describes component to which given action
+                                  relates
+                                type: string
+                              env:
+                                description: Optional list of environment variables
+                                  that have to be set before running the command
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              hotReloadCapable:
+                                description: "Whether the command is capable to reload
+                                  itself when source code changes. If set to `true`
+                                  the command won't be restarted and it is expected
+                                  to handle file changes on its own. \n Default value
+                                  is `false`"
+                                type: boolean
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                              workingDir:
+                                description: "Working directory where the command
+                                  should be executed \n Special variables that can
+                                  be used: \n  - `$PROJECTS_ROOT`: A path where projects
+                                  sources are mounted as defined by container component's
+                                  sourceMapping. \n  - `$PROJECT_SOURCE`: A path to
+                                  a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
+                                type: string
+                            type: object
+                          id:
+                            description: Mandatory identifier that allows referencing
+                              this command in composite commands, from a parent, or
+                              in events.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - id
+                        type: object
+                      type: array
+                    components:
+                      description: Overrides of components encapsulated in a parent
+                        devfile or a plugin. Overriding is done according to K8S strategic
+                        merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - container
+                        - required:
+                          - kubernetes
+                        - required:
+                          - openshift
+                        - required:
+                          - volume
+                        - required:
+                          - image
+                        properties:
+                          attributes:
+                            description: Map of implementation-dependant free-form
+                              YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          componentType:
+                            description: Type of component
+                            enum:
+                            - Container
+                            - Kubernetes
+                            - Openshift
+                            - Volume
+                            - Image
+                            type: string
+                          container:
+                            description: Allows adding and configuring devworkspace-related
+                              containers
+                            properties:
+                              annotation:
+                                description: Annotations that should be added to specific
+                                  resources for this container
+                                properties:
+                                  deployment:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to deployment
+                                    type: object
+                                  service:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to service
+                                    type: object
+                                type: object
+                              args:
+                                description: "The arguments to supply to the command
+                                  running the dockerimage component. The arguments
+                                  are supplied either to the default command provided
+                                  in the image or to the overridden command. \n Defaults
+                                  to an empty array, meaning use whatever is defined
+                                  in the image."
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                description: "The command to run in the dockerimage
+                                  component instead of the default one provided in
+                                  the image. \n Defaults to an empty array, meaning
+                                  use whatever is defined in the image."
+                                items:
+                                  type: string
+                                type: array
+                              cpuLimit:
+                                type: string
+                              cpuRequest:
+                                type: string
+                              dedicatedPod:
+                                description: "Specify if a container should run in
+                                  its own separated pod, instead of running as part
+                                  of the main development environment pod. \n Default
+                                  value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              env:
+                                description: "Environment variables used in this container.
+                                  \n The following variables are reserved and cannot
+                                  be overridden via env: \n  - `$PROJECTS_ROOT` \n
+                                  \ - `$PROJECT_SOURCE`"
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              memoryLimit:
+                                type: string
+                              memoryRequest:
+                                type: string
+                              mountSources:
+                                description: "Toggles whether or not the project source
+                                  code should be mounted in the component. \n Defaults
+                                  to true for all component types except plugins and
+                                  components that set `dedicatedPod` to true."
+                                type: boolean
+                              sourceMapping:
+                                description: Optional specification of the path in
+                                  the container where project sources should be transferred/mounted
+                                  when `mountSources` is `true`. When omitted, the
+                                  default value of /projects is used.
+                                type: string
+                              volumeMounts:
+                                description: List of volumes mounts that should be
+                                  mounted is this container.
+                                items:
+                                  description: Volume that should be mounted to a
+                                    component container
+                                  properties:
+                                    name:
+                                      description: The volume mount name is the name
+                                        of an existing `Volume` component. If several
+                                        containers mount the same volume name then
+                                        they will reuse the same volume and will be
+                                        able to access to the same files.
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: The path in the component container
+                                        where the volume should be mounted. If not
+                                        path is mentioned, default path is the is
+                                        `/<name>`.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          image:
+                            description: Allows specifying the definition of an image
+                              for outer loop builds
+                            oneOf:
+                            - required:
+                              - dockerfile
+                            - required:
+                              - autoBuild
+                            properties:
+                              autoBuild:
+                                description: "Defines if the image should be built
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              dockerfile:
+                                description: Allows specifying dockerfile type build
+                                oneOf:
+                                - required:
+                                  - uri
+                                - required:
+                                  - devfileRegistry
+                                - required:
+                                  - git
+                                properties:
+                                  args:
+                                    description: The arguments to supply to the dockerfile
+                                      build.
+                                    items:
+                                      type: string
+                                    type: array
+                                  buildContext:
+                                    description: Path of source directory to establish
+                                      build context. Defaults to ${PROJECT_SOURCE}
+                                      in the container
+                                    type: string
+                                  devfileRegistry:
+                                    description: Dockerfile's Devfile Registry source
+                                    properties:
+                                      id:
+                                        description: Id in a devfile registry that
+                                          contains a Dockerfile. The src in the OCI
+                                          registry required for the Dockerfile build
+                                          will be downloaded for building the image.
+                                        type: string
+                                      registryUrl:
+                                        description: Devfile Registry URL to pull
+                                          the Dockerfile from when using the Devfile
+                                          Registry as Dockerfile src. To ensure the
+                                          Dockerfile gets resolved consistently in
+                                          different environments, it is recommended
+                                          to always specify the `devfileRegistryUrl`
+                                          when `Id` is used.
+                                        type: string
+                                    type: object
+                                  git:
+                                    description: Dockerfile's Git source
+                                    properties:
+                                      checkoutFrom:
+                                        description: Defines from what the project
+                                          should be checked out. Required if there
+                                          are more than one remote configured
+                                        properties:
+                                          remote:
+                                            description: The remote name should be
+                                              used as init. Required if there are
+                                              more than one remote configured
+                                            type: string
+                                          revision:
+                                            description: The revision to checkout
+                                              from. Should be branch name, tag or
+                                              commit id. Default branch is used if
+                                              missing or specified revision is not
+                                              found.
+                                            type: string
+                                        type: object
+                                      fileLocation:
+                                        description: Location of the Dockerfile in
+                                          the Git repository when using git as Dockerfile
+                                          src. Defaults to Dockerfile.
+                                        type: string
+                                      remotes:
+                                        additionalProperties:
+                                          type: string
+                                        description: The remotes map which should
+                                          be initialized in the git project. Projects
+                                          must have at least one remote configured
+                                          while StarterProjects & Image Component's
+                                          Git source can only have at most one remote
+                                          configured.
+                                        type: object
+                                    type: object
+                                  rootRequired:
+                                    description: "Specify if a privileged builder
+                                      pod is required. \n Default value is `false`"
+                                    type: boolean
+                                  srcType:
+                                    description: Type of Dockerfile src
+                                    enum:
+                                    - Uri
+                                    - DevfileRegistry
+                                    - Git
+                                    type: string
+                                  uri:
+                                    description: URI Reference of a Dockerfile. It
+                                      can be a full URL or a relative URI from the
+                                      current devfile as the base URI.
+                                    type: string
+                                type: object
+                              imageName:
+                                description: Name of the image for the resulting outerloop
+                                  build
+                                type: string
+                              imageType:
+                                description: Type of image
+                                enum:
+                                - Dockerfile
+                                - AutoBuild
+                                type: string
+                            type: object
+                          kubernetes:
+                            description: Allows importing into the devworkspace the
+                              Kubernetes resources defined in a given manifest. For
+                              example this allows reusing the Kubernetes definitions
+                              used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          name:
+                            description: Mandatory name that allows referencing the
+                              component from other elements (such as commands) or
+                              from an external devfile that may reference this component
+                              through a parent or a plugin.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          openshift:
+                            description: Allows importing into the devworkspace the
+                              OpenShift resources defined in a given manifest. For
+                              example this allows reusing the OpenShift definitions
+                              used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          volume:
+                            description: Allows specifying the definition of a volume
+                              shared by several other components
+                            properties:
+                              ephemeral:
+                                description: Ephemeral volumes are not stored persistently
+                                  across restarts. Defaults to false
+                                type: boolean
+                              size:
+                                description: Size of the volume
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    id:
+                      description: Id in a registry that contains a Devfile yaml file
+                      type: string
+                    importReferenceType:
+                      description: type of location from where the referenced template
+                        structure should be retrieved
+                      enum:
+                      - Uri
+                      - Id
+                      - Kubernetes
+                      type: string
+                    kubernetes:
+                      description: Reference to a Kubernetes CRD of type DevWorkspaceTemplate
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    name:
+                      description: Mandatory name that allows referencing the component
+                        from other elements (such as commands) or from an external
+                        devfile that may reference this component through a parent
+                        or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    registryUrl:
+                      description: Registry URL to pull the parent devfile from when
+                        using id in the parent reference. To ensure the parent devfile
+                        gets resolved consistently in different environments, it is
+                        recommended to always specify the `registryUrl` when `id`
+                        is used.
+                      type: string
+                    uri:
+                      description: URI Reference of a parent devfile YAML file. It
+                        can be a full URL or a relative URI with the current devfile
+                        as the base URI.
+                      type: string
+                    version:
+                      description: Specific stack/sample version to pull the parent
+                        devfile from, when using id in the parent reference. To specify
+                        `version`, `id` must be defined and used as the import reference
+                        source. `version` can be either a specific stack version,
+                        or `latest`. If no `version` specified, default version will
+                        be used.
+                      pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               routingClass:
                 type: string
               started:

--- a/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -4145,6 +4145,857 @@ spec:
           spec:
             description: DevWorkspaceSpec defines the desired state of DevWorkspace
             properties:
+              contributions:
+                items:
+                  oneOf:
+                  - required:
+                    - uri
+                  - required:
+                    - id
+                  - required:
+                    - kubernetes
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML
+                        attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    commands:
+                      description: Overrides of commands encapsulated in a parent
+                        devfile or a plugin. Overriding is done according to K8S strategic
+                        merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - exec
+                        - required:
+                          - apply
+                        - required:
+                          - composite
+                        properties:
+                          apply:
+                            description: "Command that consists in applying a given
+                              component definition, typically bound to a devworkspace
+                              event. \n For example, when an `apply` command is bound
+                              to a `preStart` event, and references a `container`
+                              component, it will start the container as a K8S initContainer
+                              in the devworkspace POD, unless the component has its
+                              `dedicatedPod` field set to `true`. \n When no `apply`
+                              command exist for a given component, it is assumed the
+                              component will be applied at devworkspace start by default,
+                              unless `deployByDefault` for that component is set to
+                              false."
+                            properties:
+                              component:
+                                description: Describes component that will be applied
+                                type: string
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                            type: object
+                          attributes:
+                            description: Map of implementation-dependant free-form
+                              YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          commandType:
+                            description: Type of devworkspace command
+                            enum:
+                            - Exec
+                            - Apply
+                            - Composite
+                            type: string
+                          composite:
+                            description: Composite command that allows executing several
+                              sub-commands either sequentially or concurrently
+                            properties:
+                              commands:
+                                description: The commands that comprise this composite
+                                  command
+                                items:
+                                  type: string
+                                type: array
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                              parallel:
+                                description: Indicates if the sub-commands should
+                                  be executed concurrently
+                                type: boolean
+                            type: object
+                          exec:
+                            description: CLI Command executed in an existing component
+                              container
+                            properties:
+                              commandLine:
+                                description: "The actual command-line string \n Special
+                                  variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                  A path where projects sources are mounted as defined
+                                  by container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
+                                  A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
+                                type: string
+                              component:
+                                description: Describes component to which given action
+                                  relates
+                                type: string
+                              env:
+                                description: Optional list of environment variables
+                                  that have to be set before running the command
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              group:
+                                description: Defines the group this command is part
+                                  of
+                                properties:
+                                  isDefault:
+                                    description: Identifies the default command for
+                                      a given group kind
+                                    type: boolean
+                                  kind:
+                                    description: Kind of group the command is part
+                                      of
+                                    enum:
+                                    - build
+                                    - run
+                                    - test
+                                    - debug
+                                    - deploy
+                                    type: string
+                                type: object
+                              hotReloadCapable:
+                                description: "Whether the command is capable to reload
+                                  itself when source code changes. If set to `true`
+                                  the command won't be restarted and it is expected
+                                  to handle file changes on its own. \n Default value
+                                  is `false`"
+                                type: boolean
+                              label:
+                                description: Optional label that provides a label
+                                  for this command to be used in Editor UI menus for
+                                  example
+                                type: string
+                              workingDir:
+                                description: "Working directory where the command
+                                  should be executed \n Special variables that can
+                                  be used: \n  - `$PROJECTS_ROOT`: A path where projects
+                                  sources are mounted as defined by container component's
+                                  sourceMapping. \n  - `$PROJECT_SOURCE`: A path to
+                                  a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
+                                type: string
+                            type: object
+                          id:
+                            description: Mandatory identifier that allows referencing
+                              this command in composite commands, from a parent, or
+                              in events.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - id
+                        type: object
+                      type: array
+                    components:
+                      description: Overrides of components encapsulated in a parent
+                        devfile or a plugin. Overriding is done according to K8S strategic
+                        merge patch standard rules.
+                      items:
+                        oneOf:
+                        - required:
+                          - container
+                        - required:
+                          - kubernetes
+                        - required:
+                          - openshift
+                        - required:
+                          - volume
+                        - required:
+                          - image
+                        properties:
+                          attributes:
+                            description: Map of implementation-dependant free-form
+                              YAML attributes.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          componentType:
+                            description: Type of component
+                            enum:
+                            - Container
+                            - Kubernetes
+                            - Openshift
+                            - Volume
+                            - Image
+                            type: string
+                          container:
+                            description: Allows adding and configuring devworkspace-related
+                              containers
+                            properties:
+                              annotation:
+                                description: Annotations that should be added to specific
+                                  resources for this container
+                                properties:
+                                  deployment:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to deployment
+                                    type: object
+                                  service:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations to be added to service
+                                    type: object
+                                type: object
+                              args:
+                                description: "The arguments to supply to the command
+                                  running the dockerimage component. The arguments
+                                  are supplied either to the default command provided
+                                  in the image or to the overridden command. \n Defaults
+                                  to an empty array, meaning use whatever is defined
+                                  in the image."
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                description: "The command to run in the dockerimage
+                                  component instead of the default one provided in
+                                  the image. \n Defaults to an empty array, meaning
+                                  use whatever is defined in the image."
+                                items:
+                                  type: string
+                                type: array
+                              cpuLimit:
+                                type: string
+                              cpuRequest:
+                                type: string
+                              dedicatedPod:
+                                description: "Specify if a container should run in
+                                  its own separated pod, instead of running as part
+                                  of the main development environment pod. \n Default
+                                  value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              env:
+                                description: "Environment variables used in this container.
+                                  \n The following variables are reserved and cannot
+                                  be overridden via env: \n  - `$PROJECTS_ROOT` \n
+                                  \ - `$PROJECT_SOURCE`"
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              memoryLimit:
+                                type: string
+                              memoryRequest:
+                                type: string
+                              mountSources:
+                                description: "Toggles whether or not the project source
+                                  code should be mounted in the component. \n Defaults
+                                  to true for all component types except plugins and
+                                  components that set `dedicatedPod` to true."
+                                type: boolean
+                              sourceMapping:
+                                description: Optional specification of the path in
+                                  the container where project sources should be transferred/mounted
+                                  when `mountSources` is `true`. When omitted, the
+                                  default value of /projects is used.
+                                type: string
+                              volumeMounts:
+                                description: List of volumes mounts that should be
+                                  mounted is this container.
+                                items:
+                                  description: Volume that should be mounted to a
+                                    component container
+                                  properties:
+                                    name:
+                                      description: The volume mount name is the name
+                                        of an existing `Volume` component. If several
+                                        containers mount the same volume name then
+                                        they will reuse the same volume and will be
+                                        able to access to the same files.
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: The path in the component container
+                                        where the volume should be mounted. If not
+                                        path is mentioned, default path is the is
+                                        `/<name>`.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          image:
+                            description: Allows specifying the definition of an image
+                              for outer loop builds
+                            oneOf:
+                            - required:
+                              - dockerfile
+                            - required:
+                              - autoBuild
+                            properties:
+                              autoBuild:
+                                description: "Defines if the image should be built
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              dockerfile:
+                                description: Allows specifying dockerfile type build
+                                oneOf:
+                                - required:
+                                  - uri
+                                - required:
+                                  - devfileRegistry
+                                - required:
+                                  - git
+                                properties:
+                                  args:
+                                    description: The arguments to supply to the dockerfile
+                                      build.
+                                    items:
+                                      type: string
+                                    type: array
+                                  buildContext:
+                                    description: Path of source directory to establish
+                                      build context. Defaults to ${PROJECT_SOURCE}
+                                      in the container
+                                    type: string
+                                  devfileRegistry:
+                                    description: Dockerfile's Devfile Registry source
+                                    properties:
+                                      id:
+                                        description: Id in a devfile registry that
+                                          contains a Dockerfile. The src in the OCI
+                                          registry required for the Dockerfile build
+                                          will be downloaded for building the image.
+                                        type: string
+                                      registryUrl:
+                                        description: Devfile Registry URL to pull
+                                          the Dockerfile from when using the Devfile
+                                          Registry as Dockerfile src. To ensure the
+                                          Dockerfile gets resolved consistently in
+                                          different environments, it is recommended
+                                          to always specify the `devfileRegistryUrl`
+                                          when `Id` is used.
+                                        type: string
+                                    type: object
+                                  git:
+                                    description: Dockerfile's Git source
+                                    properties:
+                                      checkoutFrom:
+                                        description: Defines from what the project
+                                          should be checked out. Required if there
+                                          are more than one remote configured
+                                        properties:
+                                          remote:
+                                            description: The remote name should be
+                                              used as init. Required if there are
+                                              more than one remote configured
+                                            type: string
+                                          revision:
+                                            description: The revision to checkout
+                                              from. Should be branch name, tag or
+                                              commit id. Default branch is used if
+                                              missing or specified revision is not
+                                              found.
+                                            type: string
+                                        type: object
+                                      fileLocation:
+                                        description: Location of the Dockerfile in
+                                          the Git repository when using git as Dockerfile
+                                          src. Defaults to Dockerfile.
+                                        type: string
+                                      remotes:
+                                        additionalProperties:
+                                          type: string
+                                        description: The remotes map which should
+                                          be initialized in the git project. Projects
+                                          must have at least one remote configured
+                                          while StarterProjects & Image Component's
+                                          Git source can only have at most one remote
+                                          configured.
+                                        type: object
+                                    type: object
+                                  rootRequired:
+                                    description: "Specify if a privileged builder
+                                      pod is required. \n Default value is `false`"
+                                    type: boolean
+                                  srcType:
+                                    description: Type of Dockerfile src
+                                    enum:
+                                    - Uri
+                                    - DevfileRegistry
+                                    - Git
+                                    type: string
+                                  uri:
+                                    description: URI Reference of a Dockerfile. It
+                                      can be a full URL or a relative URI from the
+                                      current devfile as the base URI.
+                                    type: string
+                                type: object
+                              imageName:
+                                description: Name of the image for the resulting outerloop
+                                  build
+                                type: string
+                              imageType:
+                                description: Type of image
+                                enum:
+                                - Dockerfile
+                                - AutoBuild
+                                type: string
+                            type: object
+                          kubernetes:
+                            description: Allows importing into the devworkspace the
+                              Kubernetes resources defined in a given manifest. For
+                              example this allows reusing the Kubernetes definitions
+                              used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          name:
+                            description: Mandatory name that allows referencing the
+                              component from other elements (such as commands) or
+                              from an external devfile that may reference this component
+                              through a parent or a plugin.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          openshift:
+                            description: Allows importing into the devworkspace the
+                              OpenShift resources defined in a given manifest. For
+                              example this allows reusing the OpenShift definitions
+                              used to deploy some runtime components in production.
+                            oneOf:
+                            - required:
+                              - uri
+                            - required:
+                              - inlined
+                            properties:
+                              deployByDefault:
+                                description: "Defines if the component should be deployed
+                                  during startup. \n Default value is `false`"
+                                type: boolean
+                              endpoints:
+                                items:
+                                  properties:
+                                    annotation:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations to be added to Kubernetes
+                                        Ingress or Openshift Route
+                                      type: object
+                                    attributes:
+                                      description: "Map of implementation-dependant
+                                        string-based free-form attributes. \n Examples
+                                        of Che-specific attributes: \n - cookiesAuthEnabled:
+                                        \"true\" / \"false\", \n - type: \"terminal\"
+                                        / \"ide\" / \"ide-dev\","
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    exposure:
+                                      description: "Describes how the endpoint should
+                                        be exposed on the network. \n - `public` means
+                                        that the endpoint will be exposed on the public
+                                        network, typically through a K8S ingress or
+                                        an OpenShift route. \n - `internal` means
+                                        that the endpoint will be exposed internally
+                                        outside of the main devworkspace POD, typically
+                                        by K8S services, to be consumed by other elements
+                                        running on the same cloud internal network.
+                                        \n - `none` means that the endpoint will not
+                                        be exposed and will only be accessible inside
+                                        the main devworkspace POD, on a local address.
+                                        \n Default value is `public`"
+                                      enum:
+                                      - public
+                                      - internal
+                                      - none
+                                      type: string
+                                    name:
+                                      maxLength: 63
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    path:
+                                      description: Path of the endpoint URL
+                                      type: string
+                                    protocol:
+                                      description: "Describes the application and
+                                        transport protocols of the traffic that will
+                                        go through this endpoint. \n - `http`: Endpoint
+                                        will have `http` traffic, typically on a TCP
+                                        connection. It will be automaticaly promoted
+                                        to `https` when the `secure` field is set
+                                        to `true`. \n - `https`: Endpoint will have
+                                        `https` traffic, typically on a TCP connection.
+                                        \n - `ws`: Endpoint will have `ws` traffic,
+                                        typically on a TCP connection. It will be
+                                        automaticaly promoted to `wss` when the `secure`
+                                        field is set to `true`. \n - `wss`: Endpoint
+                                        will have `wss` traffic, typically on a TCP
+                                        connection. \n - `tcp`: Endpoint will have
+                                        traffic on a TCP connection, without specifying
+                                        an application protocol. \n - `udp`: Endpoint
+                                        will have traffic on an UDP connection, without
+                                        specifying an application protocol. \n Default
+                                        value is `http`"
+                                      enum:
+                                      - http
+                                      - https
+                                      - ws
+                                      - wss
+                                      - tcp
+                                      - udp
+                                      type: string
+                                    secure:
+                                      description: Describes whether the endpoint
+                                        should be secured and protected by some authentication
+                                        process. This requires a protocol of `https`
+                                        or `wss`.
+                                      type: boolean
+                                    targetPort:
+                                      description: Port number to be used within the
+                                        container component. The same port cannot
+                                        be used by two different container components.
+                                      type: integer
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              inlined:
+                                description: Inlined manifest
+                                type: string
+                              locationType:
+                                description: Type of Kubernetes-like location
+                                enum:
+                                - Uri
+                                - Inlined
+                                type: string
+                              uri:
+                                description: Location in a file fetched from a uri.
+                                type: string
+                            type: object
+                          volume:
+                            description: Allows specifying the definition of a volume
+                              shared by several other components
+                            properties:
+                              ephemeral:
+                                description: Ephemeral volumes are not stored persistently
+                                  across restarts. Defaults to false
+                                type: boolean
+                              size:
+                                description: Size of the volume
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    id:
+                      description: Id in a registry that contains a Devfile yaml file
+                      type: string
+                    importReferenceType:
+                      description: type of location from where the referenced template
+                        structure should be retrieved
+                      enum:
+                      - Uri
+                      - Id
+                      - Kubernetes
+                      type: string
+                    kubernetes:
+                      description: Reference to a Kubernetes CRD of type DevWorkspaceTemplate
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    name:
+                      description: Mandatory name that allows referencing the component
+                        from other elements (such as commands) or from an external
+                        devfile that may reference this component through a parent
+                        or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    registryUrl:
+                      description: Registry URL to pull the parent devfile from when
+                        using id in the parent reference. To ensure the parent devfile
+                        gets resolved consistently in different environments, it is
+                        recommended to always specify the `registryUrl` when `id`
+                        is used.
+                      type: string
+                    uri:
+                      description: URI Reference of a parent devfile YAML file. It
+                        can be a full URL or a relative URI with the current devfile
+                        as the base URI.
+                      type: string
+                    version:
+                      description: Specific stack/sample version to pull the parent
+                        devfile from, when using id in the parent reference. To specify
+                        `version`, `id` must be defined and used as the import reference
+                        source. `version` can be either a specific stack version,
+                        or `latest`. If no `version` specified, default version will
+                        be used.
+                      pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               routingClass:
                 type: string
               started:

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -115,7 +115,7 @@ if $USE_DEFAULT_ENV; then
   export PROJECT_CLONE_IMG=${PROJECT_CLONE_IMG:-"quay.io/devfile/project-clone:next"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic
-  export DEVWORKSPACE_API_VERSION=32cae1f8e42c22035138ef6ee93080bc47d751c6
+  export DEVWORKSPACE_API_VERSION=fe7c10eaa530b12b19cfb0e22e221e753391304c
   export ROUTING_SUFFIX='""'
   export FORCE_DEVWORKSPACE_CRDS_UPDATE=true
 fi

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/devworkspace-operator
 go 1.16
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20220414122024-32cae1f8e42c
+	github.com/devfile/api/v2 v2.0.0-20220928161623-fe7c10eaa530
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
-github.com/devfile/api/v2 v2.0.0-20220414122024-32cae1f8e42c h1:yyidoxal8ngJWDxRuVZMNh4PBwqDIzOkTeOagtmRiy0=
-github.com/devfile/api/v2 v2.0.0-20220414122024-32cae1f8e42c/go.mod h1:kLX/nW93gigOHXK3NLeJL2fSS/sgEe+OHu8bo3aoOi4=
+github.com/devfile/api/v2 v2.0.0-20220928161623-fe7c10eaa530 h1:pZvf4AZrf/ZwV2AwQnTInlUpns+Wj9JYtPRtBDiFHzk=
+github.com/devfile/api/v2 v2.0.0-20220928161623-fe7c10eaa530/go.mod h1:dN7xFrOVG+iPqn4UKGibXLd5oVsdE8XyK9OEb5JL3aI=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/pkg/library/container/container.go
+++ b/pkg/library/container/container.go
@@ -44,7 +44,7 @@ import (
 //
 // Note: Requires DevWorkspace to be flattened (i.e. the DevWorkspace contains no Parent or Components of type Plugin)
 func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, pullPolicy string) (*v1alpha1.PodAdditions, error) {
-	if !flatten.DevWorkspaceIsFlattened(workspace) {
+	if !flatten.DevWorkspaceIsFlattened(workspace, nil) {
 		return nil, fmt.Errorf("devfile is not flattened")
 	}
 	podAdditions := &v1alpha1.PodAdditions{}

--- a/pkg/library/flatten/common.go
+++ b/pkg/library/flatten/common.go
@@ -17,14 +17,24 @@ package flatten
 
 import dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 
-func DevWorkspaceIsFlattened(devworkspace *dw.DevWorkspaceTemplateSpec) bool {
+func DevWorkspaceIsFlattened(devworkspace *dw.DevWorkspaceTemplateSpec, contributions []dw.ComponentContribution) bool {
+	if devworkspace == nil {
+		return len(contributions) == 0
+	}
+
 	if devworkspace.Parent != nil {
 		return false
 	}
+
+	if len(contributions) > 0 {
+		return false
+	}
+
 	for _, component := range devworkspace.Components {
 		if component.Plugin != nil {
 			return false
 		}
 	}
+
 	return true
 }

--- a/pkg/library/flatten/flatten.go
+++ b/pkg/library/flatten/flatten.go
@@ -52,9 +52,9 @@ type ResolverTools struct {
 
 // ResolveDevWorkspace takes a devworkspace and returns a "resolved" version of it -- i.e. one where all plugins and parents
 // are inlined as components.
-func ResolveDevWorkspace(workspace *dw.DevWorkspaceTemplateSpec, tooling ResolverTools) (*dw.DevWorkspaceTemplateSpec, *variables.VariableWarning, error) {
+func ResolveDevWorkspace(workspace *dw.DevWorkspaceTemplateSpec, contributions []dw.ComponentContribution, tooling ResolverTools) (*dw.DevWorkspaceTemplateSpec, *variables.VariableWarning, error) {
 	resolutionCtx := &resolutionContextTree{}
-	resolvedDW, err := recursiveResolve(workspace, tooling, resolutionCtx)
+	resolvedDW, err := recursiveResolve(workspace, contributions, tooling, resolutionCtx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,49 +75,73 @@ func ResolveDevWorkspace(workspace *dw.DevWorkspaceTemplateSpec, tooling Resolve
 	return resolvedDW, nil, nil
 }
 
-func recursiveResolve(workspace *dw.DevWorkspaceTemplateSpec, tooling ResolverTools, resolveCtx *resolutionContextTree) (*dw.DevWorkspaceTemplateSpec, error) {
-	if DevWorkspaceIsFlattened(workspace) {
+func recursiveResolve(workspace *dw.DevWorkspaceTemplateSpec, contributions []dw.ComponentContribution, tooling ResolverTools, resolveCtx *resolutionContextTree) (*dw.DevWorkspaceTemplateSpec, error) {
+	if DevWorkspaceIsFlattened(workspace, contributions) {
 		return workspace.DeepCopy(), nil
 	}
 
-	resolvedParent := &dw.DevWorkspaceTemplateSpecContent{}
-	if workspace.Parent != nil {
-		resolvedParentSpec, err := resolveParentComponent(workspace.Parent, tooling)
+	var pluginSpecContents []*dw.DevWorkspaceTemplateSpecContent
+	for _, contribution := range contributions {
+		pluginComponent, err := resolvePluginComponent(contribution.Name, &contribution.PluginComponent, tooling)
 		if err != nil {
 			return nil, err
 		}
-		if !DevWorkspaceIsFlattened(resolvedParentSpec) {
-			// TODO: implemenent this
-			return nil, fmt.Errorf("parents containing plugins or parents are not supported")
+		newCtx := resolveCtx.addPlugin(contribution.Name, &contribution.PluginComponent)
+		if err := newCtx.hasCycle(); err != nil {
+			return nil, err
 		}
-		annotate.AddSourceAttributesForTemplate("parent", resolvedParentSpec)
-		resolvedParent = &resolvedParentSpec.DevWorkspaceTemplateSpecContent
+
+		resolvedPlugin, err := recursiveResolve(pluginComponent, nil, tooling, newCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		annotate.AddSourceAttributesForTemplate(contribution.Name, resolvedPlugin)
+		pluginSpecContents = append(pluginSpecContents, &resolvedPlugin.DevWorkspaceTemplateSpecContent)
 	}
-	resolvedContent := workspace.DevWorkspaceTemplateSpecContent.DeepCopy()
-	resolvedContent.Components = nil
 
-	var pluginSpecContents []*dw.DevWorkspaceTemplateSpecContent
-	for _, component := range workspace.Components {
-		if component.Plugin == nil {
-			// No action necessary
-			resolvedContent.Components = append(resolvedContent.Components, component)
-		} else {
-			pluginComponent, err := resolvePluginComponent(component.Name, component.Plugin, tooling)
+	resolvedParent := &dw.DevWorkspaceTemplateSpecContent{}
+	resolvedContent := &dw.DevWorkspaceTemplateSpecContent{}
+	if workspace != nil {
+		resolvedContent = workspace.DevWorkspaceTemplateSpecContent.DeepCopy()
+		resolvedContent.Components = nil
+	}
+	if workspace != nil {
+		if workspace.Parent != nil {
+			resolvedParentSpec, err := resolveParentComponent(workspace.Parent, tooling)
 			if err != nil {
 				return nil, err
 			}
-			newCtx := resolveCtx.addPlugin(component.Name, component.Plugin)
-			if err := newCtx.hasCycle(); err != nil {
-				return nil, err
+			if !DevWorkspaceIsFlattened(resolvedParentSpec, nil) {
+				// TODO: implemenent this
+				return nil, fmt.Errorf("parents containing plugins or parents are not supported")
 			}
+			annotate.AddSourceAttributesForTemplate("parent", resolvedParentSpec)
+			resolvedParent = &resolvedParentSpec.DevWorkspaceTemplateSpecContent
+		}
 
-			resolvedPlugin, err := recursiveResolve(pluginComponent, tooling, newCtx)
-			if err != nil {
-				return nil, err
+		for _, component := range workspace.Components {
+			if component.Plugin == nil {
+				// No action necessary
+				resolvedContent.Components = append(resolvedContent.Components, component)
+			} else {
+				pluginComponent, err := resolvePluginComponent(component.Name, component.Plugin, tooling)
+				if err != nil {
+					return nil, err
+				}
+				newCtx := resolveCtx.addPlugin(component.Name, component.Plugin)
+				if err := newCtx.hasCycle(); err != nil {
+					return nil, err
+				}
+
+				resolvedPlugin, err := recursiveResolve(pluginComponent, nil, tooling, newCtx)
+				if err != nil {
+					return nil, err
+				}
+
+				annotate.AddSourceAttributesForTemplate(component.Name, resolvedPlugin)
+				pluginSpecContents = append(pluginSpecContents, &resolvedPlugin.DevWorkspaceTemplateSpecContent)
 			}
-
-			annotate.AddSourceAttributesForTemplate(component.Name, resolvedPlugin)
-			pluginSpecContents = append(pluginSpecContents, &resolvedPlugin.DevWorkspaceTemplateSpecContent)
 		}
 	}
 

--- a/pkg/library/flatten/flatten_test.go
+++ b/pkg/library/flatten/flatten_test.go
@@ -32,7 +32,7 @@ func TestResolveDevWorkspaceKubernetesReference(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
-			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, nil, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -55,7 +55,7 @@ func TestResolveDevWorkspacePluginRegistry(t *testing.T) {
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
 
-			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, nil, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -78,7 +78,7 @@ func TestResolveDevWorkspacePluginURI(t *testing.T) {
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
 
-			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, nil, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -101,7 +101,7 @@ func TestResolveDevWorkspaceParents(t *testing.T) {
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
 
-			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, nil, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -127,7 +127,7 @@ func TestResolveDevWorkspaceMissingDefaults(t *testing.T) {
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "")
 
-			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, nil, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -150,7 +150,7 @@ func TestResolveDevWorkspaceAnnotations(t *testing.T) {
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines devworkspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
 
-			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, nil, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -173,7 +173,7 @@ func TestResolveDevWorkspaceTemplateNamespaceRestriction(t *testing.T) {
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines devworkspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-namespace")
 
-			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, nil, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -196,7 +196,7 @@ func TestMergesDuplicateVolumeComponents(t *testing.T) {
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
 
-			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, nil, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -219,7 +219,28 @@ func TestMergeContainerContributions(t *testing.T) {
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
 
-			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, testResolverTools)
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, nil, testResolverTools)
+			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
+				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
+			} else {
+				if !assert.NoError(t, err, "Should not return error") {
+					return
+				}
+				assert.Truef(t, cmp.Equal(tt.Output.DevWorkspace, outputWorkspace, testutil.WorkspaceTemplateDiffOpts),
+					"DevWorkspace should match expected output:\n%s",
+					cmp.Diff(tt.Output.DevWorkspace, outputWorkspace, testutil.WorkspaceTemplateDiffOpts))
+			}
+		})
+	}
+}
+
+func TestMergeSpecContributions(t *testing.T) {
+	tests := testutil.LoadAllTestsOrPanic(t, "testdata/spec-contributions")
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			testResolverTools := getTestingTools(tt.Input, "test-namespace")
+
+			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, tt.Input.Contributions, testResolverTools)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {

--- a/pkg/library/flatten/internal/testutil/common.go
+++ b/pkg/library/flatten/internal/testutil/common.go
@@ -54,7 +54,10 @@ type TestCase struct {
 }
 
 type TestInput struct {
+	// DevWorkspace is the .spec.template field of a DevWorkspace
 	DevWorkspace *dw.DevWorkspaceTemplateSpec `json:"devworkspace,omitempty"`
+	// Contributions is the .spec.containerContributions field of a DevWorkspace
+	Contributions []dw.ComponentContribution `json:"contributions,omitempty"`
 	// DevWorkspaceResources is a map of string keys to devworkspace templates
 	DevWorkspaceResources map[string]dw.DevWorkspaceTemplate `json:"devworkspaceResources,omitempty"`
 	// DevfileResources is a map of string keys to devfile resources

--- a/pkg/library/flatten/testdata/spec-contributions/adds-resources.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/adds-resources.yaml
@@ -1,0 +1,46 @@
+name: "Adds attributes from contribution"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          memoryLimit: 1Gi
+          memoryRequest: 1000Mi
+          cpuLimit: 1500m
+          cpuRequest: "1"
+  contributions:
+    - name: test-contribution
+      uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          memoryLimit: 512Mi
+          memoryRequest: 1.5G
+          cpuLimit: "0.5"
+          cpuRequest: 500m
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "test-contribution"
+        container:
+          image: test-image
+          memoryLimit: 1536Mi
+          memoryRequest: "2548576000" # 1.5G + 1000Mi = 1.5*1000^3 + 1000*1024^2
+          cpuLimit: "2"
+          cpuRequest: 1500m

--- a/pkg/library/flatten/testdata/spec-contributions/adds-unmerged-elements.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/adds-unmerged-elements.yaml
@@ -1,0 +1,75 @@
+name: "Adds unmerged elements"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+  contributions:
+    - name: test-contribution
+      uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        volume: {}
+      commands:
+      - name: plugin-command
+        apply:
+          component: unmerged-container
+      events:
+        prestart:
+          - plugin-command
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "test-contribution"
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        volume: {}
+    commands:
+      - name: plugin-command
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        apply:
+          component: unmerged-container
+    events:
+        prestart:
+          - plugin-command

--- a/pkg/library/flatten/testdata/spec-contributions/che-code-usecase.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/che-code-usecase.yaml
@@ -1,0 +1,188 @@
+name: "Merges Che Code IDE contribution"
+
+input:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+          memoryLimit: 2Gi
+          mountSources: true
+  contributions:
+    - name: che-code
+      uri: che-code.yaml
+
+  devfileResources:
+    che-code.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: che-code
+      commands:
+        - id: init-container-command
+          apply:
+            component: che-code-injector
+      events:
+        preStart:
+          - init-container-command
+      components:
+        - name: che-code-runtime-description
+          attributes:
+            app.kubernetes.io/component: che-code-runtime
+            app.kubernetes.io/part-of: che-code.eclipse.org
+            controller.devfile.io/container-contribution: true
+          container:
+            image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+            command:
+              - /checode/entrypoint-volume.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 1024Mi
+            memoryRequest: 256Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+            endpoints:
+              - name: che-code
+                attributes:
+                  type: main
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                path: '?tkn=eclipse-che'
+                secure: false
+                protocol: https
+              - name: code-redirect-1
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13131
+                exposure: public
+                protocol: http
+              - name: code-redirect-2
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13132
+                exposure: public
+                protocol: http
+              - name: code-redirect-3
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13133
+                exposure: public
+                protocol: http
+        - name: checode
+          volume: {}
+        - name: che-code-injector
+          container:
+            image: quay.io/che-incubator/che-code:insiders
+            command:
+              - /entrypoint-init-container.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+
+output:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          app.kubernetes.io/component: che-code-runtime
+          app.kubernetes.io/part-of: che-code.eclipse.org
+          controller.devfile.io/merged-contributions: "che-code"
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          command:
+            - /checode/entrypoint-volume.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 3Gi
+          memoryRequest: 256Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+            - name: che-code
+              attributes:
+                type: main
+                cookiesAuthEnabled: true
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              path: '?tkn=eclipse-che'
+              secure: false
+              protocol: https
+            - name: code-redirect-1
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13131
+              exposure: public
+              protocol: http
+            - name: code-redirect-2
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13132
+              exposure: public
+              protocol: http
+            - name: code-redirect-3
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13133
+              exposure: public
+              protocol: http
+          mountSources: true
+      - name: checode
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        volume: {}
+      - name: che-code-injector
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        container:
+          image: quay.io/che-incubator/che-code:insiders
+          command:
+            - /entrypoint-init-container.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+    commands:
+      - id: init-container-command
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        apply:
+          component: che-code-injector
+    events:
+      preStart:
+          - init-container-command

--- a/pkg/library/flatten/testdata/spec-contributions/empty-workspace.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/empty-workspace.yaml
@@ -1,0 +1,7 @@
+name: "Workspace that defines no contributions or components"
+
+input:
+  devworkspace: {}
+
+output:
+  devworkspace: {}

--- a/pkg/library/flatten/testdata/spec-contributions/error_bad-plugin-merge.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_bad-plugin-merge.yaml
@@ -1,0 +1,25 @@
+name: "Attempting to override undefined plugin component"
+
+input:
+  contributions:
+    - name: "bad-override"
+      kubernetes:
+        name: override
+      components:
+        - name: non-existent
+          container:
+            memoryLimit: 512Mi
+  devworkspaceResources:
+    override:
+      metadata:
+        name: override
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+      spec:
+        components:
+          - name: my-component
+            container:
+              image: test-image
+
+output:
+  errRegexp: "Some Components do not override any existing element: non-existent.*"

--- a/pkg/library/flatten/testdata/spec-contributions/error_conflicting-merge.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_conflicting-merge.yaml
@@ -1,0 +1,27 @@
+name: "Component conflicts with plugin component"
+
+input:
+  devworkspace:
+    components:
+      - name: my-component
+        container:
+          image: test-image
+  contributions:
+    - name: "component-conflict"
+      kubernetes:
+        name: test-plugin
+
+  devworkspaceResources:
+    test-plugin:
+      metadata:
+        name: test-plugin
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+      spec:
+        components:
+          - name: my-component
+            container:
+              image: test-image
+
+output:
+  errRegexp: "Some Components are already defined in plugin '.*': my-component.*"

--- a/pkg/library/flatten/testdata/spec-contributions/error_error-when-retrieving-plugin.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_error-when-retrieving-plugin.yaml
@@ -1,0 +1,13 @@
+name: "Error retrieving plugin"
+
+input:
+  contributions:
+    - name: "bad-plugin"
+      kubernetes:
+        name: test-plugin
+  errors:
+    test-plugin:
+      message: "Internal k8s error"
+
+output:
+  errRegexp: ".*failed to retrieve.*bad-plugin.*Internal k8s error.*"

--- a/pkg/library/flatten/testdata/spec-contributions/error_fetch-unparseable-file.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_fetch-unparseable-file.yaml
@@ -1,0 +1,20 @@
+name: "DevWorkspace reference URI containing non-devfile type content"
+
+input:
+  contributions:
+    - name: test-plugin
+      uri: "https://my-plugin.io/test"
+  devworkspaceResources:
+    "https://my-plugin.io/test":
+      metadata:
+        name: test-plugin
+      spec:
+        components:
+          - name: plugin-a
+            container:
+              name: test-container
+              image: test-image
+
+
+output:
+  errRegexp: "could not find devfile or devworkspace object at 'https://my-plugin.io/test'"

--- a/pkg/library/flatten/testdata/spec-contributions/error_invalid-schema-version.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_invalid-schema-version.yaml
@@ -1,0 +1,19 @@
+name: "DevWorkspace references plugin with invalid schemaVersion"
+
+input:
+  contributions:
+    - name: test-plugin
+      uri: https://test-registry.io/old-devfiles
+  devfileResources:
+    "https://test-registry.io/old-devfiles":
+      schemaVersion: 1.0.0
+      metadata:
+        name: "plugin-a"
+      components:
+        - name: plugin-a
+          container:
+            name: test-container
+            image: test-image
+
+output:
+  errRegexp: "could not process devfile: unsupported schemaVersion '1.0.0'"

--- a/pkg/library/flatten/testdata/spec-contributions/error_on-fetch.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_on-fetch.yaml
@@ -1,0 +1,12 @@
+name: "Error when fetching plugin"
+
+input:
+  contributions:
+    - name: test-plugin
+      uri: https://test-registry.io/error
+  errors:
+    "https://test-registry.io/error":
+      message: "testing error"
+
+output:
+  errRegexp: "failed to fetch file from.*testing error"

--- a/pkg/library/flatten/testdata/spec-contributions/error_plugin-not-found-k8s.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_plugin-not-found-k8s.yaml
@@ -1,0 +1,14 @@
+name: "Referenced plugin cannot be found"
+
+input:
+  contributions:
+    - name: "bad-plugin"
+      kubernetes:
+        name: test-plugin
+  errors:
+    test-plugin:
+      isNotFound: true
+      message: "Plugin not found"
+
+output:
+  errRegexp: "plugin for component bad-plugin not found.*"

--- a/pkg/library/flatten/testdata/spec-contributions/error_plugin-not-found-uri.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_plugin-not-found-uri.yaml
@@ -1,0 +1,12 @@
+name: "Plugin not found in at URI"
+
+input:
+  contributions:
+    - name: test-plugin
+      uri: "https://test-registry.io/notfound"
+  errors:
+    "https://test-registry.io/notfound":
+      statusCode: 404
+
+output:
+  errRegexp: "could not fetch file from.*got status 404"

--- a/pkg/library/flatten/testdata/spec-contributions/error_plugin-references-self.yml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_plugin-references-self.yml
@@ -1,0 +1,25 @@
+name: "Plugin references self"
+
+input:
+  contributions:
+    - name: "plugin-a"
+      kubernetes:
+        name: plugin-a
+  devworkspaceResources:
+    plugin-a:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-a
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+      spec:
+        components:
+          - name: plugin-a
+            plugin:
+              kubernetes:
+                name: plugin-a
+                namespace: devworkspace-plugins
+
+output:
+  errRegexp: "DevWorkspace has an cycle in references.*"

--- a/pkg/library/flatten/testdata/spec-contributions/error_plugins-have-cycle.yml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_plugins-have-cycle.yml
@@ -1,0 +1,39 @@
+name: "Plugins have reference cycle"
+
+input:
+  contributions:
+    - name: "plugin-a"
+      kubernetes:
+        name: plugin-a
+  devworkspaceResources:
+    plugin-a:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-a
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+      spec:
+        components:
+          - name: plugin-b
+            plugin:
+              kubernetes:
+                name: plugin-b
+                namespace: devworkspace-plugins
+    plugin-b:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-b
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+      spec:
+        components:
+          - name: plugin-a
+            plugin:
+              kubernetes:
+                name: plugin-a
+                namespace: devworkspace-plugins
+
+output:
+  errRegexp: "DevWorkspace has an cycle in references.*"

--- a/pkg/library/flatten/testdata/spec-contributions/merges-list-elements.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/merges-list-elements.yaml
@@ -1,0 +1,88 @@
+name: "Merges list elements in contribution"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          volumeMounts:
+            - name: test-volume
+              path: test-volume-path
+          endpoints:
+            - name: test-endpoint-1
+              targetPort: 8888
+              exposure: internal
+              protocol: https
+            - name: test-endpoint-2
+              targetPort: 8889
+              exposure: internal
+              protocol: https
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+  contributions:
+    - name: test-contribution
+      uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          volumeMounts:
+            - name: contrib-volume
+              path: contrib-volume-path
+          endpoints:
+            - name: contrib-endpoint-1
+              targetPort: 9999
+              exposure: public
+              protocol: https
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+            - name: CONTRIB_ENVVAR_2
+              value: CONTRIB_VALUE_2
+
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "test-contribution"
+        container:
+          image: test-image
+          volumeMounts:
+            - name: test-volume
+              path: test-volume-path
+            - name: contrib-volume
+              path: contrib-volume-path
+          endpoints:
+            - name: test-endpoint-1
+              targetPort: 8888
+              exposure: internal
+              protocol: https
+            - name: test-endpoint-2
+              targetPort: 8889
+              exposure: internal
+              protocol: https
+            - name: contrib-endpoint-1
+              targetPort: 9999
+              exposure: public
+              protocol: https
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+            - name: CONTRIB_ENVVAR_2
+              value: CONTRIB_VALUE_2

--- a/pkg/library/flatten/testdata/spec-contributions/nested-plugins-annotation.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/nested-plugins-annotation.yaml
@@ -1,0 +1,46 @@
+name: "DevWorkspace annotates nested plugins with the first plugin"
+
+input:
+  contributions:
+    - name: root-plugin
+      kubernetes:
+        name: test-plugin-a
+        namespace: test-ns
+  devworkspaceResources:
+    test-plugin-a:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-a
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+      spec:
+        components:
+          - name: plugin-b
+            plugin:
+              kubernetes:
+                name: test-plugin-b
+                namespace: test-ns
+    test-plugin-b:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: plugin-b
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+      spec:
+        components:
+          - name: plugin-b-container
+            container:
+              name: test-container
+              image: test-img
+
+output:
+  devworkspace:
+    components:
+      - name: plugin-b-container
+        attributes:
+          controller.devfile.io/imported-by: "root-plugin"
+        container:
+          name: test-container
+          image: test-img

--- a/pkg/library/flatten/testdata/spec-contributions/no-op-if-no-contribution.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/no-op-if-no-contribution.yaml
@@ -1,0 +1,81 @@
+name: "Adds unmerged elements"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+  contributions:
+    - name: test-contribution
+      uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        # attributes:
+        #   controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        volume: {}
+      commands:
+      - name: plugin-command
+        apply:
+          component: unmerged-container
+      events:
+        prestart:
+          - plugin-command
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        volume: {}
+    commands:
+      - name: plugin-command
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        apply:
+          component: unmerged-container
+    events:
+        prestart:
+          - plugin-command

--- a/pkg/library/flatten/testdata/spec-contributions/no-op-if-no-target.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/no-op-if-no-target.yaml
@@ -1,0 +1,80 @@
+name: "Adds unmerged elements"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        # attributes:
+        #   controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+  contributions:
+    - name: test-contribution
+      uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        volume: {}
+      commands:
+      - name: plugin-command
+        apply:
+          component: unmerged-container
+      events:
+        prestart:
+          - plugin-command
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        container:
+          image: test-image
+          env:
+            - name: TEST_ENVVAR
+              value: TEST_VALUE
+      - name: test-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: contribution-image
+          env:
+            - name: CONTRIB_ENVVAR
+              value: CONTRIB_VALUE
+      - name: unmerged-container
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        container:
+          image: unmerged-container
+      - name: unmerged-volume
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        volume: {}
+    commands:
+      - name: plugin-command
+        attributes:
+          controller.devfile.io/imported-by: test-contribution
+        apply:
+          component: unmerged-container
+    events:
+        prestart:
+          - plugin-command

--- a/pkg/library/flatten/testdata/spec-contributions/nodejs-workspace.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/nodejs-workspace.yaml
@@ -1,0 +1,524 @@
+name: "Theia and NodeJS plugin workspace"
+
+input:
+  devworkspace:
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    components:
+      - name: nodejs
+        container:
+          image: quay.io/eclipse/che-nodejs10-ubi:nightly
+          memoryLimit: 512Mi
+          endpoints:
+            - name: nodejs
+              protocol: http
+              targetPort: 3000
+          mountSources: true
+    commands:
+      - id: download-dependencies
+        exec:
+          component: nodejs
+          commandLine: npm install
+          workingDir: ${PROJECTS_ROOT}/project/app
+      - id: run-the-app
+        exec:
+          component: nodejs
+          commandLine: nodemon app.js
+          workingDir: ${PROJECTS_ROOT}/project/app
+      - id: run-the-app-with-debugging-enabled
+        exec:
+          component: nodejs
+          commandLine: nodemon --inspect app.js
+          workingDir: ${PROJECTS_ROOT}/project/app
+      - id: stop-the-app
+        exec:
+          component: nodejs
+          commandLine: >-
+              node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
+              echo "Stopping node server with PIDs: ${node_server_pids}" &&
+              kill -15 ${node_server_pids} &>/dev/null && echo 'Done.'
+      - id: attach-remote-debugger
+        vscodeLaunch:
+          inlined: |
+            {
+              "version": "0.2.0",
+              "configurations": [
+                {
+                  "type": "node",
+                  "request": "attach",
+                  "name": "Attach to Remote",
+                  "address": "localhost",
+                  "port": 9229,
+                  "localRoot": "${workspaceFolder}",
+                  "remoteRoot": "${workspaceFolder}"
+                }
+              ]
+            }
+  contributions:
+    - name: che-theia
+      kubernetes:
+        name: theia-next
+        namespace: devworkspace-plugins
+    - name: machine-exec
+      kubernetes:
+        name: machine-exec
+        namespace: devworkspace-plugins
+    - name: typescript
+      kubernetes:
+        name: vscode-typescript
+        namespace: devworkspace-plugins
+      components:
+        - name: sidecar-typescript
+          container:
+            memoryLimit: 512Mi
+
+  devworkspaceResources:
+    theia-next:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: theia-next
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+      spec:
+        components:
+          - name: plugins
+            volume: {}
+          - name: remote-endpoint
+            volume: {} # TODO: Fix this once ephemeral volumes are supported
+          - name: vsx-installer  # Mainly reads the container objects and searches for those
+                                  # with che-theia.eclipse.org/vscode-extensions attributes to get VSX urls
+                                  # Those found in the dedicated containers components are with a sidecar,
+                                  # Those found in the che-theia container are without a sidecar.
+            attributes:
+              "app.kubernetes.io/part-of": che-theia.eclipse.org
+              "app.kubernetes.io/component": bootstrapper
+            container:
+              args:
+                - /bin/sh
+                - '-c'
+                - |
+                  KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}" &&\
+                  TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\
+                  WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" $KUBE_API_ENDPOINT) &&\
+                  IFS=$'\n' &&\
+                  for container in $(echo $WORKSPACE | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
+                    dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - ) ;\
+                    urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - ) ;\
+                    mkdir -p $dest ;\
+                    unset IFS &&\
+                    for url in $(echo $urls | sed 's/[",]/ /g' - ); do \
+                      echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\
+                    done \
+                  done \
+              image: 'quay.io/samsahai/curl:latest'
+              volumeMounts:
+                - path: "/plugins"
+                  name: plugins
+          - name: remote-runtime-injector
+            attributes:
+              "app.kubernetes.io/part-of": che-theia.eclipse.org
+              "app.kubernetes.io/component": bootstrapper
+            container:                          #### corresponds to `initContainer` definition in old meta.yaml.
+              image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0"
+              volumeMounts:
+                - path: "/remote-endpoint"
+                  name: remote-endpoint
+              env:
+                - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+                  value: /remote-endpoint/plugin-remote-endpoint
+                - name: REMOTE_ENDPOINT_VOLUME_NAME
+                  value: remote-endpoint
+          - name: theia-ide
+            attributes:
+              "app.kubernetes.io/name": che-theia.eclipse.org
+              "app.kubernetes.io/part-of": che.eclipse.org
+              "app.kubernetes.io/component": editor
+
+              # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
+              # contains the vscode-pull-request-github vscode plugin.
+              "che-theia.eclipse.org/vscode-extensions":
+                - https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix
+            container:
+              image: "quay.io/eclipse/che-theia:next"
+              env:
+                - name: THEIA_PLUGINS
+                  value: local-dir:///plugins
+                - name: HOSTED_PLUGIN_HOSTNAME
+                  value: 0.0.0.0
+                - name: HOSTED_PLUGIN_PORT
+                  value: "3130"
+                - name: THEIA_HOST
+                  value: 0.0.0.0
+              volumeMounts:
+                - path: "/plugins"
+                  name: plugins
+              mountSources: true
+              memoryLimit: "512M"
+              endpoints:
+                - name: "theia"
+                  exposure: public
+                  targetPort: 3100
+                  secure: true
+                  protocol: http
+                  attributes:
+                    type: main
+                - name: "webviews"
+                  exposure: public
+                  targetPort: 3100
+                  protocol: http
+                  secure: true
+                  attributes:
+                    type: webview
+                    unique: "true"
+                - name: "theia-dev"
+                  exposure: public
+                  targetPort: 3130
+                  protocol: http
+                  attributes:
+                    type: ide-dev
+                - name: "theia-redir-1"
+                  exposure: public
+                  targetPort: 13131
+                  protocol: http
+                - name: "theia-redir-2"
+                  exposure: public
+                  targetPort: 13132
+                  protocol: http
+                - name: "theia-redir-3"
+                  exposure: public
+                  targetPort: 13133
+                  protocol: http
+        commands:
+          # Commands coming from plugin editor
+          - id: inject-theia-in-remote-sidecar
+            apply:
+              component: remote-runtime-injector
+          - id: copy-vsx
+            apply:
+              component: vsx-installer
+        events:
+          preStart:
+            - inject-theia-in-remote-sidecar
+            - copy-vsx
+
+    machine-exec:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: machine-exec
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+        labels:
+          "devworkspace.devfile.io/editor-compatibility": "che-theia"
+      spec:
+        components:
+          - name: che-machine-exec
+            attributes:
+              "app.kubernetes.io/name": che-terminal.eclipse.org
+              "app.kubernetes.io/part-of": che.eclipse.org
+              "app.kubernetes.io/component": terminal
+            container:
+              image: "quay.io/eclipse/che-machine-exec:7.20.0"
+              command: ['/go/bin/che-machine-exec']
+              args:
+                - '--url'
+                - '0.0.0.0:4444'
+                - '--pod-selector'
+                - controller.devfile.io/devworkspace_id=$(DEVWORKSPACE_ID)
+              endpoints:
+                - name: "che-mach-exec"
+                  exposure: public
+                  targetPort: 4444
+                  protocol: ws
+                  secure: true
+                  attributes:
+                    type: terminal
+
+    vscode-typescript:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: vscode-typescript
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+        labels:
+          "devworkspace.devfile.io/editor-compatibility": "che-theia"
+      spec:
+        components:
+          - name: sidecar-typescript
+            attributes:
+              "app.kubernetes.io/part-of": che-theia.eclipse.org
+              "app.kubernetes.io/component": vscode-plugin
+
+              # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
+              # contains the typescript vscode plugin.
+              "che-theia.eclipse.org/vscode-extensions":
+                - https://download.jboss.org/jbosstools/vscode/3rdparty/ms-code.typescript/che-typescript-language-1.35.1.vsix
+
+            container:
+              image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"
+              memoryLimit: '512Mi'
+              env:
+                - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+                  value: /remote-endpoint/plugin-remote-endpoint
+                - name: THEIA_PLUGINS
+                  value: local-dir:///plugins/sidecars/vscode-typescript
+              volumeMounts:
+                - path: "/remote-endpoint"
+                  name: remote-endpoint
+                - name: plugins
+                  path: /plugins
+
+
+output:
+  devworkspace:
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+
+    components:
+
+      - name: theia-ide
+        attributes:
+          "app.kubernetes.io/name": che-theia.eclipse.org
+          "app.kubernetes.io/part-of": che.eclipse.org
+          "app.kubernetes.io/component": editor
+
+          # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
+          # contains the vscode-pull-request-github vscode plugin.
+          "che-theia.eclipse.org/vscode-extensions":
+            - https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix
+          controller.devfile.io/imported-by: "che-theia"
+        container:
+          image: "quay.io/eclipse/che-theia:next"
+          env:
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins
+            - name: HOSTED_PLUGIN_HOSTNAME
+              value: 0.0.0.0
+            - name: HOSTED_PLUGIN_PORT
+              value: "3130"
+            - name: THEIA_HOST
+              value: 0.0.0.0
+          volumeMounts:
+            - path: "/plugins"
+              name: plugins
+          mountSources: true
+          memoryLimit: "512M"
+          endpoints:
+            - name: "theia"
+              exposure: public
+              targetPort: 3100
+              secure: true
+              protocol: http
+              attributes:
+                type: main
+            - name: "webviews"
+              exposure: public
+              targetPort: 3100
+              protocol: http
+              secure: true
+              attributes:
+                type: webview
+                unique: "true"
+            - name: "theia-dev"
+              exposure: public
+              targetPort: 3130
+              protocol: http
+              attributes:
+                type: ide-dev
+            - name: "theia-redir-1"
+              exposure: public
+              targetPort: 13131
+              protocol: http
+            - name: "theia-redir-2"
+              exposure: public
+              targetPort: 13132
+              protocol: http
+            - name: "theia-redir-3"
+              exposure: public
+              targetPort: 13133
+              protocol: http
+
+      - name: plugins
+        attributes:
+          controller.devfile.io/imported-by: "che-theia"
+        volume: {}
+
+      - name: vsx-installer  # Mainly reads the container objects and searches for those
+                            # with che-theia.eclipse.org/vscode-extensions attributes to get VSX urls
+                            # Those found in the dedicated containers components are with a sidecar,
+                            # Those found in the che-theia container are without a sidecar.
+        attributes:
+          "app.kubernetes.io/part-of": che-theia.eclipse.org
+          "app.kubernetes.io/component": bootstrapper
+          controller.devfile.io/imported-by: "che-theia"
+        container:
+          args:
+            - /bin/sh
+            - '-c'
+            - |
+              KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${CHE_WORKSPACE_NAMESPACE}/devworkspaces/${CHE_WORKSPACE_NAME}" &&\
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) &&\
+              WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" $KUBE_API_ENDPOINT) &&\
+              IFS=$'\n' &&\
+              for container in $(echo $WORKSPACE | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do \
+                dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - ) ;\
+                urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - ) ;\
+                mkdir -p $dest ;\
+                unset IFS &&\
+                for url in $(echo $urls | sed 's/[",]/ /g' - ); do \
+                  echo; echo downloading $urls to $dest; curl -L $url > $dest/$(basename $url) ;\
+                done \
+              done \
+          image: 'quay.io/samsahai/curl:latest'
+          volumeMounts:
+            - path: "/plugins"
+              name: plugins
+
+      - name: remote-endpoint
+        attributes:
+          controller.devfile.io/imported-by: "che-theia"
+        volume: {}
+          # ephemeral: true                #### We should add it in the Devfile 2.0 spec ! Not critical to implement at start though
+
+      - name: remote-runtime-injector
+        attributes:
+          "app.kubernetes.io/part-of": che-theia.eclipse.org
+          "app.kubernetes.io/component": bootstrapper
+          controller.devfile.io/imported-by: "che-theia"
+        container:                          #### corresponds to `initContainer` definition in old meta.yaml.
+          image: "quay.io/eclipse/che-theia-endpoint-runtime-binary:7.20.0"
+          volumeMounts:
+            - path: "/remote-endpoint"
+              name: remote-endpoint
+          env:
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint
+            - name: REMOTE_ENDPOINT_VOLUME_NAME
+              value: remote-endpoint
+
+      - name: che-machine-exec
+        attributes:
+          "app.kubernetes.io/name": che-terminal.eclipse.org
+          "app.kubernetes.io/part-of": che.eclipse.org
+          "app.kubernetes.io/component": terminal
+          controller.devfile.io/imported-by: "machine-exec"
+        container:
+          image: "quay.io/eclipse/che-machine-exec:7.20.0"
+          command: ['/go/bin/che-machine-exec']
+          args:
+            - '--url'
+            - '0.0.0.0:4444'
+            - '--pod-selector'
+            - controller.devfile.io/devworkspace_id=$(DEVWORKSPACE_ID)
+          endpoints:
+            - name: "che-mach-exec"
+              exposure: public
+              targetPort: 4444
+              protocol: ws
+              secure: true
+              attributes:
+                type: terminal
+      - name: sidecar-typescript
+        attributes:
+          "app.kubernetes.io/part-of": che-theia.eclipse.org
+          "app.kubernetes.io/component": vscode-plugin
+
+          # Added by Che-theia at start when detecting, after cloning, that the extensions.json in the repo
+          # contains the typescript vscode plugin.
+          "che-theia.eclipse.org/vscode-extensions":
+            - https://download.jboss.org/jbosstools/vscode/3rdparty/ms-code.typescript/che-typescript-language-1.35.1.vsix
+
+          controller.devfile.io/imported-by: "typescript"
+
+        container:
+          image: "quay.io/eclipse/che-sidecar-node:10-0cb5d78"
+          memoryLimit: '512Mi'
+          env:
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins/sidecars/vscode-typescript
+          volumeMounts:
+            - path: "/remote-endpoint"
+              name: remote-endpoint
+            - name: plugins
+              path: /plugins
+
+      # User runtime container
+      - name: nodejs
+        container:
+          image: quay.io/eclipse/che-nodejs10-ubi:nightly
+          memoryLimit: 512Mi
+          endpoints:
+            - name: nodejs
+              protocol: http
+              targetPort: 3000
+          mountSources: true
+
+    commands:
+
+      # Commands coming from plugin editor
+      - id: inject-theia-in-remote-sidecar
+        attributes:
+          controller.devfile.io/imported-by: "che-theia"
+        apply:
+          component: remote-runtime-injector
+      - id: copy-vsx
+        attributes:
+          controller.devfile.io/imported-by: "che-theia"
+        apply:
+          component: vsx-installer
+
+      # User commands
+      - id: download-dependencies
+        exec:
+          component: nodejs
+          commandLine: npm install
+          workingDir: ${PROJECTS_ROOT}/project/app
+      - id: run-the-app
+        exec:
+          component: nodejs
+          commandLine: nodemon app.js
+          workingDir: ${PROJECTS_ROOT}/project/app
+      - id: run-the-app-with-debugging-enabled
+        exec:
+          component: nodejs
+          commandLine: nodemon --inspect app.js
+          workingDir: ${PROJECTS_ROOT}/project/app
+      - id: stop-the-app
+        exec:
+          component: nodejs
+          commandLine: >-
+              node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
+              echo "Stopping node server with PIDs: ${node_server_pids}" &&
+              kill -15 ${node_server_pids} &>/dev/null && echo 'Done.'
+      - id: attach-remote-debugger
+        vscodeLaunch:
+          inlined: |
+            {
+              "version": "0.2.0",
+              "configurations": [
+                {
+                  "type": "node",
+                  "request": "attach",
+                  "name": "Attach to Remote",
+                  "address": "localhost",
+                  "port": 9229,
+                  "localRoot": "${workspaceFolder}",
+                  "remoteRoot": "${workspaceFolder}"
+                }
+              ]
+            }
+
+    events:
+      preStart:
+        - inject-theia-in-remote-sidecar
+        - copy-vsx

--- a/pkg/library/flatten/testdata/spec-contributions/resolve-devworkspace-instead-of-devfile.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/resolve-devworkspace-instead-of-devfile.yaml
@@ -1,0 +1,29 @@
+name: "DevWorkspace references DevWorkspaceTemplate plugin from registry"
+
+input:
+  contributions:
+    - name: test-plugin
+      uri: "https://my-plugin.io/test"
+  devworkspaceResources:
+    "https://my-plugin.io/test":
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: test-plugin
+      spec:
+        components:
+          - name: plugin-a
+            container:
+              name: test-container
+              image: test-image
+
+
+output:
+  devworkspace:
+    components:
+      - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        container:
+          name: test-container
+          image: test-image

--- a/pkg/library/flatten/testdata/spec-contributions/resolve-multiple-plugins-by-uri.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/resolve-multiple-plugins-by-uri.yaml
@@ -1,0 +1,43 @@
+name: "DevWorkspace references plugins from multiple plugin registries"
+
+input:
+  contributions:
+    - name: test-plugin
+      uri: "https://my-plugin.io/test"
+    - name: test-plugin-2
+      uri: "https://my-plugin-alt.io/test"
+  devfileResources:
+    "https://my-plugin.io/test":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-a"
+      components:
+        - name: plugin-a
+          container:
+            name: test-container
+            image: test-image
+    "https://my-plugin-alt.io/test":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-b"
+      components:
+        - name: plugin-b
+          container:
+            name: test-container-b
+            image: test-image
+
+output:
+  devworkspace:
+    components:
+      - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        container:
+          name: test-container
+          image: test-image
+      - name: plugin-b
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin-2"
+        container:
+          name: test-container-b
+          image: test-image

--- a/pkg/library/flatten/testdata/spec-contributions/resolve-plugin-by-uri.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/resolve-plugin-by-uri.yaml
@@ -1,0 +1,26 @@
+name: "DevWorkspace references plugin by URI"
+
+input:
+  contributions:
+    - name: test-plugin
+      uri: "https://my-plugin.io/test"
+  devfileResources:
+    "https://my-plugin.io/test":
+      schemaVersion: 2.0.0
+      metadata:
+        name: "plugin-a"
+      components:
+        - name: plugin-a
+          container:
+            name: test-container
+            image: test-image
+
+output:
+  devworkspace:
+    components:
+      - name: plugin-a
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        container:
+          name: test-container
+          image: test-image

--- a/pkg/library/flatten/testdata/spec-contributions/theia-merge-usecase.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/theia-merge-usecase.yaml
@@ -1,0 +1,386 @@
+name: "Merges Theia IDE contribution"
+
+input:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+          memoryLimit: 2Gi
+          mountSources: true
+  contributions:
+    - name: theia-ide
+      uri: theia-ide.yaml
+
+  devfileResources:
+    theia-ide.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: theia-ide
+      commands:
+        - id: init-container-command
+          apply:
+            component: remote-runtime-injector
+      events:
+        preStart:
+          - init-container-command
+      components:
+        - name: theia-ide-contributions
+          attributes:
+            controller.devfile.io/container-contribution: true
+          container:
+            args:
+              - sh
+              - '-c'
+              - '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}'
+            env:
+              - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+                value: /remote-endpoint/plugin-remote-endpoint
+              - name: THEIA_PLUGINS
+                value: local-dir:///plugins/sidecars/tools
+            memoryLimit: 512Mi
+            volumeMounts:
+              - name: plugins
+                path: /plugins
+              - name: remote-endpoint
+                path: /remote-endpoint
+            image: quay.io/devfile/universal-developer-image@sha256:53cec58dd190dd1e06100478ae879d7c28abd8fc883d5fdf5be3eb6e943fe5e7
+        - name: theia-ide
+          container:
+            image: quay.io/eclipse/che-theia:next
+            env:
+              - name: THEIA_PLUGINS
+                value: local-dir:///plugins
+              - name: HOSTED_PLUGIN_HOSTNAME
+                value: 0.0.0.0
+              - name: HOSTED_PLUGIN_PORT
+                value: '3130'
+              - name: THEIA_HOST
+                value: 127.0.0.1
+            volumeMounts:
+              - name: plugins
+                path: /plugins
+              - name: theia-local
+                path: /home/theia/.theia
+            mountSources: true
+            memoryLimit: 512M
+            cpuLimit: 1500m
+            cpuRequest: 100m
+            endpoints:
+              - name: theia
+                attributes:
+                  type: main
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                secure: false
+                protocol: https
+              - name: webviews
+                attributes:
+                  type: webview
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  unique: true
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                secure: false
+                protocol: https
+              - name: mini-browser
+                attributes:
+                  type: mini-browser
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  unique: true
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                secure: false
+                protocol: https
+              - name: theia-dev
+                attributes:
+                  type: ide-dev
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3130
+                exposure: public
+                protocol: http
+              - name: theia-redirect-1
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13131
+                exposure: public
+                protocol: http
+              - name: theia-redirect-2
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13132
+                exposure: public
+                protocol: http
+              - name: theia-redirect-3
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13133
+                exposure: public
+                protocol: http
+              - name: terminal
+                attributes:
+                  type: collocated-terminal
+                  discoverable: false
+                  cookiesAuthEnabled: true
+                  urlRewriteSupported: true
+                targetPort: 3333
+                exposure: public
+                secure: false
+                protocol: wss
+          attributes:
+            app.kubernetes.io/component: che-theia
+            app.kubernetes.io/part-of: che-theia.eclipse.org
+        - name: plugins
+          volume: {}
+        - name: theia-local
+          volume: {}
+        - name: che-machine-exec
+          container:
+            image: quay.io/eclipse/che-machine-exec:next
+            command:
+              - /go/bin/che-machine-exec
+              - '--url'
+              - 127.0.0.1:3333
+              - '--idle-timeout'
+              - 15m
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+          attributes:
+            app.kubernetes.io/component: machine-exec
+            app.kubernetes.io/part-of: che-theia.eclipse.org
+        - name: remote-runtime-injector
+          container:
+            image: quay.io/eclipse/che-theia-endpoint-runtime-binary:next
+            env:
+              - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+                value: /remote-endpoint/plugin-remote-endpoint
+              - name: REMOTE_ENDPOINT_VOLUME_NAME
+                value: remote-endpoint
+            volumeMounts:
+              - name: plugins
+                path: /plugins
+              - name: remote-endpoint
+                path: /remote-endpoint
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+          attributes:
+            app.kubernetes.io/component: remote-runtime-injector
+            app.kubernetes.io/part-of: che-theia.eclipse.org
+        - name: remote-endpoint
+          volume:
+            ephemeral: true
+
+
+output:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          controller.devfile.io/merged-contributions: "theia-ide"
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins/sidecars/tools
+          args:
+            - sh
+            - '-c'
+            - '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}'
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+          volumeMounts:
+            - name: plugins
+              path: /plugins
+            - name: remote-endpoint
+              path: /remote-endpoint
+          memoryLimit: 2560Mi # 2Gi = 2048Mi + 512Mi
+          mountSources: true
+      - name: theia-ide
+        attributes:
+          app.kubernetes.io/component: che-theia
+          app.kubernetes.io/part-of: che-theia.eclipse.org
+          controller.devfile.io/imported-by: theia-ide
+        container:
+          image: quay.io/eclipse/che-theia:next
+          env:
+            - name: THEIA_PLUGINS
+              value: local-dir:///plugins
+            - name: HOSTED_PLUGIN_HOSTNAME
+              value: 0.0.0.0
+            - name: HOSTED_PLUGIN_PORT
+              value: '3130'
+            - name: THEIA_HOST
+              value: 127.0.0.1
+          volumeMounts:
+            - name: plugins
+              path: /plugins
+            - name: theia-local
+              path: /home/theia/.theia
+          mountSources: true
+          memoryLimit: 512M
+          cpuLimit: 1500m
+          cpuRequest: 100m
+          endpoints:
+            - name: theia
+              attributes:
+                type: main
+                cookiesAuthEnabled: true
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              secure: false
+              protocol: https
+            - name: webviews
+              attributes:
+                type: webview
+                cookiesAuthEnabled: true
+                discoverable: false
+                unique: true
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              secure: false
+              protocol: https
+            - name: mini-browser
+              attributes:
+                type: mini-browser
+                cookiesAuthEnabled: true
+                discoverable: false
+                unique: true
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              secure: false
+              protocol: https
+            - name: theia-dev
+              attributes:
+                type: ide-dev
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3130
+              exposure: public
+              protocol: http
+            - name: theia-redirect-1
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13131
+              exposure: public
+              protocol: http
+            - name: theia-redirect-2
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13132
+              exposure: public
+              protocol: http
+            - name: theia-redirect-3
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13133
+              exposure: public
+              protocol: http
+            - name: terminal
+              attributes:
+                type: collocated-terminal
+                discoverable: false
+                cookiesAuthEnabled: true
+                urlRewriteSupported: true
+              targetPort: 3333
+              exposure: public
+              secure: false
+              protocol: wss
+      - name: plugins
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+        volume: {}
+      - name: theia-local
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+        volume: {}
+      - name: che-machine-exec
+        attributes:
+          app.kubernetes.io/component: machine-exec
+          app.kubernetes.io/part-of: che-theia.eclipse.org
+          controller.devfile.io/imported-by: theia-ide
+        container:
+          image: quay.io/eclipse/che-machine-exec:next
+          command:
+            - /go/bin/che-machine-exec
+            - '--url'
+            - 127.0.0.1:3333
+            - '--idle-timeout'
+            - 15m
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+      - name: remote-runtime-injector
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+          app.kubernetes.io/component: remote-runtime-injector
+          app.kubernetes.io/part-of: che-theia.eclipse.org
+        container:
+          image: quay.io/eclipse/che-theia-endpoint-runtime-binary:next
+          env:
+            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+              value: /remote-endpoint/plugin-remote-endpoint
+            - name: REMOTE_ENDPOINT_VOLUME_NAME
+              value: remote-endpoint
+          volumeMounts:
+            - name: plugins
+              path: /plugins
+            - name: remote-endpoint
+              path: /remote-endpoint
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+      - name: remote-endpoint
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+        volume:
+          ephemeral: true
+    commands:
+      - id: init-container-command
+        attributes:
+          controller.devfile.io/imported-by: theia-ide
+        apply:
+          component: remote-runtime-injector
+    events:
+      preStart:
+        - init-container-command

--- a/pkg/library/flatten/testdata/spec-contributions/web-terminal-with-plugin.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/web-terminal-with-plugin.yaml
@@ -1,0 +1,84 @@
+name: "Web terminal default"
+
+input:
+  devworkspace:
+    components:
+      - name: dev
+        container:
+          memoryLimit: "256Mi"
+          image: quay.io/wto/web-terminal-tooling:latest
+          args: ["tail", "-f", "/dev/null"]
+          env:
+            - name: PS1
+              value: \[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]
+  contributions:
+    - name: web-terminal
+      kubernetes:
+        name: web-terminal
+        namespace: devworkspace-plugins
+  devworkspaceResources:
+    web-terminal:
+      kind: DevWorkspaceTemplate
+      apiVersion: workspace.devfile.io/v1alpha2
+      metadata:
+        name: web-terminal
+        annotations:
+          "controller.devfile.io/allow-import-from": "*"
+        labels:
+          "devworkspace.devfile.io/editor-name": "web-terminal"
+      spec:
+        components:
+          - name: web-terminal
+            container:
+              image: quay.io/eclipse/che-machine-exec:nightly
+              command: ["/go/bin/che-machine-exec",
+                        "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+                        "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
+                        "--pod-selector", "controller.devfile.io/devworkspace_id=$(DEVWORKSPACE_ID)",
+                        "--use-bearer-token",
+                        "--use-tls"]
+              endpoints:
+                - name: web-terminal
+                  targetPort: 4444
+                  attributes:
+                    protocol: http
+                    type: main
+                    discoverable: "false"
+                    secure: "true"
+              env:
+                - name: USE_BEARER_TOKEN
+                  value: "true"
+
+output:
+  devworkspace:
+    components:
+      - name: dev
+        container:
+          image: quay.io/wto/web-terminal-tooling:latest
+          memoryLimit: 256Mi
+          args: ["tail", "-f", "/dev/null"]
+          env:
+            - value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
+              name: PS1
+      - name: web-terminal
+        attributes:
+          controller.devfile.io/imported-by: "web-terminal"
+        container:
+          image: quay.io/eclipse/che-machine-exec:nightly
+          command: ["/go/bin/che-machine-exec",
+                    "--authenticated-user-id", "$(DEVWORKSPACE_CREATOR)",
+                    "--idle-timeout", "$(DEVWORKSPACE_IDLE_TIMEOUT)",
+                    "--pod-selector", "controller.devfile.io/devworkspace_id=$(DEVWORKSPACE_ID)",
+                    "--use-bearer-token",
+                    "--use-tls"]
+          endpoints:
+            - name: web-terminal
+              targetPort: 4444
+              attributes:
+                protocol: http
+                type: main
+                discoverable: "false"
+                secure: "true"
+          env:
+            - name: USE_BEARER_TOKEN
+              value: "true"

--- a/samples/theia-next-contributions.yaml
+++ b/samples/theia-next-contributions.yaml
@@ -1,0 +1,28 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: theia-next
+spec:
+  started: true
+  template:
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    commands:
+      - id: say-hello
+        exec:
+          component: theia-ide
+          commandLine: echo "Hello from $(pwd)"
+          workingDir: ${PROJECTS_ROOT}/project/app
+
+  contributions:
+    - name: theia
+      uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
+      components:
+        - name: theia-ide
+          container:
+            env:
+              - name: THEIA_HOST
+                value: 0.0.0.0


### PR DESCRIPTION
### What does this PR do?
Adds support for the `.spec.contributions` field as described in https://github.com/devfile/api/issues/874. The new field functions the same as current `plugin` components but can be defined separately from `.spec.template`, allowing easier conversion from devfile to devworkspace and back.

For test cases, I copied most of the existing tests for plugins functionality and adapted them to use contributions instead. 

### What issues does this PR fix or reference?
Part of https://github.com/devfile/devworkspace-operator/issues/656

### Is it tested? How?
This PR adds a new sample: `samples/theia-next-contributions.yaml` that uses the new field instead of a theia plugin component. This should behave identically to the current `theia-next.yaml` sample.

In addition I've rewritten the samples from #844 to use contributions instead of plugin components:
* checode + golang [[link]](https://gist.github.com/amisevsk/b44ab9d83c2ac6cb4c500ad16ee70ca7#file-code-golang-devfile-yaml):
    ```
    kubectl apply -f https://gist.githubusercontent.com/amisevsk/b44ab9d83c2ac6cb4c500ad16ee70ca7/raw/a4506801c3d20e6a1423a98238d7e8d9636005f3/code-golang.devfile.yaml
    ```

* theia + golang [[link]](https://gist.github.com/amisevsk/b44ab9d83c2ac6cb4c500ad16ee70ca7#file-theia-golang-devworkspace-yaml):
    ```
    kubectl apply -f https://gist.githubusercontent.com/amisevsk/b44ab9d83c2ac6cb4c500ad16ee70ca7/raw/a4506801c3d20e6a1423a98238d7e8d9636005f3/theia-golang.devworkspace.yaml
    ```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
