### PR TITLE
Fix issue where existing SA causes failure when reconciling

### DIFF
--- a/pkg/provision/sync/update.go
+++ b/pkg/provision/sync/update.go
@@ -51,9 +51,11 @@ func serviceUpdateFunc(spec, cluster crclient.Object) (crclient.Object, error) {
 }
 
 func serviceAccountUpdateFunc(spec, cluster crclient.Object) (crclient.Object, error) {
-	if cluster != nil {
-		spec.SetResourceVersion(cluster.GetResourceVersion())
+	if cluster == nil {
+		// May occur if ServiceAccount is not cached by the operator
+		return spec, nil
 	}
+	spec.SetResourceVersion(cluster.GetResourceVersion())
 	ownerrefs := spec.GetOwnerReferences()
 	for _, clusterOwnerref := range cluster.GetOwnerReferences() {
 		if !containsOwnerRef(clusterOwnerref, ownerrefs) {


### PR DESCRIPTION
### What does this PR do?
Minor fixup to https://github.com/devfile/devworkspace-operator/pull/963, discovered literally 5 minutes after merging: given a config like
```yaml
  workspace:
    serviceAccount:
      serviceAccountName: test-sa
```
DWO will panic reconciling DevWorkspaces if the `test-sa` serviceaccount already exists (as it tries to update it)

### What issues does this PR fix or reference?
N/A 

### Is it tested? How?
1. Create DevWorkspaceOperatorConfig with
```yaml
  workspace:
    serviceAccount:
      serviceAccountName: test-sa
```
2. Create a serviceaccount: `kubectl create sa test-sa`
3. Create a DevWorkspace -- should start, SA should be updated to have label `controller.devfile.io/devworkspace_id: ""` and ownerref for the DevWorkspace

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
