### PR TITLE
Add annotation for setting access mode on automounted configmap/secret files

### DIFF
--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -117,6 +117,7 @@ By default, resources will be mounted based on the resource name:
 Mounting resources can be additionally configured via **annotations**:
 
 * `controller.devfile.io/mount-path`: configure where the resource should be mounted
+* `controller.devfile.io/mount-access-mode`: for secrets and configmaps only, configure file permissions on files mounted from this configmap/secret. Permissions can be specified in decimal (e.g. `"511"`) or octal notation by prefixing with a "0" (e.g. `"0777"`)
 * `controller.devfile.io/mount-as`: for secrets and configmaps only, configure how the resource should be mounted to the workspace
 +
 --

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -42,6 +42,28 @@ const (
 	// DevWorkspaceMountLabel is the label key to store if a configmap, secret, or PVC should be mounted to the devworkspace
 	DevWorkspaceMountLabel = "controller.devfile.io/mount-to-devworkspace"
 
+	// DevWorkspaceMountPathAnnotation is the annotation key to store the mount path for the secret or configmap.
+	// If no mount path is provided, configmaps will be mounted at /etc/config/<configmap-name>, secrets will
+	// be mounted at /etc/secret/<secret-name>, and persistent volume claims will be mounted to /tmp/<claim-name>
+	DevWorkspaceMountPathAnnotation = "controller.devfile.io/mount-path"
+
+	// DevWorkspaceMountAsAnnotation is the annotation key to configure the way how configmaps or secrets should be mounted.
+	// Supported options:
+	// - "env" - mount as environment variables
+	// - "file" - mount as files within the mount path
+	// - "subpath" - mount keys as subpath volume mounts within the mount path
+	// When a configmap or secret is mounted via "file", the keys within the configmap/secret are mounted as files
+	// within a directory, erasing all contents of the directory. Mounting via "subpath" leaves existing files in the
+	// mount directory changed, but prevents on-cluster changes to the configmap/secret propagating to the container
+	// until it is restarted.
+	// If mountAs is not provided, the default behaviour will be to mount as a file.
+	DevWorkspaceMountAsAnnotation = "controller.devfile.io/mount-as"
+
+	// DevWorkspaceMountAccessModeAnnotation is an annotation key used to configure the access mode for configmaps and
+	// secrets mounted using the 'controller.devfile.io/mount-to-devworkspace' annotation. The access mode annotation
+	// can either be specified as a decimal (e.g. '416') or as an octal by prefixing the number with zero (e.g. '0640')
+	DevWorkspaceMountAccessModeAnnotation = "controller.devfile.io/mount-access-mode"
+
 	// DevWorkspaceGitCredentialLabel is the label key to specify if the secret is a git credential. All secrets who
 	// specify this label in a namespace will consolidate into one secret before mounting into a devworkspace.
 	// Only secret data with the credentials key will be used and credentials must be the base64 encoded version
@@ -66,23 +88,6 @@ const (
 	// when Git credentials are defined. This secret combines the values of any secrets labelled
 	// "controller.devfile.io/git-credential"
 	GitCredentialsMergedSecretName = "devworkspace-merged-git-credentials"
-
-	// DevWorkspaceMountPathAnnotation is the annotation key to store the mount path for the secret or configmap.
-	// If no mount path is provided, configmaps will be mounted at /etc/config/<configmap-name>, secrets will
-	// be mounted at /etc/secret/<secret-name>, and persistent volume claims will be mounted to /tmp/<claim-name>
-	DevWorkspaceMountPathAnnotation = "controller.devfile.io/mount-path"
-
-	// DevWorkspaceMountAsAnnotation is the annotation key to configure the way how configmaps or secrets should be mounted.
-	// Supported options:
-	// - "env" - mount as environment variables
-	// - "file" - mount as files within the mount path
-	// - "subpath" - mount keys as subpath volume mounts within the mount path
-	// When a configmap or secret is mounted via "file", the keys within the configmap/secret are mounted as files
-	// within a directory, erasing all contents of the directory. Mounting via "subpath" leaves existing files in the
-	// mount directory changed, but prevents on-cluster changes to the configmap/secret propagating to the container
-	// until it is restarted.
-	// If mountAs is not provided, the default behaviour will be to mount as a file.
-	DevWorkspaceMountAsAnnotation = "controller.devfile.io/mount-as"
 
 	// DevWorkspaceMountAsEnv is the annotation value for DevWorkspaceMountAsAnnotation to mount the resource as environment variables
 	// via envFrom

--- a/pkg/provision/automount/common.go
+++ b/pkg/provision/automount/common.go
@@ -335,7 +335,7 @@ func getAccessModeForAutomount(obj k8sclient.Object) (*int32, error) {
 		return nil, err
 	}
 	if accessMode64 < 0 || accessMode64 > 0777 {
-		return nil, fmt.Errorf("invalid access mode annotation: %o", accessMode64)
+		return nil, fmt.Errorf("invalid access mode annotation: value '%s' parsed to %o (octal)", accessModeStr, accessMode64)
 	}
 	accessMode32 := int32(accessMode64)
 	return &accessMode32, nil

--- a/pkg/provision/automount/common_test.go
+++ b/pkg/provision/automount/common_test.go
@@ -17,12 +17,22 @@ package automount
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 )
 
 type mountedVolumeType int
@@ -33,7 +43,123 @@ const (
 	configMapVolumeType
 )
 
-const testContainerName = "testContainer"
+const (
+	testContainerName = "testContainer"
+	testNamespace     = "test-namespace"
+)
+
+type testCase struct {
+	Name  string `json:"name"`
+	Input struct {
+		// Secrets and Configmaps are necessary for deserialization from a testcase
+		Secrets    []corev1.Secret    `json:"secrets"`
+		ConfigMaps []corev1.ConfigMap `json:"configmaps"`
+		// allObjects contains all Secrets and Configmaps defined above, for convenience
+		allObjects []client.Object
+	} `json:"input"`
+	Output struct {
+		// List of volumes expected in the resulting podAdditions; if the name of any volume
+		// starts with '/', the name will be overwritten to common.AutoMountProjectedVolumeName(name)
+		Volumes []corev1.Volume `json:"volumes"`
+		// List of volumeMounts expected in the resulting podAdditions; if the name of any volumeMount
+		// starts with '/', the name will be overwritten to common.AutoMountProjectedVolumeName(name)
+		VolumeMounts []corev1.VolumeMount   `json:"volumeMounts"`
+		EnvFrom      []corev1.EnvFromSource `json:"envFrom"`
+		ErrRegexp    *string                `json:"errRegexp"`
+	} `json:"output"`
+	TestPath string
+}
+
+var testDiffOpts = cmp.Options{
+	cmpopts.SortSlices(func(a, b corev1.Volume) bool {
+		return a.Name < b.Name
+	}),
+	cmpopts.SortSlices(func(a, b corev1.VolumeMount) bool {
+		if a.Name == b.Name {
+			return a.MountPath < b.MountPath
+		}
+		return a.Name < b.Name
+	}),
+	cmpopts.SortSlices(func(a, b corev1.EnvFromSource) bool {
+		switch {
+		case a.ConfigMapRef != nil && b.ConfigMapRef != nil:
+			return a.ConfigMapRef.Name < b.ConfigMapRef.Name
+		case a.ConfigMapRef != nil && b.ConfigMapRef == nil:
+			return true
+		case a.ConfigMapRef == nil && b.ConfigMapRef != nil:
+			return false
+		default:
+			return a.SecretRef.Name < b.SecretRef.Name
+		}
+	}),
+	cmpopts.SortSlices(func(a, b corev1.VolumeProjection) bool {
+		switch {
+		case a.ConfigMap != nil && b.ConfigMap != nil:
+			return a.ConfigMap.Name < b.ConfigMap.Name
+		case a.ConfigMap == nil && b.ConfigMap != nil:
+			return true
+		case a.ConfigMap != nil && b.ConfigMap == nil:
+			return false
+		default:
+			return a.Secret.Name < b.Secret.Name
+		}
+	}),
+}
+
+func TestProvisionAutomountResourcesInto(t *testing.T) {
+	tests := loadAllTestCasesOrPanic(t, "testdata")
+	testContainer := corev1.Container{
+		Name:  "test-container",
+		Image: "test-image",
+	}
+	testPodAdditions := &v1alpha1.PodAdditions{
+		Containers:     []corev1.Container{testContainer},
+		InitContainers: []corev1.Container{testContainer},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
+			podAdditions := testPodAdditions.DeepCopy()
+			testAPI := sync.ClusterAPI{
+				Client: fake.NewClientBuilder().WithObjects(tt.Input.allObjects...).Build(),
+			}
+			// Note: this test does not allow for returning AutoMountError with isFatal: false (i.e. no retrying)
+			// and so is not suitable for testing automount features that provision cluster resources (yet)
+			err := ProvisionAutoMountResourcesInto(podAdditions, testAPI, testNamespace)
+			if tt.Output.ErrRegexp != nil {
+				if !assert.Error(t, err, "Expected an error but got none") {
+					return
+				}
+				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Expected error messages to match")
+			} else {
+				if !assert.NoError(t, err, "Unexpected error") {
+					return
+				}
+				assert.Truef(t, cmp.Equal(tt.Output.Volumes, podAdditions.Volumes, testDiffOpts),
+					"Volumes should match expected output:\n%s",
+					cmp.Diff(tt.Output.Volumes, podAdditions.Volumes, testDiffOpts))
+
+				for _, container := range podAdditions.Containers {
+					assert.Truef(t, cmp.Equal(tt.Output.VolumeMounts, container.VolumeMounts, testDiffOpts),
+						"Container VolumeMounts should match expected output:\n%s",
+						cmp.Diff(tt.Output.VolumeMounts, container.VolumeMounts, testDiffOpts))
+					assert.Truef(t, cmp.Equal(tt.Output.EnvFrom, container.EnvFrom, testDiffOpts),
+						"Container EnvFrom should match expected output:\n%s",
+						cmp.Diff(tt.Output.EnvFrom, container.EnvFrom, testDiffOpts))
+				}
+
+				for _, container := range podAdditions.InitContainers {
+					assert.Truef(t, cmp.Equal(tt.Output.VolumeMounts, container.VolumeMounts, testDiffOpts),
+						"Container VolumeMounts should match expected output:\n%s",
+						cmp.Diff(tt.Output.VolumeMounts, container.VolumeMounts, testDiffOpts))
+					assert.Truef(t, cmp.Equal(tt.Output.EnvFrom, container.EnvFrom, testDiffOpts),
+						"Container EnvFrom should match expected output:\n%s",
+						cmp.Diff(tt.Output.EnvFrom, container.EnvFrom, testDiffOpts))
+				}
+			}
+		})
+	}
+}
 
 func TestCheckAutoMountVolumesForCollision(t *testing.T) {
 	type volumeDesc struct {
@@ -220,4 +346,60 @@ func TestCheckAutoMountVolumesForCollision(t *testing.T) {
 			}
 		})
 	}
