### PR TITLE
feat: warn when trying to use unsupported devfile features

### DIFF
--- a/webhook/workspace/handler/testdata/warning/add-all-unsupported-features.yaml
+++ b/webhook/workspace/handler/testdata/warning/add-all-unsupported-features.yaml
@@ -1,0 +1,57 @@
+name: "Add every unsupported devfile feature to a workspace"
+
+input:
+  oldWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+      - name: projects
+        volume:
+          ephemeral: true
+
+  newWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+          dedicatedPod: true
+          annotation:
+            service:
+              key: value
+          endpoints:
+            - name: web
+              targetPort: 8080
+              exposure: public
+              annotation:
+                key: value
+      - name: projects
+        volume:
+          ephemeral: true
+          size: 10Gi
+      - name: image-component
+        image:
+          imageName: python-image:latest
+          autoBuild: true
+          dockerfile:
+            uri: docker/Dockerfile
+            args:
+              - 'MY_ENV=/home/path'
+            buildContext: .
+            rootRequired: false
+      - name: custom-component
+        custom:
+          componentClass: "some-component-class"
+    events:
+      preStop: 
+        - eventA
+        - eventB
+        - eventC
+      postStop:
+        - eventD
+        - eventE
+        - eventF
+
+output:
+  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.annotation.service, used by components: testing-container-1; components[].container.endpoints[].annotations, used by components: testing-container-1; components[].container.dedicatedPod, used by components: testing-container-1; components[].image, used by components: image-component; components[].custom, used by components: custom-component; components[].volume.size, used by components: projects; events.postStop: eventD, eventE, eventF; events.preStop: eventA, eventB, eventC"
+  newWarningsPresent: true

--- a/webhook/workspace/handler/testdata/warning/add-unsupported-features-when-none-present.yaml
+++ b/webhook/workspace/handler/testdata/warning/add-unsupported-features-when-none-present.yaml
@@ -1,0 +1,26 @@
+name: "Add unsupported devfile features when initial workspace did not contain any unsupported features"
+
+input:
+  oldWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+      - name: projects
+        volume:
+          ephemeral: true
+
+  newWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+          dedicatedPod: true
+      - name: projects
+        volume:
+          ephemeral: true
+          size: "10Gi"
+
+output:
+  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.dedicatedPod, used by components: testing-container-1; components[].volume.size, used by components: projects"
+  newWarningsPresent: true

--- a/webhook/workspace/handler/testdata/warning/add-unsupported-features-when-some-present.yaml
+++ b/webhook/workspace/handler/testdata/warning/add-unsupported-features-when-some-present.yaml
@@ -1,0 +1,37 @@
+name: "Add unsupported devfile features to workspace that already contains unsupported features"
+
+input:
+  oldWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+          dedicatedPod: true
+      - name: projects
+        volume:
+          ephemeral: true
+
+  newWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+          dedicatedPod: true
+      - name: projects
+        volume:
+          ephemeral: true
+          size: "10Gi"
+      - name: image-component
+        image:
+          imageName: python-image:latest
+          autoBuild: true
+          dockerfile:
+            uri: docker/Dockerfile
+            args:
+              - 'MY_ENV=/home/path'
+            buildContext: .
+            rootRequired: false
+
+output:
+  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].image, used by components: image-component; components[].volume.size, used by components: projects"
+  newWarningsPresent: true

--- a/webhook/workspace/handler/testdata/warning/remove-all-unsupported-features.yaml
+++ b/webhook/workspace/handler/testdata/warning/remove-all-unsupported-features.yaml
@@ -1,0 +1,30 @@
+name: "Remove all unsupported devfile features from workspace"
+
+input:
+  oldWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+          dedicatedPod: true
+          endpoints:
+            - name: web
+              targetPort: 8080
+              exposure: public
+              annotation:
+                key: value
+      - name: projects
+        volume:
+          ephemeral: true
+
+  newWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+      - name: projects
+        volume:
+          ephemeral: true
+
+output:
+  newWarningsPresent: false

