### PR TITLE
Don't update timestamps on conditions with status 'Unknown'

### DIFF
--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -109,12 +109,16 @@ func syncConditions(workspaceStatus *dw.DevWorkspaceStatus, currentStatus *curre
 
 		currCondition, ok := currentStatus.conditions[workspaceCondition.Type]
 		if !ok {
-			// Didn't observe this condition this time; set status to unknown
-			workspaceCondition.LastTransitionTime = currTransitionTime
-			workspaceCondition.Status = corev1.ConditionUnknown
-			workspaceCondition.Message = ""
-			workspaceCondition.Reason = ""
-			newConditions = append(newConditions, workspaceCondition)
+			if workspaceCondition.Status == corev1.ConditionUnknown {
+				newConditions = append(newConditions, workspaceCondition)
+			} else {
+				// Didn't observe this condition this time; set status to unknown
+				workspaceCondition.LastTransitionTime = currTransitionTime
+				workspaceCondition.Status = corev1.ConditionUnknown
+				workspaceCondition.Message = ""
+				workspaceCondition.Reason = ""
+				newConditions = append(newConditions, workspaceCondition)
+			}
 		} else {
 			// Update condition if needed
 			if workspaceCondition.Status != currCondition.Status || workspaceCondition.Message != currCondition.Message || workspaceCondition.Reason != currCondition.Reason {


### PR DESCRIPTION
### What does this PR do?
Fix an issue where DWO always attempts to update conditions with status 'Unknown' to have a current timestamp. This can trigger an issue in when the workqueue is longer than 1s long, as each reconcile updates timestamps, triggering another reconcile.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1095

### Is it tested? How?
Test using reproducer on issue.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
