### PR TITLE
Floor the Grafana Prometheus queries for workspace starts/fails

### DIFF
--- a/docs/grafana/grafana-dashboard.json
+++ b/docs/grafana/grafana-dashboard.json
@@ -258,7 +258,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (source) (increase(devworkspace_started_total[$__interval]))",
+          "expr": "sum by (source) (floor(increase(devworkspace_started_total[$__interval])))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "Workspaces started (source={{source}})",
@@ -512,14 +512,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(devworkspace_fail_total[$__interval]))",
+          "expr": "sum(floor(increase(devworkspace_fail_total[$__interval])))",
           "interval": "",
           "legendFormat": "Failures",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "sum(increase(devworkspace_started_success_total[$__interval]))",
+          "expr": "sum(floor(increase(devworkspace_started_success_total[$__interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Successes",


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

### What does this PR do?
Floors the devworkspace start and devworkspace start success/failure metrics so that decimal points don't appear in the dashboard



### What issues does this PR fix or reference?
The dashboard can display non integer values for the devworkspace start and devworkspace start success/failure metrics, which does not make much sense:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/83611742/199846548-ab0b6b86-dd17-42c1-a978-c0176598a662.png">

This is because the [increase() function](https://prometheus.io/docs/prometheus/latest/querying/functions/#increase) used to determine the #of starts in a time interval, extrapolates the given data points (# of starts, successes/failures and what time they happened) within the given time interval. Extrapolating here does not make much sense because # of starts, successes/failures should be integer values.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
