### PR TITLE
Add basis for future automated functional/regression tests of project-clone container

### DIFF
--- a/project-clone/test/project-clone-test-basic.devworkspace.yaml
+++ b/project-clone/test/project-clone-test-basic.devworkspace.yaml
@@ -1,0 +1,74 @@
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspace
+metadata:
+  name: project-clone-test-basic
+  labels:
+    app.kubernetes.io/name: devworkspace-project-clone-tests
+    app.kubernetes.io/part-of: devworkspace-operator
+  annotations:
+    controller.devfile.io/debug-start: "true"
+spec:
+  started: true
+  routingClass: 'basic'
+  template:
+    attributes:
+      controller.devfile.io/storage-type: ephemeral
+    variables:
+          test_runner_image: quay.io/devfile/project-clone:next # Requires git, bash
+          main_repo: https://github.com/devfile/devworkspace-operator.git
+          default_branch_name: main
+    projects:
+      - name: test-project
+        git:
+          remotes:
+            main-origin: "{{main_repo}}"
+          checkoutFrom:
+            revision: "{{default_branch_name}}"
+    components:
+      - name: test-project-clone
+        container:
+          image: "{{test_runner_image}}"
+          memoryLimit: 512Mi
+          mountSources: true
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -e
+
+              fail() {
+                echo "[ERROR] $1"
+                echo "[ERROR] See project-clone logs: "
+                echo "[ERROR]    oc logs -n $DEVWORKSPACE_NAMESPACE deploy/$DEVWORKSPACE_ID -c project-clone"
+                exit 1
+              }
+
+              if [ -f "${PROJECTS_ROOT}/project-clone-errors.log" ]; then
+                echo "==== BEGIN PROJECT CLONE LOGS ===="
+                sed 's/^/    /g' "${PROJECTS_ROOT}/project-clone-errors.log"
+                echo "====  END PROJECT CLONE LOGS  ===="
+                echo -e "\n\n"
+              fi
+
+              if [ ! -d "${PROJECTS_ROOT}/${project_dir}" ]; then
+                fail "Project $project_dir not cloned successfully"
+              fi
+
+              echo "Testing default project set up"
+              cd ${PROJECTS_ROOT}/test-project
+              branch_name=$(git rev-parse --abbrev-ref HEAD)
+              if [ "$branch_name" != "{{default_branch_name}}" ]; then
+                fail "Project does not have default branch checked out"
+              fi
+              tracking_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+              if [ "$tracking_branch" != "main-origin/{{default_branch_name}}" ]; then
+                fail "Default project's branch does not track remote branch"
+              fi
+              remote_url=$(git config remote.main-origin.url)
+              if [ "$remote_url" != "{{main_repo}}" ]; then
+                fail "Remote 'main-origin' not configured"
+              fi
+              echo "Project is on $branch_name, tracking $tracking_branch, with remotes configured"
+
+              echo "Test succeeded. Sleeping indefinitely"
+              tail -f /dev/null

