### PR TITLE
Backport fixes for #1049 and #1046 to 0.19.x branch

### DIFF
--- a/pkg/library/status/check.go
+++ b/pkg/library/status/check.go
@@ -96,11 +96,6 @@ func CheckPodsState(workspaceID string, namespace string, labelSelector k8sclien
 		if msg, err := CheckPodEvents(&pod, workspaceID, ignoredEvents, clusterAPI); err != nil || msg != "" {
 			return msg, err
 		}
-		if pod.Status.Phase == corev1.PodPending {
-			if msg := checkPodConditions(&pod); msg != "" {
-				return msg, nil
-			}
-		}
 	}
 	return "", nil
 }
@@ -168,18 +163,6 @@ func checkIfUnrecoverableEventIgnored(reason string, ignoredEvents []string) (ig
 		}
 	}
 	return false
-}
-
-func checkPodConditions(pod *corev1.Pod) (msg string) {
-	if pod.Status.Conditions != nil {
-		for _, condition := range pod.Status.Conditions {
-			// Pod unschedulable condition
-			if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse && condition.Reason == corev1.PodReasonUnschedulable {
-				return fmt.Sprintf("Pod is unschedulable: %s", condition.Message)
-			}
-		}
-	}
-	return ""
 }
 
 // Returns the number of times an event has occurred.


### PR DESCRIPTION
### What does this PR do?
Cherry pick fixes to 0.19.x branch:

* PR https://github.com/devfile/devworkspace-operator/pull/1047 fixing issue https://github.com/devfile/devworkspace-operator/issues/1046
* PR https://github.com/devfile/devworkspace-operator/pull/1050 fixing issue https://github.com/devfile/devworkspace-operator/pull/1049

### What issues does this PR fix or reference?
#1049 and #1046 in 0.19.x branch

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
