### PR TITLE
Update GitHub actions to latest versions

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: 3.8
     -
       name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     -
       name: Cache go modules
       id: cache-mod

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -32,21 +32,21 @@ jobs:
 
     steps:
     - name: Checkout devworkspace-operator source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set output for Git short SHA
       id: git-sha
       run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Login to quay.io
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
 
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         push: true
@@ -56,7 +56,7 @@ jobs:
         file: ./build/Dockerfile
 
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         push: true
@@ -118,10 +118,10 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Checkout devworkspace-operator source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to quay.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: 3.8
     -
       name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     -
       name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
@@ -125,7 +125,7 @@ jobs:
     steps:
     -
       name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     -
       name: Check if dockerimage build is working
       run: docker build -f ./build/Dockerfile .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           go-version: 1.18.4
 
       - name: Clone source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Login to quay.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
### What does this PR do?
Update:
* actions/checkout@v2 -> v3
* docker/login-action@v1 -> v2
* docker/build-push-action@v2 -> v3

This is required to remove warnings around
* usage of save-state and set-output
* usage of Node.js 12 actions

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
