### PR TITLE
Add support for Kubernetes and OpenShift-type DevWorkspace components

### DIFF
--- a/controllers/workspace/condition.go
+++ b/controllers/workspace/condition.go
@@ -29,6 +29,7 @@ var conditionOrder = []dw.DevWorkspaceConditionType{
 	dw.DevWorkspaceRoutingReady,
 	dw.DevWorkspaceServiceAccountReady,
 	conditions.PullSecretsReady,
+	conditions.KubeComponentsReady,
 	conditions.DeploymentReady,
 	dw.DevWorkspaceReady,
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/cache"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	kubesync "github.com/devfile/devworkspace-operator/pkg/library/kubernetes"
 	"github.com/devfile/devworkspace-operator/pkg/webhook"
 	"github.com/devfile/devworkspace-operator/version"
 
@@ -104,6 +105,10 @@ func main() {
 	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	setupLog.Info(fmt.Sprintf("Commit: %s", version.Commit))
 	setupLog.Info(fmt.Sprintf("BuildTime: %s", version.BuildTime))
+
+	if err := kubesync.InitializeDeserializer(scheme); err != nil {
+		setupLog.Error(err, "failed to initialized Kubernetes objects decoder")
+	}
 
 	cacheFunc, err := cache.GetCacheFunc()
 	if err != nil {

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -22,6 +22,7 @@ const (
 	PullSecretsReady     dw.DevWorkspaceConditionType = "PullSecretsReady"
 	DevWorkspaceResolved dw.DevWorkspaceConditionType = "DevWorkspaceResolved"
 	StorageReady         dw.DevWorkspaceConditionType = "StorageReady"
+	KubeComponentsReady  dw.DevWorkspaceConditionType = "KubernetesComponentsProvisioned"
 	DeploymentReady      dw.DevWorkspaceConditionType = "DeploymentReady"
 	DevWorkspaceWarning  dw.DevWorkspaceConditionType = "DevWorkspaceWarning"
 )

--- a/pkg/library/kubernetes/common_test.go
+++ b/pkg/library/kubernetes/common_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+	testAPI    = sync.ClusterAPI{
+		Scheme: testScheme,
+	}
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
+	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
+	utilruntime.Must(dw.AddToScheme(testScheme))
+}

--- a/pkg/library/kubernetes/deserialize.go
+++ b/pkg/library/kubernetes/deserialize.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	gosync "sync"
+
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	decoder      runtime.Decoder
+	decoderMutex gosync.Mutex
+)
+
+func InitializeDeserializer(scheme *runtime.Scheme) error {
+	decoderMutex.Lock()
+	defer decoderMutex.Unlock()
+	if decoder != nil {
+		return fmt.Errorf("attempting to re-initialize kubernetes object decoder")
+	}
+	decoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
+	return nil
+}
+
+func deserializeToObject(jsonObj []byte, api sync.ClusterAPI) (client.Object, error) {
+	if decoder == nil {
+		return nil, fmt.Errorf("kubernetes object deserializer is not initialized")
+	}
+	obj, _, err := decoder.Decode(jsonObj, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if obj.GetObjectKind().GroupVersionKind().Kind == "List" {
+		return nil, fmt.Errorf("objects of kind 'List' are unsupported")
+	}
+	clientObj, ok := obj.(client.Object)
+	if !ok {
+		// Should never occur but to avoid a panic
+		return nil, fmt.Errorf("object does not have standard metadata and cannot be processed")
+	}
+	return clientObj, nil
+}

--- a/pkg/library/kubernetes/deserialize_test.go
+++ b/pkg/library/kubernetes/deserialize_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	api    = sync.ClusterAPI{
+		Scheme: scheme,
+	}
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(dw.AddToScheme(scheme))
+}
+
+func TestDeserializeObject(t *testing.T) {
+	InitializeDeserializer(scheme)
+	defer func() {
+		decoder = nil
+	}()
+	tests := []struct {
+		name              string
+		filePath          string
+		expectedObjStub   client.Object
+		expectedErrRegexp string
+	}{
+		{
+			name:            "Deserializes Pod",
+			filePath:        "testdata/k8s_objects/pod.yaml",
+			expectedObjStub: &corev1.Pod{},
+		},
+		{
+			name:            "Deserializes Service",
+			filePath:        "testdata/k8s_objects/service.yaml",
+			expectedObjStub: &corev1.Service{},
+		},
+		{
+			name:            "Deserializes ConfigMap",
+			filePath:        "testdata/k8s_objects/configmap.yaml",
+			expectedObjStub: &corev1.ConfigMap{},
+		},
+		{
+			name:              "Kubernetes list",
+			filePath:          "testdata/k8s_objects/kubernetes-list.yaml",
+			expectedErrRegexp: "objects of kind 'List' are unsupported",
+		},
+		{
+			name:              "Random yaml that is not a Kubernetes object",
+			filePath:          "testdata/k8s_objects/non-k8s-object.yaml",
+			expectedErrRegexp: "Object 'Kind' is missing",
+		},
+		{
+			name:              "Object with unrecognized kind",
+			filePath:          "testdata/k8s_objects/unrecognized-kind.yaml",
+			expectedErrRegexp: "no kind .* is registered for version .* in scheme",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s (%s)", tt.name, tt.filePath), func(t *testing.T) {
+			jsonBytes := readBytesFromFile(t, tt.filePath)
+			actualObj, err := deserializeToObject(jsonBytes, api)
+			if tt.expectedErrRegexp != "" {
+				if !assert.Error(t, err, "Expect error to be returned") {
+					return
+				}
+				assert.Regexp(t, tt.expectedErrRegexp, err.Error(), "Expect error to match pattern")
+			} else {
+				if !assert.NoError(t, err, "Expect no error to be returned") {
+					return
+				}
+				err := yaml.Unmarshal(jsonBytes, tt.expectedObjStub)
+				assert.NoError(t, err)
+				assert.True(t, cmp.Equal(tt.expectedObjStub, actualObj), cmp.Diff(tt.expectedObjStub, actualObj))
+			}
+		})
+	}
+}
+
+func TestErrorIfDeserializerNotInitialized(t *testing.T) {
+	_, err := deserializeToObject([]byte(""), api)
+	assert.Error(t, err)
+	assert.Equal(t, "kubernetes object deserializer is not initialized", err.Error())
+}
+
+func readBytesFromFile(t *testing.T, filePath string) []byte {
+	bytes, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes
+}

--- a/pkg/library/kubernetes/errors.go
+++ b/pkg/library/kubernetes/errors.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import "github.com/devfile/devworkspace-operator/pkg/provision/sync"
+
+type RetryError struct {
+	Err error
+}
+
+func (e *RetryError) Error() string {
+	return e.Err.Error()
+}
+
+type FailError struct {
+	Err error
+}
+
+func (e *FailError) Error() string {
+	return e.Err.Error()
+}
+
+func wrapSyncError(err error) error {
+	switch syncErr := err.(type) {
+	case *sync.NotInSyncError:
+		return &RetryError{syncErr}
+	case *sync.UnrecoverableSyncError:
+		return &FailError{syncErr}
+	case *sync.WarningError:
+		return &WarningError{syncErr}
+	default:
+		return err
+	}
+}
+
+type WarningError struct {
+	Err error
+}
+
+func (e *WarningError) Error() string {
+	return e.Err.Error()
+}

