### PR TITLE
Add code coverage GitHub Action 

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,50 @@
+name: Code Coverage Report
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  coverage-report:
+    name: Check Code Coverage
+    runs-on: ubuntu-20.04
+    steps:
+    -
+      name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.6
+    -
+      name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    -
+      name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    -
+      name: Cache go modules
+      id: cache-mod
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    -
+      name: Download dependencies
+      run: go mod download
+      if: steps.cache-mod.outputs.cache-hit != 'true'
+    -
+      name: Run Go Tests
+      run: |
+        python -m pip install --upgrade pip yq
+        make test
+    - 
+      name: Build Codecov report
+      uses: codecov/codecov-action@v1
+      with:
+        files: cover.out

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dev Workspace Operator
 
+[![codecov](https://codecov.io/gh/devfile/devworkspace-operator/branch/main/graph/badge.svg)](https://codecov.io/gh//devfile/devworkspace-operator)
+
 Dev Workspace operator repository that contains the controller for the DevWorkspace Custom Resource. The Kubernetes API of the DevWorkspace is defined in the https://github.com/devfile/api repository.
 
 ## DevWorkspace CR
@@ -180,3 +182,5 @@ This will delete all custom resource definitions created for the controller, as 
 #### GitHub actions
 
 - [Next Dockerimage](https://github.com/devfile/devworkspace-operator/blob/main/.github/workflows/dockerimage-next.yml) action builds main branch and pushes it to [quay.io/devfile/devworkspace-controller:next](https://quay.io/repository/devfile/devworkspace-controller?tag=latest&tab=tags)
+
+- [Code Coverage Report](./.github/workflows/code-coverage.yml) action creates a code coverage report using [codecov.io](https://about.codecov.io/). 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+    annotations: false


### PR DESCRIPTION
### What does this PR do?
Enables the creation of code coverage reports for the repository.
A new CI action will run for PR's and for pushes to the main branch. The latter is required to have coverage reports which PR coverage reports can be compared against.  

I've [disabled](https://docs.codecov.com/docs/github-checks#disabling-github-checks-patch-annotations) the annotations which point out which lines of code are not tested, as I personally find them to make PR's harder to read.

I also added the codecov badge to the README. 

One thing to note: the [codecov GH app](https://github.com/apps/codecov) must be enabled. I sent a request for this yesterday and saw today that it seems to be enabled. So there shouldn't be any issue there.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/929

### Is it tested? How?
~~Testing is a bit tricky as this GH actions can only really be tested after they are merged.~~ 
**Edit:** Apparently, the code coverage action is running in this PR.. though it is likely to not work correctly as the main branch does not have a code coverage report uploaded to codecov.io yet.

I did test out the action [on my own fork of the repo](https://github.com/AObuchow/devworkspace-operator/pull/7#issuecomment-1267178317), and it seems to be working as expected.

I did not however test that the badge is working as expected, this will have to be verified after this PR is merged.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
