### PR TITLE
Clean up and update README.md

### DIFF
--- a/build/make/olm.mk
+++ b/build/make/olm.mk
@@ -50,12 +50,7 @@ build_bundle_and_index: _print_vars _check_skopeo_installed _check_opm_version
 
 ### register_catalogsource: create the catalogsource to make the operator be available on the marketplace
 register_catalogsource: _check_skopeo_installed
-	INDEX_DIGEST=$$(skopeo inspect docker://$(DWO_INDEX_IMG) | jq -r '.Digest')
-	INDEX_IMG=$(DWO_INDEX_IMG)
-	INDEX_IMG_DIGEST="$${INDEX_IMG%:*}@$${INDEX_DIGEST}"
-
-	# replace references of catalogsource img with your image
-	sed -e "s|quay.io/devfile/devworkspace-operator-index:next|$${INDEX_IMG_DIGEST}|g" ./catalog-source.yaml \
+	sed -e "s|quay.io/devfile/devworkspace-operator-index:next|$(DWO_INDEX_IMG)|g" ./catalog-source.yaml \
 	  | oc apply -f -
 
 ### unregister_catalogsource: unregister the catalogsource and delete the imageContentSourcePolicy


### PR DESCRIPTION
### What does this PR do?
Update README.md:

* Consistent headings for sections/subsections (rather than a mix of level 2 and 3); fix some clumsy wording
* Add section for DevWorkspaceOperatorConfig CR
* Update section on installing via OLM to include DWO-built index images are options (release and next)
    * Update how OLM install works to avoid using digest -- indexes should use tagged images to pick up updates
* Add wait steps in documentation for running locally to ensure webhooks are available before scaling controller to 0

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
