### PR TITLE
Fix next build github action not including bundle in channel

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -175,6 +175,7 @@ jobs:
             --bundle-tag ${DWO_BUNDLE_TAG} \
             --index-image ${DWO_INDEX_IMG} \
             --container-tool docker \
+            --debug \
             --force
 
           ## Build digests bundle from next bundle and build digests catalog from that
@@ -189,3 +190,6 @@ jobs:
           cp ./olm-catalog/next/{channel,package}.yaml ./olm-catalog/next-digest
           docker build . -t ${DWO_DIGEST_INDEX_IMG} -f build/index.next-digest.Dockerfile
           docker push ${DWO_DIGEST_INDEX_IMG}
+
+          git restore "$OUTDIR"
+          git clean -fd "$OUTDIR"

--- a/build/scripts/build_digests_bundle.sh
+++ b/build/scripts/build_digests_bundle.sh
@@ -137,7 +137,7 @@ info "Resolved image $NEW_BUNDLE_DIGEST from $PUSH_IMAGE"
 info "Rendering $NEW_BUNDLE_DIGEST to $RENDER"
 BUNDLE_YAML=$(opm render "$NEW_BUNDLE_DIGEST" --output yaml | sed '/---/d')
 BUNDLE_NAME="$(echo "$BUNDLE_YAML" | yq -r ".name")"
-BUNDLE_FILE="${RENDER}/${BUNDLE_NAME}.bundle.yaml"
+BUNDLE_FILE=$(readlink -m "${RENDER}/${BUNDLE_NAME}.bundle.yaml")
 if [ -f "$BUNDLE_FILE" ]; then
   error "Bundle file $BUNDLE_FILE already exists"
 fi


### PR DESCRIPTION
### What does this PR do?
Fix failing next-build GH action. `build_index_image.sh` by default cleans up changes, meaning the channel copied in the action does not include an entry for the `next` bundle.

This PR is a follow-up to https://github.com/devfile/devworkspace-operator/pull/1120

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