--- a/pkg/library/kubernetes/provision.go
+++ b/pkg/library/kubernetes/provision.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// HandleKubernetesComponents processes the Kubernetes and OpenShift components of a DevWorkspace,
+// creating/updating objects on the cluster. This function does not verify if the workspace owner
+// has the correct permissions to create/update/delete these objects and instead assumes the
+// workspace owner has all applicable RBAC permissions.
+// Only Kubernetes/OpenShift components that are inlined are supported; components that define
+// a URI will cause a FailError to be returned
+func HandleKubernetesComponents(workspace *common.DevWorkspaceWithConfig, api sync.ClusterAPI) error {
+	kubeComponents, err := filterForKubeLikeComponents(workspace.Spec.Template.Components)
+	if err != nil {
+		return err
+	}
+	if len(kubeComponents) == 0 {
+		return nil
+	}
+	for _, component := range kubeComponents {
+		// Ignore error as we filtered list above
+		k8sLikeComponent, _ := getK8sLikeComponent(component)
+		obj, err := deserializeToObject([]byte(k8sLikeComponent.Inlined), api)
+		if err != nil {
+			return &FailError{fmt.Errorf("could not process component %s: %w", component.Name, err)}
+		}
+		if err := addMetadata(obj, workspace, api); err != nil {
+			return &RetryError{fmt.Errorf("failed to add ownerref for component %s: %w", component.Name, err)}
+		}
+		if err := checkForExistingObject(obj, api); err != nil {
+			return &FailError{fmt.Errorf("could not process component %s: %w", component.Name, err)}
+		}
+		var syncErr error
+		if sync.IsRecognizedObject(obj) {
+			_, syncErr = sync.SyncObjectWithCluster(obj, api)
+		} else {
+			_, syncErr = sync.SyncUnrecognizedObjectWithCluster(obj, api)
+		}
+		if syncErr != nil {
+			return wrapSyncError(syncErr)
+		}
+	}
+	return nil
+}
+
+func checkForExistingObject(obj client.Object, api sync.ClusterAPI) error {
+	objType := reflect.TypeOf(obj).Elem()
+	clusterObj := reflect.New(objType).Interface().(crclient.Object)
+	err := api.Client.Get(api.Ctx, client.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, clusterObj)
+	switch {
+	case err == nil:
+		break
+	case k8sErrors.IsNotFound(err):
+		// Object does not exist yet; safe to create
+		return nil
+	default:
+		return err
+	}
+	existingWorkspaceID := clusterObj.GetLabels()[constants.DevWorkspaceIDLabel]
+	expectedWorkspaceID := obj.GetLabels()[constants.DevWorkspaceIDLabel]
+	if existingWorkspaceID != expectedWorkspaceID {
+		return fmt.Errorf("object %s exists and is not owned by this workspace", obj.GetName())
+	}
+	if err := checkOwnerrefs(clusterObj.GetOwnerReferences(), obj.GetOwnerReferences()); err != nil {
+		return fmt.Errorf("object %s exists and is not owned by this workspace", obj.GetName())
+	}
+	return nil
+}
+
+func addMetadata(obj client.Object, workspace *common.DevWorkspaceWithConfig, api sync.ClusterAPI) error {
+	obj.SetNamespace(workspace.Namespace)
+	if err := controllerutil.SetOwnerReference(workspace.DevWorkspace, obj, api.Scheme); err != nil {
+		return err
+	}
+	newLabels := map[string]string{}
+	for k, v := range obj.GetLabels() {
+		newLabels[k] = v
+	}
+	newLabels[constants.DevWorkspaceIDLabel] = workspace.Status.DevWorkspaceId
+	newLabels[constants.DevWorkspaceCreatorLabel] = workspace.Labels[constants.DevWorkspaceCreatorLabel]
+	if obj.GetObjectKind().GroupVersionKind().Kind == "Secret" {
+		newLabels[constants.DevWorkspaceWatchSecretLabel] = "true"
+	}
+	if obj.GetObjectKind().GroupVersionKind().Kind == "ConfigMap" {
+		newLabels[constants.DevWorkspaceWatchConfigMapLabel] = "true"
+	}
+	obj.SetLabels(newLabels)
+	return nil
+}

