### PR TITLE
Fix endpoints handling

### DIFF
--- a/controllers/controller/devworkspacerouting/solvers/resolve_endpoints.go
+++ b/controllers/controller/devworkspacerouting/solvers/resolve_endpoints.go
@@ -18,6 +18,8 @@ package solvers
 import (
 	"fmt"
 	"net/url"
+	"path"
+	"strings"
 
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
@@ -95,7 +97,10 @@ func getURLForEndpoint(endpoint controllerv1alpha1.Endpoint, host, basePath stri
 		// If endpoint path is empty and we try to join it, we lose the trailing slash in paths:
 		// example.com/base/path/ --> example.com/base/path
 		if endpointUrl.Path != "" {
-			resolvedUrl = resolvedUrl.JoinPath(endpointUrl.Path)
+			resolvedUrl.Path = path.Join(resolvedUrl.Path, endpointUrl.Path)
+			if strings.HasSuffix(endpointUrl.Path, "/") {
+				resolvedUrl.Path = resolvedUrl.Path + "/"
+			}
 		}
 		// If path is empty but has query parameters/fragments, set path to "/". While example.com?query=param is valid
 		// most browsers prefer example.com/?query=param, and the slash was required in obsoleted RFCs.

--- a/controllers/controller/devworkspacerouting/solvers/resolve_endpoints_test.go
+++ b/controllers/controller/devworkspacerouting/solvers/resolve_endpoints_test.go
@@ -39,7 +39,7 @@ func TestGetUrlForEndpoint(t *testing.T) {
 			endpointPath: "",
 			secure:       false,
 
-			outURL: "http://example.com/",
+			outURL: "http://example.com",
 		},
 		{
 			name:         "Resolves secure URL with no path components",
@@ -48,7 +48,7 @@ func TestGetUrlForEndpoint(t *testing.T) {
 			endpointPath: "",
 			secure:       true,
 
-			outURL: "https://example.com/",
+			outURL: "https://example.com",
 		},
 		{
 			name:         "Resolves URL with basepath component, including trailing slash",
@@ -69,7 +69,7 @@ func TestGetUrlForEndpoint(t *testing.T) {
 			outURL: "https://example.com/test/path",
 		},
 		{
-			name:         "Resolves URL with endpoint path component",
+			name:         "Resolves URL with absolute endpoint path component",
 			host:         "example.com",
 			basePath:     "",
 			endpointPath: "/endpoint/path/",
@@ -96,13 +96,22 @@ func TestGetUrlForEndpoint(t *testing.T) {
 			outURL: "https://example.com/?test=param",
 		},
 		{
-			name:         "Resolves URL with query param in endpoint path and base path",
+			name:         "Resolves URL with query param in endpoint path and base path with trailing slash",
 			host:         "example.com",
 			basePath:     "/base/path/",
 			endpointPath: "?test=param",
 			secure:       true,
 
 			outURL: "https://example.com/base/path/?test=param",
+		},
+		{
+			name:         "Resolves URL with query param in endpoint path and base path",
+			host:         "example.com",
+			basePath:     "/base/path",
+			endpointPath: "?test=param",
+			secure:       true,
+
+			outURL: "https://example.com/base/path?test=param",
 		},
 		{
 			name:         "Resolves URL with query param and path in endpoint path",

--- a/controllers/controller/devworkspacerouting/solvers/resolve_endpoints_test.go
+++ b/controllers/controller/devworkspacerouting/solvers/resolve_endpoints_test.go
@@ -122,6 +122,24 @@ func TestGetUrlForEndpoint(t *testing.T) {
 
 			outURL: "https://example.com/base/path/endpoint/path#test",
 		},
+		{
+			name:         "Resolves URL with absolute endpoint and base path components",
+			host:         "example.com",
+			basePath:     "/base/path/",
+			endpointPath: "/endpoint/path",
+			secure:       true,
+
+			outURL: "https://example.com/base/path/endpoint/path",
+		},
+		{
+			name:         "Resolves URL with absolute path and query param",
+			host:         "example.com",
+			basePath:     "/base/path/",
+			endpointPath: "/?query=param",
+			secure:       true,
+
+			outURL: "https://example.com/base/path/?query=param",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?
Improves how the basic routing solver handles endpoints that define paths/queries/fragments.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1031

### Is it tested? How?
Tests are updated. To test directly, apply the following workspace and test that resolved endpoints in the DevWorkspaceRouting match what is expected on OpenShift and Kubernetes:
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace
spec:
  started: true
  routingClass: 'basic'
  template:
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryLimit: 512Mi
          mountSources: true
          command:
            - "tail"
            - "-f"
            - "/dev/null"
          endpoints:
            - name: test-query
              attributes:
                type: main
              targetPort: 8888
              exposure: public
              path: /?test-param
              protocol: http
            - name: test-path-query
              targetPort: 8889
              exposure: public
              path: /test/path/?test-param
              protocol: http
            - name: test-path
              targetPort: 8890
              exposure: public
              path: /test/path/
              protocol: http
            - name: test-no-path
              targetPort: 8891
              exposure: public
              protocol: http
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
