### PR TITLE
Fixup PR check action for checking files format

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,9 +74,7 @@ jobs:
       run: |
         go install github.com/google/addlicense@latest
         go install golang.org/x/tools/cmd/goimports@latest
-        make check_fmt
-        if [[ $? != 0 ]]
-        then
+        if ! make check_fmt; then
           echo "not well formatted sources are found:"
           git --no-pager diff
           exit 1


### PR DESCRIPTION
### What does this PR do?

Fix a minor issue with the PR check when checking format. Previously, action would end as soon as make check_fmt returned a non-zero code, preventing the rest of the step from running.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
