### PR TITLE
Revert "fix: check pods for unschedulable condition" (#978)

### DIFF
--- a/pkg/library/status/check.go
+++ b/pkg/library/status/check.go
@@ -96,11 +96,6 @@ func CheckPodsState(workspaceID string, namespace string, labelSelector k8sclien
 		if msg, err := CheckPodEvents(&pod, workspaceID, ignoredEvents, clusterAPI); err != nil || msg != "" {
 			return msg, err
 		}
-		if pod.Status.Phase == corev1.PodPending {
-			if msg := checkPodConditions(&pod); msg != "" {
-				return msg, nil
-			}
-		}
 	}
 	return "", nil
 }
@@ -168,18 +163,6 @@ func checkIfUnrecoverableEventIgnored(reason string, ignoredEvents []string) (ig
 		}
 	}
 	return false
-}
-
-func checkPodConditions(pod *corev1.Pod) (msg string) {
-	if pod.Status.Conditions != nil {
-		for _, condition := range pod.Status.Conditions {
-			// Pod unschedulable condition
-			if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse && condition.Reason == corev1.PodReasonUnschedulable {
-				return fmt.Sprintf("Pod is unschedulable: %s", condition.Message)
-			}
-		}
-	}
-	return ""
 }
 
 // Returns the number of times an event has occurred.


### PR DESCRIPTION
### What does this PR do?
This reverts commit 0cad9a076dc13cacad5f681b79b8dbdb6aeb7c6d.

The changes made in the original commit were obsoleted by https://github.com/devfile/devworkspace-operator/commit/255d699bd0c762094faaeb622533f23f69168161. The original commit introduced a bug where it is impossible to ignore  the `FailedScheduling` event, as the `PodUnschedulable` condition will still occur and get caught.

### What issues does this PR fix or reference?
#1046


### Is it tested? How?
1. Add FailedScheduling to the ignoredUnrecoverableEvents, as well as set the `progressTimeout` to 30 seconds (for convenience) in the DWOC: `kubectl edit dwoc -n $NAMESPACE`

```diff
apiVersion: controller.devfile.io/v1alpha1
config:
  routing:
    clusterHostSuffix: 192.168.39.246.nip.io
    defaultRoutingClass: basic
  workspace:
+    ignoredUnrecoverableEvents:
+    - FailedScheduling
+    progressTimeout: 30s
    imagePullPolicy: Always
```

2. Start a workspace that causes a FailedScheduling event, e.g. by requesting more CPU than the cluster can provide:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next-high-cpu
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
          components:
            - name: theia-ide
              container:
                env:
                  - name: THEIA_HOST
                    value: 0.0.0.0
                memoryRequest: 2Gi
                memoryLimit: 16Gi
                cpuRequest: 4000m
                cpuLimit: 8000m
    commands:
      - id: say-hello
        exec:
          component: theia-ide
          commandLine: echo "Hello from $(pwd)"
          workingDir: ${PROJECTS_ROOT}/project/app
```
3. Observe the workspace status: `kubectl get dw -n $NAMESPACE -w`. The workspace should fail only when the timeout occurs, simply stating that it was not able to progress pass the starting phase (rather than stating that the `Pod is unschedulable: 0/1 nodes are available: 1 Insufficient cpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.`...)


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
