### PR TITLE
Update Grafana dashboard title and avg start time query

### DIFF
--- a/docs/grafana/grafana-dashboard.json
+++ b/docs/grafana/grafana-dashboard.json
@@ -1316,7 +1316,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {

--- a/docs/grafana/grafana-dashboard.json
+++ b/docs/grafana/grafana-dashboard.json
@@ -129,7 +129,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(sum by (source) (increase(devworkspace_startup_time_sum[$__interval]))) / (sum by (source) (increase(devworkspace_startup_time_count[$__interval])))",
+          "expr": "(sum by (source) (increase(devworkspace_startup_time_sum[$__range]))) / (sum by (source) (increase(devworkspace_startup_time_count[$__range])))",
           "interval": "",
           "legendFormat": "Average startup time (source={{source}})",
           "refId": "A"
@@ -645,7 +645,7 @@
           "refId": "A"
         }
       ],
-      "title": "DevWorkspace Startup Failure Reasons",
+      "title": "DevWorkspace Failure Reasons",
       "type": "piechart"
     },
     {


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

### What does this PR do?
Updates the `DevWorkspace Startup Failure Reasons` panel title to `DevWorkspace Failure Reasons`, since a devworkspace can fail after startup (for example, if a container shuts down after devworkspace startup).

This PR also updates the `Average Workspace Start Time` query to use `$__range` rather than `$__interval`.
The reason for this is that while `$__interval` is useful for graphs where multiple data points are computed and displayed over a time interval, it is not too useful when computing just one datapoint over a time interval (in this case, the `Average Workspace Start Time`)

Docs for `$__interval` and `$__range` and other variables can be found here: https://grafana.com/docs/grafana/v9.0/variables/variable-types/global-variables/#__interval


### What issues does this PR fix or reference?
n/a

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Can be tested by following the steps to run the monitoring stack locally: https://github.com/devfile/devworkspace-operator/blob/main/docs/grafana/README.md

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
