### PR TITLE
Write output of shell commands to log file in project-clone; clone all projects even if error

### DIFF
--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -183,8 +183,8 @@ func GitResolveReference(projectPath, remote, revision string) (GitRefType, erro
 
 func executeCommand(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
+	cmd.Stderr = log.Writer()
+	cmd.Stdout = log.Writer()
 	return cmd.Run()
 }
 

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -59,6 +59,7 @@ func main() {
 		log.Printf("Failed to read current DevWorkspace: %s", err)
 		os.Exit(1)
 	}
+	encounteredError := false
 	for _, project := range workspace.Projects {
 		log.Printf("Processing project %s", project.Name)
 		var err error
@@ -74,9 +75,11 @@ func main() {
 		}
 		if err != nil {
 			log.Printf("Encountered error while setting up project %s: %s", project.Name, err)
-			copyLogFileToProjectsRoot()
-			os.Exit(0)
+			encounteredError = true
 		}
+	}
+	if encounteredError {
+		copyLogFileToProjectsRoot()
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Ensure that any output (stdout, stderr) from shell commands run by project clone also get stored in the temp log file. This allows viewing more information on errors when an issue causes project clone to fail to set up projects correctly.

Previously, only logs from the main project clone process were saved and copied into the $PROJECTS_ROOT directory, meaning logs coming from e.g. git itself only appeared in pod logs, not in the file copied into /projects.

Additionally, this PR makes project-clone continue attempting to set up projects even after one project fails.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1122
Closes https://github.com/devfile/devworkspace-operator/issues/1101

### Is it tested? How?
Changes from this PR are pushed to `quay.io/amisevsk/project-clone:dev`

To test, you can use the following DevWorkspace and DevWorkspaceOperatorConfig

<details>
  <summary>DevWorkspaceOperatorConfig.yaml (click to expand) </summary>
  
```yaml
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
config:
  workspace:
    projectClone: 
      image: quay.io/amisevsk/project-clone:dev
```

</details>

<details>
  <summary>DevWorkspace.yaml (click to expand) </summary>
  
```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: plain
spec:
  routingClass: basic
  started: true
  template:
    attributes:
      controller.devfile.io/storage-type: ephemeral
      controller.devfile.io/devworkspace-config:
        name: devworkspace-operator-config
        namespace: <NAMESPACE_OF_DWOC>   # Set this to the namespace of the DWOC created above
    projects:
    - name: 1-devworkspace-operator-default
      git:
        remotes:
          origin: https://github.com/devfile/devworkspace-operator.git
    - name: 2-devworkspace-operator-tag
      git:
        remotes:
          origin: https://github.com/devfile/devworkspace-operator.git
        checkoutFrom:
          revision: v0.11.0
    - name: 3-devworkspace-operator-branch
      git:
        remotes:
          origin: https://github.com/devfile/devworkspace-operator.git
        checkoutFrom:
          revision: 0.11.x
    - name: non-exist
      git:
        remotes:
          origin: https://github.com/devfile/devworkspace-operator-non-exist.git
    - name: 4-devworkspace-operator-branch-with-remote
      git:
        remotes:
          origin: https://github.com/devfile/devworkspace-operator.git
          amisevsk: https://github.com/amisevsk/devworkspace-operator.git
        checkoutFrom:
          revision: 0.11.x
          remote: amisevsk
    - name: 5-devworkspace-operator-hash
      git:
        remotes:
          origin: https://github.com/devfile/devworkspace-operator.git
        checkoutFrom:
          revision: cbd808f5d13bb87dd8597e7e1312c72e11ab080f
    components:
    - container:
        command:
        - tail
        - -f
        - /dev/null
        image: quay.io/amisevsk/web-terminal-tooling:dev
        memoryLimit: 512Mi
        mountSources: true
        sourceMapping: /projects
      name: web-terminal
```

</details>

The workspace, once started, should 
* Contain output of `git` operations in `/projects/project-clone-errors.log` (i.e. this file should match the logs of the project-clone init container)
    * This verifies that https://github.com/devfile/devworkspace-operator/issues/1122 is resolved
* `/projects` should contain directories similar to
    ```
    1-devworkspace-operator-default/
    2-devworkspace-operator-tag/
    3-devworkspace-operator-branch/
    4-devworkspace-operator-branch-with-remote/
    5-devworkspace-operator-hash/
    project-clone-errors.log
    ```
    i.e. regular projects should all be cloned, instead of just projects numbered 1-3
    * This verifies that https://github.com/devfile/devworkspace-operator/issues/1101 is resolved


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
