### PR TITLE
[backport-0.21.x] Don't fail workspaces if they have kube components that use URI

### DIFF
--- a/pkg/library/kubernetes/testdata/provision_tests/error-if-object-not-inlined.yaml
+++ b/pkg/library/kubernetes/testdata/provision_tests/error-if-object-not-inlined.yaml
@@ -25,4 +25,4 @@ input:
               targetPort: 8081
 
 output:
-  errRegexp: "components that define a URI are unsupported"
+  errRegexp: "Ignored components that use unsupported features"


### PR DESCRIPTION
### What does this PR do?
Backport PR https://github.com/devfile/devworkspace-operator/pull/1104 to 0.21.x branch for inclusion in 0.21.0 release.

### What issues does this PR fix or reference?
#1103 in 0.21

### Is it tested? How?
See original PR

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