--- a/project-clone/test/project-clone-test.devworkspace.yaml
+++ b/project-clone/test/project-clone-test.devworkspace.yaml
@@ -1,0 +1,154 @@
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspace
+metadata:
+  name: project-clone-test
+  labels:
+    app.kubernetes.io/name: devworkspace-project-clone-tests
+    app.kubernetes.io/part-of: devworkspace-operator
+  annotations:
+    controller.devfile.io/debug-start: "true"
+spec:
+  started: true
+  routingClass: 'basic'
+  template:
+    attributes:
+      controller.devfile.io/storage-type: ephemeral
+    variables:
+      test_runner_image: quay.io/devfile/project-clone:next # Requires git, bash
+      main_repo: https://github.com/devfile/devworkspace-operator.git
+      fork_repo: https://github.com/amisevsk/devworkspace-operator.git
+      checkout_branch: 0.21.x
+      checkout_tag: v0.21.0
+      checkout_hash: e17b2754
+      default_branch_name: main
+    projects:
+      - name: default-project-setup
+        git:
+          remotes:
+            main-origin: "{{main_repo}}"
+      - name: test-checkout-branch
+        git:
+          checkoutFrom:
+            remote: origin
+            revision: "{{checkout_branch}}"
+          remotes:
+            origin: "{{main_repo}}"
+            fork: "{{fork_repo}}"
+      - name: test-checkout-tag
+        git:
+          checkoutFrom:
+            remote: fork
+            revision: "{{checkout_tag}}"
+          remotes:
+            origin: "{{main_repo}}"
+            fork: "{{fork_repo}}"
+      - name: test-checkout-hash
+        git:
+          checkoutFrom:
+            remote: fork
+            revision: "{{checkout_hash}}"
+          remotes:
+            origin: "{{main_repo}}"
+            fork: "{{fork_repo}}"
+    components:
+      - name: test-project-clone
+        container:
+          image: "{{test_runner_image}}"
+          memoryLimit: 512Mi
+          mountSources: true
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -e
+
+              fail() {
+                echo "[ERROR] $1"
+                echo "[ERROR] See project-clone logs: "
+                echo "[ERROR]    oc logs -n $DEVWORKSPACE_NAMESPACE deploy/$DEVWORKSPACE_ID -c project-clone"
+                exit 1
+              }
+
+              if [ -f "${PROJECTS_ROOT}/project-clone-errors.log" ]; then
+                echo "==== BEGIN PROJECT CLONE LOGS ===="
+                sed 's/^/    /g' "${PROJECTS_ROOT}/project-clone-errors.log"
+                echo "====  END PROJECT CLONE LOGS  ===="
+                echo -e "\n\n"
+              fi
+
+              for project_dir in "default-project-setup" "test-checkout-branch" "test-checkout-tag" "test-checkout-hash"; do
+                if [ ! -d "${PROJECTS_ROOT}/${project_dir}" ]; then
+                  fail "Project $project_dir not cloned successfully"
+                fi
+              done
+
+              echo "Testing default project set up"
+              cd "${PROJECTS_ROOT}/default-project-setup"
+              branch_name=$(git rev-parse --abbrev-ref HEAD)
+              if [ "$branch_name" != "{{default_branch_name}}" ]; then
+                fail "Project does not have default branch checked out"
+              fi
+              tracking_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+              if [ "$tracking_branch" != "main-origin/{{default_branch_name}}" ]; then
+                fail "Default project's branch does not track remote branch"
+              fi
+              remote_url=$(git config remote.main-origin.url)
+              if [ "$remote_url" != "{{main_repo}}" ]; then
+                fail "Remote 'main-origin' not configured"
+              fi
+              echo "Project is on $branch_name, tracking $tracking_branch, with remotes configured"
+
+              echo "Testing branch checkout project set up"
+              cd "${PROJECTS_ROOT}/test-checkout-branch"
+              branch_name=$(git rev-parse --abbrev-ref HEAD)
+              if [ "$branch_name" != "{{checkout_branch}}" ]; then
+                fail "Project does not have {{checkout_branch}} branch checked out"
+              fi
+              tracking_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+              if [ "$tracking_branch" != "origin/{{checkout_branch}}" ]; then
+                fail "Checked out branch does not track remote branch origin/{{checkout_branch}}"
+              fi
+              remote_url=$(git config remote.origin.url)
+              if [ "$remote_url" != "{{main_repo}}" ]; then
+                fail "Remote 'origin' not configured"
+              fi
+              remote_url=$(git config remote.fork.url)
+              if [ "$remote_url" != "{{fork_repo}}" ]; then
+                fail "Remote 'fork' not configured"
+              fi
+              echo "Project is on $branch_name, tracking $tracking_branch, with remotes configured"
+
+              echo "Testing tag checkout project set up"
+              cd "${PROJECTS_ROOT}/test-checkout-tag"
+              tag_name=$(git describe --tags)
+              if [ "$tag_name" != "{{checkout_tag}}" ]; then
+                fail "Project does not have tag {{checkout_tag}} checked out"
+              fi
+              remote_url=$(git config remote.origin.url)
+              if [ "$remote_url" != "{{main_repo}}" ]; then
+                fail "Remote 'origin' not configured"
+              fi
+              remote_url=$(git config remote.fork.url)
+              if [ "$remote_url" != "{{fork_repo}}" ]; then
+                fail "Remote 'fork' not configured"
+              fi
+              echo "Project is on tag $tag_name, with remotes configured"
+
+              echo "Testing hash checkout project set up"
+              cd "${PROJECTS_ROOT}/test-checkout-hash"
+              commit_hash=$(git rev-parse HEAD)
+              if [[ "$commit_hash" == "{{checkout_hash}}"* ]]; then
+                fail "Current HEAD is not at {{checkout_hash}}"
+              fi
+              remote_url=$(git config remote.origin.url)
+              if [ "$remote_url" != "{{main_repo}}" ]; then
+                fail "Remote 'origin' not configured"
+              fi
+              remote_url=$(git config remote.fork.url)
+              if [ "$remote_url" != "{{fork_repo}}" ]; then
+                fail "Remote 'fork' not configured"
+              fi
+              echo "Project is on commit $commit_hash, with remotes configured"
+
+              echo "[SUCCESS] Test succeeded. Sleeping indefinitely"
+              tail -f /dev/null


### PR DESCRIPTION
### What does this PR do?
In verifying PR https://github.com/devfile/devworkspace-operator/pull/1115, I worked on a semi-automatic regression test for project-clone functionality to ensure the PR wasn't breaking existing behavior. I figured it's worth adding this to the repository so that it's not lost to time.

This PR adds sample DevWorkspaces to `project-clone/test/` that tests project clone functionality at a basic level: they verify that projects can be cloned, and that branches, tags, and revisions can be correctly checked out from both the origin and a fork of the repository. If any project is not set up as expected, the workspace enters a failed state (potentially after a few restarts), indicating that there is a problem. If the "test" "succeeds", the workspace enters and stays in a running state. Logs for a successful test look like 
```
Defaulted container "test-project-clone" out of: test-project-clone, project-clone (init)
Testing default project set up
Project is on main, tracking main-origin/main, with remotes configured
Testing branch checkout project set up
Project is on 0.21.x, tracking origin/0.21.x, with remotes configured
Testing tag checkout project set up
Project is on tag v0.21.0, with remotes configured
Testing hash checkout project set up
Project is on commit 79ed3e1ef80da390f7793777c658ecbd13260adc, with remotes configured
[SUCCESS] Test succeeded. Sleeping indefinitely
```

The workspace makes use of devfile variables to enable configuration of the key elements being tested (main repo, fork repo, branch, tag, revision) so that it can more easily be adapted in the future (though it is harder to read as a result)

The `project-clone-test-basic.devworkspace.yaml` file is a simpler, more basic test of the functionality above -- it just verifies that we can successfully clone a project from a repository. It was useful for testing that https://github.com/devfile/devworkspace-operator/issues/1114 was resolved (where the self-signed certificates repo I used to test did not have a fork, branches, tags, etc.)

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Tests can be run by applying these DevWorkspaces to any cluster where DWO is installed.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
