### PR TITLE
Update titles for Grafana dashboard

### DIFF
--- a/docs/grafana/grafana-dashboard.json
+++ b/docs/grafana/grafana-dashboard.json
@@ -74,7 +74,7 @@
       },
       "id": 31,
       "panels": [],
-      "title": "DevWorkspace-specific metrics",
+      "title": "DevWorkspace Metrics",
       "type": "row"
     },
     {
@@ -526,7 +526,7 @@
           "refId": "B"
         }
       ],
-      "title": "DevWorkspace successes/failures",
+      "title": "DevWorkspace Successes/Failures",
       "type": "timeseries"
     },
     {
@@ -586,7 +586,7 @@
           "refId": "A"
         }
       ],
-      "title": "DevWorkspace failure rate",
+      "title": "DevWorkspace Failure Rate",
       "type": "stat"
     },
     {
@@ -715,7 +715,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Webhooks in flight",
+      "title": "Webhooks in Flight",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -862,7 +862,7 @@
           "refId": "A"
         }
       ],
-      "title": "Webhooks latency (/mutate)",
+      "title": "Webhooks Latency (/mutate)",
       "tooltip": {
         "show": true,
         "showHistogram": false
@@ -928,7 +928,7 @@
           "refId": "A"
         }
       ],
-      "title": "Reconcile time",
+      "title": "Reconcile Time",
       "tooltip": {
         "show": true,
         "showHistogram": false
@@ -993,7 +993,7 @@
           "refId": "A"
         }
       ],
-      "title": "Webhooks latency (/convert)",
+      "title": "Webhooks Latency (/convert)",
       "tooltip": {
         "show": true,
         "showHistogram": false


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

### What does this PR do?
Updates Grafana dashboard panel titles' capitializations to be consistent with each other
<img width="2070" alt="image" src="https://user-images.githubusercontent.com/83611742/197070041-3544b7dc-513f-4295-becd-db76bb6c208b.png">
<img width="1545" alt="image" src="https://user-images.githubusercontent.com/83611742/197070313-fac2e66d-df0a-4fba-820e-d18158497a94.png">


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
It is a minor change, but it can be tested by following the monitoring docs on a fresh cluster: https://www.eclipse.org/che/docs/stable/administration-guide/monitoring-the-dev-workspace-operator/

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
