### PR TITLE
support configuring workspace deploymentStrategy in DWOC

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -17,6 +17,7 @@ package v1alpha1
 
 import (
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,6 +101,14 @@ type WorkspaceConfig struct {
 	// not specified, the default value of "Always" is used.
 	// +kubebuilder:validation:Enum=IfNotPresent;Always;Never
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
+	// DeploymentStrategy defines the deployment strategy to use to replace existing DevWorkspace pods
+	// with new ones. The available deployment stragies are "Recreate" and "RollingUpdate".
+	// With the "Recreate" deployment strategy, the existing workspace pod is killed before the new one is created.
+	// With the "RollingUpdate" deployment strategy, a new workspace pod is created and the existing workspace pod is deleted
+	// only when the new workspace pod is in a ready state.
+	// If not specified, the default "Recreate" deployment strategy is used.
+	// +kubebuilder:validation:Enum=Recreate;RollingUpdate
+	DeploymentStrategy appsv1.DeploymentStrategyType `json:"deploymentStrategy,omitempty"`
 	// PVCName defines the name used for the persistent volume claim created
 	// to support workspace storage when the 'common' storage class is used.
 	// If not specified, the default value of `claim-devworkspace` is used.

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -1439,6 +1439,12 @@ spec:
                         description: "Map of key-value variables used for string replacement in the devfile. Values can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for \n  - schemaVersion, metadata, parent source \n  - element identifiers, e.g. command id, component name, endpoint name, project name \n  - references to identifiers, e.g. in events, a command's component, container's volume mount name \n  - string enums, e.g. command group kind, endpoint exposure"
                         type: object
                     type: object
+                  deploymentStrategy:
+                    description: DeploymentStrategy defines the deployment strategy to use to replace existing DevWorkspace pods with new ones. The available deployment stragies are "Recreate" and "RollingUpdate". With the "Recreate" deployment strategy, the existing workspace pod is killed before the new one is created. With the "RollingUpdate" deployment strategy, a new workspace pod is created and the existing workspace pod is deleted only when the new workspace pod is in a ready state. If not specified, the default "Recreate" deployment strategy is used.
+                    enum:
+                    - Recreate
+                    - RollingUpdate
+                    type: string
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should sit idle before being automatically scaled down. Proper functionality of this configuration property requires support in the workspace being started. If not specified, the default value of "15m" is used.
                     type: string

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -2276,6 +2276,20 @@ spec:
                           e.g. command group kind, endpoint exposure"
                         type: object
                     type: object
+                  deploymentStrategy:
+                    description: DeploymentStrategy defines the deployment strategy
+                      to use to replace existing DevWorkspace pods with new ones.
+                      The available deployment stragies are "Recreate" and "RollingUpdate".
+                      With the "Recreate" deployment strategy, the existing workspace
+                      pod is killed before the new one is created. With the "RollingUpdate"
+                      deployment strategy, a new workspace pod is created and the
+                      existing workspace pod is deleted only when the new workspace
+                      pod is in a ready state. If not specified, the default "Recreate"
+                      deployment strategy is used.
+                    enum:
+                    - Recreate
+                    - RollingUpdate
+                    type: string
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2276,6 +2276,20 @@ spec:
                           e.g. command group kind, endpoint exposure"
                         type: object
                     type: object
+                  deploymentStrategy:
+                    description: DeploymentStrategy defines the deployment strategy
+                      to use to replace existing DevWorkspace pods with new ones.
+                      The available deployment stragies are "Recreate" and "RollingUpdate".
+                      With the "Recreate" deployment strategy, the existing workspace
+                      pod is killed before the new one is created. With the "RollingUpdate"
+                      deployment strategy, a new workspace pod is created and the
+                      existing workspace pod is deleted only when the new workspace
+                      pod is in a ready state. If not specified, the default "Recreate"
+                      deployment strategy is used.
+                    enum:
+                    - Recreate
+                    - RollingUpdate
+                    type: string
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -2276,6 +2276,20 @@ spec:
                           e.g. command group kind, endpoint exposure"
                         type: object
                     type: object
+                  deploymentStrategy:
+                    description: DeploymentStrategy defines the deployment strategy
+                      to use to replace existing DevWorkspace pods with new ones.
+                      The available deployment stragies are "Recreate" and "RollingUpdate".
+                      With the "Recreate" deployment strategy, the existing workspace
+                      pod is killed before the new one is created. With the "RollingUpdate"
+                      deployment strategy, a new workspace pod is created and the
+                      existing workspace pod is deleted only when the new workspace
+                      pod is in a ready state. If not specified, the default "Recreate"
+                      deployment strategy is used.
+                    enum:
+                    - Recreate
+                    - RollingUpdate
+                    type: string
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2276,6 +2276,20 @@ spec:
                           e.g. command group kind, endpoint exposure"
                         type: object
                     type: object
+                  deploymentStrategy:
+                    description: DeploymentStrategy defines the deployment strategy
+                      to use to replace existing DevWorkspace pods with new ones.
+                      The available deployment stragies are "Recreate" and "RollingUpdate".
+                      With the "Recreate" deployment strategy, the existing workspace
+                      pod is killed before the new one is created. With the "RollingUpdate"
+                      deployment strategy, a new workspace pod is created and the
+                      existing workspace pod is deleted only when the new workspace
+                      pod is in a ready state. If not specified, the default "Recreate"
+                      deployment strategy is used.
+                    enum:
+                    - Recreate
+                    - RollingUpdate
+                    type: string
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -2275,6 +2275,20 @@ spec:
                           e.g. command group kind, endpoint exposure"
                         type: object
                     type: object
+                  deploymentStrategy:
+                    description: DeploymentStrategy defines the deployment strategy
+                      to use to replace existing DevWorkspace pods with new ones.
+                      The available deployment stragies are "Recreate" and "RollingUpdate".
+                      With the "Recreate" deployment strategy, the existing workspace
+                      pod is killed before the new one is created. With the "RollingUpdate"
+                      deployment strategy, a new workspace pod is created and the
+                      existing workspace pod is deleted only when the new workspace
+                      pod is in a ready state. If not specified, the default "Recreate"
+                      deployment strategy is used.
+                    enum:
+                    - Recreate
+                    - RollingUpdate
+                    type: string
                   idleTimeout:
                     description: IdleTimeout determines how long a workspace should
                       sit idle before being automatically scaled down. Proper functionality

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
@@ -32,8 +33,9 @@ var defaultConfig = &v1alpha1.OperatorConfiguration{
 		ClusterHostSuffix:   "", // is auto discovered when running on OpenShift. Must be defined by CR on Kubernetes.
 	},
 	Workspace: &v1alpha1.WorkspaceConfig{
-		ImagePullPolicy: "Always",
-		PVCName:         "claim-devworkspace",
+		ImagePullPolicy:    "Always",
+		DeploymentStrategy: appsv1.RecreateDeploymentStrategyType,
+		PVCName:            "claim-devworkspace",
 		ServiceAccount: &v1alpha1.ServiceAccountConfig{
 			DisableCreation: pointer.Bool(false),
 		},

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -290,6 +290,9 @@ func mergeConfig(from, to *controller.OperatorConfiguration) {
 		if from.Workspace.ImagePullPolicy != "" {
 			to.Workspace.ImagePullPolicy = from.Workspace.ImagePullPolicy
 		}
+		if from.Workspace.DeploymentStrategy != "" {
+			to.Workspace.DeploymentStrategy = from.Workspace.DeploymentStrategy
+		}
 		if from.Workspace.IdleTimeout != "" {
 			to.Workspace.IdleTimeout = from.Workspace.IdleTimeout
 		}
@@ -398,6 +401,9 @@ func GetCurrentConfigString(currConfig *controller.OperatorConfiguration) string
 	if workspace != nil {
 		if workspace.ImagePullPolicy != defaultConfig.Workspace.ImagePullPolicy {
 			config = append(config, fmt.Sprintf("workspace.imagePullPolicy=%s", workspace.ImagePullPolicy))
+		}
+		if workspace.DeploymentStrategy != defaultConfig.Workspace.DeploymentStrategy {
+			config = append(config, fmt.Sprintf("workspace.deploymentStrategy=%s", workspace.DeploymentStrategy))
 		}
 		if workspace.PVCName != defaultConfig.Workspace.PVCName {
 			config = append(config, fmt.Sprintf("workspace.pvcName=%s", workspace.PVCName))

--- a/pkg/config/sync_test.go
+++ b/pkg/config/sync_test.go
@@ -100,10 +100,9 @@ func TestMergesAllFieldsFromClusterConfig(t *testing.T) {
 		func(s *string, c fuzz.Continue) { *s = "a" + c.RandString() },
 		// The only valid deployment strategies are Recreate and RollingUpdate
 		func(deploymentStrategy *appsv1.DeploymentStrategyType, c fuzz.Continue) {
-			switch c.Int() % 2 {
-			case 0:
+			if c.Int()%2 == 0 {
 				*deploymentStrategy = appsv1.RollingUpdateDeploymentStrategyType
-			default:
+			} else {
 				*deploymentStrategy = appsv1.RecreateDeploymentStrategyType
 			}
 		},

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -16,6 +16,8 @@
 // Package constants defines constant values used throughout the DevWorkspace Operator
 package constants
 
+import "k8s.io/apimachinery/pkg/util/intstr"
+
 // Labels which should be used for controller related objects
 var ControllerAppLabels = func() map[string]string {
 	return map[string]string{
@@ -23,6 +25,13 @@ var ControllerAppLabels = func() map[string]string {
 		"app.kubernetes.io/part-of": "devworkspace-operator",
 	}
 }
+
+var (
+	// Maximum number of unavailable workspace pods when using the RollingUpdate deployment strategy
+	RollingUpdateMaxUnavailable = intstr.FromInt(0)
+	// Maximum number of excesss workspace pods when using the RollingUpdate deployment strategy
+	RollingUpdateMaximumSurge = intstr.FromInt(1)
+)
 
 // Internal constants
 const (

--- a/pkg/library/status/check.go
+++ b/pkg/library/status/check.go
@@ -51,6 +51,7 @@ var unrecoverablePodEventReasons = map[string]int32{
 
 var unrecoverableDeploymentConditionReasons = []string{
 	"FailedCreate",
+	"ProgressDeadlineExceeded",
 }
 
 func CheckDeploymentStatus(deployment *appsv1.Deployment, workspace *common.DevWorkspaceWithConfig) (ready bool) {

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -93,7 +93,7 @@ func SyncDeploymentToCluster(
 		return DeploymentProvisioningStatus{ProvisioningStatus{Err: err}}
 	}
 	clusterDeployment := clusterObj.(*appsv1.Deployment)
-	deploymentReady := status.CheckDeploymentStatus(clusterDeployment)
+	deploymentReady := status.CheckDeploymentStatus(clusterDeployment, workspace)
 	if deploymentReady {
 		return DeploymentProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{

--- a/pkg/provision/workspace/deployment.go
+++ b/pkg/provision/workspace/deployment.go
@@ -199,6 +199,16 @@ func getSpecDeployment(
 		return nil, err
 	}
 
+	deploymentStrategy := appsv1.DeploymentStrategy{
+		Type: workspace.Config.Workspace.DeploymentStrategy,
+	}
+	if workspace.Config.Workspace.DeploymentStrategy == appsv1.RollingUpdateDeploymentStrategyType {
+		deploymentStrategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+			MaxUnavailable: &constants.RollingUpdateMaxUnavailable,
+			MaxSurge:       &constants.RollingUpdateMaximumSurge,
+		}
+	}
+
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        common.DeploymentName(workspace.Status.DevWorkspaceId),
@@ -213,9 +223,7 @@ func getSpecDeployment(
 					constants.DevWorkspaceIDLabel: workspace.Status.DevWorkspaceId,
 				},
 			},
-			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RecreateDeploymentStrategyType,
-			},
+			Strategy: deploymentStrategy,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      workspace.Status.DevWorkspaceId,


### PR DESCRIPTION
### What does this PR do?

This PR adds a new DWOC field `config.workspace.deploymentStrategy` which allows for specifying the workspace deployment strategy in the DWOC. The possible choices are `Recreate` (Default) and `RollingUpdate`.

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1045 & https://github.com/eclipse/che/issues/21974 

### Is it tested? How?

Edit the DWOC and set the `deploymentStrategy` field to `RollingUpdate`. Also, ensure that the only accepted options for the `deploymentStrategy` field are `Recreate` and `RollingUpdate`.

```diff
kind: DevWorkspaceOperatorConfig
apiVersion: controller.devfile.io/v1alpha1
config:
  routing:
    clusterHostSuffix: 192.168.39.117.nip.io
    defaultRoutingClass: basic
  workspace:
+    deploymentStrategy: RollingUpdate
    imagePullPolicy: Always
```

Deploy a workspace and modify a field that would change the deployment spec, for example, modify one of the container's CPU or Memory request. 

To try this out, you could apply the following devworkspace:

```YAML
cat <<EOF | kubectl apply -f - 
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace
  namespace: devworkspace-controller
spec:
  started: true
  routingClass: 'basic'
  template:
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryLimit: 5Gi
          memoryRequest: 256Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
EOF
```

Next, watch the workspace status (as it will change when the rolling update occurs): `kubectl get dw -n devworkspace-controller`

Once the workspace is running, you could then increase the `memoryRequest`:  `kubectl edit dwoc -n plain-devworkspace -n devworkspace-controller`

```diff
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
(...)
spec:
  routingClass: basic
  started: true
  template:
    components:
    - container:
        command:
        - tail
        - -f
        - /dev/null
        image: quay.io/wto/web-terminal-tooling:next
        memoryLimit: 5Gi
+        memoryRequest: 1Gi
        mountSources: true
        sourceMapping: /projects
      name: web-terminal
```


Under the workspace's deployment (which could be checked on the OpenShift or Kubernetes dashboard) you should see a second pod get created and started before the old one is terminated. 

You should also see the devworkspace status phase change from Running -> Starting -> Running:

```
$ kubectl get dw -n $NAMESPACE -w
NAME                 DEVWORKSPACE ID             PHASE      INFO
plain-devworkspace   workspacec3a273cb552340a5   Starting   Waiting for workspace deployment
plain-devworkspace   workspacec3a273cb552340a5   Running    Workspace is running
plain-devworkspace   workspacec3a273cb552340a5   Running    Workspace is running
plain-devworkspace   workspacec3a273cb552340a5   Running    Workspace is running
plain-devworkspace   workspacec3a273cb552340a5   Starting   Networking ready
plain-devworkspace   workspacec3a273cb552340a5   Starting   Waiting for workspace deployment
plain-devworkspace   workspacec3a273cb552340a5   Running    Workspace is running
```

#### Extra test case: removing the deploymentStrategy from the DWOC

1. Set the `deploymentStrategy` to `RollingUpdate` in the DWOC
2. Apply a workspace (`kubectl apply -f ./samples/plain-devworkspace -n $NAMESPACE`), ensure the deployments `spec.strategy.type` is `RollingUpdate` 
3. Remove the `deploymentStrategy` field from the DWOC
4. Trigger a reconcile on the workspace (e.g. add an annotation)
5. Check the workspace deployment, the `spec.strategy.type` field should be `Recreate`

In other words, when the `deploymentStrategy` field is absent from the DWOC, the deployment strategy will be `Recreate`


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
