### PR TITLE
Update overrides documentation to link to strategic merge docs

### DIFF
--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -241,7 +241,7 @@ configuration will use the global values.
 ## Fine-grained configuration of workspace pods and containers
 The attributes `pod-overrides` and `container-overrides` can be applied to DevWorkspaces in order to configure fields on the Kubernetes objects that are not normally exposed through the Kubernetes API.
 
-The format for overrides is the same as the object being overridden -- a pod template in the case of pod-overrides and a container in the case of container-overrides. The value of the attribute is applied via Kubernetes _strategic merge_ to patch the default configuration according to predefined merge rules.
+The format for overrides is the same as the object being overridden -- a pod template in the case of pod-overrides and a container in the case of container-overrides. The value of the attribute is applied via Kubernetes _strategic merge_ to patch the default configuration according to predefined merge rules. By default, strategic merge patch will update objects in place, leaving fields not specified in the patch unchanged, though this can be configured using patch directives. See https://github.com/kubernetes/community/blob/3892a416b2b59df3a7c9e5910ad12655f738aad1/contributors/devel/sig-api-machinery/strategic-merge-patch.md[strategic merge patch documentation] for details.
 
 The value of attributes can be specified as yaml or json. In other words, both
 [source,yaml]


### PR DESCRIPTION
### What does this PR do?
Include a basic description of how strategic merge patch works in the documentation and include a link to Kubernetes docs.

### What issues does this PR fix or reference?
N/A, recommended in issue: https://github.com/devfile/devworkspace-operator/issues/966#issuecomment-1319824061

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
