### PR TITLE
Use theia-latest instead of theia-next in samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To see all rules supported by the makefile, run `make help`
 
 ### Test run controller
 1. Take a look samples devworkspace configuration in `./samples` folder.
-2. Apply any of them by executing `kubectl apply -f ./samples/flattened_theia-next.yaml -n <namespace>`
+2. Apply any of them by executing `kubectl apply -f ./samples/theia-latest.yaml -n <namespace>`
 3. As soon as devworkspace is started you're able to get IDE url by executing `kubectl get devworkspace -n <namespace>`
 
 ### Run controller locally

--- a/samples/container-overrides.yaml
+++ b/samples/container-overrides.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next
+  name: theia-next-container-overrides
 spec:
   started: true
 

--- a/samples/ephemeral-storage.yaml
+++ b/samples/ephemeral-storage.yaml
@@ -15,7 +15,7 @@ spec:
     components:
       - name: theia
         plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
+          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
           components:
             - name: theia-ide
               container:

--- a/samples/ephemeral-storage.yaml
+++ b/samples/ephemeral-storage.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next
+  name: theia-next-ephemeral
 spec:
   started: true
   template:

--- a/samples/git-clone-sample.yaml
+++ b/samples/git-clone-sample.yaml
@@ -21,7 +21,7 @@ spec:
     components:
       - name: theia
         plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
+          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
           components:
             - name: theia-ide
               container:

--- a/samples/per-workspace-storage.yaml
+++ b/samples/per-workspace-storage.yaml
@@ -15,7 +15,7 @@ spec:
     components:
       - name: theia
         plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
+          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
           components:
             - name: theia-ide
               container:

--- a/samples/per-workspace-storage.yaml
+++ b/samples/per-workspace-storage.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next
+  name: theia-next-per-workspace
 spec:
   started: true
   template:

--- a/samples/pod-overrides.yaml
+++ b/samples/pod-overrides.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next
+  name: theia-next-pod-overrides
 spec:
   started: true
   template:

--- a/samples/pod-overrides.yaml
+++ b/samples/pod-overrides.yaml
@@ -23,7 +23,7 @@ spec:
     components:
       - name: theia
         plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
+          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
           components:
             - name: theia-ide
               container:

--- a/samples/theia-latest-contributions.yaml
+++ b/samples/theia-latest-contributions.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next
+  name: theia-latest
 spec:
   started: true
   template:
@@ -10,19 +10,19 @@ spec:
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
-    components:
-      - name: theia
-        plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
-          components:
-            - name: theia-ide
-              container:
-                env:
-                  - name: THEIA_HOST
-                    value: 0.0.0.0
     commands:
       - id: say-hello
         exec:
           component: theia-ide
           commandLine: echo "Hello from $(pwd)"
           workingDir: ${PROJECTS_ROOT}/project/app
+
+  contributions:
+    - name: theia
+      uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
+      components:
+        - name: theia-ide
+          container:
+            env:
+              - name: THEIA_HOST
+                value: 0.0.0.0

--- a/samples/theia-latest-contributions.yaml
+++ b/samples/theia-latest-contributions.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-latest
+  name: theia-latest-contributions
 spec:
   started: true
   template:

--- a/samples/theia-latest.yaml
+++ b/samples/theia-latest.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next
+  name: theia-latest
 spec:
   started: true
   template:
@@ -10,19 +10,19 @@ spec:
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    components:
+      - name: theia
+        plugin:
+          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
+          components:
+            - name: theia-ide
+              container:
+                env:
+                  - name: THEIA_HOST
+                    value: 0.0.0.0
     commands:
       - id: say-hello
         exec:
           component: theia-ide
           commandLine: echo "Hello from $(pwd)"
           workingDir: ${PROJECTS_ROOT}/project/app
-
-  contributions:
-    - name: theia
-      uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/next/devfile.yaml
-      components:
-        - name: theia-ide
-          container:
-            env:
-              - name: THEIA_HOST
-                value: 0.0.0.0


### PR DESCRIPTION
This PR replaces usage of the theia-next devfile URI (which is now broken) with the theia-latest devfile URI for all samples that were using theia-next.

I also modified the names of the sample workspaces so that they would all be unique, preventing any conflicts when applying multiple samples at the same time. This isn't necessary (though I've found it useful in the past) and the commit for it can be removed if desired. 

### What issues does this PR fix or reference?
Fix #992

### Is it tested? How?
1. Deploy DWO
2. `kubectl apply -f ` the following samples:
- `theia-latest.yaml`
- `theia-latest-contributions.yaml`
- `pod-overrides.yaml`
- `ephemeral-storage.yaml`
- `per-workspace-storage.yaml`
- `git-clone-sample.yaml`
3. Ensure they all start up sucessfully with `kubectl get dw -w`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