+}
+
+func loadAllTestCasesOrPanic(t *testing.T, fromDir string) []testCase {
+	files, err := os.ReadDir(fromDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tests []testCase
+	for _, file := range files {
+		if file.IsDir() {
+			tests = append(tests, loadAllTestCasesOrPanic(t, filepath.Join(fromDir, file.Name()))...)
+		} else {
+			tests = append(tests, loadTestCaseOrPanic(t, filepath.Join(fromDir, file.Name())))
+		}
+	}
+	return tests
+}
+
+func loadTestCaseOrPanic(t *testing.T, testPath string) testCase {
+	bytes, err := os.ReadFile(testPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var test testCase
+	if err := yaml.Unmarshal(bytes, &test); err != nil {
+		t.Fatal(err)
+	}
+
+	// Go doesn't allow conversion to interfaces (e.g. client.Object) for elements of slices,
+	// so we have to add one at a time
+	for idx := range test.Input.ConfigMaps {
+		test.Input.allObjects = append(test.Input.allObjects, &test.Input.ConfigMaps[idx])
+	}
+	for idx := range test.Input.Secrets {
+		test.Input.allObjects = append(test.Input.allObjects, &test.Input.Secrets[idx])
+	}
+
+	// Overwrite namespace for convenience
+	for _, obj := range test.Input.allObjects {
+		obj.SetNamespace(testNamespace)
+	}
+
+	// Overwrite volume and volumeMount names for projected volumes
+	for idx, vol := range test.Output.Volumes {
+		if strings.HasPrefix(vol.Name, "/") {
+			test.Output.Volumes[idx].Name = common.AutoMountProjectedVolumeName(vol.Name)
+		}
+	}
+	for idx, vm := range test.Output.VolumeMounts {
+		if strings.HasPrefix(vm.Name, "/") {
+			test.Output.VolumeMounts[idx].Name = common.AutoMountProjectedVolumeName(vm.Name)
+		}
+	}
+
+	test.TestPath = testPath
+	return test
 }

--- a/pkg/provision/automount/gitconfig.go
+++ b/pkg/provision/automount/gitconfig.go
@@ -78,8 +78,8 @@ func ProvisionGitConfiguration(api sync.ClusterAPI, namespace string) (*Resource
 		return nil, &AutoMountError{IsFatal: false, Err: err}
 	}
 	resources := flattenAutomountResources([]Resources{
-		getAutomountSecret(mergedGitCredentialsMountPath, constants.DevWorkspaceMountAsFile, mergedCredentialsSecret),
-		getAutomountConfigmap("/etc/", constants.DevWorkspaceMountAsSubpath, gitConfigMap),
+		getAutomountSecret(mergedGitCredentialsMountPath, constants.DevWorkspaceMountAsFile, defaultAccessMode, mergedCredentialsSecret),
+		getAutomountConfigmap("/etc/", constants.DevWorkspaceMountAsSubpath, defaultAccessMode, gitConfigMap),
 	})
 
 	return &resources, nil

--- a/pkg/provision/automount/gitconfig_test.go
+++ b/pkg/provision/automount/gitconfig_test.go
@@ -35,7 +35,6 @@ var (
 		gitTLSHostKey:        "github.com",
 		gitTLSCertificateKey: "sample_data_here",
 	}
-	testNamespace = "test-namespace"
 )
 
 func TestUserCredentialsAreMountedWithOneCredential(t *testing.T) {

--- a/pkg/provision/automount/projected.go
+++ b/pkg/provision/automount/projected.go
@@ -104,12 +104,14 @@ func generateProjectedVolume(mountPath string, volumeMounts []corev1.VolumeMount
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: volume.Secret.SecretName,
 				},
+				Items: volume.Secret.Items,
 			}
 		case volume.ConfigMap != nil:
 			projection.ConfigMap = &corev1.ConfigMapProjection{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: volume.ConfigMap.Name,
 				},
+				Items: volume.ConfigMap.Items,
 			}
 		default:
 			return nil, nil, fmt.Errorf("unrecognized volume type for volume %s", volume.Name)

