### PR TITLE
Update some metadata names from samples to be more accurate

### DIFF
--- a/samples/container-overrides.yaml
+++ b/samples/container-overrides.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next-container-overrides
+  name: web-terminal-container-overrides
 spec:
   started: true
 

--- a/samples/ephemeral-storage.yaml
+++ b/samples/ephemeral-storage.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next-ephemeral
+  name: theia-latest-ephemeral
 spec:
   started: true
   template:

--- a/samples/per-workspace-storage.yaml
+++ b/samples/per-workspace-storage.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next-per-workspace
+  name: theia-latest-per-workspace
 spec:
   started: true
   template:

--- a/samples/pod-overrides.yaml
+++ b/samples/pod-overrides.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-next-pod-overrides
+  name: theia-latest-pod-overrides
 spec:
   started: true
   template:


### PR DESCRIPTION
### What does this PR do?
Updates samples that used `theia-next...` in their `metadata.name` to be `theia-latest...`

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/pull/994#pullrequestreview-1223309653

### Is it tested? How?
`kubectl/oc apply -f` the following samples:
- `kubectl apply -f ./samples/pod-overrides.yaml`
- `kubectl apply -f ./samples/container-overrides.yaml`
- `kubectl apply -f ./samples/ephemeral-storage.yaml`
- `kubectl apply -f ./samples/per-workspace-storage.yaml`
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