--- a/webhook/workspace/handler/testdata/warning/remove-single-unsupported-feature.yaml
+++ b/webhook/workspace/handler/testdata/warning/remove-single-unsupported-feature.yaml
@@ -1,0 +1,31 @@
+name: "Remove single unsupported devfile features from workspace"
+
+input:
+  oldWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+          dedicatedPod: true
+          endpoints:
+            - name: web
+              targetPort: 8080
+              exposure: public
+              annotation:
+                key: value
+      - name: projects
+        volume:
+          ephemeral: true
+
+  newWorkspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image
+          dedicatedPod: true
+      - name: projects
+        volume:
+          ephemeral: true
+
+output:
+  newWarningsPresent: false

--- a/webhook/workspace/handler/warning.go
+++ b/webhook/workspace/handler/warning.go
@@ -1,0 +1,179 @@
+//
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package handler
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+)
+
+type unsupportedWarnings struct {
+	serviceAnnotations  map[string]bool
+	endpointAnnotations map[string]bool
+	dedicatedPod        map[string]bool
+	imageComponent      map[string]bool
+	customComponent     map[string]bool
+	volumeSize          map[string]bool
+	eventPostStop       map[string]bool
+	eventPreStop        map[string]bool
+}
+
+// Returns an initialized unsupportedWarnings struct
+func newUnsupportedWarnings() *unsupportedWarnings {
+	return &unsupportedWarnings{
+		serviceAnnotations:  make(map[string]bool),
+		endpointAnnotations: make(map[string]bool),
+		dedicatedPod:        make(map[string]bool),
+		imageComponent:      make(map[string]bool),
+		customComponent:     make(map[string]bool),
+		volumeSize:          make(map[string]bool),
+		eventPostStop:       make(map[string]bool),
+		eventPreStop:        make(map[string]bool),
+	}
+}
+
+func checkUnsupportedFeatures(devWorkspaceSpec dwv2.DevWorkspaceTemplateSpec) (warnings *unsupportedWarnings) {
+	warnings = newUnsupportedWarnings()
+	for _, component := range devWorkspaceSpec.Components {
+		if component.Container != nil {
+			if component.Container.Annotation != nil && component.Container.Annotation.Service != nil {
+				warnings.serviceAnnotations[component.Name] = true
+			}
+			for _, endpoint := range component.Container.Endpoints {
+				if endpoint.Annotations != nil {
+					warnings.endpointAnnotations[component.Name] = true
+				}
+			}
+			if component.Container.DedicatedPod != nil && *component.Container.DedicatedPod {
+				warnings.dedicatedPod[component.Name] = true
+			}
+		}
+
+		if component.Image != nil {
+			warnings.imageComponent[component.Name] = true
+		}
+		if component.Custom != nil {
+			warnings.customComponent[component.Name] = true
+		}
+		if component.Volume != nil && component.Volume.Size != "" {
+			warnings.volumeSize[component.Name] = true
+		}
+	}
+	if devWorkspaceSpec.Events != nil {
+		if len(devWorkspaceSpec.Events.PostStop) > 0 {
+			for _, event := range devWorkspaceSpec.Events.PostStop {
+				warnings.eventPostStop[event] = true
+			}
+		}
+		if len(devWorkspaceSpec.Events.PreStop) > 0 {
+			for _, event := range devWorkspaceSpec.Events.PreStop {
+				warnings.eventPreStop[event] = true
+			}
+
+		}
+	}
+	return warnings
+}
+
+func unsupportedWarningsPresent(warnings *unsupportedWarnings) bool {
+	return len(warnings.serviceAnnotations) > 0 ||
+		len(warnings.endpointAnnotations) > 0 ||
+		len(warnings.dedicatedPod) > 0 ||
+		len(warnings.imageComponent) > 0 ||
+		len(warnings.customComponent) > 0 ||
+		len(warnings.volumeSize) > 0 ||
+		len(warnings.eventPostStop) > 0 ||
+		len(warnings.eventPreStop) > 0
+}
+
+func formatUnsupportedFeaturesWarning(warnings *unsupportedWarnings) string {
+	var msg []string
+
+	// Returns warning names in sorted order
+	getWarningNames := func(warningsMap map[string]bool) []string {
+		var warningNames []string
+		for name := range warningsMap {
+			warningNames = append(warningNames, name)
+		}
+		sort.Strings(warningNames)
+		return warningNames
+	}
+
+	if len(warnings.serviceAnnotations) > 0 {
+		serviceAnnotationsMsg := "components[].container.annotation.service, used by components: " + strings.Join(getWarningNames(warnings.serviceAnnotations), ", ")
+		msg = append(msg, serviceAnnotationsMsg)
+	}
+	if len(warnings.endpointAnnotations) > 0 {
+		endpointAnnotationsMsg := "components[].container.endpoints[].annotations, used by components: " + strings.Join(getWarningNames(warnings.endpointAnnotations), ", ")
+		msg = append(msg, endpointAnnotationsMsg)
+	}
+	if len(warnings.dedicatedPod) > 0 {
+		dedicatedPodMsg := "components[].container.dedicatedPod, used by components: " + strings.Join(getWarningNames(warnings.dedicatedPod), ", ")
+		msg = append(msg, dedicatedPodMsg)
+	}
+	if len(warnings.imageComponent) > 0 {
+		imageComponentMsg := "components[].image, used by components: " + strings.Join(getWarningNames(warnings.imageComponent), ", ")
+		msg = append(msg, imageComponentMsg)
+	}
+	if len(warnings.customComponent) > 0 {
+		customComponentMsg := "components[].custom, used by components: " + strings.Join(getWarningNames(warnings.customComponent), ", ")
+		msg = append(msg, customComponentMsg)
+	}
+	if len(warnings.volumeSize) > 0 {
+		volumeSizeMsg := "components[].volume.size, used by components: " + strings.Join(getWarningNames(warnings.volumeSize), ", ")
+		msg = append(msg, volumeSizeMsg)
+	}
+	if len(warnings.eventPostStop) > 0 {
+		eventPostStopMsg := "events.postStop: " + strings.Join(getWarningNames(warnings.eventPostStop), ", ")
+		msg = append(msg, eventPostStopMsg)
+	}
+	if len(warnings.eventPreStop) > 0 {
+		eventPreStopMsg := "events.preStop: " + strings.Join(getWarningNames(warnings.eventPreStop), ", ")
+		msg = append(msg, eventPreStopMsg)
+	}
+	return fmt.Sprintf("Unsupported Devfile features are present in this workspace. The following features will have no effect: %s", strings.Join(msg, "; "))
+}
+
+// Returns unsupported feature warnings that are present in the new workspace
+// but not present in the old workspace
+func checkForAddedUnsupportedFeatures(oldWksp, newWksp *dwv2.DevWorkspace) *unsupportedWarnings {
+	oldWarnings := checkUnsupportedFeatures(oldWksp.Spec.Template)
+	newWarnings := checkUnsupportedFeatures(newWksp.Spec.Template)
+	addedWarnings := newUnsupportedWarnings()
+
+	getAddedWarnings := func(old, new map[string]bool) map[string]bool {
+		newWarningNames := make(map[string]bool)
+		for name := range new {
+			if !old[name] {
+				newWarningNames[name] = true
+			}
+		}
+		return newWarningNames
+	}
+
+	addedWarnings.serviceAnnotations = getAddedWarnings(oldWarnings.serviceAnnotations, newWarnings.serviceAnnotations)
+	addedWarnings.endpointAnnotations = getAddedWarnings(oldWarnings.endpointAnnotations, newWarnings.endpointAnnotations)
+	addedWarnings.dedicatedPod = getAddedWarnings(oldWarnings.dedicatedPod, newWarnings.dedicatedPod)
+	addedWarnings.imageComponent = getAddedWarnings(oldWarnings.imageComponent, newWarnings.imageComponent)
+	addedWarnings.customComponent = getAddedWarnings(oldWarnings.customComponent, newWarnings.customComponent)
+	addedWarnings.volumeSize = getAddedWarnings(oldWarnings.volumeSize, newWarnings.volumeSize)
+	addedWarnings.eventPreStop = getAddedWarnings(oldWarnings.eventPreStop, newWarnings.eventPreStop)
+	addedWarnings.eventPostStop = getAddedWarnings(oldWarnings.eventPostStop, newWarnings.eventPostStop)
+	return addedWarnings
+}

