### PR TITLE
fix: make dashboard failure panels consider current time interval

### DIFF
--- a/docs/grafana/grafana-dashboard.json
+++ b/docs/grafana/grafana-dashboard.json
@@ -580,7 +580,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(devworkspace_fail_total) / sum(devworkspace_started_total) * 100.0",
+          "expr": "sum(increase(devworkspace_fail_total[$__range])) / sum(increase(devworkspace_started_total[$__range])) * 100.0",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -637,7 +637,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "devworkspace_fail_total{}",
+          "expr": "sum(increase(devworkspace_fail_total[$__range])) by (reason)",
           "format": "time_series",
           "instant": false,
           "interval": "",


### PR DESCRIPTION


Signed-off-by: David Kwon <dakwon@redhat.com>

### What does this PR do?
The time interval specified in Grafana on the top right is now being used when computing the data for the `DevWorkspace Failure Rate` and `DevWorkspace Startup Failure Reasons` panels. Other DW dashboard panels like `Average Workspace Start Time`, `Workspace Starts`, `Workspace Startup Duration`, `DevWorkspace Successes/Failures` etc. all make use of the current time interval in its metrics query. 

Previously, these panels were using the current, most up-to-date values of the `devworkspace_fail_total` and `devworkspace_started_total` counters, meaning that, if the time interval on Grafana on the top right of the dashboard adjusted, the same values for are being used. In other words, the `DevWorkspace Failure Rate` and `DevWorkspace Startup Failure Reasons` panels previously did not display data within the selected time interval.


<details>
<summary>Before this PR:</summary>
<br>

https://user-images.githubusercontent.com/83611742/202014870-547f3de6-db6e-4916-ae7a-85ca1b2fd3a3.mov

</details>

<details>
<summary>After this PR:</summary>
<br>

https://user-images.githubusercontent.com/83611742/202014840-661bdbcb-5dc4-4592-a3aa-be42ecb6dae6.mov

</details>


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Can be tested by following the steps to run the monitoring stack locally: https://github.com/devfile/devworkspace-operator/blob/main/docs/grafana/README.md

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