--- a/pkg/provision/automount/testdata/errorBadAccessMode.yaml
+++ b/pkg/provision/automount/testdata/errorBadAccessMode.yaml
@@ -1,0 +1,21 @@
+name: "Returns error when access mode is invalid"
+
+input:
+  configmaps:
+  -
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-file-configmap
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-configmap: 'true'
+      annotations:
+        controller.devfile.io/mount-as: file
+        controller.devfile.io/mount-path: /tmp/configmap/file
+        controller.devfile.io/mount-access-mode: "777" # Not parsed as octal
+    data:
+      configmap-key: "hello"
+
+output:
+  errRegexp: "invalid access mode annotation: value '777' parsed to 1411 \\(octal\\)"

--- a/pkg/provision/automount/testdata/testProvisionsConfigmaps.yaml
+++ b/pkg/provision/automount/testdata/testProvisionsConfigmaps.yaml
@@ -1,0 +1,70 @@
+name: Provisions automount configmaps to containers
+
+input:
+  configmaps:
+    -
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-file-configmap
+        labels:
+          controller.devfile.io/mount-to-devworkspace: "true"
+          controller.devfile.io/watch-configmap: 'true'
+        annotations:
+          controller.devfile.io/mount-as: file
+          controller.devfile.io/mount-path: /tmp/configmap/file
+      data:
+        configmap-key: "hello"
+    -
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-subpath-configmap
+        labels:
+          controller.devfile.io/mount-to-devworkspace: "true"
+          controller.devfile.io/watch-configmap: 'true'
+        annotations:
+          controller.devfile.io/mount-as: subpath
+          controller.devfile.io/mount-path: /tmp/configmap/subpath
+      data:
+        configmap-key: "This is secret"
+        configmap-key-2: "This is also secret I guess"
+    -
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-env-configmap
+        labels:
+          controller.devfile.io/mount-to-devworkspace: "true"
+          controller.devfile.io/watch-configmap: 'true'
+        annotations:
+          controller.devfile.io/mount-as: env
+      data:
+        CONFIGMAP_ENV_1: CONFIGMAP_ENV_1_VALUE
+        CONFIGMAP_ENV_2: CONFIGMAP_ENV_2_VALUE
+
+output:
+  volumes:
+  - name: test-file-configmap
+    configmap:
+      name: test-file-configmap
+      defaultMode: 0640
+  - name: test-subpath-configmap
+    configmap:
+      name: test-subpath-configmap
+      defaultMode: 0640
+  volumeMounts:
+  - name: test-file-configmap
+    readOnly: true
+    mountPath: /tmp/configmap/file
+  - name: test-subpath-configmap
+    readOnly: true
+    mountPath: /tmp/configmap/subpath/configmap-key
+    subpath: configmap-key
+  - name: test-subpath-configmap
+    readOnly: true
+    mountPath: /tmp/configmap/subpath/configmap-key-2
+    subpath: configmap-key-2
+  envFrom:
+  - configmapRef:
+      name: test-env-configmap

