### PR TITLE
Show ignoredUnrecoverableEvents on timeout if they occurred

### DIFF
--- a/controllers/workspace/metrics/deployment_provisioning.go
+++ b/controllers/workspace/metrics/deployment_provisioning.go
@@ -17,8 +17,6 @@ package metrics
 
 import (
 	"strings"
-
-	"github.com/devfile/devworkspace-operator/pkg/provision/workspace"
 )
 
 var badRequestFailures = []string{
@@ -37,15 +35,14 @@ var infrastructureFailures = []string{
 // DetermineProvisioningFailureReason scans a deployment provisioning status info message
 // and returns the corresponding failure reason.
 // If a failure reason cannot be found, an Unknown reason is returned.
-func DetermineProvisioningFailureReason(status workspace.DeploymentProvisioningStatus) FailureReason {
-	failStartupMsg := status.Info()
+func DetermineProvisioningFailureReason(statusMessage string) FailureReason {
 	for _, failure := range badRequestFailures {
-		if strings.Contains(failStartupMsg, failure) {
+		if strings.Contains(statusMessage, failure) {
 			return ReasonBadRequest
 		}
 	}
 	for _, failure := range infrastructureFailures {
-		if strings.Contains(failStartupMsg, failure) {
+		if strings.Contains(statusMessage, failure) {
 			return ReasonInfrastructureFailure
 		}
 	}

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -136,7 +135,7 @@ func SyncDeploymentToCluster(
 }
 
 // DeleteWorkspaceDeployment deletes the deployment for the DevWorkspace
-func DeleteWorkspaceDeployment(ctx context.Context, workspace *common.DevWorkspaceWithConfig, client runtimeClient.Client) (wait bool, err error) {
+func DeleteWorkspaceDeployment(ctx context.Context, workspace *common.DevWorkspaceWithConfig, client k8sclient.Client) (wait bool, err error) {
 	err = client.Delete(ctx, &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: workspace.Namespace,
@@ -153,14 +152,14 @@ func DeleteWorkspaceDeployment(ctx context.Context, workspace *common.DevWorkspa
 }
 
 // ScaleDeploymentToZero scales the cluster deployment to zero
-func ScaleDeploymentToZero(ctx context.Context, workspace *common.DevWorkspaceWithConfig, client runtimeClient.Client) error {
+func ScaleDeploymentToZero(ctx context.Context, workspace *common.DevWorkspaceWithConfig, client k8sclient.Client) error {
 	patch := []byte(`{"spec":{"replicas": 0}}`)
 	err := client.Patch(ctx, &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: workspace.Namespace,
 			Name:      common.DeploymentName(workspace.Status.DevWorkspaceId),
 		},
-	}, runtimeClient.RawPatch(types.StrategicMergePatchType, patch))
+	}, k8sclient.RawPatch(types.StrategicMergePatchType, patch))
 
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return err


### PR DESCRIPTION
### What does this PR do?
If a workspace timeout occurs, the workspace deployment's container statuses & pod events (including events listed in the DWOC's `ignoredUnrecoverableEvents`) are checked for failures. If a failure occurred, it is reference in the timeout error message. 

I also fixed a duplicate import of the controller-runtime client in `deployment.go`

#### Some extra notes:
- I wanted to write an envtest test to verify this fix, but it seemed to be more tricky than I hoped:

    - I tried manually creating a `FailedSchedling` event in the envtest environment, but DWO wouldn't catch it. This seems to be due to the fact that the test environment doesn't have a deployment controller, so the workspace deployment doesn't create pods that the `FailedScheduling` event can be associated with. Manually creating a pod with the appropriate workspace labels doesn't seem to work either.


    - Manually creating the event with `USE_EXISTING_CLUSTER=true` set didn't seem to work either, though this is probably the best approach. In my testing, the workspace pod only had the `FailedMount` event (due to some PVC provisioning error); the manually created `FailedScheduling` event wasn't being associated with the workspace pod. Drawbacks of this approach (using an existing cluster) include an increase in the duration of the entire testing suite and additional effort required (e.g. deleting the test namespace on cleanup, potentially waiting longer for PVC cleanup, and setting up Minikube on the CI)


### What issues does this PR fix or reference?
 #1041

### Is it tested? How?
1. Configure the DWOC so that the `FailedScheduling` event is ignored, and set the `progressTimeout` to 1 minute (so that you don't have to wait the default 5 minutes for the timeout to occur): `kubectl edit dwoc -n $NAMESPACE`

```diff
kind: DevWorkspaceOperatorConfig
apiVersion: controller.devfile.io/v1alpha1
config:
  routing:
    clusterHostSuffix: 192.168.39.74.nip.io
    defaultRoutingClass: basic
  workspace:
+    ignoredUnrecoverableEvents:
+    - FailedScheduling
+    progressTimeout: 1m
    imagePullPolicy: Always
```
2. Create a workspace that will cause a `FailedScheduling` event. E.g. a workspace that requests more CPU than the cluster can provide:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next-high-cpu
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: theia
        plugin:
          uri: https://che-plugin-registry-main.surge.sh/v3/plugins/eclipse/che-theia/latest/devfile.yaml
          components:
            - name: theia-ide
              container:
                env:
                  - name: THEIA_HOST
                    value: 0.0.0.0
                memoryRequest: 2Gi
                memoryLimit: 16Gi
                cpuRequest: 4000m
                cpuLimit: 8000m
    commands:
      - id: say-hello
        exec:
          component: theia-ide
          commandLine: echo "Hello from $(pwd)"
          workingDir: ${PROJECTS_ROOT}/project/app
```

3. Check the workspace deployment status: `kubectl get dw -n $NAMESPACE -w`

4. After a minute, the workspace should fail. The error message should detail that a timeout occurred, and that the FailedScheduling event occurred:

```
NAME                  DEVWORKSPACE ID             PHASE      INFO
theia-next-high-cpu   workspace656dfe6d86764967   Starting   Waiting for workspace deployment
theia-next-high-cpu   workspace656dfe6d86764967   Failing    devworkspace failed to progress past phase 'Starting' for longer than timeout (1m). Reason: Detected unrecoverable event FailedScheduling: 0/1 nodes are available: 1 Insufficient cpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod..
theia-next-high-cpu   workspace656dfe6d86764967   Failed     devworkspace failed to progress past phase 'Starting' for longer than timeout (1m). Reason: Detected unrecoverable event FailedScheduling: 0/1 nodes are available: 1 Insufficient cpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod..
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
