### PR TITLE
[WIP] Don't set default project-clone CPU limit unless we have to

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -116,6 +116,13 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - limitranges
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - pods/exec
           verbs:
           - create
@@ -342,7 +349,7 @@ spec:
                 - name: RELATED_IMAGE_kube_rbac_proxy
                   value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
                 - name: RELATED_IMAGE_project_clone
-                  value: quay.io/devfile/project-clone:next
+                  value: quay.io/amisevsk/project-clone:dev
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -483,7 +490,7 @@ spec:
     name: devworkspace_webhook_server
   - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
     name: kube_rbac_proxy
-  - image: quay.io/devfile/project-clone:next
+  - image: quay.io/amisevsk/project-clone:dev
     name: project_clone
   - image: registry.access.redhat.com/ubi8-micro:8.8-1
     name: pvc_cleanup_job

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -24164,6 +24164,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - limitranges
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods/exec
   verbs:
   - create
@@ -24508,7 +24515,7 @@ spec:
         - name: RELATED_IMAGE_kube_rbac_proxy
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
+          value: quay.io/amisevsk/project-clone:dev
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: RELATED_IMAGE_kube_rbac_proxy
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
+          value: quay.io/amisevsk/project-clone:dev
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -40,6 +40,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - limitranges
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods/exec
   verbs:
   - create

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -24164,6 +24164,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - limitranges
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods/exec
   verbs:
   - create
@@ -24510,7 +24517,7 @@ spec:
         - name: RELATED_IMAGE_kube_rbac_proxy
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
+          value: quay.io/amisevsk/project-clone:dev
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: RELATED_IMAGE_kube_rbac_proxy
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
+          value: quay.io/amisevsk/project-clone:dev
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME

--- a/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -40,6 +40,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - limitranges
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods/exec
   verbs:
   - create

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -101,7 +101,7 @@ spec:
       name: devworkspace_webhook_server
     - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
       name: kube_rbac_proxy
-    - image: quay.io/devfile/project-clone:next
+    - image: quay.io/amisevsk/project-clone:dev
       name: project_clone
     - image: registry.access.redhat.com/ubi8-micro:8.8-1
       name: pvc_cleanup_job

--- a/deploy/templates/components/rbac/role.yaml
+++ b/deploy/templates/components/rbac/role.yaml
@@ -39,6 +39,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - limitranges
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods/exec
   verbs:
   - create

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -26,6 +26,11 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+// defaultProjectCloneCPULimit CPU limit to be used for project clone when a limitrange
+// may override a container that does not set a CPU limit. By default, the project clone
+// container does not get a CPU limit.
+var defaultProjectCloneCPULimit = resource.MustParse("1000m")
+
 // defaultConfig represents the default configuration for the DevWorkspace Operator.
 var defaultConfig = &v1alpha1.OperatorConfiguration{
 	Routing: &v1alpha1.RoutingConfig{
@@ -56,7 +61,7 @@ var defaultConfig = &v1alpha1.OperatorConfiguration{
 			Resources: &corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
-					corev1.ResourceCPU:    resource.MustParse("1000m"),
+					corev1.ResourceCPU:    defaultProjectCloneCPULimit,
 				},
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("128Mi"),


### PR DESCRIPTION
### What does this PR do?
This PR changes how the default project-clone CPU limit is handled: if the configured value for the project-clone CPU limit is a) the default value (`1000m`) and b) there are no limit ranges present in the workspace's namespace, we no longer set a CPU limit for project-clone.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1126
Related: https://github.com/eclipse/che/issues/22198, https://github.com/devfile/devworkspace-operator/pull/1111

### Is it tested? How?
Test:
1. By default, project-clone container does not specify a CPU limit
2. If the DWOC is configured with a non-default value (e.g. `1001m`), that value is used for the project-clone CPU limit
3. If a limitRange is created in the workspace's namespace, the default CPU limit of `1000m` is used for the project-clone container.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
