### PR TITLE
Update Go version to 1.18

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
### What does this PR do?
Update Go version to 1.18:

* Set Prow CI image to use Go 1.18 (should fix e2e test failures in https://github.com/devfile/devworkspace-operator/pull/997)
* Set Go version 1.18.4 in GitHub Actions
* Set go.mod to 1.18 and run `go mod tidy`

This matches what is currently used in builder images for the controller/webhooks server/project-clone.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
