### PR TITLE
Use projected volumes for automount resources if they share a mount path

### DIFF
--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -16,6 +16,7 @@
 package common
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"regexp"
 	"strings"
@@ -128,6 +129,13 @@ func AutoMountSecretVolumeName(volumeName string) string {
 
 func AutoMountPVCVolumeName(pvcName string) string {
 	return pvcName
+}
+
+func AutoMountProjectedVolumeName(mountPath string) string {
+	// To avoid issues around sanitizing mountPath to generate a unique name (length, allowed chars)
+	// just use the sha256 hash of mountPath
+	hash := sha256.Sum256([]byte(mountPath))
+	return fmt.Sprintf("projected-%x", hash[:10])
 }
 
 func WorkspaceRoleName() string {

--- a/pkg/provision/automount/projected.go
+++ b/pkg/provision/automount/projected.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package automount
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+// mergeProjectedVolumes merges secret and configmap automount resources that share a mount path
+// into projected volumes.
+func mergeProjectedVolumes(resources *Resources) (*Resources, error) {
+	mergedResources := &Resources{}
+
+	// Map of mountPath -> volumeMount, to detect colliding volumeMounts
+	mountPathToVolumeMounts := map[string][]corev1.VolumeMount{}
+	needsProjectedVolume := false
+	// Ordered list of mountPaths to process, to avoid random iteration order on maps
+	var mountPathOrder []string
+	for _, volumeMount := range resources.VolumeMounts {
+		if len(mountPathToVolumeMounts[volumeMount.MountPath]) == 0 {
+			mountPathOrder = append(mountPathOrder, volumeMount.MountPath)
+		} else {
+			needsProjectedVolume = true
+		}
+		mountPathToVolumeMounts[volumeMount.MountPath] = append(mountPathToVolumeMounts[volumeMount.MountPath], volumeMount)
+	}
+	if !needsProjectedVolume {
+		// Return early and do nothing if we didn't find a mountPath collision above
+		return resources, nil
+	}
+	sort.Strings(mountPathOrder)
+
+	// Map of volume names -> volumes, for easier lookup
+	volumeNameToVolume := map[string]corev1.Volume{}
+	for _, volume := range resources.Volumes {
+		volumeNameToVolume[volume.Name] = volume
+	}
+
+	for _, mountPath := range mountPathOrder {
+		volumeMounts := mountPathToVolumeMounts[mountPath]
+		switch len(volumeMounts) {
+		case 0:
+			continue
+		case 1:
+			// No projected volume necessary
+			mergedResources.VolumeMounts = append(mergedResources.VolumeMounts, volumeMounts[0])
+			volume := volumeNameToVolume[volumeMounts[0].Name]
+			mergedResources.Volumes = append(mergedResources.Volumes, volume)
+		default:
+			vm, vol, err := generateProjectedVolume(mountPath, volumeMounts, volumeNameToVolume)
+			if err != nil {
+				return nil, err
+			}
+			mergedResources.VolumeMounts = append(mergedResources.VolumeMounts, *vm)
+			mergedResources.Volumes = append(mergedResources.Volumes, *vol)
+		}
+	}
+
+	mergedResources.EnvFromSource = resources.EnvFromSource
+
+	return mergedResources, nil
+}
+
+// generateProjectedVolume creates a projected Volume and VolumeMount that should be used in place multiple VolumeMounts
+// with the same mountPath.
+func generateProjectedVolume(mountPath string, volumeMounts []corev1.VolumeMount, volumeNameToVolume map[string]corev1.Volume) (*corev1.VolumeMount, *corev1.Volume, error) {
+	volumeName := common.AutoMountProjectedVolumeName(mountPath)
+	projectedVolume := &corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				DefaultMode: pointer.Int32(0640),
+			},
+		},
+	}
+
+	for _, vm := range volumeMounts {
+		if err := checkCanUseProjectedVolumes(volumeMounts, volumeNameToVolume); err != nil {
+			return nil, nil, err
+		}
+
+		volume := volumeNameToVolume[vm.Name]
+		projection := corev1.VolumeProjection{}
+		switch {
+		case volume.Secret != nil:
+			projection.Secret = &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: volume.Secret.SecretName,
+				},
+			}
+		case volume.ConfigMap != nil:
+			projection.ConfigMap = &corev1.ConfigMapProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: volume.ConfigMap.Name,
+				},
+			}
+		default:
+			return nil, nil, fmt.Errorf("unrecognized volume type for volume %s", volume.Name)
+		}
+		projectedVolume.Projected.Sources = append(projectedVolume.Projected.Sources, projection)
+	}
+
+	projectedVolumeMount := &corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: mountPath,
+		ReadOnly:  true,
+	}
+
+	return projectedVolumeMount, projectedVolume, nil
+}
+
+// checkCanProjectedVolumes checks whether a set of volumeMounts (assumed to share the same mountPath) can be merged
+// into a single VolumeMount and projected Volume. Returns an error if VolumeMounts should not be merged.
+func checkCanUseProjectedVolumes(volumeMounts []corev1.VolumeMount, volumeNameToVolume map[string]corev1.Volume) error {
+	isError := false
+	for _, vm := range volumeMounts {
+		// If any of the volumeMounts is using a subPath (and mountPaths collide) this is not an issue we can fix. This shouldn't
+		// happen often with automount volumes as it would require e.g. two configmaps with the same mountPath and key
+		if vm.SubPath != "" || vm.SubPathExpr != "" {
+			isError = true
+		}
+		vol := volumeNameToVolume[vm.Name]
+		if vol.PersistentVolumeClaim != nil {
+			isError = true
+		}
+	}
+	if isError {
+		var problemNames []string
+		for _, vm := range volumeMounts {
+			problemNames = append(problemNames, formatVolumeDescription(volumeNameToVolume[vm.Name]))
+		}
+		return fmt.Errorf("auto-mounted volumes from (%s) have the same mount path", strings.Join(problemNames, ", "))
+	}
+	return nil
+}