--- a/pkg/library/kubernetes/provision_test.go
+++ b/pkg/library/kubernetes/provision_test.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	testlog "github.com/go-logr/logr/testing"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+)
+
+type testCase struct {
+	Name             string     `json:"name,omitempty"`
+	Input            testInput  `json:"input,omitempty"`
+	Output           testOutput `json:"output,omitempty"`
+	originalFilename string
+}
+
+type testInput struct {
+	Components      []dw.Component `json:"components,omitempty"`
+	ExistingObjects clusterObjects `json:"existingObjects,omitempty"`
+}
+
+type testOutput struct {
+	ExpectedObjects clusterObjects `json:"expectedObjects,omitempty"`
+	ErrRegexp       *string        `json:"errRegexp,omitempty"`
+}
+
+type clusterObjects struct {
+	Pods     []corev1.Pod     `json:"pods,omitempty"`
+	Services []corev1.Service `json:"services,omitempty"`
+}
+
+const (
+	testID               = "test-devworkspaceID"
+	testCreatorID        = "test-creatorID"
+	testDevWorkspaceName = "test-devworkspace"
+	testDevWorkspaceUID  = "test-UID"
+	testNamespace        = "test-devworkspace"
+)
+
+var testDevWorkspace = &dw.DevWorkspace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      testDevWorkspaceName,
+		Namespace: testNamespace,
+		Labels: map[string]string{
+			constants.DevWorkspaceCreatorLabel: testCreatorID,
+		},
+		UID: testDevWorkspaceUID,
+	},
+	Spec: dw.DevWorkspaceSpec{
+		Template: dw.DevWorkspaceTemplateSpec{
+			DevWorkspaceTemplateSpecContent: dw.DevWorkspaceTemplateSpecContent{},
+		},
+	},
+	Status: dw.DevWorkspaceStatus{
+		DevWorkspaceId: testID,
+	},
+}
+
+func TestHandleKubernetesComponents(t *testing.T) {
+	if err := InitializeDeserializer(testScheme); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	defer func() { decoder = nil }()
+	tests := loadAllTestCasesOrPanic(t, "testdata/provision_tests")
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.originalFilename), func(t *testing.T) {
+			testClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(collectClusterObj(tt.Input.ExistingObjects)...).Build()
+			api := sync.ClusterAPI{
+				Client: testClient,
+				Scheme: testScheme,
+				Logger: testlog.TestLogger{T: t},
+			}
+			wksp := &common.DevWorkspaceWithConfig{
+				DevWorkspace: testDevWorkspace.DeepCopy(),
+			}
+			wksp.Spec.Template.Components = append(wksp.Spec.Template.Components, tt.Input.Components...)
+			// Repeat function as long as it returns RetryError
+			i := 0
+			maxIters := 30
+			var err error
+			retryErr := &RetryError{}
+			for err = HandleKubernetesComponents(wksp, api); errors.As(err, &retryErr); err = HandleKubernetesComponents(wksp, api) {
+				i += 1
+				assert.LessOrEqual(t, i, maxIters, "HandleKubernetesComponents did no complete within %d iterations", maxIters)
+			}
+
+			if tt.Output.ErrRegexp != nil {
+				if !assert.Error(t, err, "Expected error to be returned") {
+					return
+				}
+				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error())
+			} else {
+				if !assert.NoError(t, err, "Unexpected error returned") {
+					return
+				}
+				for _, obj := range collectClusterObj(tt.Output.ExpectedObjects) {
+					objType := reflect.TypeOf(obj).Elem()
+					clusterObj := reflect.New(objType).Interface().(client.Object)
+					err := testClient.Get(api.Ctx, types.NamespacedName{Name: obj.GetName(), Namespace: wksp.Namespace}, clusterObj)
+					if !assert.NoError(t, err, "Expect object to be created on cluster: %s %s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName()) {
+						return
+					}
+					assert.True(t, cmp.Equal(obj, clusterObj, cmpopts.IgnoreTypes(metav1.ObjectMeta{}, metav1.TypeMeta{})),
+						"Expect objects to match: %s", cmp.Diff(obj, clusterObj, cmpopts.IgnoreTypes(metav1.ObjectMeta{}, metav1.TypeMeta{})))
+					assert.Equal(t, clusterObj.GetLabels()[constants.DevWorkspaceIDLabel], testID, "Object should get devworkspace ID label")
+					assert.Equal(t, clusterObj.GetLabels()[constants.DevWorkspaceCreatorLabel], testCreatorID, "Object should get devworkspace ID label")
+					assert.Contains(t, clusterObj.GetOwnerReferences(), metav1.OwnerReference{
+						Kind:       "DevWorkspace",
+						APIVersion: "workspace.devfile.io/v1alpha2",
+						Name:       testDevWorkspaceName,
+						UID:        testDevWorkspaceUID,
+					})
+				}
+			}
+		})
+	}
+}
+
+func TestSecretAndConfigMapProvisioning(t *testing.T) {
+	if err := InitializeDeserializer(testScheme); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	defer func() { decoder = nil }()
+
+	testClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	api := sync.ClusterAPI{
+		Client: testClient,
+		Scheme: testScheme,
+		Logger: testlog.TestLogger{T: t},
+	}
+	wksp := &common.DevWorkspaceWithConfig{
+		DevWorkspace: testDevWorkspace.DeepCopy(),
+	}
+	cmInline := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"test-configmap"},"data":{"test":"data"}}`
+	secretInline := `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"test-secret"},"data":{"test":"dGVzdAo="}}`
+	wksp.Spec.Template.Components = append(wksp.Spec.Template.Components,
+		dw.Component{
+			Name: "test-configmap",
+			ComponentUnion: dw.ComponentUnion{
+				Kubernetes: &dw.KubernetesComponent{
+					K8sLikeComponent: dw.K8sLikeComponent{
+						DeployByDefault: pointer.BoolPtr(true),
+						K8sLikeComponentLocation: dw.K8sLikeComponentLocation{
+							Inlined: cmInline,
+						},
+					},
+				},
+			},
+		},
+		dw.Component{
+			Name: "test-secret",
+			ComponentUnion: dw.ComponentUnion{
+				Kubernetes: &dw.KubernetesComponent{
+					K8sLikeComponent: dw.K8sLikeComponent{
+						DeployByDefault: pointer.BoolPtr(true),
+						K8sLikeComponentLocation: dw.K8sLikeComponentLocation{
+							Inlined: secretInline,
+						},
+					},
+				},
+			},
+		},
+	)
+	// Repeat function as long as it returns RetryError
+	i := 0
+	maxIters := 30
+	var err error
+	retryErr := &RetryError{}
+	for err = HandleKubernetesComponents(wksp, api); errors.As(err, &retryErr); err = HandleKubernetesComponents(wksp, api) {
+		i += 1
+		assert.LessOrEqual(t, i, maxIters, "HandleKubernetesComponents did no complete within %d iterations", maxIters)
+	}
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	clusterConfigmap := &corev1.ConfigMap{}
+	err = testClient.Get(api.Ctx, types.NamespacedName{Name: "test-configmap", Namespace: wksp.Namespace}, clusterConfigmap)
+	if !assert.NoError(t, err, "Expect configmap 'test-configmap' to be created on cluster") {
+		return
+	}
+	assert.Contains(t, clusterConfigmap.GetLabels(), constants.DevWorkspaceWatchConfigMapLabel)
+
+	clusterSecret := &corev1.Secret{}
+	err = testClient.Get(api.Ctx, types.NamespacedName{Name: "test-secret", Namespace: wksp.Namespace}, clusterSecret)
+	if !assert.NoError(t, err, "Expect secret 'test-secret' to be created on cluster") {
+		return
+	}
+	assert.Contains(t, clusterSecret.GetLabels(), constants.DevWorkspaceWatchSecretLabel)
+}
+
+func TestHasKubelikeComponent(t *testing.T) {
+	noComponents := loadTestCaseOrPanic(t, "testdata/provision_tests/no-k8s-components-devworkspace.yaml")
+	workspaceWithoutK8sComponents := &common.DevWorkspaceWithConfig{
+		DevWorkspace: testDevWorkspace.DeepCopy(),
+	}
+	workspaceWithoutK8sComponents.Spec.Template.Components = append(workspaceWithoutK8sComponents.Spec.Template.Components, noComponents.Input.Components...)
+	assert.False(t, HasKubelikeComponent(workspaceWithoutK8sComponents))
+
+	hasComponents := loadTestCaseOrPanic(t, "testdata/provision_tests/creates-k8s-objects.yaml")
+	workspaceWithK8sComponents := &common.DevWorkspaceWithConfig{
+		DevWorkspace: testDevWorkspace.DeepCopy(),
+	}
+	workspaceWithK8sComponents.Spec.Template.Components = append(workspaceWithK8sComponents.Spec.Template.Components, hasComponents.Input.Components...)
+	assert.True(t, HasKubelikeComponent(workspaceWithK8sComponents))
+}
+
+func loadAllTestCasesOrPanic(t *testing.T, fromDir string) []testCase {
+	files, err := os.ReadDir(fromDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tests []testCase
+	for _, file := range files {
+		if file.IsDir() {
+			tests = append(tests, loadAllTestCasesOrPanic(t, filepath.Join(fromDir, file.Name()))...)
+		} else {
+			tests = append(tests, loadTestCaseOrPanic(t, filepath.Join(fromDir, file.Name())))
+		}
+	}
+	return tests
+}
+
+func loadTestCaseOrPanic(t *testing.T, testPath string) testCase {
+	bytes, err := os.ReadFile(testPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var test testCase
+	if err := yaml.Unmarshal(bytes, &test); err != nil {
+		t.Fatal(err)
+	}
+	test.originalFilename = testPath
+	return test
+}
+
+func collectClusterObj(clusterObjs clusterObjects) []client.Object {
+	var objs []client.Object
+	for _, pod := range clusterObjs.Pods {
+		pod := pod
+		pod.Namespace = testNamespace
+		objs = append(objs, &pod)
+	}
+	for _, svc := range clusterObjs.Services {
+		svc := svc
+		svc.Namespace = testNamespace
+		objs = append(objs, &svc)
+	}
+	return objs
+}

--- a/pkg/library/kubernetes/testdata/k8s_objects/configmap.yaml
+++ b/pkg/library/kubernetes/testdata/k8s_objects/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+data:
+  key: value

--- a/pkg/library/kubernetes/testdata/k8s_objects/kubernetes-list.yaml
+++ b/pkg/library/kubernetes/testdata/k8s_objects/kubernetes-list.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: List
+metadata:
+  resourceVersion: ""
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: test-pod
+    labels:
+      testLabel: testPod
+  spec:
+    containers:
+    - name: test-container
+      image: test-image
+      resources:
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+      ports:
+        - containerPort: 8080

--- a/pkg/library/kubernetes/testdata/k8s_objects/non-k8s-object.yaml
+++ b/pkg/library/kubernetes/testdata/k8s_objects/non-k8s-object.yaml
@@ -1,0 +1,6 @@
+random: ymal
+that: does
+not:
+  satisfy:
+    - typeMeta
+    - objectMeta

--- a/pkg/library/kubernetes/testdata/k8s_objects/pod.yaml
+++ b/pkg/library/kubernetes/testdata/k8s_objects/pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    testLabel: testPod
+spec:
+  containers:
+  - name: test-container
+    image: test-image
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+      - containerPort: 8080

--- a/pkg/library/kubernetes/testdata/k8s_objects/service.yaml
+++ b/pkg/library/kubernetes/testdata/k8s_objects/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  selector:
+    test: test-app
+  ports:
+  - port: 8080
+    targetPort: 8081

--- a/pkg/library/kubernetes/testdata/k8s_objects/unrecognized-kind.yaml
+++ b/pkg/library/kubernetes/testdata/k8s_objects/unrecognized-kind.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Plod
+metadata:
+  name: test-pod
+  labels:
+    testLabel: testPod
+spec:
+  containers:
+  - name: test-container
+    image: test-image
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    ports:
+      - containerPort: 8080

--- a/pkg/library/kubernetes/testdata/provision_tests/creates-k8s-objects.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/creates-k8s-objects.yaml
@@ -1,0 +1,72 @@
+name: "Creates Kubernetes objects when specified in DevWorkspace"
+
+input:
+  components:
+    - name: "container-component"
+      container:
+        image: "test-image"
+    - name: "test-pod"
+      kubernetes:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test-pod
+            labels:
+              testLabel: testPod
+          spec:
+            containers:
+            - name: test-container
+              image: test-image
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
+              ports:
+                - containerPort: 8080
+    - name: "test-service"
+      openshift:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            selector:
+              test: test-app
+            ports:
+            - port: 8080
+              targetPort: 8081
+
+output:
+  expectedObjects:
+    services:
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: test-service
+        spec:
+          selector:
+            test: test-app
+          ports:
+          - port: 8080
+            targetPort: 8081
+    pods:
+      - apiVersion: v1
+        kind: Pod
+        metadata:
+          name: test-pod
+          labels:
+            testLabel: testPod
+        spec:
+          containers:
+          - name: test-container
+            image: test-image
+            resources:
+              limits:
+                memory: "128Mi"
+                cpu: "500m"
+            ports:
+              - containerPort: 8080

--- a/pkg/library/kubernetes/testdata/provision_tests/error-if-object-exists-no-devworkspaceID.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/error-if-object-exists-no-devworkspaceID.yaml
@@ -1,0 +1,67 @@
+name: "Returns an error if the object already exists in the cluster and has wrong DevWorkspace ID"
+
+input:
+  components:
+    - name: "container-component"
+      container:
+        image: "test-image"
+    - name: "test-pod"
+      kubernetes:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test-pod
+            labels:
+              testLabel: testPod
+          spec:
+            containers:
+            - name: test-container
+              image: test-image
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
+              ports:
+                - containerPort: 8080
+    - name: "test-service"
+      openshift:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            selector:
+              test: test-app
+            ports:
+            - port: 8080
+              targetPort: 8081
+  existingObjects:
+    pods:
+      - apiVersion: v1
+        kind: Pod
+        metadata:
+          name: test-pod
+          labels:
+            controller.devfile.io/devworkspace_id: wrong-devworkspaceID
+          ownerReferences:
+            - kind:       DevWorkspace
+              apiVersion: workspace.devfile.io/v1alpha2
+              name:       test-devworkspace
+              uid:        test-UID
+        spec:
+          containers:
+          - name: test-container
+            image: test-image
+            resources:
+              limits:
+                memory: "128Mi"
+                cpu: "500m"
+            ports:
+              - containerPort: 8080
+
+output:
+  errRegexp: "object .* exists and is not owned by this workspace"

--- a/pkg/library/kubernetes/testdata/provision_tests/error-if-object-exists-no-ownerref.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/error-if-object-exists-no-ownerref.yaml
@@ -1,0 +1,67 @@
+name: "Returns an error if the object already exists in the cluster and has wrong ownerref"
+
+input:
+  components:
+    - name: "container-component"
+      container:
+        image: "test-image"
+    - name: "test-pod"
+      kubernetes:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test-pod
+            labels:
+              testLabel: testPod
+          spec:
+            containers:
+            - name: test-container
+              image: test-image
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
+              ports:
+                - containerPort: 8080
+    - name: "test-service"
+      openshift:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            selector:
+              test: test-app
+            ports:
+            - port: 8080
+              targetPort: 8081
+  existingObjects:
+    pods:
+      - apiVersion: v1
+        kind: Pod
+        metadata:
+          name: test-pod
+          labels:
+            controller.devfile.io/devworkspace_id: test-devworkspaceID
+          ownerReferences:
+            - kind:       DevWorkspace
+              apiVersion: workspace.devfile.io/v1alpha2
+              name:       test-devworkspace
+              uid:        wrong-UID
+        spec:
+          containers:
+          - name: test-container
+            image: test-image
+            resources:
+              limits:
+                memory: "128Mi"
+                cpu: "500m"
+            ports:
+              - containerPort: 8080
+
+output:
+  errRegexp: "object .* exists and is not owned by this workspace"

--- a/pkg/library/kubernetes/testdata/provision_tests/error-if-object-exists.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/error-if-object-exists.yaml
@@ -1,0 +1,62 @@
+name: "Returns an error if the object already exists in the cluster and is not owned by DevWorkspace"
+
+input:
+  components:
+    - name: "container-component"
+      container:
+        image: "test-image"
+    - name: "test-pod"
+      kubernetes:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test-pod
+            labels:
+              testLabel: testPod
+          spec:
+            containers:
+            - name: test-container
+              image: test-image
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
+              ports:
+                - containerPort: 8080
+    - name: "test-service"
+      openshift:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            selector:
+              test: test-app
+            ports:
+            - port: 8080
+              targetPort: 8081
+  existingObjects:
+    pods:
+      - apiVersion: v1
+        kind: Pod
+        metadata:
+          name: test-pod
+          labels:
+            testLabel: testPod
+        spec:
+          containers:
+          - name: test-container
+            image: test-image
+            resources:
+              limits:
+                memory: "128Mi"
+                cpu: "500m"
+            ports:
+              - containerPort: 8080
+
+output:
+  errRegexp: "object .* exists and is not owned by this workspace"

--- a/pkg/library/kubernetes/testdata/provision_tests/error-if-object-not-inlined.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/error-if-object-not-inlined.yaml
@@ -1,0 +1,28 @@
+name: "Error if Kuberenetes component is not inlined"
+
+input:
+  components:
+    - name: "container-component"
+      container:
+        image: "test-image"
+    - name: "test-pod"
+      kubernetes:
+        deployByDefault: true
+        uri: test-uri
+    - name: "test-service"
+      openshift:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            selector:
+              test: test-app
+            ports:
+            - port: 8080
+              targetPort: 8081
+
+output:
+  errRegexp: "components that define a URI are unsupported"

--- a/pkg/library/kubernetes/testdata/provision_tests/ignores-non-deployByDefault.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/ignores-non-deployByDefault.yaml
@@ -1,0 +1,72 @@
+name: "Ignores Kubernetes/OpenShift components with deployByDefault=false"
+
+input:
+  components:
+    - name: "container-component"
+      container:
+        image: "test-image"
+    - name: "test-pod"
+      kubernetes:
+        inlined: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test-pod
+            labels:
+              testLabel: testPod
+          spec:
+            containers:
+            - name: test-container
+              image: test-image
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
+              ports:
+                - containerPort: 8080
+    - name: "test-service"
+      openshift:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            selector:
+              test: test-app
+            ports:
+            - port: 8080
+              targetPort: 8081
+  existingObjects:
+    pods:
+      - apiVersion: v1
+        kind: Pod
+        metadata:
+          name: test-pod
+          labels:
+            testLabel: testPod
+        spec:
+          containers:
+          - name: test-container
+            image: test-image-to-update
+            resources:
+              limits:
+                memory: "128Mi"
+                cpu: "500m"
+            ports:
+              - containerPort: 8080
+
+output:
+  expectedObjects:
+    services:
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: test-service
+        spec:
+          selector:
+            test: test-app
+          ports:
+          - port: 8080
+            targetPort: 8081

--- a/pkg/library/kubernetes/testdata/provision_tests/no-k8s-components-devworkspace.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/no-k8s-components-devworkspace.yaml
@@ -1,0 +1,9 @@
+name: "Does nothing if DevWorkspace defines no Kubernetes/OpenShift components"
+
+input:
+  components:
+    - name: "container-component"
+      container:
+        image: "test-image"
+
+output: {}

--- a/pkg/library/kubernetes/testdata/provision_tests/updates-existing-owned-objects.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/updates-existing-owned-objects.yaml
@@ -1,0 +1,115 @@
+name: "Updates existing objects when they are owned by current DevWorkspace"
+
+input:
+  components:
+    - name: "container-component"
+      container:
+        image: "test-image"
+    - name: "test-pod"
+      kubernetes:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test-pod
+            labels:
+              testLabel: testPod
+          spec:
+            containers:
+            - name: test-container
+              image: test-image
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
+              ports:
+                - containerPort: 8080
+    - name: "test-service"
+      openshift:
+        deployByDefault: true
+        inlined: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: test-service
+          spec:
+            selector:
+              test: test-app
+            ports:
+            - port: 8080
+              targetPort: 8081
+  existingObjects:
+    services:
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: test-service
+          labels:
+            controller.devfile.io/devworkspace_id: test-devworkspaceID
+          ownerReferences:
+            - kind:       DevWorkspace
+              apiVersion: workspace.devfile.io/v1alpha2
+              name:       test-devworkspace
+              uid:        test-UID
+        spec:
+          selector:
+            test: test-app
+          ports:
+          - port: 8080
+            targetPort: 8081
+          - port: 9090
+            targetPort: 9090
+    pods:
+      - apiVersion: v1
+        kind: Pod
+        metadata:
+          name: test-pod
+          labels:
+            controller.devfile.io/devworkspace_id: test-devworkspaceID
+          ownerReferences:
+            - kind:       DevWorkspace
+              apiVersion: workspace.devfile.io/v1alpha2
+              name:       test-devworkspace
+              uid:        test-UID
+        spec:
+          containers:
+          - name: test-container
+            image: test-image-to-update
+            resources:
+              limits:
+                memory: "128Mi"
+                cpu: "500m"
+            ports:
+              - containerPort: 8080
+
+output:
+  expectedObjects:
+    services:
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: test-service
+        spec:
+          selector:
+            test: test-app
+          ports:
+          - port: 8080
+            targetPort: 8081
+    pods:
+      - apiVersion: v1
+        kind: Pod
+        metadata:
+          name: test-pod
+          labels:
+            testLabel: testPod
+        spec:
+          containers:
+          - name: test-container
+            image: test-image
+            resources:
+              limits:
+                memory: "128Mi"
+                cpu: "500m"
+            ports:
+              - containerPort: 8080

--- a/pkg/library/kubernetes/util.go
+++ b/pkg/library/kubernetes/util.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func filterForKubeLikeComponents(components []dw.Component) ([]dw.Component, error) {
+	var k8sLikeComponents []dw.Component
+	for _, component := range components {
+		k8sLikeComponent, err := getK8sLikeComponent(component)
+		if err != nil {
+			continue
+		}
+		if k8sLikeComponent.Uri != "" {
+			return nil, &FailError{fmt.Errorf("kubernetes/openshift components that define a URI are unsupported (component %s)", component.Name)}
+		}
+		if k8sLikeComponent.Inlined == "" {
+			continue
+		}
+		k8sLikeComponents = append(k8sLikeComponents, component)
+	}
+	return k8sLikeComponents, nil
+}
+
+// getK8sLikeComponent returns the K8sLikeComponent from a DevWorkspace component,
+// allowing Kubernetes and OpenShift components to be processed in the same way.
+// Returns error if component is not a kube-like component.
+func getK8sLikeComponent(component dw.Component) (*dw.K8sLikeComponent, error) {
+	switch {
+	case component.Kubernetes != nil:
+		return &component.Kubernetes.K8sLikeComponent, nil
+	case component.Openshift != nil:
+		return &component.Openshift.K8sLikeComponent, nil
+	default:
+		return nil, fmt.Errorf("not a kube-like component")
+	}
+}
+
+func checkOwnerrefs(ownerrefs, subset []metav1.OwnerReference) error {
+	for _, checkOwnerref := range subset {
+		found := false
+		for _, ownerref := range ownerrefs {
+			if ownerref.Name == checkOwnerref.Name && ownerref.UID == checkOwnerref.UID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("ownerref not found")
+		}
+	}
+	return nil
+}

--- a/pkg/library/kubernetes/util.go
+++ b/pkg/library/kubernetes/util.go
@@ -17,8 +17,18 @@ import (
 	"fmt"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func HasKubelikeComponent(workspace *common.DevWorkspaceWithConfig) bool {
+	for _, component := range workspace.Spec.Template.Components {
+		if component.Kubernetes != nil || component.Openshift != nil {
+			return true
+		}
+	}
+	return false
+}
 
 func filterForKubeLikeComponents(components []dw.Component) ([]dw.Component, error) {
 	var k8sLikeComponents []dw.Component

--- a/pkg/library/kubernetes/util.go
+++ b/pkg/library/kubernetes/util.go
@@ -43,7 +43,9 @@ func filterForKubeLikeComponents(components []dw.Component) ([]dw.Component, err
 		if k8sLikeComponent.Inlined == "" {
 			continue
 		}
-		k8sLikeComponents = append(k8sLikeComponents, component)
+		if k8sLikeComponent.GetDeployByDefault() {
+			k8sLikeComponents = append(k8sLikeComponents, component)
+		}
 	}
 	return k8sLikeComponents, nil
 }

--- a/pkg/provision/sync/cluster_api.go
+++ b/pkg/provision/sync/cluster_api.go
@@ -67,3 +67,17 @@ type UnrecoverableSyncError struct {
 func (e *UnrecoverableSyncError) Error() string {
 	return e.Cause.Error()
 }
+
+// WarningError is returned when syncing is successful and can continue but there is a warning
+// regarding the objects synced to the cluster (e.g. they will not be updated)
+type WarningError struct {
+	Message string
+	Err     error
+}
+
+func (e *WarningError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s", e.Message, e.Err)
+	}
+	return e.Message
+}

--- a/pkg/provision/sync/cluster_api.go
+++ b/pkg/provision/sync/cluster_api.go
@@ -68,6 +68,10 @@ func (e *UnrecoverableSyncError) Error() string {
 	return e.Cause.Error()
 }
 
+func (e *UnrecoverableSyncError) Unwrap() error {
+	return e.Cause
+}
+
 // WarningError is returned when syncing is successful and can continue but there is a warning
 // regarding the objects synced to the cluster (e.g. they will not be updated)
 type WarningError struct {
@@ -80,4 +84,8 @@ func (e *WarningError) Error() string {
 		return fmt.Sprintf("%s: %s", e.Message, e.Err)
 	}
 	return e.Message
+}
+
+func (e *WarningError) Unwrap() error {
+	return e.Err
 }

--- a/pkg/provision/sync/diff.go
+++ b/pkg/provision/sync/diff.go
@@ -29,6 +29,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -141,8 +142,7 @@ func podDiffFunc(spec, cluster crclient.Object) (delete, update bool) {
 	}
 	if specPod.Spec.TerminationGracePeriodSeconds != nil &&
 		specPod.Spec.TerminationGracePeriodSeconds != clusterPod.Spec.TerminationGracePeriodSeconds {
-		negOne := int64(-1)
-		if clusterPod.Spec.TerminationGracePeriodSeconds == &negOne {
+		if clusterPod.Spec.TerminationGracePeriodSeconds == pointer.Int64(-1) {
 			return false, true
 		} else {
 			return true, false

--- a/pkg/provision/sync/diffopts.go
+++ b/pkg/provision/sync/diffopts.go
@@ -65,6 +65,10 @@ var deploymentDiffOpts = cmp.Options{
 	}),
 }
 
+var podDiffOpts = cmp.Options{
+	cmpopts.IgnoreFields(corev1.Pod{}, "TypeMeta", "ObjectMeta", "Status"),
+}
+
 var configmapDiffOpts = cmp.Options{
 	cmpopts.IgnoreFields(corev1.ConfigMap{}, "TypeMeta", "ObjectMeta"),
 }

--- a/pkg/provision/sync/sync.go
+++ b/pkg/provision/sync/sync.go
@@ -196,6 +196,8 @@ func printDiff(specObj, clusterObj crclient.Object, log logr.Logger) {
 			diffOpts = rolebindingDiffOpts
 		case *appsv1.Deployment:
 			diffOpts = deploymentDiffOpts
+		case *corev1.Pod:
+			diffOpts = podDiffOpts
 		case *corev1.ConfigMap:
 			diffOpts = configmapDiffOpts
 		case *corev1.Secret:

--- a/pkg/provision/sync/sync.go
+++ b/pkg/provision/sync/sync.go
@@ -31,6 +31,15 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// IsRecognizedObject returns whether the provided object kind is recognized by the sync package to support updating
+// existing objects on the cluster. If the object is not recognized, passing it to SyncObjectWithCluster will fail.
+// Instead, SyncUnrecognizedObjectWithCluster should be used.
+func IsRecognizedObject(specObj crclient.Object) bool {
+	objType := reflect.TypeOf(specObj).Elem()
+	_, ok := diffFuncs[objType]
+	return ok
+}
+
 // SyncObjectWithCluster synchronises the state of specObj to the cluster, creating or updating the cluster object
 // as required. If specObj is in sync with the cluster, returns the object as it exists on the cluster. Returns a
 // NotInSyncError if an update is required, UnrecoverableSyncError if object provided is invalid, or generic error
@@ -70,6 +79,59 @@ func SyncObjectWithCluster(specObj crclient.Object, api ClusterAPI) (crclient.Ob
 		return nil, updateObjectGeneric(specObj, clusterObj, api)
 	}
 	return clusterObj, nil
+}
+
+// SyncUnrecognizedObjectWithCluster allows syncing objects not supported by SyncObjectWithCluster. As there is
+// no generic way of deciding if an object needs to be updated, a WarningError is returned if the object exists
+// on the cluster. The only object updating performed by this function is to ensure labels/annotations and
+// ownerReferences in specObj are synced to the cluster.
+// The reason arbitrary updates are not supported is 1) certain objects have defaulted fields that can always
+// trigger naive diff checks (causing reconciles to get stuck), and 2) it's unknown which fields are unmodifiable,
+// (e.g. services must keep ClusterIP once set; pod fields cannot be changed after creation)
+func SyncUnrecognizedObjectWithCluster(specObj crclient.Object, api ClusterAPI) (crclient.Object, error) {
+	objType := reflect.TypeOf(specObj).Elem()
+	clusterObj := reflect.New(objType).Interface().(crclient.Object)
+
+	err := api.Client.Get(api.Ctx, types.NamespacedName{Name: specObj.GetName(), Namespace: specObj.GetNamespace()}, clusterObj)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return nil, createObjectGeneric(specObj, api)
+		}
+		return nil, err
+	}
+	update, delete := unrecognizedObjectDiffFunc(specObj, clusterObj)
+	if update {
+		toUpdate, err := unrecognizedObjectUpdateFunc(specObj, clusterObj)
+		if err != nil {
+			return nil, &UnrecoverableSyncError{err}
+		}
+		err = api.Client.Update(api.Ctx, toUpdate)
+		switch {
+		case err == nil:
+			api.Logger.Info("Updated object", "kind", reflect.TypeOf(specObj).Elem().String(), "name", specObj.GetName())
+			return nil, NewNotInSync(specObj, UpdatedObjectReason)
+		case k8sErrors.IsConflict(err):
+			return nil, NewNotInSync(specObj, NeedRetryReason)
+		case k8sErrors.IsInvalid(err), k8sErrors.IsForbidden(err):
+			return nil, &UnrecoverableSyncError{err}
+		default:
+			return nil, err
+		}
+	}
+	if delete {
+		if err := api.Client.Delete(api.Ctx, clusterObj); err != nil {
+			if k8sErrors.IsForbidden(err) {
+				return nil, &UnrecoverableSyncError{fmt.Errorf("failed to delete object %s: %w", clusterObj.GetName(), err)}
+			}
+			return nil, err
+		}
+		api.Logger.Info("Deleted object", "kind", reflect.TypeOf(specObj).Elem().String(), "name", specObj.GetName())
+		return nil, NewNotInSync(specObj, DeletedObjectReason)
+	}
+	kind := specObj.GetObjectKind().GroupVersionKind().GroupKind().String()
+	return clusterObj, &WarningError{
+		Message: fmt.Sprintf("Unrecognized object kind %s. Object will not be updated on cluster", kind),
+	}
 }
 
 func createObjectGeneric(specObj crclient.Object, api ClusterAPI) error {

--- a/webhook/workspace/handler/kubernetes.go
+++ b/webhook/workspace/handler/kubernetes.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func (h *WebhookHandler) validateKubernetesObjectPermissionsOnCreate(ctx context.Context, req admission.Request, wksp *dwv2.DevWorkspace) error {
+func (h *WebhookHandler) validateKubernetesObjectPermissionsOnCreate(ctx context.Context, req admission.Request, wksp *dwv2.DevWorkspaceTemplateSpec) error {
 	kubeComponents := getKubeComponentsFromWorkspace(wksp)
 	for componentName, component := range kubeComponents {
 		if component.Uri != "" {
@@ -42,7 +42,7 @@ func (h *WebhookHandler) validateKubernetesObjectPermissionsOnCreate(ctx context
 	return nil
 }
 
-func (h *WebhookHandler) validateKubernetesObjectPermissionsOnUpdate(ctx context.Context, req admission.Request, newWksp, oldWksp *dwv2.DevWorkspace) error {
+func (h *WebhookHandler) validateKubernetesObjectPermissionsOnUpdate(ctx context.Context, req admission.Request, newWksp, oldWksp *dwv2.DevWorkspaceTemplateSpec) error {
 	newKubeComponents := getKubeComponentsFromWorkspace(newWksp)
 	oldKubeComponents := getKubeComponentsFromWorkspace(oldWksp)
 
@@ -145,9 +145,9 @@ func (h *WebhookHandler) validatePermissionsOnObject(ctx context.Context, req ad
 
 // getKubeComponentsFromWorkspace returns the Kubernetes (and OpenShift) components in a workspace
 // in a map with component names as keys.
-func getKubeComponentsFromWorkspace(wksp *dwv2.DevWorkspace) map[string]dwv2.K8sLikeComponent {
+func getKubeComponentsFromWorkspace(wksp *dwv2.DevWorkspaceTemplateSpec) map[string]dwv2.K8sLikeComponent {
 	kubeComponents := map[string]dwv2.K8sLikeComponent{}
-	for _, component := range wksp.Spec.Template.Components {
+	for _, component := range wksp.Components {
 		kubeComponent, err := getKubeLikeComponent(&component)
 		if err != nil {
 			continue
@@ -170,7 +170,7 @@ func getKubeLikeComponent(component *dwv2.Component) (*dwv2.K8sLikeComponent, er
 	return nil, fmt.Errorf("component does not specify kubernetes or openshift fields")
 }
 
-func (h *WebhookHandler) validateKubernetesObjectPermissionsOnCreate_v1alpha1(ctx context.Context, req admission.Request, wksp *dwv1.DevWorkspace) error {
+func (h *WebhookHandler) validateKubernetesObjectPermissionsOnCreate_v1alpha1(ctx context.Context, req admission.Request, wksp *dwv1.DevWorkspaceTemplateSpec) error {
 	kubeComponents := getKubeComponentsFromWorkspace_v1alpha1(wksp)
 	for componentName, component := range kubeComponents {
 		if component.Uri != "" {
@@ -186,7 +186,7 @@ func (h *WebhookHandler) validateKubernetesObjectPermissionsOnCreate_v1alpha1(ct
 	return nil
 }
 
-func (h *WebhookHandler) validateKubernetesObjectPermissionsOnUpdate_v1alpha1(ctx context.Context, req admission.Request, newWksp, oldWksp *dwv1.DevWorkspace) error {
+func (h *WebhookHandler) validateKubernetesObjectPermissionsOnUpdate_v1alpha1(ctx context.Context, req admission.Request, newWksp, oldWksp *dwv1.DevWorkspaceTemplateSpec) error {
 	newKubeComponents := getKubeComponentsFromWorkspace_v1alpha1(newWksp)
 	oldKubeComponents := getKubeComponentsFromWorkspace_v1alpha1(oldWksp)
 
@@ -209,9 +209,9 @@ func (h *WebhookHandler) validateKubernetesObjectPermissionsOnUpdate_v1alpha1(ct
 	return nil
 }
 
-func getKubeComponentsFromWorkspace_v1alpha1(wksp *dwv1.DevWorkspace) map[string]dwv1.K8sLikeComponent {
+func getKubeComponentsFromWorkspace_v1alpha1(wksp *dwv1.DevWorkspaceTemplateSpec) map[string]dwv1.K8sLikeComponent {
 	kubeComponents := map[string]dwv1.K8sLikeComponent{}
-	for _, component := range wksp.Spec.Template.Components {
+	for _, component := range wksp.Components {
 		kubeComponent, err := getKubeLikeComponent_v1alpha1(&component)
 		if err != nil {
 			continue

--- a/webhook/workspace/handler/kubernetes.go
+++ b/webhook/workspace/handler/kubernetes.go
@@ -89,6 +89,9 @@ func (h *WebhookHandler) validatePermissionsOnObject(ctx context.Context, req ad
 	if kind == "Role" || kind == "Rolebinding" || kind == "ClusterRole" || kind == "ClusterRoleBinding" {
 		return fmt.Errorf("kubernetes RBAC objects are not permitted within DevWorkspace components")
 	}
+	if kind == "DevWorkspace" || kind == "DevWorkspaceTemplate" {
+		return fmt.Errorf("DevWorkspace objects are not permitted within DevWorkspace components")
+	}
 
 	// Workaround to get the correct resource type for a given kind -- probably fragile
 	// Convert e.g. Pod -> pods, Deployment -> deployments

--- a/webhook/workspace/handler/kubernetes.go
+++ b/webhook/workspace/handler/kubernetes.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	authv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/yaml"
+)
+
+func (h *WebhookHandler) validateKubernetesObjectPermissionsOnCreate(ctx context.Context, req admission.Request, wksp *dwv2.DevWorkspace) error {
+	kubeComponents := getKubeComponentsFromWorkspace(wksp)
+	for componentName, component := range kubeComponents {
+		if component.Uri != "" {
+			return fmt.Errorf("kubenetes components specified via URI are unsupported")
+		}
+		if component.Inlined == "" {
+			return fmt.Errorf("kubernetes component does not define inlined content")
+		}
+		if err := h.validatePermissionsOnObject(ctx, req, componentName, component.Inlined); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *WebhookHandler) validateKubernetesObjectPermissionsOnUpdate(ctx context.Context, req admission.Request, newWksp, oldWksp *dwv2.DevWorkspace) error {
+	newKubeComponents := getKubeComponentsFromWorkspace(newWksp)
+	oldKubeComponents := getKubeComponentsFromWorkspace(oldWksp)
+
+	for componentName, newComponent := range newKubeComponents {
+		if newComponent.Uri != "" {
+			return fmt.Errorf("kubenetes components specified via URI are unsupported")
+		}
+		if newComponent.Inlined == "" {
+			return fmt.Errorf("kubernetes component does not define inlined content")
+		}
+
+		oldComponent, ok := oldKubeComponents[componentName]
+		if !ok || oldComponent.Inlined != newComponent.Inlined {
+			// Review new components
+			if err := h.validatePermissionsOnObject(ctx, req, componentName, newComponent.Inlined); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (h *WebhookHandler) validatePermissionsOnObject(ctx context.Context, req admission.Request, componentName, component string) error {
+
+	typeMeta := &metav1.TypeMeta{}
+	if err := yaml.Unmarshal([]byte(component), typeMeta); err != nil {
+		return fmt.Errorf("failed to read content for component %s", componentName)
+	}
+	if typeMeta.Kind == "List" {
+		return fmt.Errorf("lists are not supported in Kubernetes or OpenShift components")
+	}
+
+	// Workaround to get the correct resource type for a given kind -- probably fragile
+	// Convert e.g. Pod -> pods, Deployment -> deployments
+	resourceType := fmt.Sprintf("%ss", strings.ToLower(typeMeta.Kind))
+
+	sar := &authv1.LocalSubjectAccessReview{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: req.Namespace,
+		},
+		Spec: authv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authv1.ResourceAttributes{
+				Namespace: req.Namespace,
+				Verb:      "*",
+				Group:     typeMeta.GroupVersionKind().Group,
+				Version:   typeMeta.GroupVersionKind().Version,
+				Resource:  resourceType,
+			},
+			User:   req.UserInfo.Username,
+			Groups: req.UserInfo.Groups,
+			UID:    req.UserInfo.UID,
+		},
+	}
+
+	err := h.Client.Create(ctx, sar)
+	if err != nil {
+		return fmt.Errorf("failed to create subjectaccessreview for request: %w", err)
+	}
+
+	username := req.UserInfo.Username
+	if username == "" {
+		username = req.UserInfo.UID
+	}
+
+	if !sar.Status.Allowed {
+		return fmt.Errorf("user %s does not have permissions to work with objects of kind %s defined in component %s", username, typeMeta.GroupVersionKind().String(), componentName)
+	}
+
+	return nil
+}
+
+// getKubeComponentsFromWorkspace returns the Kubernetes (and OpenShift) components in a workspace
+// in a map with component names as keys.
+func getKubeComponentsFromWorkspace(wksp *dwv2.DevWorkspace) map[string]dwv2.K8sLikeComponent {
+	kubeComponents := map[string]dwv2.K8sLikeComponent{}
+	for _, component := range wksp.Spec.Template.Components {
+		kubeComponent, err := getKubeLikeComponent(&component)
+		if err != nil {
+			continue
+		}
+		kubeComponents[component.Name] = *kubeComponent
+	}
+	return kubeComponents
+}
+
+// getKubeLikeComponent returns the definition of the Kubernetes or OpenShift
+// component defined by a general DevWorkspace Component. If the component does
+// not specify the Kubernetes or OpenShift field, an error is returned.
+func getKubeLikeComponent(component *dwv2.Component) (*dwv2.K8sLikeComponent, error) {
+	if component.Kubernetes != nil {
+		return &component.Kubernetes.K8sLikeComponent, nil
+	}
+	if component.Openshift != nil {
+		return &component.Openshift.K8sLikeComponent, nil
+	}
+	return nil, fmt.Errorf("component does not specify kubernetes or openshift fields")
+}

--- a/webhook/workspace/handler/kubernetes.go
+++ b/webhook/workspace/handler/kubernetes.go
@@ -70,8 +70,12 @@ func (h *WebhookHandler) validatePermissionsOnObject(ctx context.Context, req ad
 	if err := yaml.Unmarshal([]byte(component), typeMeta); err != nil {
 		return fmt.Errorf("failed to read content for component %s", componentName)
 	}
-	if typeMeta.Kind == "List" {
+	kind := typeMeta.Kind
+	if kind == "List" {
 		return fmt.Errorf("lists are not supported in Kubernetes or OpenShift components")
+	}
+	if kind == "Role" || kind == "Rolebinding" || kind == "ClusterRole" || kind == "ClusterRoleBinding" {
+		return fmt.Errorf("kubernetes RBAC objects are not permitted within DevWorkspace components")
 	}
 
 	// Workaround to get the correct resource type for a given kind -- probably fragile

--- a/webhook/workspace/handler/template.go
+++ b/webhook/workspace/handler/template.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
+	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func (h *WebhookHandler) MutateWorkspaceTemplateV1alpha1OnCreate(ctx context.Context, req admission.Request) admission.Response {
+	wksp := &dwv1.DevWorkspaceTemplate{}
+	err := h.Decoder.Decode(req, wksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if err := h.validateKubernetesObjectPermissionsOnCreate_v1alpha1(ctx, req, &wksp.Spec); err != nil {
+		return admission.Denied(err.Error())
+	}
+
+	return h.returnPatched(req, wksp)
+}
+
+func (h *WebhookHandler) MutateWorkspaceTemplateV1alpha2OnCreate(ctx context.Context, req admission.Request) admission.Response {
+	wksp := &dwv2.DevWorkspaceTemplate{}
+	err := h.Decoder.Decode(req, wksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if err := h.validateKubernetesObjectPermissionsOnCreate(ctx, req, &wksp.Spec); err != nil {
+		return admission.Denied(err.Error())
+	}
+
+	return h.returnPatched(req, wksp)
+}
+
+func (h *WebhookHandler) MutateWorkspaceTemplateV1alpha1OnUpdate(ctx context.Context, req admission.Request) admission.Response {
+	newWksp := &dwv1.DevWorkspaceTemplate{}
+	oldWksp := &dwv1.DevWorkspaceTemplate{}
+	err := h.parse(req, oldWksp, newWksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if err := h.validateKubernetesObjectPermissionsOnUpdate_v1alpha1(ctx, req, &newWksp.Spec, &oldWksp.Spec); err != nil {
+		return admission.Denied(err.Error())
+	}
+
+	oldCreator, found := oldWksp.Labels[constants.DevWorkspaceCreatorLabel]
+	if !found {
+		return admission.Denied(fmt.Sprintf("label '%s' is missing. Please recreate devworkspace to get it initialized", constants.DevWorkspaceCreatorLabel))
+	}
+
+	newCreator, found := newWksp.Labels[constants.DevWorkspaceCreatorLabel]
+	if !found {
+		if newWksp.Labels == nil {
+			newWksp.Labels = map[string]string{}
+		}
+		newWksp.Labels[constants.DevWorkspaceCreatorLabel] = oldCreator
+		return h.returnPatched(req, newWksp)
+	}
+
+	if newCreator != oldCreator {
+		return admission.Denied(fmt.Sprintf("label '%s' is assigned once devworkspace is created and is immutable", constants.DevWorkspaceCreatorLabel))
+	}
+
+	return admission.Allowed("new devworkspace has the same devworkspace creator as old one")
+}
+
+func (h *WebhookHandler) MutateWorkspaceTemplateV1alpha2OnUpdate(ctx context.Context, req admission.Request) admission.Response {
+	newWksp := &dwv2.DevWorkspaceTemplate{}
+	oldWksp := &dwv2.DevWorkspaceTemplate{}
+	err := h.parse(req, oldWksp, newWksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if err := h.validateKubernetesObjectPermissionsOnUpdate(ctx, req, &newWksp.Spec, &oldWksp.Spec); err != nil {
+		return admission.Denied(err.Error())
+	}
+
+	return admission.Allowed("new workspace has the same devworkspace as old one")
+}

--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -38,7 +38,7 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha1OnCreate(ctx context.Context, re
 
 	wksp.Labels = maputils.Append(wksp.Labels, constants.DevWorkspaceCreatorLabel, req.UserInfo.UID)
 
-	if err := h.validateKubernetesObjectPermissionsOnCreate_v1alpha1(ctx, req, wksp); err != nil {
+	if err := h.validateKubernetesObjectPermissionsOnCreate_v1alpha1(ctx, req, &wksp.Spec.Template); err != nil {
 		return admission.Denied(err.Error())
 	}
 
@@ -58,7 +58,7 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnCreate(ctx context.Context, re
 		return admission.Denied(err.Error())
 	}
 
-	if err := h.validateKubernetesObjectPermissionsOnCreate(ctx, req, wksp); err != nil {
+	if err := h.validateKubernetesObjectPermissionsOnCreate(ctx, req, &wksp.Spec.Template); err != nil {
 		return admission.Denied(err.Error())
 	}
 
@@ -86,7 +86,7 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha1OnUpdate(ctx context.Context, re
 		return admission.Denied(msg)
 	}
 
-	if err := h.validateKubernetesObjectPermissionsOnUpdate_v1alpha1(ctx, req, newWksp, oldWksp); err != nil {
+	if err := h.validateKubernetesObjectPermissionsOnUpdate_v1alpha1(ctx, req, &newWksp.Spec.Template, &oldWksp.Spec.Template); err != nil {
 		return admission.Denied(err.Error())
 	}
 
@@ -166,7 +166,7 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnUpdate(ctx context.Context, re
 		return admission.Denied(err.Error())
 	}
 
-	if err := h.validateKubernetesObjectPermissionsOnUpdate(ctx, req, newWksp, oldWksp); err != nil {
+	if err := h.validateKubernetesObjectPermissionsOnUpdate(ctx, req, &newWksp.Spec.Template, &oldWksp.Spec.Template); err != nil {
 		return admission.Denied(err.Error())
 	}
 

--- a/webhook/workspace/handler/workspace.go
+++ b/webhook/workspace/handler/workspace.go
@@ -54,6 +54,10 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnCreate(ctx context.Context, re
 		return admission.Denied(err.Error())
 	}
 
+	if err := h.validateKubernetesObjectPermissionsOnCreate(ctx, req, wksp); err != nil {
+		return admission.Denied(err.Error())
+	}
+
 	if warnings := checkUnsupportedFeatures(wksp.Spec.Template); unsupportedWarningsPresent(warnings) {
 		return h.returnPatched(req, wksp).WithWarnings(formatUnsupportedFeaturesWarning(warnings))
 	}
@@ -151,6 +155,10 @@ func (h *WebhookHandler) MutateWorkspaceV1alpha2OnUpdate(ctx context.Context, re
 	}
 
 	if err := h.validateUserPermissions(ctx, req, newWksp, oldWksp); err != nil {
+		return admission.Denied(err.Error())
+	}
+
+	if err := h.validateKubernetesObjectPermissionsOnUpdate(ctx, req, newWksp, oldWksp); err != nil {
 		return admission.Denied(err.Error())
 	}
 


### PR DESCRIPTION
### What does this PR do?
Add support for components of type Kubernetes and OpenShift to the DevWorkspace Operator, with the caveats
* `deployByDefault=false` components are ignored
* Only inlined components are permitted, to allow to checking RBAC (so that user can't effectively impersonate the controller serviceaccount)
* RBAC objects/DevWorkspaces/DevWorkspaceTemplates are not allowed

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/798

### Is it tested? How?
Test by creating DevWorkspaces that use kubernetes components, e.g.:
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: test-dw
spec:
  started: true
  template:
    attributes:
      controller.devfile.io/storage-type: ephemeral
    components:
      - name: terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
      - name: test-service
        kubernetes:
          deployByDefault: true
          inlined: |
            apiVersion: v1
            kind: Service
            metadata:
              name: test-service
              labels:
                testing: "true"
            spec:
              selector:
                test: test-app
              ports:
              - port: 8080
                targetPort: 8081
      - name: test-pod
        openshift:
          deployByDefault: true
          inlined: |
            apiVersion: v1
            kind: Pod
            metadata:
              name: test-pod
              labels:
                test: test-app
            spec:
              containers:
              - name: test-container
                image: quay.io/wto/web-terminal-tooling:next
                resources:
                  limits:
                    memory: "128Mi"
                    cpu: "500m"
                ports:
                  - containerPort: 8080
                command:
                  - "tail"
                  - "-f"
                  - "/dev/null"
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
