### PR TITLE
Add support for starter projects in DevWorkspaces

### DIFF
--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -94,6 +94,30 @@ spec:
       controller.devfile.io/project-clone: disable
 ----
 
+### Configuring sparse checkout for projects
+The project-level attribute `sparseCheckout` can be used to enable a sparse checkout for a given project. The value of this attribute should be a list of paths within the project that should be included in the sparse checkout, separated by spaces. For example, the project
+
+[source,yaml]
+----
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-workspace
+spec:
+  template:
+    projects:
+      - name: devworkspace-operator
+        attributes:
+          sparseCheckout: "docs"
+        git:
+          remotes:
+            origin: "https://github.com/devfile/devworkspace-operator.git"
+----
+
+will clone the DevWorkspace Operator sparsely, so only the `docs` directory is present.
+
+For more information on sparse checkouts, see documentation for [git sparse-checkout](https://git-scm.com/docs/git-sparse-checkout)
+
 ## Automatically mounting volumes, configmaps, and secrets
 Existing configmaps, secrets, and persistent volume claims on the cluster can be configured by applying the appropriate labels. To mark a resource for mounting to workspaces, apply the **label**
 [source,yaml]

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -141,4 +141,8 @@ const (
 	//       container:
 	//         image: ...
 	ContainerOverridesAttribute = "container-overrides"
+
+	// StarterProjectAttribute is an attribute applied to the top-level attributes in a DevWorkspace to specify which
+	// starterProject in the workspace should be cloned.
+	StarterProjectAttribute = "controller.devfile.io/use-starter-project"
 )

--- a/project-clone/internal/devfile.go
+++ b/project-clone/internal/devfile.go
@@ -21,10 +21,13 @@ import (
 	"os"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/attributes"
 	"sigs.k8s.io/yaml"
 
 	"github.com/devfile/devworkspace-operator/pkg/provision/metadata"
 )
+
+const ProjectSubDir = "subDir"
 
 // GetClonePath gets the correct clonePath for a project, given the semantics in devfile/api
 func GetClonePath(project *dw.Project) string {
@@ -54,4 +57,24 @@ func ReadFlattenedDevWorkspace() (*dw.DevWorkspaceTemplateSpec, error) {
 
 	log.Printf("Read DevWorkspace at %s", flattenedDevWorkspacePath)
 	return dwts, nil
+}
+
+// StarterProjectToRegularProject converts a starter project defined in a DevWorkspace to a standard Project for
+// easier handling
+func StarterProjectToRegularProject(starterProject *dw.StarterProject) dw.Project {
+	// Note: starter project does not allow for specifying clonePath
+	project := dw.Project{
+		Name:          starterProject.Name,
+		Attributes:    starterProject.Attributes,
+		ProjectSource: starterProject.ProjectSource,
+	}
+
+	if starterProject.SubDir != "" {
+		if project.Attributes == nil {
+			project.Attributes = attributes.Attributes{}
+		}
+		project.Attributes.PutString(ProjectSubDir, starterProject.SubDir)
+	}
+
+	return project
 }

--- a/project-clone/internal/devfile.go
+++ b/project-clone/internal/devfile.go
@@ -27,7 +27,10 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/provision/metadata"
 )
 
-const ProjectSubDir = "subDir"
+const (
+	ProjectSparseCheckout = "sparseCheckout"
+	ProjectSubDir         = "subDir"
+)
 
 // GetClonePath gets the correct clonePath for a project, given the semantics in devfile/api
 func GetClonePath(project *dw.Project) string {

--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -63,7 +63,7 @@ func CloneProject(project *dw.Project, projectPath string) error {
 		}
 	}
 
-	if project.Attributes.Exists(internal.ProjectSubDir) {
+	if project.Attributes.Exists(internal.ProjectSparseCheckout) {
 		if err := shell.GitSparseCloneProject(defaultRemoteURL, defaultRemoteName, projectPath); err != nil {
 			return fmt.Errorf("failed to sparsely git clone from %s: %s", defaultRemoteURL, err)
 		}
@@ -84,14 +84,14 @@ func SetupSparseCheckout(project *dw.Project, projectPath string) error {
 	log.Printf("Setting up sparse checkout for project %s", project.Name)
 
 	var err error
-	subdir := project.Attributes.GetString(internal.ProjectSubDir, &err)
+	sparseCheckoutDir := project.Attributes.GetString(internal.ProjectSparseCheckout, &err)
 	if err != nil {
-		return fmt.Errorf("failed to read %s attribute on project %s", internal.ProjectSubDir, project.Name)
+		return fmt.Errorf("failed to read %s attribute on project %s", internal.ProjectSparseCheckout, project.Name)
 	}
-	if subdir == "" {
+	if sparseCheckoutDir == "" {
 		return nil
 	}
-	if err := shell.GitSetupSparseCheckout(projectPath, subdir); err != nil {
+	if err := shell.GitSetupSparseCheckout(projectPath, sparseCheckoutDir); err != nil {
 		return fmt.Errorf("error running sparse-checkout set: %w", err)
 	}
 

--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -93,7 +93,7 @@ func SetupRemotes(repo *git.Repository, project *dw.Project, projectPath string)
 }
 
 // CheckoutReference sets the current HEAD in repo to point at the revision and remote referenced by checkoutFrom
-func CheckoutReference(repo *git.Repository, project *dw.Project, projectPath string) error {
+func CheckoutReference(project *dw.Project, projectPath string) error {
 	checkoutFrom := project.Git.CheckoutFrom
 	if checkoutFrom == nil || checkoutFrom.Revision == "" {
 		return nil

--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -58,7 +58,7 @@ func doInitialGitClone(project *dw.Project) error {
 	if err := SetupRemotes(repo, project, tmpClonePath); err != nil {
 		return fmt.Errorf("failed to set up remotes for project: %s", err)
 	}
-	if err := CheckoutReference(repo, project, tmpClonePath); err != nil {
+	if err := CheckoutReference(project, tmpClonePath); err != nil {
 		return fmt.Errorf("failed to checkout revision: %s", err)
 	}
 

--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -49,15 +49,24 @@ func doInitialGitClone(project *dw.Project) error {
 	if err != nil {
 		return fmt.Errorf("failed to clone project: %s", err)
 	}
+
+	if project.Attributes.Exists(internal.ProjectSubDir) {
+		if err := SetupSparseCheckout(project, tmpClonePath); err != nil {
+			return fmt.Errorf("failed to set up sparse checkout on project %s: %w", project.Name, err)
+		}
+	}
+
 	repo, err := internal.OpenRepo(tmpClonePath)
 	if err != nil {
 		return fmt.Errorf("failed to open existing project in filesystem: %s", err)
 	} else if repo == nil {
 		return fmt.Errorf("unexpected error while setting up remotes for project: git repository not present")
 	}
+
 	if err := SetupRemotes(repo, project, tmpClonePath); err != nil {
 		return fmt.Errorf("failed to set up remotes for project: %s", err)
 	}
+
 	if err := CheckoutReference(project, tmpClonePath); err != nil {
 		return fmt.Errorf("failed to checkout revision: %s", err)
 	}

--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -44,9 +44,20 @@ func GitCloneProject(repoUrl, defaultRemoteName, destPath string) error {
 	return executeCommand("git", args...)
 }
 
-// GitResetProject runs `git reset --hard` in the project specified by projectPath
-func GitResetProject(projectPath string) error {
-	return executeCommand("git", "-C", projectPath, "reset", "--hard")
+func GitSparseCloneProject(repoUrl, defaultRemoteName, destPath string) error {
+	args := []string{
+		"clone",
+		"--sparse",
+		repoUrl,
+		"--origin", defaultRemoteName,
+		"--",
+		destPath,
+	}
+	return executeCommand("git", args...)
+}
+
+func GitSetupSparseCheckout(projectPath string, sparseCheckoutDir string) error {
+	return executeCommand("git", "-C", projectPath, "sparse-checkout", "set", sparseCheckoutDir)
 }
 
 func GitFetchRemote(projectPath, remote string) error {

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"syscall"
 
+	projectslib "github.com/devfile/devworkspace-operator/pkg/library/projects"
 	"github.com/devfile/devworkspace-operator/project-clone/internal"
 	"github.com/devfile/devworkspace-operator/project-clone/internal/git"
 	"github.com/devfile/devworkspace-operator/project-clone/internal/zip"
@@ -59,8 +60,18 @@ func main() {
 		log.Printf("Failed to read current DevWorkspace: %s", err)
 		os.Exit(1)
 	}
+
+	projects := workspace.Projects
+
+	starterProject, err := projectslib.GetStarterProject(workspace)
+	if err != nil {
+		log.Printf("Encountered error while processing starterProjects: %s", err)
+	} else if starterProject != nil {
+		projects = append(projects, internal.StarterProjectToRegularProject(starterProject))
+	}
+
 	encounteredError := false
-	for _, project := range workspace.Projects {
+	for _, project := range projects {
 		log.Printf("Processing project %s", project.Name)
 		var err error
 		switch {

--- a/project-clone/test/project-clone-test.devworkspace.yaml
+++ b/project-clone/test/project-clone-test.devworkspace.yaml
@@ -19,7 +19,7 @@ spec:
       fork_repo: https://github.com/amisevsk/devworkspace-operator.git
       checkout_branch: 0.21.x
       checkout_tag: v0.21.0
-      checkout_hash: e17b2754
+      checkout_hash: d3897be0
       default_branch_name: main
     projects:
       - name: default-project-setup
@@ -137,7 +137,7 @@ spec:
               echo "Testing hash checkout project set up"
               cd "${PROJECTS_ROOT}/test-checkout-hash"
               commit_hash=$(git rev-parse HEAD)
-              if [[ "$commit_hash" == "{{checkout_hash}}"* ]]; then
+              if [[ "$commit_hash" != "{{checkout_hash}}"* ]]; then
                 fail "Current HEAD is not at {{checkout_hash}}"
               fi
               remote_url=$(git config remote.origin.url)

--- a/project-clone/test/sparse-clone-test.devworkspace.yaml
+++ b/project-clone/test/sparse-clone-test.devworkspace.yaml
@@ -1,7 +1,7 @@
 apiVersion: workspace.devfile.io/v1alpha2
 kind: DevWorkspace
 metadata:
-  name: project-clone-test-basic
+  name: sparse-clone-project-test
   labels:
     app.kubernetes.io/name: devworkspace-project-clone-tests
     app.kubernetes.io/part-of: devworkspace-operator
@@ -14,16 +14,26 @@ spec:
     attributes:
       controller.devfile.io/storage-type: ephemeral
     variables:
-          test_runner_image: quay.io/devfile/project-clone:next # Requires git, bash
-          main_repo: https://github.com/devfile/devworkspace-operator.git
-          default_branch_name: main
+      test_runner_image: quay.io/devfile/project-clone:next # Requires git, bash
+      main_repo: https://github.com/devfile/devworkspace-operator.git
+      fork_repo: https://github.com/amisevsk/devworkspace-operator.git
+      checkout_branch: 0.21.x
+      project_subdir: project-clone
+      default_branch_name: main
     projects:
-      - name: test-project
+      - name: default-project-setup
         git:
           remotes:
             main-origin: "{{main_repo}}"
+      - name: sparse-clone-project-1
+        attributes:
+          sparseCheckout: "project-clone" # Can't use variable here as they are not replaced in attributes
+        git:
           checkoutFrom:
-            revision: "{{default_branch_name}}"
+            remote: origin
+            revision: "{{checkout_branch}}"
+          remotes:
+            origin: "{{main_repo}}"
     components:
       - name: test-project-clone
         container:
@@ -50,12 +60,14 @@ spec:
                 echo -e "\n\n"
               fi
 
-              if [ ! -d "${PROJECTS_ROOT}/${project_dir}" ]; then
-                fail "Project $project_dir not cloned successfully"
-              fi
+              for project_dir in "default-project-setup" "sparse-clone-project-1"; do
+                if [ ! -d "${PROJECTS_ROOT}/${project_dir}" ]; then
+                  fail "Project $project_dir not cloned successfully"
+                fi
+              done
 
               echo "Testing default project set up"
-              cd ${PROJECTS_ROOT}/test-project
+              cd "${PROJECTS_ROOT}/default-project-setup"
               branch_name=$(git rev-parse --abbrev-ref HEAD)
               if [ "$branch_name" != "{{default_branch_name}}" ]; then
                 fail "Project does not have default branch checked out"
@@ -69,6 +81,26 @@ spec:
                 fail "Remote 'main-origin' not configured"
               fi
               echo "Project is on $branch_name, tracking $tracking_branch, with remotes configured"
+
+              echo "Testing sparse-clone project is set up"
+              cd "${PROJECTS_ROOT}/sparse-clone-project-1"
+              branch_name=$(git rev-parse --abbrev-ref HEAD)
+              if [ "$branch_name" != "{{checkout_branch}}" ]; then
+                fail "Project does not have {{checkout_branch}} branch checked out"
+              fi
+              tracking_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+              if [ "$tracking_branch" != "origin/{{checkout_branch}}" ]; then
+                fail "Checked out branch does not track remote branch origin/{{checkout_branch}}"
+              fi
+              remote_url=$(git config remote.origin.url)
+              if [ "$remote_url" != "{{main_repo}}" ]; then
+                fail "Remote 'origin' not configured"
+              fi
+              sparse_checkout_dirs=$(git sparse-checkout list)
+              if [ "$sparse_checkout_dirs" != "{{project_subdir}}" ]; then
+                fail "Sparse checkout is not configured"
+              fi
+              echo "Project is on $branch_name, tracking $tracking_branch, with remotes and sparse checkout configured"
 
               echo "[SUCCESS] Test succeeded. Sleeping indefinitely"
               tail -f /dev/null

--- a/project-clone/test/starter-project-test.devworkspace.yaml
+++ b/project-clone/test/starter-project-test.devworkspace.yaml
@@ -89,23 +89,12 @@ spec:
 
               echo "Testing starter project is set up"
               cd "${PROJECTS_ROOT}/starter-project-1"
-              branch_name=$(git rev-parse --abbrev-ref HEAD)
-              if [ "$branch_name" != "{{checkout_branch}}" ]; then
-                fail "Project does not have {{checkout_branch}} branch checked out"
+              if [ $(git rev-parse --is-inside-work-tree) == "true" ]; then
+                fail "Do not expect subDir starter project to be a git repository"
               fi
-              tracking_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
-              if [ "$tracking_branch" != "origin/{{checkout_branch}}" ]; then
-                fail "Checked out branch does not track remote branch origin/{{checkout_branch}}"
-              fi
-              remote_url=$(git config remote.origin.url)
-              if [ "$remote_url" != "{{main_repo}}" ]; then
-                fail "Remote 'origin' not configured"
-              fi
-              sparse_checkout_dirs=$(git sparse-checkout list)
-              if [ "$sparse_checkout_dirs" != "{{project_subdir}}" ]; then
-                fail "Sparse checkout is not configured"
-              fi
-              echo "Project is on $branch_name, tracking $tracking_branch, with remotes and sparse checkout configured"
+              echo "Files inside starter project directory:"
+              ls -l
+              echo "Project directory is present"
 
               echo "[SUCCESS] Test succeeded. Sleeping indefinitely"
               tail -f /dev/null

--- a/project-clone/test/starter-project-test.devworkspace.yaml
+++ b/project-clone/test/starter-project-test.devworkspace.yaml
@@ -1,0 +1,111 @@
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspace
+metadata:
+  name: starter-project-test
+  labels:
+    app.kubernetes.io/name: devworkspace-project-clone-tests
+    app.kubernetes.io/part-of: devworkspace-operator
+  annotations:
+    controller.devfile.io/debug-start: "true"
+spec:
+  started: true
+  routingClass: 'basic'
+  template:
+    attributes:
+      controller.devfile.io/storage-type: ephemeral
+      controller.devfile.io/use-starter-project: starter-project-1
+    variables:
+      test_runner_image: quay.io/devfile/project-clone:next # Requires git, bash
+      main_repo: https://github.com/devfile/devworkspace-operator.git
+      fork_repo: https://github.com/amisevsk/devworkspace-operator.git
+      checkout_branch: 0.21.x
+      project_subdir: project-clone
+      default_branch_name: main
+    projects:
+      - name: default-project-setup
+        git:
+          remotes:
+            main-origin: "{{main_repo}}"
+    starterProjects:
+      - name: starter-project-1
+        subDir: "{{project_subdir}}"
+        git:
+          checkoutFrom:
+            remote: origin
+            revision: "{{checkout_branch}}"
+          remotes:
+            origin: "{{main_repo}}"
+      - name: starter-project-2
+        git:
+          remotes:
+            origin: "{{fork_repo}}"
+    components:
+      - name: test-project-clone
+        container:
+          image: "{{test_runner_image}}"
+          memoryLimit: 512Mi
+          mountSources: true
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -e
+
+              fail() {
+                echo "[ERROR] $1"
+                echo "[ERROR] See project-clone logs: "
+                echo "[ERROR]    oc logs -n $DEVWORKSPACE_NAMESPACE deploy/$DEVWORKSPACE_ID -c project-clone"
+                exit 1
+              }
+
+              if [ -f "${PROJECTS_ROOT}/project-clone-errors.log" ]; then
+                echo "==== BEGIN PROJECT CLONE LOGS ===="
+                sed 's/^/    /g' "${PROJECTS_ROOT}/project-clone-errors.log"
+                echo "====  END PROJECT CLONE LOGS  ===="
+                echo -e "\n\n"
+              fi
+
+              for project_dir in "default-project-setup" "starter-project-1"; do
+                if [ ! -d "${PROJECTS_ROOT}/${project_dir}" ]; then
+                  fail "Project $project_dir not cloned successfully"
+                fi
+              done
+
+              echo "Testing default project set up"
+              cd "${PROJECTS_ROOT}/default-project-setup"
+              branch_name=$(git rev-parse --abbrev-ref HEAD)
+              if [ "$branch_name" != "{{default_branch_name}}" ]; then
+                fail "Project does not have default branch checked out"
+              fi
+              tracking_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+              if [ "$tracking_branch" != "main-origin/{{default_branch_name}}" ]; then
+                fail "Default project's branch does not track remote branch"
+              fi
+              remote_url=$(git config remote.main-origin.url)
+              if [ "$remote_url" != "{{main_repo}}" ]; then
+                fail "Remote 'main-origin' not configured"
+              fi
+              echo "Project is on $branch_name, tracking $tracking_branch, with remotes configured"
+
+              echo "Testing starter project is set up"
+              cd "${PROJECTS_ROOT}/starter-project-1"
+              branch_name=$(git rev-parse --abbrev-ref HEAD)
+              if [ "$branch_name" != "{{checkout_branch}}" ]; then
+                fail "Project does not have {{checkout_branch}} branch checked out"
+              fi
+              tracking_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
+              if [ "$tracking_branch" != "origin/{{checkout_branch}}" ]; then
+                fail "Checked out branch does not track remote branch origin/{{checkout_branch}}"
+              fi
+              remote_url=$(git config remote.origin.url)
+              if [ "$remote_url" != "{{main_repo}}" ]; then
+                fail "Remote 'origin' not configured"
+              fi
+              sparse_checkout_dirs=$(git sparse-checkout list)
+              if [ "$sparse_checkout_dirs" != "{{project_subdir}}" ]; then
+                fail "Sparse checkout is not configured"
+              fi
+              echo "Project is on $branch_name, tracking $tracking_branch, with remotes and sparse checkout configured"
+
+              echo "[SUCCESS] Test succeeded. Sleeping indefinitely"
+              tail -f /dev/null


### PR DESCRIPTION
### What does this PR do?
See https://github.com/devfile/devworkspace-operator/pull/1130#issuecomment-1604925774 for additional information; initially starterProject's `subDir` field was handled incorrectly.

Add attribute `controller.devfile.io/use-starter-project` (naming suggestions welcome) which can be applied in the top-level attributes of a devfile/DevWorkspace to select a starter project from the `.spec.template.starterProjects` array. If a starterProject is selected in this way, it is converted internally (within project-clone) to a regular project and processed alongside any other projects defined in the DevWorkspace. 

In order to support the `subDir` field on starterProjects, project-clone can now also perform sparse checkouts (though this is still not user-facing for regular projects at the moment).

I also simplified the git operations in the project clone directory -- we don't need to change dirs before running commands and can instead use the `-C` commandline option to `git`. 

A future improvement would be to expose `selectedStarterProject` as a DevWorkspace template field, rather than relying on the attribute.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1084

### Is it tested? How?
Changes to the project-clone container are pushed to `quay.io/amisevsk/project-clone:starter-projects`

PR contains a devfile useful for basic smoke testing of starter projects support: `project-clone/test/starter-project-test.devworkspace.yaml`

For manual verification, various devfiles in https://registry.devfile.io/viewer contain starter projects (e.g. [Go](https://registry.devfile.io/devfiles/go/1.0.2), which is a basic example, or [.NET 5.0](https://registry.devfile.io/devfiles/dotnet50/1.0.3) which includes a subDir. To make testing devfiles from the registry a little simpler, you can use the `yq` script:
```bash
YQ_SCRIPT='{
    "kind": "DevWorkspace",
    "apiVersion": "workspace.devfile.io/v1alpha2",
    "metadata": {
      "name": .metadata.name
    },
    "spec": {
      "started": true,
      "routingClass": "basic",
      "template": (. | del(.metadata, .schemaVersion))
    }
  }'
curl <raw-devfile> | yq -y "$YQ_SCRIPT" | kubectl apply -f -
```
(you will need to add the `controller.devfile.io/use-starter-project` attribute to actually select a project)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
