### PR TITLE
chore: document unsupported devfile 2.2.x features

### DIFF
--- a/docs/unsupported-devfile-api.adoc
+++ b/docs/unsupported-devfile-api.adoc
@@ -1,0 +1,18 @@
+# Unsupported Devfile API
+
+The following features of the Devfile API that are not yet supported by the DevWorkspace-Operator:
+
+[options="header"]
+|================================================================================================================================================================================================
+| DevFile feature                               | Related issue                                                                                                                                  
+| `components.container.annotation.service`     | https://github.com/devfile/devworkspace-operator/issues/799[Support setting annotations on services/endpoints from DevWorkspace]               
+| `components.container.endpoints.annotations`  | https://github.com/devfile/devworkspace-operator/issues/799[Support setting annotations on services/endpoints from DevWorkspace]               
+| `components.container.dedicatedPod`           |                                                                                                                                                
+| `components.volume.size`                      | https://github.com/devfile/devworkspace-operator/issues/947[Compute required size for per-workspace PVC when all volumes have sizes specified.]
+| `components.image`                            | https://github.com/eclipse/che/issues/21186[Support Devfile v2 outer loop components of type image and kubernetes]                             
+| `components.custom`                           |                                                                                                                                                
+| `events.postStop`                             |                                                                                                                                                
+| `events.preStop`                              |                                                                                                                                                                                             
+|================================================================================================================================================================================================
+
+If there is no corresponding issue for a Devfile feature you'd like to use, please feel free to submit a feature request.


### PR DESCRIPTION
### What does this PR do?
Adds additional documentation regarding which DevFile 2.2.x features are not yet supported by DWO.

### What issues does this PR fix or reference?
Fix #983

### Is it tested? How?
n/a, though you can see how the document looks [here](https://github.com/AObuchow/devworkspace-operator/blob/document_unsupported_api/docs/unsupported-devfile-api.adoc).

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
