### PR TITLE
Add container security context field to DevWorkspace Operator Config

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -142,9 +142,8 @@ type WorkspaceConfig struct {
 	// but the objects will be left on the cluster). The default value is false.
 	CleanupOnStop *bool `json:"cleanupOnStop,omitempty"`
 	// PodSecurityContext overrides the default PodSecurityContext used for all workspace-related
-	// pods created by the DevWorkspace Operator when running on Kubernetes. On OpenShift, this
-	// configuration option is ignored. If set, the entire pod security context is overridden;
-	// values are not merged.
+	// pods created by the DevWorkspace Operator. If set, the entire pod security context is
+	// overridden; values are not merged.
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// DefaultTemplate defines an optional DevWorkspace Spec Template which gets applied to the workspace
 	// if the workspace's Template Spec Components are not defined. The DefaultTemplate will overwrite the existing

--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -145,6 +145,10 @@ type WorkspaceConfig struct {
 	// pods created by the DevWorkspace Operator. If set, the entire pod security context is
 	// overridden; values are not merged.
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	// ContainerSecurityContext overrides the default ContainerSecurityContext used for all
+	// workspace-related containers created by the DevWorkspace Operator. If set, the entire
+	// container security context is overridden; values are not merged.
+	ContainerSecurityContext *corev1.SecurityContext `json:"containerSecurityContext,omitempty"`
 	// DefaultTemplate defines an optional DevWorkspace Spec Template which gets applied to the workspace
 	// if the workspace's Template Spec Components are not defined. The DefaultTemplate will overwrite the existing
 	// Template Spec, with the exception of Projects (if any are defined).

--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -142,12 +142,12 @@ type WorkspaceConfig struct {
 	// but the objects will be left on the cluster). The default value is false.
 	CleanupOnStop *bool `json:"cleanupOnStop,omitempty"`
 	// PodSecurityContext overrides the default PodSecurityContext used for all workspace-related
-	// pods created by the DevWorkspace Operator. If set, the entire pod security context is
-	// overridden; values are not merged.
+	// pods created by the DevWorkspace Operator. If set, defined values are merged into the default
+	// configuration
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// ContainerSecurityContext overrides the default ContainerSecurityContext used for all
-	// workspace-related containers created by the DevWorkspace Operator. If set, the entire
-	// container security context is overridden; values are not merged.
+	// workspace-related containers created by the DevWorkspace Operator. If set, defined
+	// values are merged into the default configuration
 	ContainerSecurityContext *corev1.SecurityContext `json:"containerSecurityContext,omitempty"`
 	// DefaultTemplate defines an optional DevWorkspace Spec Template which gets applied to the workspace
 	// if the workspace's Template Spec Components are not defined. The DefaultTemplate will overwrite the existing

--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -556,6 +556,11 @@ func (in *WorkspaceConfig) DeepCopyInto(out *WorkspaceConfig) {
 		*out = new(v1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ContainerSecurityContext != nil {
+		in, out := &in.ContainerSecurityContext, &out.ContainerSecurityContext
+		*out = new(v1.SecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DefaultTemplate != nil {
 		in, out := &in.DefaultTemplate, &out.DefaultTemplate
 		*out = new(v1alpha2.DevWorkspaceTemplateSpecContent)

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -292,7 +292,10 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
-	devfilePodAdditions, err := containerlib.GetKubeContainersFromDevfile(&workspace.Spec.Template, workspace.Config.Workspace.ImagePullPolicy)
+	devfilePodAdditions, err := containerlib.GetKubeContainersFromDevfile(
+		&workspace.Spec.Template,
+		workspace.Config.Workspace.ContainerSecurityContext,
+		workspace.Config.Workspace.ImagePullPolicy)
 	if err != nil {
 		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus)
 	}

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -63,7 +63,7 @@ spec:
                     description: CleanupOnStop governs how the Operator handles stopped DevWorkspaces. If set to true, additional resources associated with a DevWorkspace (e.g. services, deployments, configmaps, etc.) will be removed from the cluster when a DevWorkspace has .spec.started = false. If set to false, resources will be scaled down (e.g. deployments but the objects will be left on the cluster). The default value is false.
                     type: boolean
                   containerSecurityContext:
-                    description: ContainerSecurityContext overrides the default ContainerSecurityContext used for all workspace-related containers created by the DevWorkspace Operator. If set, the entire container security context is overridden; values are not merged.
+                    description: ContainerSecurityContext overrides the default ContainerSecurityContext used for all workspace-related containers created by the DevWorkspace Operator. If set, defined values are merged into the default configuration
                     properties:
                       allowPrivilegeEscalation:
                         description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
@@ -1452,7 +1452,7 @@ spec:
                     - Never
                     type: string
                   podSecurityContext:
-                    description: PodSecurityContext overrides the default PodSecurityContext used for all workspace-related pods created by the DevWorkspace Operator. If set, the entire pod security context is overridden; values are not merged.
+                    description: PodSecurityContext overrides the default PodSecurityContext used for all workspace-related pods created by the DevWorkspace Operator. If set, defined values are merged into the default configuration
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -62,6 +62,90 @@ spec:
                   cleanupOnStop:
                     description: CleanupOnStop governs how the Operator handles stopped DevWorkspaces. If set to true, additional resources associated with a DevWorkspace (e.g. services, deployments, configmaps, etc.) will be removed from the cluster when a DevWorkspace has .spec.started = false. If set to false, resources will be scaled down (e.g. deployments but the objects will be left on the cluster). The default value is false.
                     type: boolean
+                  containerSecurityContext:
+                    description: ContainerSecurityContext overrides the default ContainerSecurityContext used for all workspace-related containers created by the DevWorkspace Operator. If set, the entire container security context is overridden; values are not merged.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem. Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   defaultStorageSize:
                     description: DefaultStorageSize defines an optional struct with fields to specify the sizes of Persistent Volume Claims for storage classes used by DevWorkspaces.
                     properties:
@@ -1368,7 +1452,7 @@ spec:
                     - Never
                     type: string
                   podSecurityContext:
-                    description: PodSecurityContext overrides the default PodSecurityContext used for all workspace-related pods created by the DevWorkspace Operator when running on Kubernetes. On OpenShift, this configuration option is ignored. If set, the entire pod security context is overridden; values are not merged.
+                    description: PodSecurityContext overrides the default PodSecurityContext used for all workspace-related pods created by the DevWorkspace Operator. If set, the entire pod security context is overridden; values are not merged.
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -100,8 +100,8 @@ spec:
                   containerSecurityContext:
                     description: ContainerSecurityContext overrides the default ContainerSecurityContext
                       used for all workspace-related containers created by the DevWorkspace
-                      Operator. If set, the entire container security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       allowPrivilegeEscalation:
                         description: 'AllowPrivilegeEscalation controls whether a
@@ -2283,8 +2283,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator. If set, the entire pod security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -97,6 +97,154 @@ spec:
                       down (e.g. deployments but the objects will be left on the cluster).
                       The default value is false.
                     type: boolean
+                  containerSecurityContext:
+                    description: ContainerSecurityContext overrides the default ContainerSecurityContext
+                      used for all workspace-related containers created by the DevWorkspace
+                      Operator. If set, the entire container security context is overridden;
+                      values are not merged.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   defaultStorageSize:
                     description: DefaultStorageSize defines an optional struct with
                       fields to specify the sizes of Persistent Volume Claims for
@@ -2135,9 +2283,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator when running on Kubernetes. On OpenShift, this configuration
-                      option is ignored. If set, the entire pod security context is
-                      overridden; values are not merged.
+                      Operator. If set, the entire pod security context is overridden;
+                      values are not merged.
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -100,8 +100,8 @@ spec:
                   containerSecurityContext:
                     description: ContainerSecurityContext overrides the default ContainerSecurityContext
                       used for all workspace-related containers created by the DevWorkspace
-                      Operator. If set, the entire container security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       allowPrivilegeEscalation:
                         description: 'AllowPrivilegeEscalation controls whether a
@@ -2283,8 +2283,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator. If set, the entire pod security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -97,6 +97,154 @@ spec:
                       down (e.g. deployments but the objects will be left on the cluster).
                       The default value is false.
                     type: boolean
+                  containerSecurityContext:
+                    description: ContainerSecurityContext overrides the default ContainerSecurityContext
+                      used for all workspace-related containers created by the DevWorkspace
+                      Operator. If set, the entire container security context is overridden;
+                      values are not merged.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   defaultStorageSize:
                     description: DefaultStorageSize defines an optional struct with
                       fields to specify the sizes of Persistent Volume Claims for
@@ -2135,9 +2283,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator when running on Kubernetes. On OpenShift, this configuration
-                      option is ignored. If set, the entire pod security context is
-                      overridden; values are not merged.
+                      Operator. If set, the entire pod security context is overridden;
+                      values are not merged.
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -100,8 +100,8 @@ spec:
                   containerSecurityContext:
                     description: ContainerSecurityContext overrides the default ContainerSecurityContext
                       used for all workspace-related containers created by the DevWorkspace
-                      Operator. If set, the entire container security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       allowPrivilegeEscalation:
                         description: 'AllowPrivilegeEscalation controls whether a
@@ -2283,8 +2283,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator. If set, the entire pod security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -97,6 +97,154 @@ spec:
                       down (e.g. deployments but the objects will be left on the cluster).
                       The default value is false.
                     type: boolean
+                  containerSecurityContext:
+                    description: ContainerSecurityContext overrides the default ContainerSecurityContext
+                      used for all workspace-related containers created by the DevWorkspace
+                      Operator. If set, the entire container security context is overridden;
+                      values are not merged.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   defaultStorageSize:
                     description: DefaultStorageSize defines an optional struct with
                       fields to specify the sizes of Persistent Volume Claims for
@@ -2135,9 +2283,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator when running on Kubernetes. On OpenShift, this configuration
-                      option is ignored. If set, the entire pod security context is
-                      overridden; values are not merged.
+                      Operator. If set, the entire pod security context is overridden;
+                      values are not merged.
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -100,8 +100,8 @@ spec:
                   containerSecurityContext:
                     description: ContainerSecurityContext overrides the default ContainerSecurityContext
                       used for all workspace-related containers created by the DevWorkspace
-                      Operator. If set, the entire container security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       allowPrivilegeEscalation:
                         description: 'AllowPrivilegeEscalation controls whether a
@@ -2283,8 +2283,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator. If set, the entire pod security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -97,6 +97,154 @@ spec:
                       down (e.g. deployments but the objects will be left on the cluster).
                       The default value is false.
                     type: boolean
+                  containerSecurityContext:
+                    description: ContainerSecurityContext overrides the default ContainerSecurityContext
+                      used for all workspace-related containers created by the DevWorkspace
+                      Operator. If set, the entire container security context is overridden;
+                      values are not merged.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   defaultStorageSize:
                     description: DefaultStorageSize defines an optional struct with
                       fields to specify the sizes of Persistent Volume Claims for
@@ -2135,9 +2283,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator when running on Kubernetes. On OpenShift, this configuration
-                      option is ignored. If set, the entire pod security context is
-                      overridden; values are not merged.
+                      Operator. If set, the entire pod security context is overridden;
+                      values are not merged.
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -96,6 +96,154 @@ spec:
                       down (e.g. deployments but the objects will be left on the cluster).
                       The default value is false.
                     type: boolean
+                  containerSecurityContext:
+                    description: ContainerSecurityContext overrides the default ContainerSecurityContext
+                      used for all workspace-related containers created by the DevWorkspace
+                      Operator. If set, the entire container security context is overridden;
+                      values are not merged.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
                   defaultStorageSize:
                     description: DefaultStorageSize defines an optional struct with
                       fields to specify the sizes of Persistent Volume Claims for
@@ -2134,9 +2282,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator when running on Kubernetes. On OpenShift, this configuration
-                      option is ignored. If set, the entire pod security context is
-                      overridden; values are not merged.
+                      Operator. If set, the entire pod security context is overridden;
+                      values are not merged.
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -99,8 +99,8 @@ spec:
                   containerSecurityContext:
                     description: ContainerSecurityContext overrides the default ContainerSecurityContext
                       used for all workspace-related containers created by the DevWorkspace
-                      Operator. If set, the entire container security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       allowPrivilegeEscalation:
                         description: 'AllowPrivilegeEscalation controls whether a
@@ -2282,8 +2282,8 @@ spec:
                   podSecurityContext:
                     description: PodSecurityContext overrides the default PodSecurityContext
                       used for all workspace-related pods created by the DevWorkspace
-                      Operator. If set, the entire pod security context is overridden;
-                      values are not merged.
+                      Operator. If set, defined values are merged into the default
+                      configuration
                     properties:
                       fsGroup:
                         description: "A special supplemental group that applies to

--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -54,6 +54,7 @@ func setupForTest(t *testing.T) {
 		t.Fatalf("failed to set up for test: %s", err)
 	}
 	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
+	setDefaultPodSecurityContext()
 	configNamespace = testNamespace
 	originalDefaultConfig := defaultConfig.DeepCopy()
 	t.Cleanup(func() {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -41,11 +41,12 @@ var defaultConfig = &v1alpha1.OperatorConfiguration{
 			Common:       &commonStorageSize,
 			PerWorkspace: &perWorkspaceStorageSize,
 		},
-		IdleTimeout:        "15m",
-		ProgressTimeout:    "5m",
-		CleanupOnStop:      pointer.BoolPtr(false),
-		PodSecurityContext: nil,
-		DefaultTemplate:    nil,
+		IdleTimeout:              "15m",
+		ProgressTimeout:          "5m",
+		CleanupOnStop:            pointer.BoolPtr(false),
+		PodSecurityContext:       nil,
+		ContainerSecurityContext: &corev1.SecurityContext{},
+		DefaultTemplate:          nil,
 	},
 }
 

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -293,6 +293,9 @@ func mergeConfig(from, to *controller.OperatorConfiguration) {
 		if from.Workspace.PodSecurityContext != nil {
 			to.Workspace.PodSecurityContext = from.Workspace.PodSecurityContext
 		}
+		if from.Workspace.ContainerSecurityContext != nil {
+			to.Workspace.ContainerSecurityContext = from.Workspace.ContainerSecurityContext
+		}
 		if from.Workspace.DefaultStorageSize != nil {
 			if to.Workspace.DefaultStorageSize == nil {
 				to.Workspace.DefaultStorageSize = &controller.StorageSizes{}
@@ -330,7 +333,7 @@ func GetCurrentConfigString(currConfig *controller.OperatorConfiguration) string
 	}
 	workspace := currConfig.Workspace
 	if workspace != nil {
-		// Don't include PodSecurityContext for now as it's less easy to compare
+		// Don't include PodSecurityContext or ContainerSecurityContext for now as it's less easy to compare
 		if workspace.ImagePullPolicy != defaultConfig.Workspace.ImagePullPolicy {
 			config = append(config, fmt.Sprintf("workspace.imagePullPolicy=%s", workspace.ImagePullPolicy))
 		}

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -96,6 +96,10 @@ func SetupControllerConfig(client crclient.Client) error {
 	if internalConfig != nil {
 		return fmt.Errorf("internal controller configuration is already set up")
 	}
+	if err := setDefaultPodSecurityContext(); err != nil {
+		return err
+	}
+
 	internalConfig = &controller.OperatorConfiguration{}
 
 	namespace, err := infrastructure.GetNamespace()

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -384,7 +385,6 @@ func GetCurrentConfigString(currConfig *controller.OperatorConfiguration) string
 	}
 	workspace := currConfig.Workspace
 	if workspace != nil {
-		// Don't include PodSecurityContext or ContainerSecurityContext for now as it's less easy to compare
 		if workspace.ImagePullPolicy != defaultConfig.Workspace.ImagePullPolicy {
 			config = append(config, fmt.Sprintf("workspace.imagePullPolicy=%s", workspace.ImagePullPolicy))
 		}
@@ -422,6 +422,12 @@ func GetCurrentConfigString(currConfig *controller.OperatorConfiguration) string
 			if workspace.DefaultStorageSize.PerWorkspace != nil && workspace.DefaultStorageSize.PerWorkspace.String() != defaultConfig.Workspace.DefaultStorageSize.PerWorkspace.String() {
 				config = append(config, fmt.Sprintf("workspace.defaultStorageSize.perWorkspace=%s", workspace.DefaultStorageSize.PerWorkspace.String()))
 			}
+		}
+		if !reflect.DeepEqual(workspace.PodSecurityContext, defaultConfig.Workspace.PodSecurityContext) {
+			config = append(config, "workspace.podSecurityContext is set")
+		}
+		if !reflect.DeepEqual(workspace.ContainerSecurityContext, defaultConfig.Workspace.ContainerSecurityContext) {
+			config = append(config, "workspace.containerSecurityContext is set")
 		}
 		if workspace.DefaultTemplate != nil {
 			config = append(config, "workspace.defaultTemplate is set")

--- a/pkg/infrastructure/cluster.go
+++ b/pkg/infrastructure/cluster.go
@@ -60,6 +60,10 @@ func InitializeForTesting(currentInfrastructure Type) {
 	initialized = true
 }
 
+func IsInitialized() bool {
+	return initialized
+}
+
 // IsOpenShift returns true if the current cluster is an OpenShift (v4.x) cluster.
 func IsOpenShift() bool {
 	if !initialized {

--- a/pkg/library/container/container.go
+++ b/pkg/library/container/container.go
@@ -33,6 +33,7 @@ import (
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/library/flatten"
 	"github.com/devfile/devworkspace-operator/pkg/library/lifecycle"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // GetKubeContainersFromDevfile converts container components in a DevWorkspace into Kubernetes containers.
@@ -45,7 +46,7 @@ import (
 // rewritten as Volumes are added to PodAdditions, in order to support e.g. using one PVC to hold all volumes
 //
 // Note: Requires DevWorkspace to be flattened (i.e. the DevWorkspace contains no Parent or Components of type Plugin)
-func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, pullPolicy string) (*v1alpha1.PodAdditions, error) {
+func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, securityContext *corev1.SecurityContext, pullPolicy string) (*v1alpha1.PodAdditions, error) {
 	if !flatten.DevWorkspaceIsFlattened(workspace, nil) {
 		return nil, fmt.Errorf("devfile is not flattened")
 	}
@@ -60,7 +61,7 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, pullPo
 		if component.Container == nil {
 			continue
 		}
-		k8sContainer, err := convertContainerToK8s(component, pullPolicy)
+		k8sContainer, err := convertContainerToK8s(component, securityContext, pullPolicy)
 		if err != nil {
 			return nil, err
 		}
@@ -80,7 +81,7 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, pullPo
 	}
 
 	for _, initComponent := range initComponents {
-		k8sContainer, err := convertContainerToK8s(initComponent, pullPolicy)
+		k8sContainer, err := convertContainerToK8s(initComponent, securityContext, pullPolicy)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/library/container/container_test.go
+++ b/pkg/library/container/container_test.go
@@ -77,7 +77,7 @@ func TestGetKubeContainersFromDevfile(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check that file is read correctly.
 			assert.True(t, len(tt.Input.Components) > 0, "Input defines no components")
-			gotPodAdditions, err := GetKubeContainersFromDevfile(tt.Input, testImagePullPolicy)
+			gotPodAdditions, err := GetKubeContainersFromDevfile(tt.Input, nil, testImagePullPolicy)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {


### PR DESCRIPTION
### What does this PR do?
* Add `.config.workspace.containerSecurityContext` field to DevWorkspaceOperatorConfig to allow configuring container-level security context for workspace pods
* Update how podSecurityContext is handled to allow specifying a configured value in OpenShift as well (previously it was ignored)
* Merge podSecurityContext values into default configuration rather than overwriting it entirely
* Minor fixes:
  * Add config package test that fuzzes config to ensure all fields are considered by merging
  * Update CRD documentation
  * Allow specifying different defaults for OpenShift and Kubernetes for podSecurityContext
  * Log when a non-default container/pod security context is used

### What issues does this PR fix or reference?
Closes #951 
Closes #952 

### Is it tested? How?
To test:
* Verify that functionality is unchanged on OpenShift when no values are configured
* Verify that it's possible to configure both container and pod security context
* Verify that pod security context does not overwrite unset fields

On Kubernetes, the following DevWorkspaceOperatorConfig fields can be used to test:
```yaml
config:
  workspace:
    containerSecurityContext:
      capabilities:
        add:
        - SETUID
        - SETGID
    podSecurityContext:
      runAsUser: 2048
```
This should result in the workspace pod having `runAsUser: 2048` and pod containers having the `SETUID` and `SETGID` capabilities.

On OpenShift, the above DWOC will likely cause the workspace to fail to start. One permissible configuration is to specify a `runAsUser` within the UID range assigned the current project, e.g.
```yaml
config:
  workspace:
    containerSecurityContext:
      runAsUser: 1000670002
    podSecurityContext:
      runAsUser: 1000670001
```
(where `1000670000` is the default UID used for running workspace pods).

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