--- a/pkg/provision/automount/testdata/testProvisionsProjectedVolumes.yaml
+++ b/pkg/provision/automount/testdata/testProvisionsProjectedVolumes.yaml
@@ -1,0 +1,62 @@
+name: "Provisions projected volumes when secrets and configmaps use same mount path"
+
+input:
+  secrets:
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: test-projected-secret
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-secret: 'true'
+      annotations:
+        controller.devfile.io/mount-as: file
+        controller.devfile.io/mount-path: /tmp/test-projected/
+    type: Opaque
+    data:
+      secret-data: aGVsbG8K # "hello"
+  configmaps:
+  -
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-projected-configmap-1
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-configmap: 'true'
+      annotations:
+        controller.devfile.io/mount-as: file
+        controller.devfile.io/mount-path: /tmp/test-projected/
+    data:
+      configmap-1-key: "hello"
+  -
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-projected-configmap-2
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-configmap: 'true'
+      annotations:
+        controller.devfile.io/mount-as: file
+        controller.devfile.io/mount-path: /tmp/test-projected/
+    data:
+      configmap-2-key: "hello"
+
+output:
+  volumes:
+  - name: "/tmp/test-projected/"
+    projected:
+      defaultMode: 0640
+      sources:
+      - secret:
+          name: test-projected-secret
+      - configmap:
+          name: test-projected-configmap-1
+      - configmap:
+          name: test-projected-configmap-2
+  volumeMounts:
+  - name: "/tmp/test-projected/"
+    readOnly: true
+    mountPath: "/tmp/test-projected/"