--- a/pkg/provision/automount/projected_test.go
+++ b/pkg/provision/automount/projected_test.go
@@ -1,0 +1,332 @@
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package automount
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+var resourcesDiffOpts = cmp.Options{
+	cmpopts.SortSlices(func(a, b corev1.Volume) bool {
+		return strings.Compare(a.Name, b.Name) > 0
+	}),
+	cmpopts.SortSlices(func(a, b corev1.VolumeMount) bool {
+		return strings.Compare(a.Name, b.Name) > 0
+	}),
+	cmpopts.SortSlices(func(a, b corev1.EnvFromSource) bool {
+		var aName, bName string
+		if a.ConfigMapRef != nil {
+			aName = a.ConfigMapRef.Name
+		} else {
+			aName = a.SecretRef.Name
+		}
+		if b.ConfigMapRef != nil {
+			bName = b.ConfigMapRef.Name
+		} else {
+			bName = b.SecretRef.Name
+		}
+
+		return strings.Compare(aName, bName) > 0
+	}),
+}
+
+func TestMergeProjectedVolumes(t *testing.T) {
+	tests := []struct {
+		name              string
+		inputResources    *Resources
+		expectedResources *Resources
+		errRegexp         string
+	}{
+		{
+			name: "No merging necessary",
+			inputResources: &Resources{
+				Volumes: []corev1.Volume{
+					testSecretVolume("test-secret"),
+					testConfigmapVolume("test-configmap"),
+					testPVCVolume("test-pvc"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					testVolumeMount("test-secret", "test-secret"),
+					testVolumeMount("test-configmap", "test-configmap"),
+					testVolumeMount("test-pvc", "test-pvc"),
+				},
+				EnvFromSource: []corev1.EnvFromSource{
+					testEnvFromSource("test-envfrom"),
+				},
+			},
+			expectedResources: &Resources{
+				Volumes: []corev1.Volume{
+					testSecretVolume("test-secret"),
+					testConfigmapVolume("test-configmap"),
+					testPVCVolume("test-pvc"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					testVolumeMount("test-secret", "test-secret"),
+					testVolumeMount("test-configmap", "test-configmap"),
+					testVolumeMount("test-pvc", "test-pvc"),
+				},
+				EnvFromSource: []corev1.EnvFromSource{
+					testEnvFromSource("test-envfrom"),
+				},
+			},
+		},
+		{
+			name: "Merges configmap and secret volume",
+			inputResources: &Resources{
+				Volumes: []corev1.Volume{
+					testSecretVolume("test-secret"),
+					testConfigmapVolume("test-configmap"),
+					testPVCVolume("test-pvc"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					testVolumeMount("test-secret", "test-path"),
+					testVolumeMount("test-configmap", "test-path"),
+					testVolumeMount("test-pvc", "test-pvc"),
+				},
+				EnvFromSource: []corev1.EnvFromSource{
+					testEnvFromSource("test-envfrom"),
+				},
+			},
+			expectedResources: &Resources{
+				Volumes: []corev1.Volume{
+					testProjectedVolume(common.AutoMountProjectedVolumeName("test-path"), []string{"test-secret"}, []string{"test-configmap"}),
+					testPVCVolume("test-pvc"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					testVolumeMount(common.AutoMountProjectedVolumeName("test-path"), "test-path"),
+					testVolumeMount("test-pvc", "test-pvc"),
+				},
+				EnvFromSource: []corev1.EnvFromSource{
+					testEnvFromSource("test-envfrom"),
+				},
+			},
+		},
+		{
+			name: "Merges only necessary volumes",
+			inputResources: &Resources{
+				Volumes: []corev1.Volume{
+					testSecretVolume("test-secret"),
+					testConfigmapVolume("test-configmap"),
+					testConfigmapVolume("test-configmap-2"),
+					testSecretVolume("test-unmerged-secret"),
+					testConfigmapVolume("test-unmerged-configmap"),
+					testPVCVolume("test-pvc"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					testVolumeMount("test-secret", "test-path"),
+					testVolumeMount("test-configmap", "test-path"),
+					testVolumeMount("test-configmap-2", "test-path"),
+					testVolumeMount("test-unmerged-secret", "secret-path"),
+					testVolumeMount("test-unmerged-configmap", "cm-path"),
+					testVolumeMount("test-pvc", "test-pvc"),
+				},
+				EnvFromSource: []corev1.EnvFromSource{
+					testEnvFromSource("test-envfrom"),
+				},
+			},
+			expectedResources: &Resources{
+				Volumes: []corev1.Volume{
+					testProjectedVolume(common.AutoMountProjectedVolumeName("test-path"), []string{"test-secret"}, []string{"test-configmap", "test-configmap-2"}),
+					testSecretVolume("test-unmerged-secret"),
+					testConfigmapVolume("test-unmerged-configmap"),
+					testPVCVolume("test-pvc"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					testVolumeMount(common.AutoMountProjectedVolumeName("test-path"), "test-path"),
+					testVolumeMount("test-unmerged-secret", "secret-path"),
+					testVolumeMount("test-unmerged-configmap", "cm-path"),
+					testVolumeMount("test-pvc", "test-pvc"),
+				},
+				EnvFromSource: []corev1.EnvFromSource{
+					testEnvFromSource("test-envfrom"),
+				},
+			},
+		},
+		{
+			name: "Error when would merge subpath volumeMount",
+			inputResources: &Resources{
+				Volumes: []corev1.Volume{
+					testSecretVolume("test-secret"),
+					testConfigmapVolume("test-configmap"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					testVolumeMount("test-secret", "test-path/subpath"),
+					testSubpathVolumeMount("test-configmap", "test-path", "subpath"),
+				},
+				EnvFromSource: []corev1.EnvFromSource{
+					testEnvFromSource("test-envfrom"),
+				},
+			},
+			errRegexp: `auto-mounted volumes from \(secret 'test-secret', configmap 'test-configmap'\) have the same mount path`,
+		},
+		{
+			name: "Error when unrecognized volume type",
+			inputResources: &Resources{
+				Volumes: []corev1.Volume{
+					{
+						Name: "unrecognized-volume",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{Path: "test"},
+						},
+					},
+					testConfigmapVolume("test-cm"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					testVolumeMount("unrecognized-volume", "test"),
+					testVolumeMount("test-cm", "test"),
+				},
+			},
+			errRegexp: `unrecognized volume type for volume unrecognized-volume`,
+		},
+		{
+			name: "Error when trying to merge PVC and configmap",
+			inputResources: &Resources{
+				Volumes: []corev1.Volume{
+					testSecretVolume("test-secret"),
+					testConfigmapVolume("test-configmap"),
+					testPVCVolume("test-pvc"),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					testVolumeMount("test-secret", "test-path"),
+					testVolumeMount("test-configmap", "test-path"),
+					testVolumeMount("test-pvc", "test-path"),
+				},
+				EnvFromSource: []corev1.EnvFromSource{
+					testEnvFromSource("test-envfrom"),
+				},
+			},
+			errRegexp: `auto-mounted volumes from \(secret 'test-secret', configmap 'test-configmap', pvc 'test-pvc'\) have the same mount path`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualResources, err := mergeProjectedVolumes(tt.inputResources)
+			if tt.errRegexp != "" {
+				if !assert.Error(t, err) {
+					return
+				}
+				assert.Regexp(t, tt.errRegexp, err.Error(), "Error message should match")
+			} else {
+				if !assert.NoError(t, err, "Should not return error") {
+					return
+				}
+				assert.True(t, cmp.Equal(tt.expectedResources.Volumes, actualResources.Volumes, resourcesDiffOpts), cmp.Diff(tt.expectedResources.Volumes, actualResources.Volumes, resourcesDiffOpts))
+				assert.True(t, cmp.Equal(tt.expectedResources.VolumeMounts, actualResources.VolumeMounts, resourcesDiffOpts), cmp.Diff(tt.expectedResources.VolumeMounts, actualResources.VolumeMounts, resourcesDiffOpts))
+				assert.True(t, cmp.Equal(tt.expectedResources.EnvFromSource, actualResources.EnvFromSource, resourcesDiffOpts), cmp.Diff(tt.expectedResources.EnvFromSource, actualResources.EnvFromSource, resourcesDiffOpts))
+			}
+		})
+	}
+}
+
+func testSecretVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: name,
+			},
+		},
+	}
+}
+
+func testConfigmapVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: name,
+				},
+			},
+		},
+	}
+}
+
+func testPVCVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: name,
+			},
+		},
+	}
+}
+
+func testVolumeMount(name, mountPath string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      name,
+		ReadOnly:  true,
+		MountPath: mountPath,
+	}
+}
+
+func testSubpathVolumeMount(name, mountPath, subpath string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      name,
+		ReadOnly:  true,
+		MountPath: path.Join(mountPath, subpath),
+		SubPath:   subpath,
+	}
+}
+
+func testEnvFromSource(name string) corev1.EnvFromSource {
+	return corev1.EnvFromSource{
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+		},
+	}
+}
+
+func testProjectedVolume(name string, secretNames, configmapNames []string) corev1.Volume {
+	vol := corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				DefaultMode: pointer.Int32(0640),
+			},
+		},
+	}
+	for _, secretName := range secretNames {
+		vol.Projected.Sources = append(vol.Projected.Sources, corev1.VolumeProjection{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: secretName,
+				},
+			},
+		})
+	}
+	for _, configmapName := range configmapNames {
+		vol.Projected.Sources = append(vol.Projected.Sources, corev1.VolumeProjection{
+			ConfigMap: &corev1.ConfigMapProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: configmapName,
+				},
+			},
+		})
+	}
+
+	return vol
+}


### PR DESCRIPTION
### What does this PR do?
Merges automount secrets/configmaps into projected volumes if they share a mountPath, avoiding workspace failures when multiple automount resources target the same path.

There are some cases where this won't work (e.g. we can't project a PVC, or correctly handle subpath volumeMounts since they're files). An error is returned in this case.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1021
Closes https://github.com/devfile/devworkspace-operator/issues/835

### Is it tested? How?
To test, create automount resources and ensure they are mounted as expected. For example, the following three resources should be merged into one in a DevWorkspace
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-secret-file
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-secret: 'true'
  annotations:
    controller.devfile.io/mount-as: file
    controller.devfile.io/mount-path: /tmp/test-projected/
type: Opaque
data:
  secret-data: aGVsbG8K # hello 
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-cm-1
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: 'true'
  annotations:
    controller.devfile.io/mount-as: file
    controller.devfile.io/mount-path: /tmp/test-projected/
data:
  configmap-2-key: "hello"
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-cm-2
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: 'true'
  annotations:
    controller.devfile.io/mount-as: file
    controller.devfile.io/mount-path: /tmp/test-projected/
data:
  configmap-1-key: "hello"
```

Need to also test that existing automount flows works as expected (PVCs, non-colliding secrets, envFrom, etc.)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
