### PR TITLE
Fix codecov action in main branch

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -40,8 +40,9 @@ jobs:
       name: Run Go Tests
       run: |
         python -m pip install --upgrade pip yq
+        go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/onsi/ginkgo/v2/ginkgo@v2.0.0
-        make test
+        make update_devworkspace_crds test
     -
       name: Build Codecov report
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
### What does this PR do?
Fixes the codecov action in main, which is currently failing.

Controller tests that use envtests depend on CRDs being available to install into the test cluster. Since these CRDs are not committed to the repository, it is necessary to download them for envtest tests to function correctly.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Tested by pushing changes my fork's main branch.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