--- a/pkg/provision/automount/testdata/testProvisionsSecrets.yaml
+++ b/pkg/provision/automount/testdata/testProvisionsSecrets.yaml
@@ -1,0 +1,67 @@
+name: "Provisions automount secrets to containers"
+
+input:
+  secrets:
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: test-env-secret
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-secret: "true"
+      annotations:
+        controller.devfile.io/mount-as: env
+    type: Opaque
+    data:
+      test_env: aGVsbG8K # "hello"
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: test-file-secret
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-secret: 'true'
+      annotations:
+        controller.devfile.io/mount-as: file
+        controller.devfile.io/mount-path: /tmp/secret/file
+    type: Opaque
+    data:
+      test_data: aGVsbG8K # "hello"
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: test-subpath-secret
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-secret: 'true'
+      annotations:
+        controller.devfile.io/mount-as: subpath
+        controller.devfile.io/mount-path: /tmp/secret/subpath
+    type: Opaque
+    data:
+      test_subpath_data: aGVsbG8K # "hello"
+
+output:
+  volumes:
+  - name: test-file-secret
+    secret:
+      secretName: test-file-secret
+      defaultMode: 0640
+  - name: test-subpath-secret
+    secret:
+      secretName: test-subpath-secret
+      defaultMode: 0640
+  volumeMounts:
+  - name: test-file-secret
+    readOnly: true
+    mountPath: /tmp/secret/file
+  - name: test-subpath-secret
+    readOnly: true
+    mountPath: /tmp/secret/subpath/test_subpath_data
+    subpath: test_subpath_data
+  envFrom:
+  - secretRef:
+      name: test-env-secret

