### PR TITLE
Detect changes in automount resources and queue reconciles for started workspaces

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -700,69 +700,6 @@ func (r *DevWorkspaceReconciler) getWorkspaceId(ctx context.Context, workspace *
 	}
 }
 
-// Mapping the pod to the devworkspace
-func dwRelatedPodsHandler(obj client.Object) []reconcile.Request {
-	labels := obj.GetLabels()
-	if _, ok := labels[constants.DevWorkspaceNameLabel]; !ok {
-		return []reconcile.Request{}
-	}
-
-	//If the dewworkspace label does not exist, do no reconcile
-	if _, ok := labels[constants.DevWorkspaceIDLabel]; !ok {
-		return []reconcile.Request{}
-	}
-
-	return []reconcile.Request{
-		{
-			NamespacedName: types.NamespacedName{
-				Name:      labels[constants.DevWorkspaceNameLabel],
-				Namespace: obj.GetNamespace(),
-			},
-		},
-	}
-}
-
-func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Request {
-	// Check if PVC is owned by a DevWorkspace (per-workspace storage case)
-	for _, ownerref := range obj.GetOwnerReferences() {
-		if ownerref.Kind != "DevWorkspace" {
-			continue
-		}
-		return []reconcile.Request{
-			{
-				NamespacedName: types.NamespacedName{
-					Name:      ownerref.Name,
-					Namespace: obj.GetNamespace(),
-				},
-			},
-		}
-	}
-
-	// TODO: Label PVCs used for workspace storage so that they can be cleaned up if non-default name is used.
-	// Otherwise, check if common PVC is deleted to make sure all DevWorkspaces see it happen
-	if obj.GetName() != wkspConfig.GetGlobalConfig().Workspace.PVCName || obj.GetDeletionTimestamp() == nil {
-		// We're looking for a deleted common PVC
-		return []reconcile.Request{}
-	}
-	dwList := &dw.DevWorkspaceList{}
-	if err := r.Client.List(context.Background(), dwList, &client.ListOptions{Namespace: obj.GetNamespace()}); err != nil {
-		return []reconcile.Request{}
-	}
-	var reconciles []reconcile.Request
-	for _, workspace := range dwList.Items {
-		storageType := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
-		if storageType == constants.CommonStorageClassType || storageType == constants.PerUserStorageClassType || storageType == "" {
-			reconciles = append(reconciles, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      workspace.GetName(),
-					Namespace: workspace.GetNamespace(),
-				},
-			})
-		}
-	}
-	return reconciles
-}
-
 func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	setupHttpClients()
 
@@ -794,7 +731,7 @@ func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &corev1.Pod{}}, handler.EnqueueRequestsFromMapFunc(dwRelatedPodsHandler)).
 		Watches(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, handler.EnqueueRequestsFromMapFunc(r.dwPVCHandler)).
 		Watches(&source.Kind{Type: &controllerv1alpha1.DevWorkspaceOperatorConfig{}}, handler.EnqueueRequestsFromMapFunc(emptyMapper), configWatcher).
-		WithEventFilter(predicates).
+		WithEventFilter(devworkspacePredicates).
 		WithEventFilter(podPredicates).
 		Complete(r)
 }

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -712,7 +712,8 @@ func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return []reconcile.Request{}
 	}
 
-	var configWatcher builder.WatchesOption = builder.WithPredicates(wkspConfig.Predicates())
+	configWatcher := builder.WithPredicates(wkspConfig.Predicates())
+	automountWatcher := builder.WithPredicates(automountPredicates)
 
 	// TODO: Set up indexing https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html#setup
 	return ctrl.NewControllerManagedBy(mgr).
@@ -730,6 +731,9 @@ func (r *DevWorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ServiceAccount{}).
 		Watches(&source.Kind{Type: &corev1.Pod{}}, handler.EnqueueRequestsFromMapFunc(dwRelatedPodsHandler)).
 		Watches(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, handler.EnqueueRequestsFromMapFunc(r.dwPVCHandler)).
+		Watches(&source.Kind{Type: &corev1.Secret{}}, handler.EnqueueRequestsFromMapFunc(r.runningWorkspacesHandler), automountWatcher).
+		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, handler.EnqueueRequestsFromMapFunc(r.runningWorkspacesHandler), automountWatcher).
+		Watches(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, handler.EnqueueRequestsFromMapFunc(r.runningWorkspacesHandler), automountWatcher).
 		Watches(&source.Kind{Type: &controllerv1alpha1.DevWorkspaceOperatorConfig{}}, handler.EnqueueRequestsFromMapFunc(emptyMapper), configWatcher).
 		WithEventFilter(devworkspacePredicates).
 		WithEventFilter(podPredicates).

