### PR TITLE
feat: add workspace.defaultSchedulerName to DWOC

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -153,6 +153,9 @@ type WorkspaceConfig struct {
 	// if the workspace's Template Spec Components are not defined. The DefaultTemplate will overwrite the existing
 	// Template Spec, with the exception of Projects (if any are defined).
 	DefaultTemplate *dw.DevWorkspaceTemplateSpecContent `json:"defaultTemplate,omitempty"`
+	// DefaultSchedulerName is the name of the pod scheduler for DevWorkspace pods.
+	// If not specified, the pod scheduler is set to the default scheduler.
+	DefaultSchedulerName string `json:"defaultSchedulerName,omitempty"`
 }
 
 // DevWorkspaceOperatorConfig is the Schema for the devworkspaceoperatorconfigs API

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -244,6 +244,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  defaultSchedulerName:
+                    description: DefaultSchedulerName is the name of the pod scheduler
+                      for DevWorkspace pods. If not specified, the pod scheduler is
+                      set to the default scheduler.
+                    type: string
                   defaultStorageSize:
                     description: DefaultStorageSize defines an optional struct with
                       fields to specify the sizes of Persistent Volume Claims for

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -317,6 +317,9 @@ func mergeConfig(from, to *controller.OperatorConfiguration) {
 			templateSpecContentCopy := from.Workspace.DefaultTemplate.DeepCopy()
 			to.Workspace.DefaultTemplate = templateSpecContentCopy
 		}
+		if from.Workspace.DefaultSchedulerName != "" {
+			to.Workspace.DefaultSchedulerName = from.Workspace.DefaultSchedulerName
+		}
 	}
 }
 

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -234,6 +234,7 @@ func getSpecDeployment(
 					Volumes:                       podAdditions.Volumes,
 					RestartPolicy:                 "Always",
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
+					SchedulerName:                 workspace.Config.Workspace.DefaultSchedulerName,
 					SecurityContext:               workspace.Config.Workspace.PodSecurityContext,
 					ServiceAccountName:            saName,
 					AutomountServiceAccountToken:  nil,


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

### What does this PR do?
Adds the `workspace.defaultSchedulerName` config to the DW operator config.

### What issues does this PR fix or reference?
Part of https://github.com/eclipse/che/issues/21803

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Checkout this PR and run locally following these steps: https://github.com/devfile/devworkspace-operator#run-controller-locally
2. Edit the `workspace.defaultSchedulerName` in the DWOC resource in the `devworkspace-controllers` namespace. Example:
```
config:
  workspace:
    defaultSchedulerName: testing123
```
3. Run `oc apply -f samples/theia-next.yaml`
4. Verify that the `spec.schedulerName` is the `defaultSchedulerName` from the DWOC resource:
<img width="841" alt="image" src="https://user-images.githubusercontent.com/83611742/201487445-9a925c54-fc6a-4798-a34a-14b323f00356.png">
(pod won't start of course, because the scheduler exists)

5. Optional testing: if `pod-overrides` in the DW is used to set the `schedulerName`, confirm that the scheduler name from the `pod-overrides` is set instead of the scheduler name from the DWOC. For example, create this DW and confirm that the pod's `spec.schedulerName` is `stork`:

```
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next-stork
spec:
  started: true
  template:
    attributes:
      pod-overrides:
        spec:
          schedulerName: stork
    components:
      - name: my-container-1
        container:
          image: quay.io/wto/web-terminal-tooling:next
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