--- a/pkg/provision/automount/testdata/testProvisionsWithAccessMode.yaml
+++ b/pkg/provision/automount/testdata/testProvisionsWithAccessMode.yaml
@@ -1,0 +1,104 @@
+name: Provisions automount resources using access mode
+
+input:
+  secrets:
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: test-file-secret
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-secret: 'true'
+      annotations:
+        controller.devfile.io/mount-as: file
+        controller.devfile.io/mount-path: /tmp/secret/file
+        controller.devfile.io/mount-access-mode: "0111"
+    type: Opaque
+    data:
+      test-data: aGVsbG8K # "hello"
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: test-projected-secret
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-secret: 'true'
+      annotations:
+        controller.devfile.io/mount-as: file
+        controller.devfile.io/mount-path: /tmp/test-projected/
+        controller.devfile.io/mount-access-mode: "0222"
+    type: Opaque
+    data:
+      test-projected-data: aGVsbG8K # "hello"
+  configmaps:
+  -
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-file-configmap
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-configmap: 'true'
+      annotations:
+        controller.devfile.io/mount-as: file
+        controller.devfile.io/mount-path: /tmp/configmap/file
+        controller.devfile.io/mount-access-mode: "0333"
+    data:
+      configmap-key: "hello"
+  -
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-projected-configmap
+      labels:
+        controller.devfile.io/mount-to-devworkspace: "true"
+        controller.devfile.io/watch-configmap: 'true'
+      annotations:
+        controller.devfile.io/mount-as: file
+        controller.devfile.io/mount-path: /tmp/test-projected/
+        controller.devfile.io/mount-access-mode: "0444"
+    data:
+      projected-configmap-key: "hello"
+      projected-configmap-key-2: "hello-2"
+
+output:
+  volumes:
+  - name: test-file-configmap
+    configmap:
+      name: test-file-configmap
+      defaultMode: 0333
+  - name: test-file-secret
+    secret:
+      secretName: test-file-secret
+      defaultMode: 0111
+  - name: /tmp/test-projected/
+    projected:
+      defaultMode: 0640
+      sources:
+      - secret:
+          name: test-projected-secret
+          items:
+          - key: test-projected-data
+            path: test-projected-data
+            mode: 0222
+      - configmap:
+          name: test-projected-configmap
+          items:
+          - key: projected-configmap-key
+            path: projected-configmap-key
+            mode: 0444
+          - key: projected-configmap-key-2
+            path: projected-configmap-key-2
+            mode: 0444
+  volumeMounts:
+  - name: test-file-configmap
+    readOnly: true
+    mountPath: /tmp/configmap/file
+  - name: test-file-secret
+    readOnly: true
+    mountPath: /tmp/secret/file
+  - name: "/tmp/test-projected/"
+    readOnly: true
+    mountPath: "/tmp/test-projected/"


