### PR TITLE
Fixup old documentation on using PAT secrets in DWO

### DIFF
--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -153,7 +153,7 @@ data:
 ----
 Note: As for automatically mounting secrets, it is necessary to apply the `controller.devfile.io/watch-secret` label to git credentials secrets
 
-This will mount a file `/tmp/.git-credentials/credentials` in all workspace containers, and construct a git config to use this file as a credentials store. The mount path specified by the `controller.devfile.io/mount-path` annotation can by omitted, in which case `/` is used (mounting a file `/credentials`).
+This will mount a file `/tmp/.git-credentials/credentials` in all workspace containers, and construct a git config to use this file as a credentials store.
 
 ## Configuring DevWorkspaces to use SSH keys for Git operations
 Git SSH keys can be configured for DevWorkspaces by mounting secrets to workspaces.


### PR DESCRIPTION
### What does this PR do?
Remove out-of-date documentation on using `mount-path` for PAT secrets. As of https://github.com/devfile/devworkspace-operator/issues/915, the mount-path annotation is ignored to allow for mounting secrets as files instead of subpath.

### What issues does this PR fix or reference?
N/A, docs update.

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
