### PR TITLE
Drop unused RELATED_IMAGE environment variables

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -367,10 +367,6 @@ spec:
                   value: 200m
                 - name: WEBHOOKS_SERVER_CPU_REQUEST
                   value: 100m
-                - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-                  value: quay.io/eclipse/che-machine-exec:nightly
-                - name: RELATED_IMAGE_web_terminal_tooling
-                  value: quay.io/wto/web-terminal-tooling:latest
                 - name: RELATED_IMAGE_pvc_cleanup_job
                   value: registry.access.redhat.com/ubi8-micro:8.4-81
                 - name: RELATED_IMAGE_async_storage_server
@@ -489,10 +485,6 @@ spec:
     name: kube_rbac_proxy
   - image: quay.io/devfile/project-clone:next
     name: project_clone
-  - image: quay.io/eclipse/che-machine-exec:nightly
-    name: plugin_redhat_developer_web_terminal_4_5_0
-  - image: quay.io/wto/web-terminal-tooling:latest
-    name: web_terminal_tooling
   - image: registry.access.redhat.com/ubi8-micro:8.4-81
     name: pvc_cleanup_job
   - image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -23892,10 +23892,6 @@ spec:
           value: 200m
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
-        - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-          value: quay.io/eclipse/che-machine-exec:nightly
-        - name: RELATED_IMAGE_web_terminal_tooling
-          value: quay.io/wto/web-terminal-tooling:latest
         - name: RELATED_IMAGE_pvc_cleanup_job
           value: registry.access.redhat.com/ubi8-micro:8.4-81
         - name: RELATED_IMAGE_async_storage_server

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -54,10 +54,6 @@ spec:
           value: 200m
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
-        - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-          value: quay.io/eclipse/che-machine-exec:nightly
-        - name: RELATED_IMAGE_web_terminal_tooling
-          value: quay.io/wto/web-terminal-tooling:latest
         - name: RELATED_IMAGE_pvc_cleanup_job
           value: registry.access.redhat.com/ubi8-micro:8.4-81
         - name: RELATED_IMAGE_async_storage_server

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -23894,10 +23894,6 @@ spec:
           value: 200m
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
-        - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-          value: quay.io/eclipse/che-machine-exec:nightly
-        - name: RELATED_IMAGE_web_terminal_tooling
-          value: quay.io/wto/web-terminal-tooling:latest
         - name: RELATED_IMAGE_pvc_cleanup_job
           value: registry.access.redhat.com/ubi8-micro:8.4-81
         - name: RELATED_IMAGE_async_storage_server

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -54,10 +54,6 @@ spec:
           value: 200m
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
-        - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-          value: quay.io/eclipse/che-machine-exec:nightly
-        - name: RELATED_IMAGE_web_terminal_tooling
-          value: quay.io/wto/web-terminal-tooling:latest
         - name: RELATED_IMAGE_pvc_cleanup_job
           value: registry.access.redhat.com/ubi8-micro:8.4-81
         - name: RELATED_IMAGE_async_storage_server

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -103,10 +103,6 @@ spec:
       name: kube_rbac_proxy
     - image: quay.io/devfile/project-clone:next
       name: project_clone
-    - image: quay.io/eclipse/che-machine-exec:nightly
-      name: plugin_redhat_developer_web_terminal_4_5_0
-    - image: quay.io/wto/web-terminal-tooling:latest
-      name: web_terminal_tooling
     - image: registry.access.redhat.com/ubi8-micro:8.4-81
       name: pvc_cleanup_job
     - image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -82,10 +82,6 @@ spec:
               value: 200m
             - name: WEBHOOKS_SERVER_CPU_REQUEST
               value: 100m
-            - name: RELATED_IMAGE_plugin_redhat_developer_web_terminal_4_5_0
-              value: "quay.io/eclipse/che-machine-exec:nightly"
-            - name: RELATED_IMAGE_web_terminal_tooling
-              value: "quay.io/wto/web-terminal-tooling:latest"
             - name: RELATED_IMAGE_devworkspace_webhook_server
               value: "quay.io/devfile/devworkspace-controller:next"
             - name: RELATED_IMAGE_pvc_cleanup_job

--- a/pkg/library/projects/clone.go
+++ b/pkg/library/projects/clone.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 // Package projects defines library functions for reconciling projects in a Devfile (i.e. cloning and maintaining state)
 package projects
 
@@ -43,7 +44,7 @@ func GetProjectCloneInitContainer(workspace *dw.DevWorkspaceTemplateSpec, pullPo
 		return nil, nil
 	}
 
-	cloneImage := images.GetProjectClonerImage()
+	cloneImage := images.GetProjectCloneImage()
 	if cloneImage == "" {
 		// Assume project clone is intentionally disabled if project clone image is not defined
 		return nil, nil


### PR DESCRIPTION
### What does this PR do?
Drops some out-of-date `RELATED_IMAGE_` environment variables. These variables were used in an earlier iteration of DWO and are no longer needed.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
