### PR TITLE
Fixup commands in next-build GH action to avoid failure.

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -191,5 +191,5 @@ jobs:
           docker build . -t ${DWO_DIGEST_INDEX_IMG} -f build/index.next-digest.Dockerfile
           docker push ${DWO_DIGEST_INDEX_IMG}
 
-          git restore "$OUTDIR"
-          git clean -fd "$OUTDIR"
+          git restore ./olm-catalog/
+          git clean -fd ./olm-catalog/


### PR DESCRIPTION
### What does this PR do?
Fix a copy-paste error in the next build GitHub action -- `$OUTDIR` is not defined in the action (and is copied accidentally from `build_index_image.sh`)

### What issues does this PR fix or reference?
next-build github action is failing (though indexes are being pushed)

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
