### PR TITLE
Add makefile rule for regenerating all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ test_e2e_debug:
 manager: generate fmt vet
 	go build -o bin/manager main.go
 
+### generate_all: regenerate all resources for operator (CRDs, manifests, bundle, etc.)
+generate_all: generate manifests generate_default_deployment generate_olm_bundle_yaml
+
 ### generate_deployment: Generates the files used for deployment from kustomize templates, using environment variables
 generate_deployment:
 	deploy/generate-deployment.sh

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ make disconnect-debug-webhook-server
 
 ```bash
 make update_devworkspace_api update_devworkspace_crds # first commit
-make generate manifests fmt generate_default_deployment generate_olm_bundle_yaml # second commit
+make generate_all # second commit
 ```
 Example of the devfile API update [PR](https://github.com/devfile/devworkspace-operator/pull/797)
 

--- a/make-release.sh
+++ b/make-release.sh
@@ -112,7 +112,7 @@ update_version() {
     --arg version "$VERSION_CSV" \
     '.metadata.name = $operator_name | .spec.version = $version' deploy/templates/components/csv/clusterserviceversion.yaml
 
-  make generate manifests fmt generate_default_deployment generate_olm_bundle_yaml
+  make generate_all
 }
 
 # Updates container images and tags used in deployment templates for a release version
@@ -144,7 +144,7 @@ update_images() {
 
   export DEFAULT_DWO_IMG
   export PROJECT_CLONE_IMG
-  make generate manifests fmt generate_default_deployment generate_olm_bundle_yaml
+  make generate_all
 }
 
 # Build and push images for specified release version. Respects the DRY_RUN flag


### PR DESCRIPTION
### What does this PR do?
Add `make generate_all` to make it easier to regenerate files in the repository. The rule is the equivalent of

    make generate manifests generate_default_deployment generate_olm_bundle_yaml

### What issues does this PR fix or reference?
N/A; convenience. Originally brought up in PR https://github.com/devfile/devworkspace-operator/pull/1111#issuecomment-1566853021

### Is it tested? How?
Run `make generate_all` and verify that all files are regenerated.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
