### PR TITLE
compute per-workspace PVC size

### DIFF
--- a/docs/unsupported-devfile-api.adoc
+++ b/docs/unsupported-devfile-api.adoc
@@ -8,7 +8,6 @@ The following features of the Devfile API that are not yet supported by the DevW
 | `components.container.annotation.service`     | https://github.com/devfile/devworkspace-operator/issues/799[Support setting annotations on services/endpoints from DevWorkspace]               
 | `components.container.endpoints.annotations`  | https://github.com/devfile/devworkspace-operator/issues/799[Support setting annotations on services/endpoints from DevWorkspace]               
 | `components.container.dedicatedPod`           |                                                                                                                                                
-| `components.volume.size`                      | https://github.com/devfile/devworkspace-operator/issues/947[Compute required size for per-workspace PVC when all volumes have sizes specified.]
 | `components.image`                            | https://github.com/eclipse/che/issues/21186[Support Devfile v2 outer loop components of type image and kubernetes]                             
 | `components.custom`                           |                                                                                                                                                
 | `events.postStop`                             |                                                                                                                                                

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -65,6 +65,7 @@ type testInput struct {
 
 type testOutput struct {
 	PodAdditions v1alpha1.PodAdditions `json:"podAdditions,omitempty"`
+	PVCSize      *resource.Quantity    `json:"pvcSize,omitempty"`
 	ErrRegexp    *string               `json:"errRegexp,omitempty"`
 }
 
@@ -301,6 +302,13 @@ func sortVolumesAndVolumeMounts(podAdditions *v1alpha1.PodAdditions) {
 		})
 	}
 	for idx, container := range podAdditions.Containers {
+		if container.VolumeMounts != nil {
+			sort.Slice(podAdditions.Containers[idx].VolumeMounts, func(i, j int) bool {
+				return strings.Compare(podAdditions.Containers[idx].VolumeMounts[i].Name, podAdditions.Containers[idx].VolumeMounts[j].Name) < 0
+			})
+		}
+	}
+	for idx, container := range podAdditions.InitContainers {
 		if container.VolumeMounts != nil {
 			sort.Slice(podAdditions.Containers[idx].VolumeMounts, func(i, j int) bool {
 				return strings.Compare(podAdditions.Containers[idx].VolumeMounts[i].Name, podAdditions.Containers[idx].VolumeMounts[j].Name) < 0

--- a/pkg/provision/storage/testdata/perWorkspace-storage/calculates-pvc-size-ignoring-ephemeral-volumes.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/calculates-pvc-size-ignoring-ephemeral-volumes.yaml
@@ -1,0 +1,76 @@
+name: "Calculates PVC size when all (non-ephemeral) volumes define their size"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+          - name: "volume-1"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: "plugins"
+            mountPath: "/plugins"
+          - name: "volume-1"
+            mountPath: "/test-3"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+      - name: volume-1
+        volume:
+          size: 1Gi
+      - name: volume-2
+        volume:
+          size: 4Gi
+      - name: volume-3
+        volume:
+          size: 512Mi
+      - name: volume-4
+        volume:
+          size: 248Mi
+      - name: volume-5
+        volume:
+          ephemeral: true
+      - name: plugins
+        volume:
+          size: 248Mi
+
+output:
+  pvcSize: 6128Mi
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "projects"
+            mountPath: "/projects-mountpath"
+          - name: storage-test-workspaceid
+            subPath: "volume-1"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "plugins"
+            mountPath: "/plugins"
+          - name: storage-test-workspaceid
+            subPath: "volume-1"
+            mountPath: "/test-3"
+    volumes:
+      - name: storage-test-workspaceid
+        persistentVolumeClaim:
+          claimName: storage-test-workspaceid
+      - name: volume-5
+        emptyDir: {}

--- a/pkg/provision/storage/testdata/perWorkspace-storage/calculates-pvc-size-when-all-defined.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/calculates-pvc-size-when-all-defined.yaml
@@ -1,0 +1,71 @@
+name: "Calculates PVC size when all volumes define their size"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+          - name: "volume-1"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: "plugins"
+            mountPath: "/plugins"
+          - name: "volume-1"
+            mountPath: "/test-3"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+      - name: volume-1
+        volume:
+          size: 1Gi
+      - name: volume-2
+        volume:
+          size: 4Gi
+      - name: volume-3
+        volume:
+          size: 512Mi
+      - name: volume-4
+        volume:
+          size: 248Mi
+      - name: plugins
+        volume:
+          size: 248Mi
+
+output:
+  pvcSize: 6128Mi
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "projects"
+            mountPath: "/projects-mountpath"
+          - name: storage-test-workspaceid
+            subPath: "volume-1"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "plugins"
+            mountPath: "/plugins"
+          - name: storage-test-workspaceid
+            subPath: "volume-1"
+            mountPath: "/test-3"
+    volumes:
+      - name: storage-test-workspaceid
+        persistentVolumeClaim:
+          claimName: storage-test-workspaceid

--- a/pkg/provision/storage/testdata/perWorkspace-storage/use-default-size-when-calculated-size-smaller-than-default.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/use-default-size-when-calculated-size-smaller-than-default.yaml
@@ -1,0 +1,70 @@
+name: "Uses default PVC size when not all volumes define their size"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+          - name: "volume-1"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: "plugins"
+            mountPath: "/plugins"
+          - name: "volume-1"
+            mountPath: "/test-3"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+      - name: volume-1
+        volume:
+          size: 1Gi
+      - name: volume-2
+        volume:
+          size: 1Gi
+      - name: volume-3
+        volume:
+          size: 512Mi
+      - name: volume-4
+        volume:
+          size: 248Mi
+      - name: plugins
+        volume: {}
+      # Calculated PVC size is 2760Mi, which is smaller than default 5Gi, so default should be used
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "projects"
+            mountPath: "/projects-mountpath"
+          - name: storage-test-workspaceid
+            subPath: "volume-1"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "plugins"
+            mountPath: "/plugins"
+          - name: storage-test-workspaceid
+            subPath: "volume-1"
+            mountPath: "/test-3"
+    volumes:
+      - name: storage-test-workspaceid
+        persistentVolumeClaim:
+          claimName: storage-test-workspaceid

--- a/pkg/provision/storage/testdata/perWorkspace-storage/uses-calculated-pvc-size-when-greater-than-default.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/uses-calculated-pvc-size-when-greater-than-default.yaml
@@ -1,0 +1,70 @@
+name: "Calculates PVC size when all volumes define their size"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+          - name: "volume-1"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: "plugins"
+            mountPath: "/plugins"
+          - name: "volume-1"
+            mountPath: "/test-3"
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          sourceMapping: "/plugins-mountpath"
+      - name: volume-1
+        volume:
+          size: 1Gi
+      - name: volume-2
+        volume:
+          size: 4Gi
+      - name: volume-3
+        volume:
+          size: 512Mi
+      - name: volume-4
+        volume:
+          size: 248Mi
+      - name: plugins
+        volume: {} # Size is not defined, but calculated PVC size will be greater than default 5Gi so, calculated size should be used
+
+output:
+  pvcSize: 5880Mi
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "projects"
+            mountPath: "/projects-mountpath"
+          - name: storage-test-workspaceid
+            subPath: "volume-1"
+            mountPath: "/test-1"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "plugins"
+            mountPath: "/plugins"
+          - name: storage-test-workspaceid
+            subPath: "volume-1"
+            mountPath: "/test-3"
+    volumes:
+      - name: storage-test-workspaceid
+        persistentVolumeClaim:
+          claimName: storage-test-workspaceid

--- a/webhook/workspace/handler/testdata/warning/add-all-unsupported-features.yaml
+++ b/webhook/workspace/handler/testdata/warning/add-all-unsupported-features.yaml
@@ -53,5 +53,5 @@ input:
         - eventF
 
 output:
-  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.annotation.service, used by components: testing-container-1; components[].container.endpoints[].annotations, used by components: testing-container-1; components[].container.dedicatedPod, used by components: testing-container-1; components[].image, used by components: image-component; components[].custom, used by components: custom-component; components[].volume.size, used by components: projects; events.postStop: eventD, eventE, eventF; events.preStop: eventA, eventB, eventC"
+  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.annotation.service, used by components: testing-container-1; components[].container.endpoints[].annotations, used by components: testing-container-1; components[].container.dedicatedPod, used by components: testing-container-1; components[].image, used by components: image-component; components[].custom, used by components: custom-component; events.postStop: eventD, eventE, eventF; events.preStop: eventA, eventB, eventC"
   newWarningsPresent: true

--- a/webhook/workspace/handler/testdata/warning/add-unsupported-features-when-none-present.yaml
+++ b/webhook/workspace/handler/testdata/warning/add-unsupported-features-when-none-present.yaml
@@ -22,5 +22,5 @@ input:
           size: "10Gi"
 
 output:
-  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.dedicatedPod, used by components: testing-container-1; components[].volume.size, used by components: projects"
+  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.dedicatedPod, used by components: testing-container-1"
   newWarningsPresent: true

--- a/webhook/workspace/handler/testdata/warning/add-unsupported-features-when-some-present.yaml
+++ b/webhook/workspace/handler/testdata/warning/add-unsupported-features-when-some-present.yaml
@@ -33,5 +33,5 @@ input:
             rootRequired: false
 
 output:
-  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].image, used by components: image-component; components[].volume.size, used by components: projects"
+  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].image, used by components: image-component"
   newWarningsPresent: true

--- a/webhook/workspace/handler/warning.go
+++ b/webhook/workspace/handler/warning.go
@@ -29,7 +29,6 @@ type unsupportedWarnings struct {
 	dedicatedPod        map[string]bool
 	imageComponent      map[string]bool
 	customComponent     map[string]bool
-	volumeSize          map[string]bool
 	eventPostStop       map[string]bool
 	eventPreStop        map[string]bool
 }
@@ -42,7 +41,6 @@ func newUnsupportedWarnings() *unsupportedWarnings {
 		dedicatedPod:        make(map[string]bool),
 		imageComponent:      make(map[string]bool),
 		customComponent:     make(map[string]bool),
-		volumeSize:          make(map[string]bool),
 		eventPostStop:       make(map[string]bool),
 		eventPreStop:        make(map[string]bool),
 	}
@@ -71,9 +69,6 @@ func checkUnsupportedFeatures(devWorkspaceSpec dwv2.DevWorkspaceTemplateSpec) (w
 		if component.Custom != nil {
 			warnings.customComponent[component.Name] = true
 		}
-		if component.Volume != nil && component.Volume.Size != "" {
-			warnings.volumeSize[component.Name] = true
-		}
 	}
 	if devWorkspaceSpec.Events != nil {
 		if len(devWorkspaceSpec.Events.PostStop) > 0 {
@@ -97,7 +92,6 @@ func unsupportedWarningsPresent(warnings *unsupportedWarnings) bool {
 		len(warnings.dedicatedPod) > 0 ||
 		len(warnings.imageComponent) > 0 ||
 		len(warnings.customComponent) > 0 ||
-		len(warnings.volumeSize) > 0 ||
 		len(warnings.eventPostStop) > 0 ||
 		len(warnings.eventPreStop) > 0
 }
@@ -135,10 +129,6 @@ func formatUnsupportedFeaturesWarning(warnings *unsupportedWarnings) string {
 		customComponentMsg := "components[].custom, used by components: " + strings.Join(getWarningNames(warnings.customComponent), ", ")
 		msg = append(msg, customComponentMsg)
 	}
-	if len(warnings.volumeSize) > 0 {
-		volumeSizeMsg := "components[].volume.size, used by components: " + strings.Join(getWarningNames(warnings.volumeSize), ", ")
-		msg = append(msg, volumeSizeMsg)
-	}
 	if len(warnings.eventPostStop) > 0 {
 		eventPostStopMsg := "events.postStop: " + strings.Join(getWarningNames(warnings.eventPostStop), ", ")
 		msg = append(msg, eventPostStopMsg)
@@ -172,7 +162,6 @@ func checkForAddedUnsupportedFeatures(oldWksp, newWksp *dwv2.DevWorkspace) *unsu
 	addedWarnings.dedicatedPod = getAddedWarnings(oldWarnings.dedicatedPod, newWarnings.dedicatedPod)
 	addedWarnings.imageComponent = getAddedWarnings(oldWarnings.imageComponent, newWarnings.imageComponent)
 	addedWarnings.customComponent = getAddedWarnings(oldWarnings.customComponent, newWarnings.customComponent)
-	addedWarnings.volumeSize = getAddedWarnings(oldWarnings.volumeSize, newWarnings.volumeSize)
 	addedWarnings.eventPreStop = getAddedWarnings(oldWarnings.eventPreStop, newWarnings.eventPreStop)
 	addedWarnings.eventPostStop = getAddedWarnings(oldWarnings.eventPostStop, newWarnings.eventPostStop)
 	return addedWarnings


### PR DESCRIPTION
### What does this PR do?
When using the per-workspace storage strategy, it is now possible for a workspace to use a PVC other than the default PVC size set in the DWOC. The non-default PVC size is calculated by summing the size of volume components in the devworkspace.

The following rules determine whether the computed PVC size will be used:

- If the PVC size is specified in a configmap, it will take priority and the computed PVC size will not be used.

- If all volumes in a devworkspace specify their size, the computed PVC size will be used.

- If all volumes in a devworkspace either specify their size or are ephemeral, the computed PVC size will be used.

- If at least one volume in a devworkspace specifies its size, and the computed PVC size is greater than the default per-workspace PVC size, the computed PVC size will be used.

In addition to this modification to the per-workspace storage strategy, the webhook warning for unsupported features was modified to stop giving warnings when `volume.size` is used. Additionally, the unsupported devfile API docs were modified to remove the mention of `volume.size`.

### What issues does this PR fix or reference?
#947

### Is it tested? How?
Some automated tests were added. Below are some manual test cases.
Before testing, do a `make docker install` while checking out the branch from this PR.
**Note:** when applying the following devworkspaces, you should notice that no webhook warning is given anymore.

#### DevWorkspace with all volume sizes defined
`kubectl apply -f ...` the following devworkspace:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace-with-volume
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
      controller.devfile.io/storage-type: per-workspace
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
      - name: test-volume
        volume:
          size: 1Gi
```

Then check that the PVC provisioned for the workspace has a size of `1Gi`.

#### DevWorkspace with all volume sizes defined except one ephemeral volume

`kubectl apply -f ...` the following devworkspace:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace-with-ephemeral-volume
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
      controller.devfile.io/storage-type: per-workspace
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
      - name: test-volume
        volume:
          size: 512Mi
      - name: test-volume-2
        volume:
          size: 512Mi
      - name: ephemeral-volume
        volume:
          ephemeral: true
```

Then check that the PVC provisioned for the workspace has a size of `1Gi`.

#### DevWorkspace where not all volume sizes are defined and computed PVC size is smaller than default

`kubectl apply -f ...` the following devworkspace:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace-with-volume-size-not-defined
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
      controller.devfile.io/storage-type: per-workspace
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
      - name: test-volume
        volume:
          size: 512Mi
      - name: test-volume-2
        volume:
          size: 1Gi
      - name: test-volume-3
        volume: {}
```

Then check that the PVC provisioned for the workspace has the **default per-workspace PVC size** of `5Gi`.


#### DevWorkspace where not all volume sizes are defined and computed PVC size is larger than default

`kubectl apply -f ...` the following devworkspace:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-dw-missing-volume-size-larger-than-default
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
      controller.devfile.io/storage-type: per-workspace
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
      - name: test-volume
        volume:
          size: 1Gi
      - name: test-volume-2
        volume:
          size: 7Gi
      - name: test-volume-3
        volume: {}
```

Then check that the PVC provisioned for the workspace has a size of `8Gi`.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
