### PR TITLE
Mention Che Code sample in README instead of Theia

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ To see all rules supported by the makefile, run `make help`
 
 ### Test run controller
 1. Take a look samples devworkspace configuration in `./samples` folder.
-2. Apply any of them by executing `kubectl apply -f ./samples/theia-latest.yaml -n <namespace>`
+2. Apply any of them by executing `kubectl apply -f ./samples/code-latest.yaml -n <namespace>`
 3. As soon as devworkspace is started you're able to get IDE url by executing `kubectl get devworkspace -n <namespace>`
 
 ### Run controller locally


### PR DESCRIPTION
### What does this PR do?
Updates the README for test running the controller to mention the Che Code sample instead of Theia. 

### What issues does this PR fix or reference?
#1027

### Is it tested? How?
N/a, but if you wanted to, do a `kubectl apply -f ./samples/code-latest.yaml -n $NAMESPACE` with DWO installed. The output should be `devworkspace.workspace.devfile.io/code-latest created` 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
