### PR TITLE
Update GitHub actions to avoid deprecated set-output usage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,7 +26,7 @@ jobs:
     -
       name: Cache go modules
       id: cache-mod
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Set output for Git short SHA
       id: git-sha
-      run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+      run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Login to quay.io
       uses: docker/login-action@v1
@@ -77,7 +77,7 @@ jobs:
     steps:
 
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-operator-sdk
         with:
           path: ~/cache
@@ -97,7 +97,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Cache OPM ${{ env.OPM_VERSION }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-opm
         with:
           path: ~/cache

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
 
     -
       name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-operator-sdk
       with:
         path: ~/cache
@@ -49,7 +49,7 @@ jobs:
     -
       name: Cache go modules
       id: cache-mod
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           fi
 
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-operator-sdk
         with:
           path: ~/cache
@@ -74,7 +74,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Cache OPM ${{ env.OPM_VERSION }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-opm
         with:
           path: ~/cache


### PR DESCRIPTION
### What does this PR do?
GitHub actions has deprecated the set-output and save-state commands. These are used in the next build (to set the Git SHA for the current commit) and within actions/cache@v2. This PR updates the next-build job to use environment files and updates actions/cache to v3

### What issues does this PR fix or reference?
N/A, maintenance.

### Is it tested? How?
Will be tested next time these jobs are run :crossed_fingers: 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
