### PR TITLE
chore: Update gcr.io/kubebuilder/kube-rbac-proxy from 0.5.0 to 0.13.1

### DIFF
--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: $(CONTROLLER_SERVICE_ACCOUNT)
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
           args:
           - "--secure-listen-address=0.0.0.0:8443"
           - "--upstream=http://127.0.0.1:8080/"
@@ -97,4 +97,4 @@ spec:
             - name: RELATED_IMAGE_project_clone
               value: "quay.io/devfile/project-clone:next"
             - name: RELATED_IMAGE_kube_rbac_proxy
-              value: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+              value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

### What does this PR do?
chore: Update gcr.io/kubebuilder/kube-rbac-proxy from 0.5.0 to 0.13.1

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21877

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