--- a/controllers/workspace/devworkspace_controller_test.go
+++ b/controllers/workspace/devworkspace_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/conditions"
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
-	"github.com/devfile/devworkspace-operator/pkg/provision/automount"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -570,7 +569,7 @@ var _ = Describe("DevWorkspace Controller", func() {
 			devworkspace := getExistingDevWorkspace(devWorkspaceName)
 			workspaceID := devworkspace.Status.DevWorkspaceId
 
-			mergedSecretNN := namespacedName(automount.GitCredentialsMergedSecretName, testNamespace)
+			mergedSecretNN := namespacedName(constants.GitCredentialsMergedSecretName, testNamespace)
 			mergedSecret := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, mergedSecretNN, mergedSecret)).Error()
 
@@ -594,7 +593,7 @@ var _ = Describe("DevWorkspace Controller", func() {
 					return err
 				}
 				for _, volume := range deploy.Spec.Template.Spec.Volumes {
-					if volume.Secret != nil && volume.Secret.SecretName == automount.GitCredentialsMergedSecretName {
+					if volume.Secret != nil && volume.Secret.SecretName == constants.GitCredentialsMergedSecretName {
 						return nil
 					}
 				}

--- a/controllers/workspace/eventhandlers.go
+++ b/controllers/workspace/eventhandlers.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	wkspConfig "github.com/devfile/devworkspace-operator/pkg/config"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// Mapping the pod to the devworkspace
+func dwRelatedPodsHandler(obj client.Object) []reconcile.Request {
+	labels := obj.GetLabels()
+	if _, ok := labels[constants.DevWorkspaceNameLabel]; !ok {
+		return []reconcile.Request{}
+	}
+
+	//If the dewworkspace label does not exist, do no reconcile
+	if _, ok := labels[constants.DevWorkspaceIDLabel]; !ok {
+		return []reconcile.Request{}
+	}
+
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      labels[constants.DevWorkspaceNameLabel],
+				Namespace: obj.GetNamespace(),
+			},
+		},
+	}
+}
+
+func (r *DevWorkspaceReconciler) dwPVCHandler(obj client.Object) []reconcile.Request {
+	// Check if PVC is owned by a DevWorkspace (per-workspace storage case)
+	for _, ownerref := range obj.GetOwnerReferences() {
+		if ownerref.Kind != "DevWorkspace" {
+			continue
+		}
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Name:      ownerref.Name,
+					Namespace: obj.GetNamespace(),
+				},
+			},
+		}
+	}
+
+	// TODO: Label PVCs used for workspace storage so that they can be cleaned up if non-default name is used.
+	// Otherwise, check if common PVC is deleted to make sure all DevWorkspaces see it happen
+	if obj.GetName() != wkspConfig.GetGlobalConfig().Workspace.PVCName || obj.GetDeletionTimestamp() == nil {
+		// We're looking for a deleted common PVC
+		return []reconcile.Request{}
+	}
+	dwList := &dw.DevWorkspaceList{}
+	if err := r.Client.List(context.Background(), dwList, &client.ListOptions{Namespace: obj.GetNamespace()}); err != nil {
+		return []reconcile.Request{}
+	}
+	var reconciles []reconcile.Request
+	for _, workspace := range dwList.Items {
+		storageType := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
+		if storageType == constants.CommonStorageClassType || storageType == constants.PerUserStorageClassType || storageType == "" {
+			reconciles = append(reconciles, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      workspace.GetName(),
+					Namespace: workspace.GetNamespace(),
+				},
+			})
+		}
+	}
+	return reconciles
+}

--- a/controllers/workspace/predicates.go
+++ b/controllers/workspace/predicates.go
@@ -25,10 +25,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// predicates filters incoming events to avoid unnecessary reconciles to failed workspaces.
+// devworkspacePredicates filters incoming events to avoid unnecessary reconciles to failed workspaces.
 // If a workspace failed and its spec is changed, we trigger reconciles to allow for fixing
 // issues in the workspace spec.
