### PR TITLE
Cherry-pick minor fixes from open PRs

### DIFF
--- a/pkg/provision/workspace/pull_secret.go
+++ b/pkg/provision/workspace/pull_secret.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -80,12 +81,14 @@ func PullSecrets(clusterAPI sync.ClusterAPI, serviceAccountName, namespace strin
 		}
 	}
 
-	if len(serviceAccount.ImagePullSecrets) == 0 && serviceAccount.CreationTimestamp.Add(pullSecretCreationTimeout).After(time.Now()) {
-		return PullSecretsProvisioningStatus{
-			ProvisioningStatus: ProvisioningStatus{
-				Requeue: true,
-				Message: "Waiting for image pull secrets",
-			},
+	if infrastructure.IsOpenShift() {
+		if len(serviceAccount.ImagePullSecrets) == 0 && serviceAccount.CreationTimestamp.Add(pullSecretCreationTimeout).After(time.Now()) {
+			return PullSecretsProvisioningStatus{
+				ProvisioningStatus: ProvisioningStatus{
+					Requeue: true,
+					Message: "Waiting for image pull secrets",
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?
Cherry-picks two quality-of-life improvements from open PRs in order to merge them sooner:

* https://github.com/devfile/devworkspace-operator/pull/957/commits/b223ec09e063787f5e996687d9e20f5b5cb7b0fd from https://github.com/devfile/devworkspace-operator/pull/957-- avoid waiting for 5 seconds on every workspace start when running in Kubernetes. This was required to make envtest tests complete in a reasonable time but is useful in general
* https://github.com/devfile/devworkspace-operator/pull/954/commits/0377b016ff8677dd9e350856275e7b3d08136fd2 from https://github.com/devfile/devworkspace-operator/pull/954 (fix `make run`/`make debug` when running on Kubernetes >=1.24).

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
