### PR TITLE
Add a Devfile and a tooling container Dockerfile

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -1,0 +1,39 @@
+schemaVersion: 2.2.0
+metadata:
+  name: devworkspace-operator
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/devworkspace-devtools:latest
+      memoryRequest: 1Gi
+      memoryLimit: 16Gi
+      cpuLimit: '4'
+      cpuRequest: '0.5'
+commands:
+  - id: build-and-push-controller
+    exec:
+      label: "1. Build and push DWO controller image"
+      component: tools
+      commandLine: |
+        read -p "ENTER a container registry org to push the devworkspace-controller image (e.g. quay.io/janedoe): " DWO_IMG_REPO &&
+        read -p "ENTER the tag for the image (e.g. dev): " DWO_IMG_TAG &&
+        export DWO_IMG=${DWO_IMG_REPO}/devworkspace-controller:${DWO_IMG_TAG} &&
+        export DOCKER=podman &&
+        make docker
+      group:
+        kind: build
+  - id: make-olm-bundle-index-catalogsource
+    exec:
+      label: "2. Build and push OLM bundle, index image and create a CatalogueSource"
+      component: tools
+      commandLine: |
+        [[ "$(oc whoami)" =~ ^kube:admin$ ]] || (echo "You need to login as kubeadmin" && false) &&
+        read -p "ENTER a container registry org to push the devworkspace images (e.g. quay.io/janedoe): " DWO_IMG_REPO &&
+        read -p "ENTER a tag for the image (e.g. dev): " DWO_IMG_TAG &&
+        export DWO_BUNDLE_IMG=${DWO_IMG_REPO}/devworkspace-operator-bundle:${DWO_IMG_TAG} &&
+        export DWO_INDEX_IMG=${DWO_IMG_REPO}/devworkspace-operator-index:${DWO_IMG_TAG} &&
+        export DEFAULT_DWO_IMG=${DWO_IMG_REPO}/devworkspace-controller:${DWO_IMG_TAG} &&
+        export DOCKER=podman &&
+        make generate_olm_bundle_yaml build_bundle_and_index register_catalogsource
+      group:
+        kind: build

--- a/.github/workflows/devtools-image-build.yml
+++ b/.github/workflows/devtools-image-build.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (c) 2019-2023 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Devtools container build
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  
+  build-devtools-img:
+
+    runs-on: ubuntu-20.04
+
+    outputs:
+      git-sha: ${{ steps.git-sha.outputs.sha }}
+
+    steps:
+      - name: Checkout devworkspace-operator source code
+        uses: actions/checkout@v3
+
+      - name: Set output for Git short SHA
+        id: git-sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Login to quay.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push devworkspace-devtools image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            quay.io/devfile/devworkspace-devtools:latest
+            quay.io/devfile/devworkspace-devtools:sha-${{ steps.git-sha.outputs.sha }}
+          file: ./build/devtools.Dockerfile

--- a/build/devtools.Dockerfile
+++ b/build/devtools.Dockerfile
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2019-2023 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM quay.io/devfile/universal-developer-image:latest
+
+USER root
+
+# Install gettext
+RUN dnf install -y gettext
+
+# Install the Operator SDK
+ENV OPERATOR_SDK_VERSION="v1.8.0"
+ENV OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}
+RUN curl -sSLO ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_amd64 && \
+    gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E && \
+    curl -sSLO ${OPERATOR_SDK_DL_URL}/checksums.txt && \
+    curl -sSLO ${OPERATOR_SDK_DL_URL}/checksums.txt.asc && \
+    gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify checksums.txt.asc && \
+    grep operator-sdk_linux_amd64 checksums.txt | sha256sum -c - && \
+    chmod +x operator-sdk_linux_amd64 && \
+    mv operator-sdk_linux_amd64 /usr/local/bin/operator-sdk && \
+    rm checksums.txt checksums.txt.asc
+
+# Install opm CLI
+ENV OPM_VERSION="v1.19.5"
+RUN curl -sSLO https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm && \
+    chmod +x linux-amd64-opm && \
+    mv linux-amd64-opm /usr/local/bin/opm
+
+USER 1001


### PR DESCRIPTION
### What does this PR do?

It adds a Devfile (plus the tooling container Dockerfile and the GH to build it) that has a couple of commands to:
- build the controller (`make docker`)
- build the bundle, the index and create the catalogue source (`make generate_olm_bundle_yaml build_bundle_and_index register_catalogsource`)

 <img width="1975" alt="image" src="https://github.com/devfile/devworkspace-operator/assets/606959/16a3ff37-8d5e-4611-aec2-9bbaccf520db">

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

It can be tested [on dogfooding instance](https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://gist.githubusercontent.com/l0rd/c04c76f577a820089626c9a59e3b3785/raw/71261b0d47f08aa2095eebd3febed70bee95a177/devfile-dwo.yaml)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
