### PR TITLE
Update commands when container contributions are merged

### DIFF
--- a/pkg/library/flatten/flatten_test.go
+++ b/pkg/library/flatten/flatten_test.go
@@ -17,6 +17,7 @@ package flatten
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/devfile/devworkspace-operator/pkg/library/flatten/internal/testutil"
@@ -28,7 +29,7 @@ import (
 func TestResolveDevWorkspaceKubernetesReference(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/k8s-ref")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
@@ -50,7 +51,7 @@ func TestResolveDevWorkspaceKubernetesReference(t *testing.T) {
 func TestResolveDevWorkspacePluginRegistry(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/plugin-id")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
@@ -73,7 +74,7 @@ func TestResolveDevWorkspacePluginRegistry(t *testing.T) {
 func TestResolveDevWorkspacePluginURI(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/plugin-uri")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
@@ -96,7 +97,7 @@ func TestResolveDevWorkspacePluginURI(t *testing.T) {
 func TestResolveDevWorkspaceParents(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/parent")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
@@ -122,7 +123,7 @@ func TestResolveDevWorkspaceMissingDefaults(t *testing.T) {
 		testutil.LoadTestCaseOrPanic(t, "testdata/general/fail-nicely-when-no-namespace.yaml"),
 	}
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "")
@@ -145,7 +146,7 @@ func TestResolveDevWorkspaceMissingDefaults(t *testing.T) {
 func TestResolveDevWorkspaceAnnotations(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/annotate")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines devworkspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
@@ -168,7 +169,7 @@ func TestResolveDevWorkspaceAnnotations(t *testing.T) {
 func TestResolveDevWorkspaceTemplateNamespaceRestriction(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/namespace-restriction")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines devworkspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-namespace")
@@ -191,7 +192,7 @@ func TestResolveDevWorkspaceTemplateNamespaceRestriction(t *testing.T) {
 func TestMergesDuplicateVolumeComponents(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/volume_merging")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
@@ -214,7 +215,7 @@ func TestMergesDuplicateVolumeComponents(t *testing.T) {
 func TestMergeContainerContributions(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/container-contributions")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
@@ -237,7 +238,7 @@ func TestMergeContainerContributions(t *testing.T) {
 func TestMergeImplicitContainerContributions(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/implicit-container-contributions")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			// sanity check: input defines components
 			assert.True(t, len(tt.Input.DevWorkspace.Components) > 0, "Test case defines workspace with no components")
 			testResolverTools := getTestingTools(tt.Input, "test-ignored")
@@ -260,7 +261,7 @@ func TestMergeImplicitContainerContributions(t *testing.T) {
 func TestMergeSpecContributions(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/spec-contributions")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			testResolverTools := getTestingTools(tt.Input, "test-namespace")
 
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, tt.Input.Contributions, testResolverTools)
@@ -281,7 +282,7 @@ func TestMergeSpecContributions(t *testing.T) {
 func TestMergeImplicitSpecContributions(t *testing.T) {
 	tests := testutil.LoadAllTestsOrPanic(t, "testdata/spec-contributions")
 	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			testResolverTools := getTestingTools(tt.Input, "test-namespace")
 
 			outputWorkspace, _, err := ResolveDevWorkspace(tt.Input.DevWorkspace, tt.Input.Contributions, testResolverTools)

--- a/pkg/library/flatten/flatten_test.go
+++ b/pkg/library/flatten/flatten_test.go
@@ -280,7 +280,7 @@ func TestMergeSpecContributions(t *testing.T) {
 }
 
 func TestMergeImplicitSpecContributions(t *testing.T) {
-	tests := testutil.LoadAllTestsOrPanic(t, "testdata/spec-contributions")
+	tests := testutil.LoadAllTestsOrPanic(t, "testdata/implicit-spec-contributions")
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
 			testResolverTools := getTestingTools(tt.Input, "test-namespace")

--- a/pkg/library/flatten/internal/testutil/common.go
+++ b/pkg/library/flatten/internal/testutil/common.go
@@ -43,14 +43,18 @@ var WorkspaceTemplateDiffOpts = cmp.Options{
 	cmpopts.SortSlices(func(a, b dw.VolumeMount) bool {
 		return strings.Compare(a.Name, b.Name) > 0
 	}),
+	cmpopts.SortSlices(func(a, b dw.Command) bool {
+		return strings.Compare(a.Key(), b.Key()) > 0
+	}),
 	// TODO: Devworkspace overriding results in empty []string instead of nil
 	cmpopts.IgnoreFields(dw.DevWorkspaceEvents{}, "PostStart", "PreStop", "PostStop"),
 }
 
 type TestCase struct {
-	Name   string     `json:"name"`
-	Input  TestInput  `json:"input"`
-	Output TestOutput `json:"output"`
+	Name     string     `json:"name"`
+	Input    TestInput  `json:"input"`
+	Output   TestOutput `json:"output"`
+	TestPath string
 }
 
 type TestInput struct {
@@ -89,6 +93,7 @@ func LoadTestCaseOrPanic(t *testing.T, testFilepath string) TestCase {
 	if err := yaml.Unmarshal(bytes, &test); err != nil {
 		t.Fatal(err)
 	}
+	test.TestPath = testFilepath
 	return test
 }
 

--- a/pkg/library/flatten/testdata/implicit-spec-contributions/error_merged-component-has-apply-command.yml
+++ b/pkg/library/flatten/testdata/implicit-spec-contributions/error_merged-component-has-apply-command.yml
@@ -1,0 +1,42 @@
+name: "Returns error if merged component is target of apply command"
+
+input:
+  devworkspace:
+    components:
+    - name: test-component
+      container:
+        image: test-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+  contributions:
+  - name: test-contribution
+    uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+      commands:
+      - id: test-apply
+        apply:
+          component: contribution
+
+output:
+  errRegexp: "apply command test-apply uses container contribution contribution as component"

--- a/pkg/library/flatten/testdata/implicit-spec-contributions/no-op-if-no-contribution.yaml
+++ b/pkg/library/flatten/testdata/implicit-spec-contributions/no-op-if-no-contribution.yaml
@@ -44,8 +44,6 @@ output:
   devworkspace:
     components:
       - name: test-component
-        attributes:
-          controller.devfile.io/merge-contribution: true
         container:
           image: test-image
           env:

--- a/pkg/library/flatten/testdata/implicit-spec-contributions/opt-out-but-merge-other-component.yaml
+++ b/pkg/library/flatten/testdata/implicit-spec-contributions/opt-out-but-merge-other-component.yaml
@@ -17,10 +17,9 @@ input:
           env:
             - name: TEST_ENVVAR
               value: TEST_VALUE
-    contributions:
-      - name: test-contribution
-        plugin:
-          uri: test-contribution.yaml
+  contributions:
+    - name: test-contribution
+      uri: test-contribution.yaml
 
   devfileResources:
     test-contribution.yaml:

--- a/pkg/library/flatten/testdata/implicit-spec-contributions/updates-commands-for-merged-components.yaml
+++ b/pkg/library/flatten/testdata/implicit-spec-contributions/updates-commands-for-merged-components.yaml
@@ -1,0 +1,65 @@
+name: "Updates commands' components after merging"
+
+input:
+  devworkspace:
+    components:
+    - name: test-component
+      container:
+        image: test-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+  contributions:
+  - name: test-contribution
+    uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+      commands:
+      - id: test-exec
+        exec:
+          component: contribution
+
+output:
+  devworkspace:
+    components:
+    - name: test-component
+      attributes:
+        controller.devfile.io/merged-contributions: "test-contribution"
+      container:
+        image: test-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+    - id: test-exec
+      attributes:
+        controller.devfile.io/imported-by: test-contribution
+      exec:
+        component: test-component

--- a/pkg/library/flatten/testdata/implicit-spec-contributions/updates-commands-for-only-merged-components.yaml
+++ b/pkg/library/flatten/testdata/implicit-spec-contributions/updates-commands-for-only-merged-components.yaml
@@ -1,0 +1,89 @@
+name: "Does not update unmerged components"
+
+input:
+  devworkspace:
+    components:
+    - name: test-component
+      container:
+        image: test-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+  contributions:
+  - name: test-contribution
+    uri: test-contribution.yaml
+  - name: test-unmerged-contribution
+    uri: test-unmerged-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+      commands:
+      - id: test-exec
+        exec:
+          component: contribution
+    test-unmerged-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-unmerged-contribution
+      components:
+      - name: unmerged-contribution
+        container:
+          image: contribution-image
+      commands:
+      - id: test-unmerged-exec
+        exec:
+          component: unmerged-contribution
+
+output:
+  devworkspace:
+    components:
+    - name: test-component
+      attributes:
+        controller.devfile.io/merged-contributions: "test-contribution"
+      container:
+        image: test-image
+    - name: unmerged-contribution
+      attributes:
+        controller.devfile.io/imported-by: test-unmerged-contribution
+      container:
+        image: contribution-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+    - id: test-exec
+      attributes:
+        controller.devfile.io/imported-by: test-contribution
+      exec:
+        component: test-component
+    - id: test-unmerged-exec
+      attributes:
+        controller.devfile.io/imported-by: test-unmerged-contribution
+      exec:
+        component: unmerged-contribution

--- a/pkg/library/flatten/testdata/plugin-uri/resolve-devworkspace-instead-of-devfile.yaml
+++ b/pkg/library/flatten/testdata/plugin-uri/resolve-devworkspace-instead-of-devfile.yaml
@@ -18,7 +18,17 @@ input:
             container:
               name: test-container
               image: test-image
-
+        commands:
+          - id: test-exec
+            exec:
+              component: plugin-a
+              commandLine: "echo 'hello world'"
+          - id: test-apply
+            apply:
+              component: plugin-a
+        events:
+          prestart:
+            - test-apply
 
 output:
   devworkspace:
@@ -29,3 +39,18 @@ output:
         container:
           name: test-container
           image: test-image
+    commands:
+      - id: test-exec
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        exec:
+          component: plugin-a
+          commandLine: "echo 'hello world'"
+      - id: test-apply
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        apply:
+          component: plugin-a
+    events:
+      prestart:
+        - test-apply

--- a/pkg/library/flatten/testdata/plugin-uri/resolve-plugin-by-uri.yaml
+++ b/pkg/library/flatten/testdata/plugin-uri/resolve-plugin-by-uri.yaml
@@ -16,6 +16,17 @@ input:
           container:
             name: test-container
             image: test-image
+      commands:
+        - id: test-exec
+          exec:
+            component: plugin-a
+            commandLine: "echo 'hello world'"
+        - id: test-apply
+          apply:
+            component: plugin-a
+      events:
+        prestart:
+          - test-apply
 
 output:
   devworkspace:
@@ -26,3 +37,18 @@ output:
         container:
           name: test-container
           image: test-image
+    commands:
+      - id: test-exec
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        exec:
+          component: plugin-a
+          commandLine: "echo 'hello world'"
+      - id: test-apply
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        apply:
+          component: plugin-a
+    events:
+      prestart:
+        - test-apply

--- a/pkg/library/flatten/testdata/spec-contributions/does-not-update-commands-if-not-merged.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/does-not-update-commands-if-not-merged.yaml
@@ -1,0 +1,73 @@
+name: "Does not update commands if not merged"
+
+input:
+  devworkspace:
+    components:
+    - name: test-component
+      attributes:
+        controller.devfile.io/merge-contribution: false
+      container:
+        image: test-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+  contributions:
+  - name: test-contribution
+    uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+      commands:
+      - id: test-exec
+        exec:
+          component: contribution
+
+output:
+  devworkspace:
+    components:
+    - name: test-component
+      attributes:
+        controller.devfile.io/merge-contribution: false
+      container:
+        image: test-image
+    - name: contribution
+      attributes:
+        controller.devfile.io/container-contribution: true
+        controller.devfile.io/imported-by: test-contribution
+      container:
+        image: contribution-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+    - id: test-exec
+      attributes:
+        controller.devfile.io/imported-by: test-contribution
+      exec:
+        component: contribution

--- a/pkg/library/flatten/testdata/spec-contributions/error_merged-component-has-apply-command.yml
+++ b/pkg/library/flatten/testdata/spec-contributions/error_merged-component-has-apply-command.yml
@@ -1,0 +1,44 @@
+name: "Returns error if merged component is target of apply command"
+
+input:
+  devworkspace:
+    components:
+    - name: test-component
+      attributes:
+        controller.devfile.io/merge-contribution: true
+      container:
+        image: test-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+  contributions:
+  - name: test-contribution
+    uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+      commands:
+      - id: test-apply
+        apply:
+          component: contribution
+
+output:
+  errRegexp: "apply command test-apply uses container contribution contribution as component"

--- a/pkg/library/flatten/testdata/spec-contributions/resolve-devworkspace-instead-of-devfile.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/resolve-devworkspace-instead-of-devfile.yaml
@@ -16,7 +16,17 @@ input:
             container:
               name: test-container
               image: test-image
-
+        commands:
+          - id: test-exec
+            exec:
+              component: plugin-a
+              commandLine: "echo 'hello world'"
+          - id: test-apply
+            apply:
+              component: plugin-a
+        events:
+          prestart:
+            - test-apply
 
 output:
   devworkspace:
@@ -27,3 +37,18 @@ output:
         container:
           name: test-container
           image: test-image
+    commands:
+      - id: test-exec
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        exec:
+          component: plugin-a
+          commandLine: "echo 'hello world'"
+      - id: test-apply
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        apply:
+          component: plugin-a
+    events:
+      prestart:
+        - test-apply

--- a/pkg/library/flatten/testdata/spec-contributions/resolve-plugin-by-uri.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/resolve-plugin-by-uri.yaml
@@ -14,6 +14,17 @@ input:
           container:
             name: test-container
             image: test-image
+      commands:
+        - id: test-exec
+          exec:
+            component: plugin-a
+            commandLine: "echo 'hello world'"
+        - id: test-apply
+          apply:
+            component: plugin-a
+      events:
+        prestart:
+          - test-apply
 
 output:
   devworkspace:
@@ -24,3 +35,18 @@ output:
         container:
           name: test-container
           image: test-image
+    commands:
+      - id: test-exec
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        exec:
+          component: plugin-a
+          commandLine: "echo 'hello world'"
+      - id: test-apply
+        attributes:
+          controller.devfile.io/imported-by: "test-plugin"
+        apply:
+          component: plugin-a
+    events:
+      prestart:
+        - test-apply

--- a/pkg/library/flatten/testdata/spec-contributions/updates-commands-for-merged-components.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/updates-commands-for-merged-components.yaml
@@ -1,0 +1,67 @@
+name: "Updates commands' components after merging"
+
+input:
+  devworkspace:
+    components:
+    - name: test-component
+      attributes:
+        controller.devfile.io/merge-contribution: true
+      container:
+        image: test-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+  contributions:
+  - name: test-contribution
+    uri: test-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+      commands:
+      - id: test-exec
+        exec:
+          component: contribution
+
+output:
+  devworkspace:
+    components:
+    - name: test-component
+      attributes:
+        controller.devfile.io/merged-contributions: "test-contribution"
+      container:
+        image: test-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+    - id: test-exec
+      attributes:
+        controller.devfile.io/imported-by: test-contribution
+      exec:
+        component: test-component

--- a/pkg/library/flatten/testdata/spec-contributions/updates-commands-for-only-merged-components.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/updates-commands-for-only-merged-components.yaml
@@ -1,0 +1,91 @@
+name: "Does not update unmerged components"
+
+input:
+  devworkspace:
+    components:
+    - name: test-component
+      attributes:
+        controller.devfile.io/merge-contribution: true
+      container:
+        image: test-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+  contributions:
+  - name: test-contribution
+    uri: test-contribution.yaml
+  - name: test-unmerged-contribution
+    uri: test-unmerged-contribution.yaml
+
+  devfileResources:
+    test-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-contribution
+      components:
+      - name: contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+      commands:
+      - id: test-exec
+        exec:
+          component: contribution
+    test-unmerged-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: test-unmerged-contribution
+      components:
+      - name: unmerged-contribution
+        container:
+          image: contribution-image
+      commands:
+      - id: test-unmerged-exec
+        exec:
+          component: unmerged-contribution
+
+output:
+  devworkspace:
+    components:
+    - name: test-component
+      attributes:
+        controller.devfile.io/merged-contributions: "test-contribution"
+      container:
+        image: test-image
+    - name: unmerged-contribution
+      attributes:
+        controller.devfile.io/imported-by: test-unmerged-contribution
+      container:
+        image: contribution-image
+    commands:
+    - id: base-apply
+      apply:
+        component: test-component
+    - id: base-exec
+      exec:
+        component: test-component
+    - id: base-composite
+      composite:
+        commands:
+        - base-apply
+        - base-exec
+    - id: test-exec
+      attributes:
+        controller.devfile.io/imported-by: test-contribution
+      exec:
+        component: test-component
+    - id: test-unmerged-exec
+      attributes:
+        controller.devfile.io/imported-by: test-unmerged-contribution
+      exec:
+        component: unmerged-contribution


### PR DESCRIPTION
### What does this PR do?
Rewrite DevWorkspace commands to target the merged component if
* They target a container-contribution component, and
* That contribution is merged into another component in the devfile

This PR treats contributions with apply commands targeting a container contribution as invalid, as it's unclear how to keep the `apply` command valid.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1029
Related: https://github.com/eclipse/che/issues/21879

### Is it tested? How?
Test cases are added. To test, you can use this [gist](https://gist.githubusercontent.com/amisevsk/a06803a66ac1b938d0cb31969f027037/raw/51b9cf17d71127830ddf169054218ffcc88373b9/sample-contribution.yaml) as a contribution in a DevWorkspace:
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace
spec:
  started: true
  routingClass: 'basic'
  template:
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
  contributions:
  - name: test-contribution
    uri: https://gist.githubusercontent.com/amisevsk/a06803a66ac1b938d0cb31969f027037/raw/51b9cf17d71127830ddf169054218ffcc88373b9/sample-contribution.yaml
```
Once the workspace is started, verify that the file mounted at `$DEVWORKSPACE_FLATTENED_DEVFILE` matches what is expected (command is updated to target the `web-terminal` component.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