--- a/webhook/workspace/handler/warning_test.go
+++ b/webhook/workspace/handler/warning_test.go
@@ -1,0 +1,96 @@
+//
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
+)
+
+type testCase struct {
+	Name   string     `json:"name,omitempty"`
+	Input  testInput  `json:"input,omitempty"`
+	Output testOutput `json:"output,omitempty"`
+}
+
+type testInput struct {
+	OldWorkspace *dwv2.DevWorkspaceTemplateSpec `json:"oldWorkspace,omitempty"`
+	NewWorkspace *dwv2.DevWorkspaceTemplateSpec `json:"newWorkspace,omitempty"`
+}
+
+type testOutput struct {
+	ExpectedWarning    *string `json:"expectedWarning,omitempty"`
+	NewWarningsPresent *bool   `json:"newWarningsPresent,omitempty"`
+}
+
+func loadTestCaseOrPanic(t *testing.T, testFilepath string) testCase {
+	bytes, err := os.ReadFile(testFilepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var test testCase
+	if err := yaml.Unmarshal(bytes, &test); err != nil {
+		t.Fatal(err)
+	}
+	return test
+}
+
+func loadAllTestCasesOrPanic(t *testing.T, fromDir string) []testCase {
+	files, err := os.ReadDir(fromDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tests []testCase
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		tests = append(tests, loadTestCaseOrPanic(t, filepath.Join(fromDir, file.Name())))
+	}
+	return tests
+}
+
+func TestModifyWorkspaceWithUnsupportedFeatures(t *testing.T) {
+	tests := loadAllTestCasesOrPanic(t, "testdata/warning")
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			// sanity check that file is read correctly.
+			assert.NotNil(t, tt.Input.OldWorkspace, "Input does not define an old workspace")
+			assert.NotNil(t, tt.Input.NewWorkspace, "Input does not define a new workspace")
+			oldWorkspace := &dwv2.DevWorkspace{}
+			oldWorkspace.Spec.Template = *tt.Input.OldWorkspace
+
+			newWorkspace := &dwv2.DevWorkspace{}
+			newWorkspace.Spec.Template = *tt.Input.NewWorkspace
+
+			warnings := checkForAddedUnsupportedFeatures(oldWorkspace, newWorkspace)
+			if tt.Output.NewWarningsPresent != nil && *tt.Output.NewWarningsPresent {
+				assert.True(t, unsupportedWarningsPresent(warnings), "New warnings expected")
+			} else {
+				assert.False(t, unsupportedWarningsPresent(warnings), "No new warnings expected")
+			}
+			if tt.Output.ExpectedWarning != nil {
+				assert.Equal(t, *tt.Output.ExpectedWarning, formatUnsupportedFeaturesWarning(warnings), "Warning message should match")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a webhook warning when trying to create a devworkspace that uses features that are [unsupported by DWO](https://github.com/devfile/devworkspace-operator/blob/main/docs/unsupported-devfile-api.adoc).

A warning is also given when adding unsupported features to an existing devworkspaces `spec.template`. When this happens, a warning is only given for unsupported features that were not already present in the devworkspace (to reduce noise and make it more obvious which modifications gave new warnings).

### What issues does this PR fix or reference?
#984

### Is it tested? How?
Some automated tests were added, however these only test internal functions and not the webhook create/update functions themselves. 

There are 3 cases to manually test, I recommend following them in order.
 
First install DWO to your cluster with the changes from this PR, i.e: `make docker install`
# Creating a devworkspace that uses unsupported features
1. Apply the following devworkspace, which uses `components.annotation.service` and `events.preStop`:

```YAML
cat <<EOF | kubectl apply -n $NAMESPACE -f -         
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: unsupported-features
spec:
  started: true
  routingClass: 'basic'
  template:
    commands:
      - id: init-cache
        exec:
          component: tools
          commandLine: "init cache"
          workingDir: /.m2
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
          annotation:
            service:
              key: value
    events:
      preStop:
        - init-cache
EOF
```
2. You should see a warning like the following:

```
Warning: Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.annotation.service, used by components: web-terminal; events.preStop: init-cache
devworkspace.workspace.devfile.io/unsupported-features created
```


# Adding new unsupported features to a devworkspace that already has unsupported features
Add an [unsupported feature](https://github.com/devfile/devworkspace-operator/blob/main/docs/unsupported-devfile-api.adoc) to the `template.spec`, e.g `spec.template.components.container.dedicatedPod`.

Continuing off the last test case: 
1. `kubectl edit dw unsupported-features -n $NAMESPACE`
```diff
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
(..)
spec:
  routingClass: basic
  started: true
  template:
    commands:
    - exec:
        commandLine: init cache
        component: tools
        workingDir: /.m2
      id: init-cache
    components:
    - container:
        annotation:
          service:
            key: value
        command:
        - tail
        - -f
        - /dev/null
        image: quay.io/wto/web-terminal-tooling:next
        memoryLimit: 512Mi
        mountSources: true
        sourceMapping: /projects
+       dedicatedPod: true
      name: web-terminal
    events:
      preStop:
      - init-cache
status:
  conditions:
(..)
```
2. You should see a warning that only mentions the newly added unsupported feature(s):
```
Warning: Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.dedicatedPod, used by components: web-terminal
devworkspace.workspace.devfile.io/unsupported-features edited
```


# Trying to remove the creator label while adding unsupported features to a devworkspace
Continuing off of the last test case: remove the `spec.template.components.container.dedicatedPod` from the devworkspace (no warnings should be given).

1. Edit the devworkspace and remove the `controller.devfile.io/creator` label, and add an unsupported feature to the `spec.template`.


```diff
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
(..)
- labels:
-   controller.devfile.io/creator: ""
  name: unsupported-features
  namespace: devworkspace-controller
  resourceVersion: "83951"
  uid: 292207f2-b776-41b7-9d93-3a4603042f04
spec:
  routingClass: basic
  started: true
  template:
    commands:
    - exec:
        commandLine: init cache
        component: tools
        workingDir: /.m2
      id: init-cache
    components:
    - container:
        annotation:
          service:
            key: value
        command:
        - tail
        - -f
        - /dev/null
+       dedicatedPod: true
        image: quay.io/wto/web-terminal-tooling:next
        memoryLimit: 512Mi
        mountSources: true
        sourceMapping: /projects
      name: web-terminal
    events:
      preStop:
      - init-cache
status:
  conditions:
```
2. The edit should result in a warning about the feature you added:
```
Warning: Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.dedicatedPod, used by components: web-terminal
devworkspace.workspace.devfile.io/unsupported-features edited
```
3. Checking the devworkspace again (`kubectl describe dw unsupported-features -n $NAMESPACE
`) should show that the `controller.devfile.io/creator` label was re-added.
 
```diff
 Name:         unsupported-features
 Namespace:    devworkspace-controller
+ Labels:       controller.devfile.io/creator=
 Annotations:  controller.devfile.io/started-at: 1669930843394
 API Version:  workspace.devfile.io/v1alpha2
 Kind:         DevWorkspace
Metadata:
(...)
Spec:
  Routing Class:  basic
  Started:        true
  Template:
    Commands:
      Exec:
        Command Line:  init cache
        Component:     tools
        Working Dir:   /.m2
      Id:              init-cache
    Components:
      Container:
        Annotation:
          Service:
            Key:  value
        Command:
          tail
          -f
          /dev/null
+       Dedicated Pod:   true
        Image:           quay.io/wto/web-terminal-tooling:next
        Memory Limit:    512Mi
        Mount Sources:   true
        Source Mapping:  /projects
      Name:              web-terminal
    Events:
      Pre Stop:
        init-cache
```


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
