### PR TITLE
Set the startedAt annotation after workspace status is updated

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -227,8 +227,9 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 		}
 		if reconcileStatus.phase == dw.DevWorkspaceStatusRunning {
-			metrics.WorkspaceRunning(clusterWorkspace, reqLogger)
-			r.syncStartedAtToCluster(ctx, clusterWorkspace, reqLogger)
+			// defer to set the startedAt annotation after the status and metrics are updated,
+			// since WorkspaceStarted and WorkspaceRunning metrics are not updated if this annotation exists
+			defer r.syncStartedAtToCluster(ctx, clusterWorkspace, reqLogger)
 		}
 
 		return r.updateWorkspaceStatus(clusterWorkspace, reqLogger, &reconcileStatus, reconcileResult, err)


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

### What does this PR do?
The `workspaceStartupTimesHist` metric was not being updated because the `Ready` condition did not exist in the DW when trying to update the metric, see the if/return statement [here](https://github.com/devfile/devworkspace-operator/blob/10771f23e9f40dd6718491e582ec997b58ab9e55/controllers/workspace/metrics/update.go#L96-L99).

When the conditions were eventually applied to the DW, the metric was still not updated because of the `startedAt` annotation, which to my knowledge helps prevent duplicate counting of some metrics when the workspace is restarted, see [here](https://github.com/devfile/devworkspace-operator/blob/10771f23e9f40dd6718491e582ec997b58ab9e55/controllers/workspace/metrics/update.go#L41-L45).


This PR sets the `startedAt` annotation after workspace status/conditions/metrics are updated, ie after:

```
return r.updateWorkspaceStatus(clusterWorkspace, reqLogger, &reconcileStatus, reconcileResult, err)
```

on line 232 of `controllers/workspace/devworkspace_controller.go`. 

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/956

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Deploy DWO on a cluster:
```
$ export NAMESPACE=devworkspace-controller
$ export DWO_IMG=quay.io/dkwon17/devworkspace-controller:metrics-start-time-fix
$ make install
```
2. Start a Prometheus a instance using the first 5 steps in these docs: https://github.com/devfile/devworkspace-operator/tree/main/docs/grafana.
3. Run `oc apply -f samples/theia-next.yaml` and wait until the workspace starts
4. On the Prometheus console, run the `devworkspace_startup_time_bucket` query and verify that the number `1` appears in all (or, almost all) of the time buckets.
<details>
  <summary>Example</summary>
  <br>
  <img width="1331" alt="image" src="https://user-images.githubusercontent.com/83611742/200935230-a9057ae3-5af9-40eb-a7b6-ba5e33102ec9.png">
  </details> 
5. Verify that when running the `devworkspace_startup_time_sum` query, the result is a positive integer
<details>
  <summary>Example</summary>
  <br>
<img width="1337" alt="image" src="https://user-images.githubusercontent.com/83611742/200935631-b2258a21-a604-46c3-a792-a6a089c8b2a2.png">
  </details> 

6. Optionally stop and start the same workspace and verify that when running the above queries again, the data is updated every after every workspace start.
7. To make sure the fix introduced in https://github.com/devfile/devworkspace-operator/pull/686 is still working, run the `devworkspace_started_total` query to determine the number of workspace startups. While the workspace is running, update the DW's yaml so that the running workspace restarts. For example,  add:
```
spec:
  template:
    events:
      postStart:
        - say-hello
```
to the DW. The workspace will restart going from `Running` to `Starting`. When the workspace is at `Running` again, run the `devworkspace_started_total` query to verify that the number of starts did not change.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