### PR DESCRIPTION
### What does this PR do?
Adds secret/configmap automount annotation
```
controller.devfile.io/mount-access-mode
```
that can be used to configure file permissions on files mounted from the secret/configmap. Access mode is propagated into merged projected volumes as well.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1072

### Is it tested? How?
To test manually, see files below

<details>
  <summary>yaml resources</summary>

* Plain configmap (mounted to `/tmp/access-mode/configmap/`):
  ```yaml
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: test-cm-accessmode
    labels:
      controller.devfile.io/mount-to-devworkspace: "true"
      controller.devfile.io/watch-configmap: 'true'
    annotations:
      controller.devfile.io/mount-as: file
      controller.devfile.io/mount-path: /tmp/access-mode/configmap/
      controller.devfile.io/mount-access-mode: "0777"
  data:
    cm-test.sh: |
      #!/bin/bash

      echo "I am a configmap"
  ```
* Plain secret (mounted to `/tmp/access-mode/secret/`):
  ```yaml
  apiVersion: v1
  kind: Secret
  metadata:
    name: test-secret-accessmode
    labels:
      controller.devfile.io/mount-to-devworkspace: "true"
      controller.devfile.io/watch-secret: 'true'
    annotations:
      controller.devfile.io/mount-as: file
      controller.devfile.io/mount-path: /tmp/access-mode/secret/
      controller.devfile.io/mount-access-mode: "0777"
  type: Opaque
  data:
    # Contents:
    # #!/bin/bash
    #
    # echo "I am a secret"
    secret-test.sh: IyEvYmluL2Jhc2gKCmVjaG8gIkkgYW0gYSBzZWNyZXQiCg==
  ```
* Projected configmaps and secrets, with different access modes (mounted to `/tmp/access-mode/projected/`):
  ```yaml
  apiVersion: v1
  kind: Secret
  metadata:
    name: test-secret-accessmode-projected
    labels:
      controller.devfile.io/mount-to-devworkspace: "true"
      controller.devfile.io/watch-secret: 'true'
    annotations:
      controller.devfile.io/mount-as: file
      controller.devfile.io/mount-path: /tmp/access-mode/projected/
      controller.devfile.io/mount-access-mode: "0777"
  type: Opaque
  data:
    secret-test.sh: IyEvYmluL2Jhc2gKCmVjaG8gIkkgYW0gYSBzZWNyZXQiCg==
  ---
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: test-cm-accessmode-projected-1
    labels:
      controller.devfile.io/mount-to-devworkspace: "true"
      controller.devfile.io/watch-configmap: 'true'
    annotations:
      controller.devfile.io/mount-as: file
      controller.devfile.io/mount-path: /tmp/access-mode/projected/
      controller.devfile.io/mount-access-mode: "0776"
  data:
    cm-test-2.sh: |
      #!/bin/bash

      echo "I am a configmap 2"
  ---
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: test-cm-accessmode-projected-2
    labels:
      controller.devfile.io/mount-to-devworkspace: "true"
      controller.devfile.io/watch-configmap: 'true'
    annotations:
      controller.devfile.io/mount-as: file
      controller.devfile.io/mount-path: /tmp/access-mode/projected/
      controller.devfile.io/mount-access-mode: "0774"
  data:
    cm-test-1.sh: |
      #!/bin/bash

      echo "I am a configmap 1"
  ```

</details>

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
