### PR TITLE
Update OpenShift deployments to use kube-rbac-proxy from kubebuilder

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -340,7 +340,7 @@ spec:
                 - name: RELATED_IMAGE_devworkspace_webhook_server
                   value: quay.io/devfile/devworkspace-controller:next
                 - name: RELATED_IMAGE_kube_rbac_proxy
-                  value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+                  value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
                 - name: RELATED_IMAGE_project_clone
                   value: quay.io/devfile/project-clone:next
                 - name: WATCH_NAMESPACE
@@ -418,7 +418,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -485,7 +485,7 @@ spec:
   relatedImages:
   - image: quay.io/devfile/devworkspace-controller:next
     name: devworkspace_webhook_server
-  - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+  - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
     name: kube_rbac_proxy
   - image: quay.io/devfile/project-clone:next
     name: project_clone

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -23867,7 +23867,7 @@ spec:
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
         - name: RELATED_IMAGE_kube_rbac_proxy
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
           value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
@@ -23947,7 +23947,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
         - name: RELATED_IMAGE_kube_rbac_proxy
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
           value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
@@ -109,7 +109,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -23869,7 +23869,7 @@ spec:
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
         - name: RELATED_IMAGE_kube_rbac_proxy
-          value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
           value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
@@ -23949,7 +23949,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
         - name: RELATED_IMAGE_kube_rbac_proxy
-          value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
           value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
@@ -109,7 +109,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/generate-deployment.sh
+++ b/deploy/generate-deployment.sh
@@ -172,7 +172,7 @@ fi
 
 # Run kustomize to build yamls
 echo "Generating config for Kubernetes"
-export RBAC_PROXY_IMAGE="${KUBE_RBAC_PROXY_IMAGE:-gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0}"
+export RBAC_PROXY_IMAGE="${KUBE_RBAC_PROXY_IMAGE:-gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1}"
 ${KUSTOMIZE} build "${SCRIPT_DIR}/templates/cert-manager" \
   | envsubst "$SUBST_VARS" \
   > "${KUBERNETES_DIR}/${COMBINED_FILENAME}"
@@ -180,7 +180,7 @@ unset RBAC_PROXY_IMAGE
 echo "File saved to ${KUBERNETES_DIR}/${COMBINED_FILENAME}"
 
 echo "Generating config for OpenShift"
-export RBAC_PROXY_IMAGE="${OPENSHIFT_RBAC_PROXY_IMAGE:-registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8}"
+export RBAC_PROXY_IMAGE="${OPENSHIFT_RBAC_PROXY_IMAGE:-gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1}"
 ${KUSTOMIZE} build "${SCRIPT_DIR}/templates/service-ca" \
   | envsubst "$SUBST_VARS" \
   > "${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
@@ -189,7 +189,7 @@ echo "File saved to ${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
 
 if $GEN_OLM; then
   echo "Generating base deployment files for OLM"
-  export RBAC_PROXY_IMAGE="${OPENSHIFT_RBAC_PROXY_IMAGE:-registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8}"
+  export RBAC_PROXY_IMAGE="${OPENSHIFT_RBAC_PROXY_IMAGE:-gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1}"
   export NAMESPACE=openshift-operators
   # Generate .spec.relatedImages for CSV based on deployment
   TMPCSV="csv.tmp.yaml"

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -99,7 +99,7 @@ spec:
   relatedImages:
     - image: quay.io/devfile/devworkspace-controller:next
       name: devworkspace_webhook_server
-    - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.8
+    - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
       name: kube_rbac_proxy
     - image: quay.io/devfile/project-clone:next
       name: project_clone


### PR DESCRIPTION
### What does this PR do?
Updates deployment template and catalog to use `gcr.io/kubebuilder/kube-rbac-proxy` instead of `registry.redhat.io/openshift4/ose-kube-rbac-proxy` as the latter image requires an OpenShift subscription. Also updates the kube-rbac-proxy image used to v0.13.1 (latest). The image is used only to secure the operator metrics endpoint.

I also considered using https://quay.io/repository/openshift/origin-kube-rbac-proxy?tab=info, however it's unclear where this image is used elsewhere.

We will need to adapt the downstream process to continue using the correct image -- created issue https://github.com/devfile/devworkspace-operator/issues/1014 to track this work.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/894

### Is it tested? How?
To test, deploy DWO from changes (i.e. using the new image) and verify that metrics work as expected.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
