### PR TITLE
Only contribute to resources defined in merge target

### DIFF
--- a/pkg/library/flatten/merge.go
+++ b/pkg/library/flatten/merge.go
@@ -24,6 +24,7 @@ import (
 	"github.com/devfile/api/v2/pkg/attributes"
 	"github.com/devfile/api/v2/pkg/utils/overriding"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
+	dwResources "github.com/devfile/devworkspace-operator/pkg/library/resources"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 )
@@ -269,7 +270,7 @@ func mergeContributionsInto(mergeInto *dw.Component, contributions []dw.Componen
 	if mergeInto == nil || mergeInto.Container == nil {
 		return nil, fmt.Errorf("attempting to merge container contributions into a non-container component")
 	}
-	totalResources, err := parseResourcesFromComponent(mergeInto)
+	totalResources, err := dwResources.ParseResourcesFromComponent(mergeInto)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +294,7 @@ func mergeContributionsInto(mergeInto *dw.Component, contributions []dw.Componen
 			mergedComponentNames = append(mergedComponentNames, component.Attributes.GetString(constants.PluginSourceAttribute, nil))
 			delete(component.Attributes, constants.PluginSourceAttribute)
 		}
-		if err := addResourceRequirements(totalResources, &component); err != nil {
+		if err := dwResources.AddResourceRequirements(totalResources, &component); err != nil {
 			return nil, err
 		}
 		component.Container.MemoryLimit = ""
@@ -327,7 +328,7 @@ func mergeContributionsInto(mergeInto *dw.Component, contributions []dw.Componen
 	}
 
 	mergedComponent := mergedSpecContent.Components[0]
-	applyResourceRequirementsToComponent(mergedComponent.Container, totalResources)
+	dwResources.ApplyResourceRequirementsToComponent(mergedComponent.Container, totalResources)
 
 	if mergedComponent.Attributes == nil {
 		mergedComponent.Attributes = attributes.Attributes{}

--- a/pkg/library/flatten/testdata/container-contributions/che-code-usecase.yaml
+++ b/pkg/library/flatten/testdata/container-contributions/che-code-usecase.yaml
@@ -115,9 +115,6 @@ output:
             - name: checode
               path: /checode
           memoryLimit: 3Gi
-          memoryRequest: 256Mi
-          cpuLimit: 500m
-          cpuRequest: 30m
           env:
             - name: GOPATH
               value: /projects:/home/user/go

--- a/pkg/library/flatten/testdata/container-contributions/only-contributes-to-defined-resources.yaml
+++ b/pkg/library/flatten/testdata/container-contributions/only-contributes-to-defined-resources.yaml
@@ -1,0 +1,62 @@
+name: "Only adds contributioon resources if they are defined in merge target"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          memoryLimit: 1Gi
+          # memoryRequest is not defined
+          # cpuLimit is not defined
+          cpuRequest: 15m
+      - name: first-contribution
+        plugin:
+          uri: first-contribution.yaml
+      - name: second-contribution
+        plugin:
+          uri: second-contribution.yaml
+
+  devfileResources:
+    first-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: first-contribution
+      components:
+      - name: first-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          memoryLimit: 512Mi
+          memoryRequest: 1.5G
+          cpuLimit: "0.5"
+          # cpuRequest is not defined
+    second-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: second-contribution
+      components:
+      - name: second-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          # memoryLimit is not defined
+          # memoryRequest is not defined
+          # cpuLimit is not defined
+          cpuRequest: 100m
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "first-contribution,second-contribution"
+        container:
+          image: test-image
+          memoryLimit: 1536Mi # 1Gi + 512Mi (from first-contribution)
+          cpuRequest: 115m # 15m + 100m (from second-contributioon) 
+

--- a/pkg/library/flatten/testdata/implicit-container-contributions/che-code-usecase.yaml
+++ b/pkg/library/flatten/testdata/implicit-container-contributions/che-code-usecase.yaml
@@ -113,9 +113,6 @@ output:
             - name: checode
               path: /checode
           memoryLimit: 3Gi
-          memoryRequest: 256Mi
-          cpuLimit: 500m
-          cpuRequest: 30m
           env:
             - name: GOPATH
               value: /projects:/home/user/go

--- a/pkg/library/flatten/testdata/implicit-container-contributions/only-contributes-to-defined-resources.yaml
+++ b/pkg/library/flatten/testdata/implicit-container-contributions/only-contributes-to-defined-resources.yaml
@@ -1,0 +1,60 @@
+name: "Only adds contributioon resources if they are defined in merge target"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        container:
+          image: test-image
+          memoryLimit: 1Gi
+          # memoryRequest is not defined
+          # cpuLimit is not defined
+          cpuRequest: 15m
+      - name: first-contribution
+        plugin:
+          uri: first-contribution.yaml
+      - name: second-contribution
+        plugin:
+          uri: second-contribution.yaml
+
+  devfileResources:
+    first-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: first-contribution
+      components:
+      - name: first-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          memoryLimit: 512Mi
+          memoryRequest: 1.5G
+          cpuLimit: "0.5"
+          # cpuRequest is not defined
+    second-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: second-contribution
+      components:
+      - name: second-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          # memoryLimit is not defined
+          # memoryRequest is not defined
+          # cpuLimit is not defined
+          cpuRequest: 100m
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "first-contribution,second-contribution"
+        container:
+          image: test-image
+          memoryLimit: 1536Mi # 1Gi + 512Mi (from first-contribution)
+          cpuRequest: 115m # 15m + 100m (from second-contributioon) 
+

--- a/pkg/library/flatten/testdata/implicit-spec-contributions/che-code-usecase.yaml
+++ b/pkg/library/flatten/testdata/implicit-spec-contributions/che-code-usecase.yaml
@@ -113,9 +113,6 @@ output:
             - name: checode
               path: /checode
           memoryLimit: 3Gi
-          memoryRequest: 256Mi
-          cpuLimit: 500m
-          cpuRequest: 30m
           env:
             - name: GOPATH
               value: /projects:/home/user/go

--- a/pkg/library/flatten/testdata/implicit-spec-contributions/only-contributes-to-defined-resources.yaml
+++ b/pkg/library/flatten/testdata/implicit-spec-contributions/only-contributes-to-defined-resources.yaml
@@ -1,0 +1,59 @@
+name: "Only adds contributioon resources if they are defined in merge target"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        container:
+          image: test-image
+          memoryLimit: 1Gi
+          # memoryRequest is not defined
+          # cpuLimit is not defined
+          cpuRequest: 15m
+  contributions:
+    - name: first-contribution
+      uri: first-contribution.yaml
+    - name: second-contribution
+      uri: second-contribution.yaml
+
+  devfileResources:
+    first-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: first-contribution
+      components:
+      - name: first-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          memoryLimit: 512Mi
+          memoryRequest: 1.5G
+          cpuLimit: "0.5"
+          # cpuRequest is not defined
+    second-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: second-contribution
+      components:
+      - name: second-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          # memoryLimit is not defined
+          # memoryRequest is not defined
+          # cpuLimit is not defined
+          cpuRequest: 100m
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "first-contribution,second-contribution"
+        container:
+          image: test-image
+          memoryLimit: 1536Mi # 1Gi + 512Mi (from first-contribution)
+          cpuRequest: 115m # 15m + 100m (from second-contributioon) 
+

--- a/pkg/library/flatten/testdata/spec-contributions/che-code-usecase.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/che-code-usecase.yaml
@@ -115,9 +115,6 @@ output:
             - name: checode
               path: /checode
           memoryLimit: 3Gi
-          memoryRequest: 256Mi
-          cpuLimit: 500m
-          cpuRequest: 30m
           env:
             - name: GOPATH
               value: /projects:/home/user/go

--- a/pkg/library/flatten/testdata/spec-contributions/only-contributes-to-defined-resources.yaml
+++ b/pkg/library/flatten/testdata/spec-contributions/only-contributes-to-defined-resources.yaml
@@ -1,0 +1,61 @@
+name: "Only adds contributioon resources if they are defined in merge target"
+
+input:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merge-contribution: true
+        container:
+          image: test-image
+          memoryLimit: 1Gi
+          # memoryRequest is not defined
+          # cpuLimit is not defined
+          cpuRequest: 15m
+  contributions:
+    - name: first-contribution
+      uri: first-contribution.yaml
+    - name: second-contribution
+      uri: second-contribution.yaml
+
+  devfileResources:
+    first-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: first-contribution
+      components:
+      - name: first-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          memoryLimit: 512Mi
+          memoryRequest: 1.5G
+          cpuLimit: "0.5"
+          # cpuRequest is not defined
+    second-contribution.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: second-contribution
+      components:
+      - name: second-contribution
+        attributes:
+          controller.devfile.io/container-contribution: true
+        container:
+          image: contribution-image
+          # memoryLimit is not defined
+          # memoryRequest is not defined
+          # cpuLimit is not defined
+          cpuRequest: 100m
+
+output:
+  devworkspace:
+    components:
+      - name: test-component
+        attributes:
+          controller.devfile.io/merged-contributions: "first-contribution,second-contribution"
+        container:
+          image: test-image
+          memoryLimit: 1536Mi # 1Gi + 512Mi (from first-contribution)
+          cpuRequest: 115m # 15m + 100m (from second-contributioon) 
+

--- a/pkg/library/resources/helper.go
+++ b/pkg/library/resources/helper.go
@@ -1,0 +1,174 @@
+//
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package resources
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+)
+
+// Takes a component and returns the resource requests and limits that it defines.
+// If a resource request or limit is not defined within the component, it will
+// not be populated in the corresponding corev1.ResourceList map.
+// Returns an error if  a non-container component is passed to the function, or if an error
+// occurs while parsing a resource limit or request.
+func ParseResourcesFromComponent(component *dw.Component) (*corev1.ResourceRequirements, error) {
+	if component.Container == nil {
+		return nil, fmt.Errorf("attempted to parse resource requirements from a non-container component")
+	}
+
+	resources := &corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
+	}
+
+	memLimitStr := component.Container.MemoryLimit
+	if memLimitStr != "" {
+		memoryLimit, err := resource.ParseQuantity(memLimitStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse memory limit for container component %s: %w", component.Name, err)
+		}
+		resources.Limits[corev1.ResourceMemory] = memoryLimit
+	}
+
+	memRequestStr := component.Container.MemoryRequest
+	if memRequestStr != "" {
+		memoryRequest, err := resource.ParseQuantity(memRequestStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse memory request for container component %s: %w", component.Name, err)
+		}
+		resources.Requests[corev1.ResourceMemory] = memoryRequest
+	}
+
+	cpuLimitStr := component.Container.CpuLimit
+	if cpuLimitStr != "" {
+		cpuLimit, err := resource.ParseQuantity(cpuLimitStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CPU limit for container component %s: %w", component.Name, err)
+		}
+		resources.Limits[corev1.ResourceCPU] = cpuLimit
+	}
+
+	cpuRequestStr := component.Container.CpuRequest
+	if cpuRequestStr != "" {
+		cpuRequest, err := resource.ParseQuantity(cpuRequestStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CPU request for container component %s: %w", component.Name, err)
+		}
+		resources.Requests[corev1.ResourceCPU] = cpuRequest
+	}
+
+	return resources, nil
+}
+
+// Adds the resource limits and requests that are set in the component "toAdd" to "resources".
+// Returns an error if the resources defined in toAdd could not be parsed.
+//
+// Note: only resources that are set in the function argument "resources" will be summed
+// with the resources set in "toAdd".
+// For example, if "resources" does not set a CPU limit but "toAdd" does set a CPU limit,
+// the CPU limit of "resources" will remain unset.
+func AddResourceRequirements(resources *corev1.ResourceRequirements, toAdd *dw.Component) error {
+	componentResources, err := ParseResourcesFromComponent(toAdd)
+	if err != nil {
+		return err
+	}
+
+	for resourceName, limit := range resources.Limits {
+		if componentLimit, ok := componentResources.Limits[resourceName]; ok {
+			limit.Add(componentLimit)
+			resources.Limits[resourceName] = limit
+		}
+	}
+
+	for resourceName, request := range resources.Requests {
+		if componentRequest, ok := componentResources.Requests[resourceName]; ok {
+			request.Add(componentRequest)
+			resources.Requests[resourceName] = request
+		}
+	}
+
+	return nil
+}
+
+// Applies the given resource limits and requirements that are non-zero to the container component.
+// If a resource limit or request has a value of zero, then the corresponding limit or request is not set
+// in the container component's resource requirements.
+func ApplyResourceRequirementsToComponent(container *dw.ContainerComponent, resources *corev1.ResourceRequirements) {
+	memLimit := resources.Limits[corev1.ResourceMemory]
+	if !memLimit.IsZero() {
+		container.MemoryLimit = memLimit.String()
+	}
+
+	cpuLimit := resources.Limits[corev1.ResourceCPU]
+	if !cpuLimit.IsZero() {
+		container.CpuLimit = cpuLimit.String()
+	}
+
+	memRequest := resources.Requests[corev1.ResourceMemory]
+	if !memRequest.IsZero() {
+		container.MemoryRequest = memRequest.String()
+	}
+
+	cpuRequest := resources.Requests[corev1.ResourceCPU]
+	if !cpuRequest.IsZero() {
+		container.CpuRequest = cpuRequest.String()
+	}
+}
+
+// ProcessResources checks that specified resources are valid (e.g. requests are less than limits) and supports
+// un-setting resources that have default values by interpreting zero as "do not set"
+func ProcessResources(resources *corev1.ResourceRequirements) (*corev1.ResourceRequirements, error) {
+	result := resources.DeepCopy()
+
+	if result.Limits.Memory().IsZero() {
+		delete(result.Limits, corev1.ResourceMemory)
+	}
+	if result.Limits.Cpu().IsZero() {
+		delete(result.Limits, corev1.ResourceCPU)
+	}
+	if result.Requests.Memory().IsZero() {
+		delete(result.Requests, corev1.ResourceMemory)
+	}
+	if result.Requests.Cpu().IsZero() {
+		delete(result.Requests, corev1.ResourceCPU)
+	}
+
+	memLimit, hasMemLimit := result.Limits[corev1.ResourceMemory]
+	memRequest, hasMemRequest := result.Requests[corev1.ResourceMemory]
+	if hasMemLimit && hasMemRequest && memRequest.Cmp(memLimit) > 0 {
+		return result, fmt.Errorf("project clone memory request (%s) must be less than limit (%s)", memRequest.String(), memLimit.String())
+	}
+
+	cpuLimit, hasCPULimit := result.Limits[corev1.ResourceCPU]
+	cpuRequest, hasCPURequest := result.Requests[corev1.ResourceCPU]
+	if hasCPULimit && hasCPURequest && cpuRequest.Cmp(cpuLimit) > 0 {
+		return result, fmt.Errorf("project clone CPU request (%s) must be less than limit (%s)", cpuRequest.String(), cpuLimit.String())
+	}
+
+	if len(result.Limits) == 0 {
+		result.Limits = nil
+	}
+	if len(result.Requests) == 0 {
+		result.Requests = nil
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
### What does this PR do?

This PR modifies the container contribution functionality for resource requirements. 

With this change, the merge target's resource requirements will be summed with contribution resource requirements **only for resource limits & requests that are already set in the merge target**. For example, if the merge target **does not** set a CPU request and a container contribution **does** set a CPU request, the resulting CPU request of the merge target will remain unset. 

This PR also moves functions related to `corev1.ResourceRequirements` into `/pkg/library/resources/`. 


### What issues does this PR fix or reference?
Fix #1056

### Is it tested? How?
I added an automated test for all 4 types of container contributions (normal, spec, implicit and implicit-spec) which verifies that resource requirements are only summed if they are defined in the merge target component. 

Additionally, the Che-Code container contribution test cases had to be modified by removing the expected CPU limit, CPU request and Memory Request as they are no longer contributed by the container contributions (since the `tools` container only defines a Memoy Limit)

#### Verify #1056 is fixed
1. Install DWO with the changes from this PR
2. Apply the Che-Code sample `kubectl apply -f ./samples/code-latest.yaml -n $NAMESPACE`
3. Check the spec of the `code-latest` workspace (`kubectl describe code-latest -n $NAMESPACE`) and ensure the `dev` container component does not have its CPU Request, CPU Limit, Memory Request or Memory Limit set.

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
