### PR TITLE
Don't fail workspaces that use Kubernetes/OpenShift components with URIs

### DIFF
--- a/pkg/library/kubernetes/testdata/provision_tests/error-if-object-not-inlined.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/error-if-object-not-inlined.yaml
@@ -25,4 +25,4 @@ input:
               targetPort: 8081
 
 output:
-  errRegexp: "components that define a URI are unsupported"
+  errRegexp: "Ignored components that use unsupported features"

--- a/webhook/workspace/handler/kubernetes.go
+++ b/webhook/workspace/handler/kubernetes.go
@@ -42,7 +42,8 @@ func (h *WebhookHandler) validateKubernetesObjectPermissionsOnCreate(ctx context
 			continue
 		}
 		if component.Uri != "" {
-			return fmt.Errorf("kubenetes components specified via URI are unsupported")
+			// We're going to ignore URI components for now
+			continue
 		}
 		if component.Inlined == "" {
 			return fmt.Errorf("kubernetes component does not define inlined content")
@@ -66,7 +67,8 @@ func (h *WebhookHandler) validateKubernetesObjectPermissionsOnUpdate(ctx context
 		}
 
 		if newComponent.Uri != "" {
-			return fmt.Errorf("kubenetes components specified via URI are unsupported")
+			// We're going to ignore URI components for now
+			continue
 		}
 		if newComponent.Inlined == "" {
 			return fmt.Errorf("kubernetes component does not define inlined content")


### PR DESCRIPTION
### What does this PR do?
Update how Kubernetes/OpenShift components with URIs are handled:

* If a component has `deployByDefault: false`, it is ignored and workspace starts normally (the component is expected to be applied later, e.g. via an apply command
* If a component has `deployByDefault: true`, it is _not_ applied to the cluster if it uses a URI, and instead the workspace gets a warning condition. This effectively downgrades the webhook rejection to a warning condition

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1103

### Is it tested? How?
Apply the DevWorkspace 
```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: plain
spec:
  routingClass: basic
  started: true
  template:
    attributes:
      controller.devfile.io/storage-type: ephemeral
    components:
    - name: web-terminal
      container:
        command: ["tail", "-f", "/dev/null"]
        image: quay.io/amisevsk/web-terminal-tooling:dev
        memoryLimit: 512Mi
        mountSources: true
    - name: test-k8s
      kubernetes: 
        deployByDefault: false
        uri: https://raw.githubusercontent.com/devfile/devworkspace-operator/main/deploy/deployment/kubernetes/objects/devworkspace-controller-metrics.Service.yaml
```

Update the workspace to set `deployByDefault`:
* If false, workspace should start normally, without any issues or warnings
* If true, the workspace should still start, but have a warning condition:
    > Ignored components that use unsupported features: component test-k8s
    > defines a Kubernetes/OpenShift component via URI


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
