### PR TITLE
Ensure order of git credentials in merged git-credentials secret

### DIFF
--- a/pkg/provision/automount/common.go
+++ b/pkg/provision/automount/common.go
@@ -18,6 +18,7 @@ package automount
 import (
 	"fmt"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -334,4 +335,16 @@ func dropItemsFieldFromVolumes(volumes []corev1.Volume) {
 			volumes[idx].Secret.Items = nil
 		}
 	}
+}
+
+func sortSecrets(secrets []corev1.Secret) {
+	sort.Slice(secrets, func(i, j int) bool {
+		return secrets[i].Name < secrets[j].Name
+	})
+}
+
+func sortConfigmaps(cms []corev1.ConfigMap) {
+	sort.Slice(cms, func(i, j int) bool {
+		return cms[i].Name < cms[j].Name
+	})
 }

--- a/pkg/provision/automount/gitconfig.go
+++ b/pkg/provision/automount/gitconfig.go
@@ -85,6 +85,7 @@ func getGitResources(api sync.ClusterAPI, namespace string) (credentialSecrets [
 	if len(secretList.Items) > 0 {
 		secrets = secretList.Items
 	}
+	sortSecrets(secrets)
 
 	configmapList := &corev1.ConfigMapList{}
 	if err := api.Client.List(api.Ctx, configmapList, k8sclient.InNamespace(namespace), tlsLabelSelector); err != nil {
@@ -94,6 +95,7 @@ func getGitResources(api sync.ClusterAPI, namespace string) (credentialSecrets [
 	if len(configmapList.Items) > 0 {
 		configmaps = configmapList.Items
 	}
+	sortConfigmaps(configmaps)
 
 	return secrets, configmaps, nil
 }

--- a/pkg/provision/sync/sync.go
+++ b/pkg/provision/sync/sync.go
@@ -200,17 +200,19 @@ func printDiff(specObj, clusterObj crclient.Object, log logr.Logger) {
 			diffOpts = podDiffOpts
 		case *corev1.ConfigMap:
 			diffOpts = configmapDiffOpts
-		case *corev1.Secret:
-			diffOpts = secretDiffOpts
 		case *v1alpha1.DevWorkspaceRouting:
 			diffOpts = routingDiffOpts
 		case *networkingv1.Ingress:
 			diffOpts = ingressDiffOpts
 		case *routev1.Route:
 			diffOpts = routeDiffOpts
+		case *corev1.Secret:
+			log.Info(fmt.Sprintf("Diff: secret %s data upated", specObj.GetName()))
+			return
 		default:
 			diffOpts = nil
 		}
+
 		log.Info(fmt.Sprintf("Diff: %s", cmp.Diff(specObj, clusterObj, diffOpts)))
 	}
 }


### PR DESCRIPTION
### What does this PR do?
In some cases, we've seen the DevWorkspace Operator perform unnecessary changes to the devworkspace-merged-git-credentials secret when multiple credentials secrets are used. This appears to be due to varying order of secrets when listing from the controller cache.

To work around this, we sort git credentials secrets (and git tls configmaps) by name, first, so that objects should always be in a defined order.

### What issues does this PR fix or reference?
N/A 

### Is it tested? How?
Hard to test as issue arises inconsistently.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
