### PR TITLE
Pin yq version in prow jobs to avoid issue installing yq

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -19,7 +19,8 @@ SHELL ["/bin/bash", "-c"]
 
 RUN yum install --assumeyes -d1 python3-pip && \
     pip3 install --upgrade setuptools && \
-    pip3 install yq && \
+    # Need to pin yq version due to version 3.2.0 requiring python 3.6 and above
+    pip3 install yq==v3.1.1 && \
     # install kubectl
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \


### PR DESCRIPTION
### What does this PR do?
The 3.2.0 release of yq is incompatible with Python 3.6 due to depending on a library/version that is only available in 3.7+. This commit pins yq to an earlier release to avoid this issue.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
