### PR TITLE
fix: fix codecov README badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dev Workspace Operator
 
-[![codecov](https://codecov.io/gh/devfile/devworkspace-operator/branch/main/graph/badge.svg)](https://codecov.io/gh//devfile/devworkspace-operator)
+[![codecov](https://codecov.io/gh/devfile/devworkspace-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/devfile/devworkspace-operator)
 
 Dev Workspace operator repository that contains the controller for the DevWorkspace Custom Resource. The Kubernetes API of the DevWorkspace is defined in the https://github.com/devfile/api repository.
 


### PR DESCRIPTION
### What does this PR do?
Fixes a typo in the code coverage badge link in the README.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/929

### Is it tested? How?
Check the README on the fork here to ensure the code coverage % is given: https://github.com/AObuchow/devworkspace-operator/tree/fix_code_cov_badge#dev-workspace-operator

![image](https://user-images.githubusercontent.com/10300119/195153334-266413ec-6daf-42b8-8194-1c9a790af510.png)


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