-var predicates = predicate.Funcs{
+var devworkspacePredicates = predicate.Funcs{
 	CreateFunc: func(_ event.CreateEvent) bool { return true },
 	DeleteFunc: func(_ event.DeleteEvent) bool { return true },
 	UpdateFunc: func(ev event.UpdateEvent) bool {

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -58,6 +58,15 @@ const (
 	// If the git host is not defined then the certificate will be used for all http repositories.
 	DevWorkspaceGitTLSLabel = "controller.devfile.io/git-tls-credential"
 
+	// GitCredentialsConfigMapName is the name used for the configmap that stores the Git configuration for workspaces
+	// in a given namespace. It is used when e.g. adding Git credentials via secret
+	GitCredentialsConfigMapName = "devworkspace-gitconfig"
+
+	// GitCredentialsMergedSecretName is the name for the merged Git credentials secret that is mounted to workspaces
+	// when Git credentials are defined. This secret combines the values of any secrets labelled
+	// "controller.devfile.io/git-credential"
+	GitCredentialsMergedSecretName = "devworkspace-merged-git-credentials"
+
 	// DevWorkspaceMountPathAnnotation is the annotation key to store the mount path for the secret or configmap.
 	// If no mount path is provided, configmaps will be mounted at /etc/config/<configmap-name>, secrets will
 	// be mounted at /etc/secret/<secret-name>, and persistent volume claims will be mounted to /tmp/<claim-name>

--- a/pkg/provision/automount/gitconfig.go
+++ b/pkg/provision/automount/gitconfig.go
@@ -116,7 +116,7 @@ func getGitResources(api sync.ClusterAPI, namespace string) (credentialSecrets [
 
 func cleanupGitConfig(api sync.ClusterAPI, namespace string) error {
 	secretNN := types.NamespacedName{
-		Name:      gitCredentialsSecretName,
+		Name:      GitCredentialsMergedSecretName,
 		Namespace: namespace,
 	}
 	tlsSecret := &corev1.Secret{}

--- a/pkg/provision/automount/gitconfig.go
+++ b/pkg/provision/automount/gitconfig.go
@@ -116,7 +116,7 @@ func getGitResources(api sync.ClusterAPI, namespace string) (credentialSecrets [
 
 func cleanupGitConfig(api sync.ClusterAPI, namespace string) error {
 	secretNN := types.NamespacedName{
-		Name:      GitCredentialsMergedSecretName,
+		Name:      constants.GitCredentialsMergedSecretName,
 		Namespace: namespace,
 	}
 	tlsSecret := &corev1.Secret{}
@@ -134,7 +134,7 @@ func cleanupGitConfig(api sync.ClusterAPI, namespace string) error {
 	}
 
 	configmapNN := types.NamespacedName{
-		Name:      gitCredentialsConfigMapName,
+		Name:      constants.GitCredentialsConfigMapName,
 		Namespace: namespace,
 	}
 	credentialsConfigMap := &corev1.ConfigMap{}

--- a/pkg/provision/automount/templates.go
+++ b/pkg/provision/automount/templates.go
@@ -31,7 +31,7 @@ const gitConfigLocation = "/etc/" + gitConfigName
 const gitCredentialsConfigMapName = "devworkspace-gitconfig"
 
 const gitCredentialsSecretKey = "credentials"
-const gitCredentialsSecretName = "devworkspace-merged-git-credentials"
+const GitCredentialsMergedSecretName = "devworkspace-merged-git-credentials"
 
 // gitLFSConfig is the default configuration that gets provisioned when git-lfs
 // is installed. It needs to be included in the overridden gitconfig to avoid
@@ -122,7 +122,7 @@ func mergeGitCredentials(namespace string, credentialSecrets []corev1.Secret) (*
 	}
 	mergedCredentials := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      gitCredentialsSecretName,
+			Name:      GitCredentialsMergedSecretName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/defaultName":      "git-config-secret",

--- a/pkg/provision/automount/templates.go
+++ b/pkg/provision/automount/templates.go
@@ -28,10 +28,8 @@ const gitTLSCertificateKey = "certificate"
 
 const gitConfigName = "gitconfig"
 const gitConfigLocation = "/etc/" + gitConfigName
-const gitCredentialsConfigMapName = "devworkspace-gitconfig"
 
 const gitCredentialsSecretKey = "credentials"
-const GitCredentialsMergedSecretName = "devworkspace-merged-git-credentials"
 
 // gitLFSConfig is the default configuration that gets provisioned when git-lfs
 // is installed. It needs to be included in the overridden gitconfig to avoid
@@ -95,7 +93,7 @@ func constructGitConfig(namespace, credentialMountPath string, certificatesConfi
 
 	gitConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      gitCredentialsConfigMapName,
+			Name:      constants.GitCredentialsConfigMapName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/defaultName":         "git-config-secret",
@@ -122,7 +120,7 @@ func mergeGitCredentials(namespace string, credentialSecrets []corev1.Secret) (*
 	}
 	mergedCredentials := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GitCredentialsMergedSecretName,
+			Name:      constants.GitCredentialsMergedSecretName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/defaultName":      "git-config-secret",


### PR DESCRIPTION
### What does this PR do?
Watches namespaces for changes to automounted resources (configmaps, secrets, PVCs -- including git credentials secrets) and queues reconciles for any started workspaces in the same namespace.

There is a new controller test to verify this functionality. To avoid erroneous passing tests, I had to reduce the timeout, which could potentially cause flakiness in the future.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/914

### Is it tested? How?
To test manually:
1. Create a workspace and wait for it to be running. Verify that the controller is no longer reconciling that workspace (i.e. there are no new events being triggered)
2. Create an automount resource and check that it is picked up and mounted to the workspace (causing it to restart)

To verify the specific case in the issue:
1. Create a workspace and wait for it to be running. Verify that the controller is no longer reconciling that workspace (i.e. there are no new events being triggered)
2. Create a git credentials secret (does not need to be valid). Verify that workspace is immediately restarted to include new volume
3. Create a second git-credentials secret (or modify the original) and verify that change is propagated to the `devworkspace-merged-git-credentials` secret immediately.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
