### PR TITLE
Fix formatting for latest version of goimports

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -169,7 +169,7 @@ type DevWorkspaceOperatorConfig struct {
 }
 
 // DevWorkspaceOperatorConfigList contains a list of DevWorkspaceOperatorConfig
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 type DevWorkspaceOperatorConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/apis/controller/v1alpha1/doc.go
+++ b/apis/controller/v1alpha1/doc.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 // Package v1alpha1 contains API Schema definitions for the controller v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +groupName=controller.devfile.io

--- a/apis/controller/v1alpha1/groupversion_info.go
+++ b/apis/controller/v1alpha1/groupversion_info.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 // Package v1alpha1 contains API Schema definitions for the controller v1alpha1 API group
 // +kubebuilder:object:generate=true
 // +groupName=controller.devfile.io

--- a/pkg/config/configmap/config.go
+++ b/pkg/config/configmap/config.go
@@ -62,9 +62,9 @@ func (wc *ControllerConfig) GetClusterRoutingSuffix() *string {
 	return wc.GetProperty(routingSuffix)
 }
 
-//GetExperimentalFeaturesEnabled returns true if experimental features should be enabled.
-//DO NOT TURN ON IT IN THE PRODUCTION.
-//Experimental features are not well tested and may be totally removed without announcement.
+// GetExperimentalFeaturesEnabled returns true if experimental features should be enabled.
+// DO NOT TURN ON IT IN THE PRODUCTION.
+// Experimental features are not well tested and may be totally removed without announcement.
 func (wc *ControllerConfig) GetExperimentalFeaturesEnabled() *string {
 	return wc.GetProperty(experimentalFeaturesEnabled)
 }

--- a/pkg/library/constants/constants.go
+++ b/pkg/library/constants/constants.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 // Package constants contains constants related to the devfile API spec (e.g. reserved env vars)
 package constants
 

