### PR TITLE
Propagate proxy environment variables into project clone container

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -312,7 +312,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Add init container to clone projects
-	if projectClone, err := projects.GetProjectCloneInitContainer(&workspace.Spec.Template, workspace.Config.Workspace.ImagePullPolicy); err != nil {
+	if projectClone, err := projects.GetProjectCloneInitContainer(&workspace.Spec.Template, workspace.Config.Workspace.ImagePullPolicy, workspace.Config.Routing.ProxyConfig); err != nil {
 		return r.failWorkspace(workspace, fmt.Sprintf("Failed to set up project-clone init container: %s", err), metrics.ReasonInfrastructureFailure, reqLogger, &reconcileStatus)
 	} else if projectClone != nil {
 		devfilePodAdditions.InitContainers = append(devfilePodAdditions.InitContainers, *projectClone)

--- a/pkg/library/env/workspaceenv.go
+++ b/pkg/library/env/workspaceenv.go
@@ -71,12 +71,12 @@ func commonEnvironmentVariables(workspaceWithConfig *common.DevWorkspaceWithConf
 		},
 	}
 
-	envvars = append(envvars, getProxyEnvVars(workspaceWithConfig.Config.Routing.ProxyConfig)...)
+	envvars = append(envvars, GetProxyEnvVars(workspaceWithConfig.Config.Routing.ProxyConfig)...)
 
 	return envvars
 }
 
-func getProxyEnvVars(proxyConfig *v1alpha1.Proxy) []corev1.EnvVar {
+func GetProxyEnvVars(proxyConfig *v1alpha1.Proxy) []corev1.EnvVar {
 	if proxyConfig == nil {
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?
Propagate proxy settings into the project clone container

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1066

### Is it tested? How?
Test that any proxy settings are propagated into the project-clone container, and that cloning a project works correctly with a proxy configured.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
