### PR TITLE
Log additional info for workspace startup process

### DIFF
--- a/controllers/workspace/condition.go
+++ b/controllers/workspace/condition.go
@@ -40,6 +40,20 @@ type workspaceConditions struct {
 	warningConditions []dw.DevWorkspaceCondition
 }
 
+func workspaceConditionsFromClusterObject(clusterConditions []dw.DevWorkspaceCondition) *workspaceConditions {
+	wkspConditions := &workspaceConditions{
+		conditions: map[dw.DevWorkspaceConditionType]dw.DevWorkspaceCondition{},
+	}
+	for _, condition := range clusterConditions {
+		if condition.Type == conditions.DevWorkspaceWarning {
+			wkspConditions.warningConditions = append(wkspConditions.warningConditions, condition)
+		} else {
+			wkspConditions.conditions[condition.Type] = condition
+		}
+	}
+	return wkspConditions
+}
+
 func (c *workspaceConditions) setConditionTrue(conditionType dw.DevWorkspaceConditionType, msg string) {
 	c.setConditionTrueWithReason(conditionType, msg, "")
 }

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -443,14 +443,16 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	reconcileStatus.setConditionTrue(conditions.DeploymentReady, "DevWorkspace deployment ready")
 
-	serverReady, err := checkServerStatus(clusterWorkspace)
+	serverReady, serverStatusCode, err := checkServerStatus(clusterWorkspace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 	if !serverReady {
+		reqLogger.Info("Main URL server not ready", "status-code", serverStatusCode)
 		reconcileStatus.setConditionFalse(dw.DevWorkspaceReady, "Waiting for editor to start")
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}
+	reqLogger.Info("Workspace is running")
 	reconcileStatus.setConditionTrue(dw.DevWorkspaceReady, "")
 	reconcileStatus.phase = dw.DevWorkspaceStatusRunning
 	return reconcile.Result{}, nil

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -225,7 +225,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				// Check if an ignoredUnrecoverableEvent occured and report it alongside the timeout notice
 				errMsg := status.CheckForIgnoredWorkspacePodEvents(workspace, clusterAPI)
 				if errMsg != "" {
-					failureMsg := fmt.Sprintf("%s. Reason: %s", timeoutErr.Error(), errMsg)
+					failureMsg := fmt.Sprintf("%s. Ignored events: %s", timeoutErr.Error(), errMsg)
 					reconcileResult = r.failWorkspace(workspace, failureMsg, metrics.DetermineProvisioningFailureReason(errMsg), reqLogger, &reconcileStatus)
 				} else {
 					reconcileResult = r.failWorkspace(workspace, timeoutErr.Error(), metrics.ReasonInfrastructureFailure, reqLogger, &reconcileStatus)


### PR DESCRIPTION
### What does this PR do?
* Log more information per reconcile to make potential issues clear:
  * Always log where reconcile is ending to avoid confusing repeated "reconciling workspace" messages in logs -- if a workspace is running, log that the previous reconcile detected it as running
  * Log error code when editor status check fails ("Main URL server not ready")
* Set message to include last phase (e.g. "waiting on editor to be ready") when workspace start times out.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1079

### Is it tested? How?
Test by starting workspaces that timeout

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