--- a/pkg/library/status/check.go
+++ b/pkg/library/status/check.go
@@ -72,8 +72,7 @@ func CheckDeploymentConditions(deployment *appsv1.Deployment) (healthy bool, err
 // checkPodsState checks if workspace-related pods are in an unrecoverable state. A pod is considered to be unrecoverable
 // if it has a container with one of the containerFailureStateReasons states, or if an unrecoverable event (with reason
 // matching unrecoverablePodEventReasons) has the pod as the involved object.
-// Returns optional message with detected unrecoverable state details
-//         error if any happens during check
+// Returns optional message with detected unrecoverable state details or error if any happens during check
 func CheckPodsState(workspaceID string, namespace string, labelSelector k8sclient.MatchingLabels, ignoredEvents []string,
 	clusterAPI sync.ClusterAPI) (stateMsg string, checkFailure error) {
 	podList := &corev1.PodList{}

--- a/pkg/provision/storage/asyncstorage/configuration.go
+++ b/pkg/provision/storage/asyncstorage/configuration.go
@@ -29,10 +29,11 @@ import (
 //
 // If the k8s objects do not exist, an SSH keypair is generated and a secret and configmap are created on the cluster.
 // This function works on two streams:
-// 1. If the async storage SSH secret for the given workspace does not exist on the cluster, an SSH keypair are generated, a
-//    Secret is synced to the cluster and the corresponding authorized key is added to the ConfigMap
-// 2. If the async storage SSH secret exists, its content is read, and the ConfigMap is verified to contain the corresponding public
-//    key in authorized_keys.
+//  1. If the async storage SSH secret for the given workspace does not exist on the cluster, an SSH keypair are generated, a
+//     Secret is synced to the cluster and the corresponding authorized key is added to the ConfigMap
+//  2. If the async storage SSH secret exists, its content is read, and the ConfigMap is verified to contain the corresponding public
+//     key in authorized_keys.
+//
 // In both cases, if the ConfigMap does not exist, it is created.
 //
 // Returns NotReadyError if changes were made to the cluster.

--- a/pkg/provision/storage/doc.go
+++ b/pkg/provision/storage/doc.go
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 // Package storage contains library functions for provisioning volumes and volumeMounts in containers according to the
 // volume components in a devfile. These functions also handle mounting project sources to containers that require it.
 //
 // TODO:
-// - Figure out how to handle 'size' parameter on volumes, given that we can't meaningfully use it for
-//   common PVC-type storage
-// - Devfile API spec is unclear on how mountSources should be handled -- mountPath is assumed to be /projects
-//   and volume name is assumed to be "projects"
-//   see issues:
-//     - https://github.com/devfile/api/issues/290
-//     - https://github.com/devfile/api/issues/291
+//   - Figure out how to handle 'size' parameter on volumes, given that we can't meaningfully use it for
+//     common PVC-type storage
+//   - Devfile API spec is unclear on how mountSources should be handled -- mountPath is assumed to be /projects
+//     and volume name is assumed to be "projects"
+//     see issues:
+//   - https://github.com/devfile/api/issues/290
+//   - https://github.com/devfile/api/issues/291
 package storage

--- a/pkg/provision/storage/shared.go
+++ b/pkg/provision/storage/shared.go
@@ -198,11 +198,11 @@ func getWorkspaceVolumes(workspace *common.DevWorkspaceWithConfig) (persistent, 
 }
 
 // processProjectsVolume handles the special case of the projects volume, for which there are four possibilities:
-// 1. The projects volume is not needed for the workspace (no component has mountSources: true)
-// 2. The projects volume is needed but not defined in the devfile. This is the usual case, as the projects volume
-//    is implicitly defined by mountSources
-// 3. The projects volume is explicitly defined in the workspace, as a regular volume.
-// 4. The projects volume is explicitly defined in the workspace as an ephemeral volume.
+//  1. The projects volume is not needed for the workspace (no component has mountSources: true)
+//  2. The projects volume is needed but not defined in the devfile. This is the usual case, as the projects volume
+//     is implicitly defined by mountSources
+//  3. The projects volume is explicitly defined in the workspace, as a regular volume.
+//  4. The projects volume is explicitly defined in the workspace as an ephemeral volume.
 //
 // To handle these cases, this function returns the projects component, if it is defined explictly (covering cases 3 and 4)
 // and a boolean defining if the projects volume is generally necessary for the workspace (covering cases 1 and 2)

--- a/project-clone/internal/zip/setup.go
+++ b/project-clone/internal/zip/setup.go
@@ -175,9 +175,13 @@ func unzip(archivePath string, destPath string) error {
 
 // dropTopLevelFolder handles the case where a zip archive contains a single folder by moving all files in a
 // single subdirectory into their parent directory. E.g., it converts
-//     /projects/my-project/my-project-main/[files]
+//
+//	/projects/my-project/my-project-main/[files]
+//
 // to
-//     /projects/my-project/[files]
+//
+//	/projects/my-project/[files]
+//
 // and removes directory /projects/my-project/my-project-master/
 // If the specified path contains additional files or directories, no changes are made.
 func dropTopLevelFolder(projectPath string) error {

--- a/test/e2e/cmd/workspaces_test.go
+++ b/test/e2e/cmd/workspaces_test.go
@@ -28,14 +28,14 @@ import (
 	"github.com/onsi/gomega"
 )
 
-//Create Constant file
+// Create Constant file
 const (
 	testResultsDirectory = "/tmp/artifacts"
 	jUnitOutputFilename  = "junit-workspaces-operator.xml"
 	testServiceAccount   = "terminal-test"
 )
 
-//SynchronizedBeforeSuite blocks is executed before run all test suites
+// SynchronizedBeforeSuite blocks is executed before run all test suites
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	log.Println("Starting to setup objects before run ginkgo suite")
 

--- a/test/e2e/pkg/client/client.go
+++ b/test/e2e/pkg/client/client.go
@@ -122,7 +122,7 @@ func (c *K8sClient) Kube() kubernetes.Interface {
 	return c.kubeClient
 }
 
-//read a source file and copy to the selected path
+// read a source file and copy to the selected path
 func copyFile(sourceFile string, destinationFile string) error {
 	input, err := os.ReadFile(sourceFile)
 	if err != nil {
@@ -136,7 +136,7 @@ func copyFile(sourceFile string, destinationFile string) error {
 	return nil
 }
 
-//generateUniqPrefixForFile generates unique prefix by using current time in milliseconds and get last 5 numbers
+// generateUniqPrefixForFile generates unique prefix by using current time in milliseconds and get last 5 numbers
 func generateUniqPrefixForFile() string {
 	//get the uniq time in seconds as string
 	prefix := strconv.FormatInt(time.Now().UnixNano(), 10)

--- a/test/e2e/pkg/client/devws.go
+++ b/test/e2e/pkg/client/devws.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-//get workspace current dev workspace status from the Custom Resource object
+// get workspace current dev workspace status from the Custom Resource object
 func (w *K8sClient) GetDevWsStatus(name, namespace string) (*dw.DevWorkspaceStatus, error) {
 	namespacedName := types.NamespacedName{
 		Name:      name,

--- a/test/e2e/pkg/client/namespace.go
+++ b/test/e2e/pkg/client/namespace.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//CreateNamespace creates a new namespace
+// CreateNamespace creates a new namespace
 func (w *K8sClient) CreateNamespace(namespace string) error {
 	_, err := w.kubeClient.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
 	if k8sErrors.IsAlreadyExists(err) {
@@ -37,12 +37,12 @@ func (w *K8sClient) CreateNamespace(namespace string) error {
 	return err
 }
 
-//DeleteNamespace deletes a namespace
+// DeleteNamespace deletes a namespace
 func (w *K8sClient) DeleteNamespace(namespace string) error {
 	return w.kubeClient.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
 }
 
-//WaitNamespaceIsTerminated waits until namespace that is marked to be removed, is fully cleaned up
+// WaitNamespaceIsTerminated waits until namespace that is marked to be removed, is fully cleaned up
 func (w *K8sClient) WaitNamespaceIsTerminated(namespace string) (err error) {
 	var delay time.Duration = 1
 	var timeout time.Duration = 60

--- a/test/e2e/pkg/client/oc.go
+++ b/test/e2e/pkg/client/oc.go
@@ -44,7 +44,7 @@ func (w *K8sClient) OcApplyWorkspace(namespace string, filePath string) (command
 	return output, nil
 }
 
-//launch 'exec' oc command in the defined pod and container
+// launch 'exec' oc command in the defined pod and container
 func (w *K8sClient) ExecCommandInContainer(podName string, namespace, commandInContainer string) (output string, err error) {
 	cmd := exec.Command("bash", "-c", fmt.Sprintf(
 		"KUBECONFIG=%s oc exec %s -n %s -c restricted-access-container -- %s",

--- a/test/e2e/pkg/client/rbac.go
+++ b/test/e2e/pkg/client/rbac.go
@@ -65,8 +65,8 @@ func (w *K8sClient) AssignRoleToSA(namespace, serviceAccount, role string) error
 	return err
 }
 
-//WaitSAToken waits until a secret with the token related to the specified SA
-//error is returned if token is not found after 10 seconds of tries
+// WaitSAToken waits until a secret with the token related to the specified SA
+// error is returned if token is not found after 10 seconds of tries
 func (w *K8sClient) WaitSAToken(namespace, serviceAccount string) (token string, err error) {
 	var delay time.Duration = 1
 	//usually the Service Account token is available just after SA is created but sometimes it's not

--- a/webhook/server/server.go
+++ b/webhook/server/server.go
@@ -104,14 +104,12 @@ func ConfigureWebhookServer(mgr manager.Manager) error {
 	return nil
 }
 
-//GetWebhookServer returns webhook server if it's configured
-//  nil otherwise
+// GetWebhookServer returns webhook server if it's configured, or nil otherwise
 func GetWebhookServer() *webhook.Server {
 	return webhookServer
 }
 
-//IsSetUp returns true if webhook server is configured
-//  false otherwise
+// IsSetUp returns true if webhook server is configured, or false otherwise
 func IsSetUp() bool {
 	return webhookServer != nil
 }

--- a/webhook/workspace/config.go
+++ b/webhook/workspace/config.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-//Configure configures mutate/validating webhooks that provides exec access into workspace for creator only
+// Configure configures mutate/validating webhooks that provides exec access into workspace for creator only
 func Configure(ctx context.Context) error {
 	log.Info("Configuring devworkspace webhooks")
 	c, err := createClient()


### PR DESCRIPTION
### What does this PR do?
The latest version of goimports arbitrarily changes some formatting rules, breaking formatting across the repository. This commit fixes this problem by

1. Making sure there's an empty line between license headers and package comments, to avoid formatting license headers
2. Applying the new required formatting for go blindly.

### What issues does this PR fix or reference?
Annoyance

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
