### PR TITLE
Update image used for PVC cleanup job by default

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -368,7 +368,7 @@ spec:
                 - name: WEBHOOKS_SERVER_CPU_REQUEST
                   value: 100m
                 - name: RELATED_IMAGE_pvc_cleanup_job
-                  value: registry.access.redhat.com/ubi8-micro:8.4-81
+                  value: registry.access.redhat.com/ubi8-micro:8.8-1
                 - name: RELATED_IMAGE_async_storage_server
                   value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
                 - name: RELATED_IMAGE_async_storage_sidecar
@@ -485,7 +485,7 @@ spec:
     name: kube_rbac_proxy
   - image: quay.io/devfile/project-clone:next
     name: project_clone
-  - image: registry.access.redhat.com/ubi8-micro:8.4-81
+  - image: registry.access.redhat.com/ubi8-micro:8.8-1
     name: pvc_cleanup_job
   - image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
     name: async_storage_server

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -24520,7 +24520,7 @@ spec:
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: registry.access.redhat.com/ubi8-micro:8.4-81
+          value: registry.access.redhat.com/ubi8-micro:8.8-1
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: registry.access.redhat.com/ubi8-micro:8.4-81
+          value: registry.access.redhat.com/ubi8-micro:8.8-1
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -24522,7 +24522,7 @@ spec:
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: registry.access.redhat.com/ubi8-micro:8.4-81
+          value: registry.access.redhat.com/ubi8-micro:8.8-1
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: registry.access.redhat.com/ubi8-micro:8.4-81
+          value: registry.access.redhat.com/ubi8-micro:8.8-1
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -103,7 +103,7 @@ spec:
       name: kube_rbac_proxy
     - image: quay.io/devfile/project-clone:next
       name: project_clone
-    - image: registry.access.redhat.com/ubi8-micro:8.4-81
+    - image: registry.access.redhat.com/ubi8-micro:8.8-1
       name: pvc_cleanup_job
     - image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
       name: async_storage_server

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -85,7 +85,7 @@ spec:
             - name: RELATED_IMAGE_devworkspace_webhook_server
               value: "quay.io/devfile/devworkspace-controller:next"
             - name: RELATED_IMAGE_pvc_cleanup_job
-              value: "registry.access.redhat.com/ubi8-micro:8.4-81"
+              value: "registry.access.redhat.com/ubi8-micro:8.8-1"
             - name: RELATED_IMAGE_async_storage_server
               value: "quay.io/eclipse/che-workspace-data-sync-storage:0.0.1"
             - name: RELATED_IMAGE_async_storage_sidecar


### PR DESCRIPTION
### What does this PR do?
Updates the image used for the PVC cleanup job to a newer version of ubi8-micro

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
PVC cleanup should be unaffected.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
