### PR TITLE
Ensure order of projected sources is sorted

### DIFF
--- a/pkg/provision/automount/projected_test.go
+++ b/pkg/provision/automount/projected_test.go
@@ -15,6 +15,7 @@ package automount
 
 import (
 	"path"
+	"sort"
 	"strings"
 	"testing"
 
@@ -309,20 +310,22 @@ func testProjectedVolume(name string, secretNames, configmapNames []string) core
 			},
 		},
 	}
-	for _, secretName := range secretNames {
-		vol.Projected.Sources = append(vol.Projected.Sources, corev1.VolumeProjection{
-			Secret: &corev1.SecretProjection{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: secretName,
-				},
-			},
-		})
-	}
+	sort.Strings(configmapNames)
+	sort.Strings(secretNames)
 	for _, configmapName := range configmapNames {
 		vol.Projected.Sources = append(vol.Projected.Sources, corev1.VolumeProjection{
 			ConfigMap: &corev1.ConfigMapProjection{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: configmapName,
+				},
+			},
+		})
+	}
+	for _, secretName := range secretNames {
+		vol.Projected.Sources = append(vol.Projected.Sources, corev1.VolumeProjection{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: secretName,
 				},
 			},
 		})


### PR DESCRIPTION
### What does this PR do?
Occasionally, the operator will get stuck updating a workspace deployment repeatedly, switching the order of sources in a projected volume. Sort projected volume sources (alphabetically, with configmaps before secrets) to ensure we always use the same order.

### What issues does this PR fix or reference?
No issue created; cannot consistently reproduce and workspaces still start, but I hit it a few times while testing. Most likely to reproduce for new workspaces started shortly after operator is rolled out.

### Is it tested? How?
Create a workspace that uses projected automount volumes. For testing, the volumes below can be used
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    controller.devfile.io/mount-as: file
    controller.devfile.io/mount-path: /tmp/test-projected/
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: "true"
  name: test-cm-1
  namespace: dw
data:
  configmap-2-key: hello
---
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    controller.devfile.io/mount-as: file
    controller.devfile.io/mount-path: /tmp/test-projected/
  labels:
    controller.devfile.io/mount-to-devworkspace: "true"
    controller.devfile.io/watch-configmap: "true"
  name: test-cm-2
  namespace: dw
data:
  configmap-2-key: hello
```
To test if reordering occurs, watch workspace startup via `kubectl get dw -w` and see if state switches from Running to Starting with no changes to the DevWorkspace object itself. In addition, if `enableExperimentalFeatures` is set in the config, the operator will log the diff of changes its making to the deployment (copy the long string and `echo -e` it)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
