### PR TITLE
Don't use go-git to list remote branches to avoid a certificates issue

### DIFF
--- a/samples/git-clone-sample.yaml
+++ b/samples/git-clone-sample.yaml
@@ -13,8 +13,8 @@ spec:
       - name: devworkspace-operator
         git:
           checkoutFrom:
-            remote: amisevsk
-            revision: clone-projects-on-start
+            remote: origin
+            revision: 0.21.x
           remotes:
             origin: "https://github.com/devfile/devworkspace-operator.git"
             amisevsk: "https://github.com/amisevsk/devworkspace-operator.git"


### PR DESCRIPTION
### What does this PR do?
Update project-clone to use `git` for determining whether a project's `checkoutFrom.revision` is a remote/local branch, tag, or hash instead of relying on go-git. 

This avoids issues where e.g. a git repository is behind a self-signed cert, where it is not easy to configure additional CA bundles for use in go-git. 

### What issues does this PR fix or reference?
Closes #1114 

### Is it tested? How?
Changes are pushed to image `quay.io/amisevsk/project-clone:dev`

To test this image with DWO:
* On Kubernetes, update the controller deployment to set the `RELATED_IMAGE_project_clone` environment variable to `quay.io/amisevsk/project-clone:dev`
* On OpenShift (installed via Operator), update the DevWorkspace Operator CSV to set the `RELATED_IMAGE_project_clone` environment variable to `quay.io/amisevsk/project-clone:dev`. Can be reset by using the value from the CSV's `relatedImages` field. 

To test that basic functionality is not changed, you can use the following devworkspace:
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: git-clone-sample-devworkspace
spec:
  started: true
  template:
    attributes:
      controller.devfile.io/storage-type: ephemeral
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
      - name: devworkspace-operator
        git:
          checkoutFrom:
            remote: origin
            revision: 0.21.x
          remotes:
            origin: "https://github.com/devfile/devworkspace-operator.git"
            amisevsk: "https://github.com/amisevsk/devworkspace-operator.git"
      - name: devworkspace-operator-tag
        git:
          checkoutFrom:
            remote: amisevsk
            revision: v0.21.0
          remotes:
            origin: "https://github.com/devfile/devworkspace-operator.git"
            amisevsk: "https://github.com/amisevsk/devworkspace-operator.git"
      - name: devworkspace-operator-hash
        git:
          checkoutFrom:
            remote: amisevsk
            revision: e17b2754
          remotes:
            origin: "https://github.com/devfile/devworkspace-operator.git"
            amisevsk: "https://github.com/amisevsk/devworkspace-operator.git"
  contributions:
    - name: che-code
      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
      components:
        - name: che-code-runtime-description
          container:
            env:
              - name: CODE_HOST
                value: 0.0.0.0
```
(There are likely additional edge cases worth testing)

To test that #1114 is resolved, specify a project that refers to a repository with self-signed certificates.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
