### PR TITLE
Update samples

### DIFF
--- a/samples/code-latest.yaml
+++ b/samples/code-latest.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-latest-contributions
+  name: code-latest
 spec:
   started: true
   template:
@@ -13,16 +13,15 @@ spec:
     commands:
       - id: say-hello
         exec:
-          component: theia-ide
+          component: che-code-runtime-description
           commandLine: echo "Hello from $(pwd)"
-          workingDir: ${PROJECTS_ROOT}/project/app
-
+          workingDir: ${PROJECT_SOURCE}/app
   contributions:
-    - name: theia
-      uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
       components:
-        - name: theia-ide
+        - name: che-code-runtime-description
           container:
             env:
-              - name: THEIA_HOST
+              - name: CODE_HOST
                 value: 0.0.0.0

--- a/samples/code-latest.yaml
+++ b/samples/code-latest.yaml
@@ -10,10 +10,14 @@ spec:
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    components:
+      - name: dev
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
     commands:
       - id: say-hello
         exec:
-          component: che-code-runtime-description
+          component: dev
           commandLine: echo "Hello from $(pwd)"
           workingDir: ${PROJECT_SOURCE}/app
   contributions:

--- a/samples/container-overrides.yaml
+++ b/samples/container-overrides.yaml
@@ -4,7 +4,6 @@ metadata:
   name: web-terminal-container-overrides
 spec:
   started: true
-
   template:
     attributes:
       controller.devfile.io/storage-type: ephemeral

--- a/samples/ephemeral-storage.yaml
+++ b/samples/ephemeral-storage.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-latest-ephemeral
+  name: code-latest-ephemeral
 spec:
   started: true
   template:
@@ -12,19 +12,18 @@ spec:
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
-    components:
-      - name: theia
-        plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
-          components:
-            - name: theia-ide
-              container:
-                env:
-                  - name: THEIA_HOST
-                    value: 0.0.0.0
     commands:
       - id: say-hello
         exec:
-          component: theia-ide
+          component: che-code-runtime-description
           commandLine: echo "Hello from $(pwd)"
-          workingDir: ${PROJECTS_ROOT}/project/app
+          workingDir: ${PROJECT_SOURCE}/app
+  contributions:
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+      components:
+        - name: che-code-runtime-description
+          container:
+            env:
+              - name: CODE_HOST
+                value: 0.0.0.0

--- a/samples/git-clone-sample.yaml
+++ b/samples/git-clone-sample.yaml
@@ -18,19 +18,18 @@ spec:
           remotes:
             origin: "https://github.com/devfile/devworkspace-operator.git"
             amisevsk: "https://github.com/amisevsk/devworkspace-operator.git"
-    components:
-      - name: theia
-        plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
-          components:
-            - name: theia-ide
-              container:
-                env:
-                  - name: THEIA_HOST
-                    value: 0.0.0.0
     commands:
       - id: say-hello
         exec:
-          component: theia-ide
+          component: che-code-runtime-description
           commandLine: echo "Hello from $(pwd)"
-          workingDir: ${PROJECTS_ROOT}/project/app
+          workingDir: ${PROJECT_SOURCE}/app
+  contributions:
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+      components:
+        - name: che-code-runtime-description
+          container:
+            env:
+              - name: CODE_HOST
+                value: 0.0.0.0

--- a/samples/per-workspace-storage.yaml
+++ b/samples/per-workspace-storage.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-latest-per-workspace
+  name: code-latest-per-workspace
 spec:
   started: true
   template:
@@ -12,19 +12,18 @@ spec:
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
-    components:
-      - name: theia
-        plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
-          components:
-            - name: theia-ide
-              container:
-                env:
-                  - name: THEIA_HOST
-                    value: 0.0.0.0
     commands:
       - id: say-hello
         exec:
-          component: theia-ide
+          component: che-code-runtime-description
           commandLine: echo "Hello from $(pwd)"
-          workingDir: ${PROJECTS_ROOT}/project/app
+          workingDir: ${PROJECT_SOURCE}/app
+  contributions:
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+      components:
+        - name: che-code-runtime-description
+          container:
+            env:
+              - name: CODE_HOST
+                value: 0.0.0.0

--- a/samples/pod-overrides.yaml
+++ b/samples/pod-overrides.yaml
@@ -1,7 +1,7 @@
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: theia-latest-pod-overrides
+  name: code-latest-pod-overrides
 spec:
   started: true
   template:
@@ -20,19 +20,18 @@ spec:
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
-    components:
-      - name: theia
-        plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
-          components:
-            - name: theia-ide
-              container:
-                env:
-                  - name: THEIA_HOST
-                    value: 0.0.0.0
     commands:
       - id: say-hello
         exec:
-          component: theia-ide
+          component: che-code-runtime-description
           commandLine: echo "Hello from $(pwd)"
-          workingDir: ${PROJECTS_ROOT}/project/app
+          workingDir: ${PROJECT_SOURCE}/app
+  contributions:
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+      components:
+        - name: che-code-runtime-description
+          container:
+            env:
+              - name: CODE_HOST
+                value: 0.0.0.0

--- a/samples/theia-latest.yaml
+++ b/samples/theia-latest.yaml
@@ -10,19 +10,18 @@ spec:
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
-    components:
-      - name: theia
-        plugin:
-          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
-          components:
-            - name: theia-ide
-              container:
-                env:
-                  - name: THEIA_HOST
-                    value: 0.0.0.0
     commands:
       - id: say-hello
         exec:
           component: theia-ide
           commandLine: echo "Hello from $(pwd)"
-          workingDir: ${PROJECTS_ROOT}/project/app
+          workingDir: ${PROJECT_SOURCE}/app
+  contributions:
+    - name: theia
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/eclipse/che-theia/latest/devfile.yaml
+      components:
+        - name: theia-ide
+          container:
+            env:
+              - name: THEIA_HOST
+                value: 0.0.0.0

--- a/samples/theia-latest.yaml
+++ b/samples/theia-latest.yaml
@@ -10,10 +10,14 @@ spec:
         git:
           remotes:
             origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    components:
+      - name: dev
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
     commands:
       - id: say-hello
         exec:
-          component: theia-ide
+          component: dev
           commandLine: echo "Hello from $(pwd)"
           workingDir: ${PROJECT_SOURCE}/app
   contributions:


### PR DESCRIPTION
### What does this PR do?
* Use https://eclipse-che.github.io/che-plugin-registry/ for plugin devfiles instead of https://che-plugin-registry-main.surge.sh
* Use che-code as editor plugin for all samples except explicit Theia sample
* Fix issues with commands (wrong path -- use `$PROJECT_SOURCE` instead of `$PROJECTS_ROOT`)
* Add `dev` containers to main samples (`code-latest.yaml` and `theia-latest.yaml`) so that container contributions are used (editor should merge component into dev component)
* Use contributions for all plugins (rather than plugin components)

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Test that samples generally work as expected. If testing on minikube, it may be necessary to pre-pull images, as the UDI image is _very_ large (3.7GB):

```bash
minikube ssh docker pull quay.io/devfile/universal-developer-image:latest
# Or, depending on the sample used
minikube ssh docker pull quay.io/devfile/universal-developer-image@sha256:d1709bbdfa076474f58f796026a2ed2dd3b24fea7e51ce2cc984e729663ff62c
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
