### PR TITLE
Fix CRD types in aggregated view and edit clusterroles

### DIFF
--- a/deploy/bundle/manifests/devworkspace-controller-edit-workspaces_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/deploy/bundle/manifests/devworkspace-controller-edit-workspaces_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -23,7 +23,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - create
   - delete

--- a/deploy/bundle/manifests/devworkspace-controller-view-workspaces_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/deploy/bundle/manifests/devworkspace-controller-view-workspaces_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -22,7 +22,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - get
   - list

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -24132,7 +24132,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - create
   - delete
@@ -24437,7 +24437,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - get
   - list

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-edit-workspaces.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-edit-workspaces.ClusterRole.yaml
@@ -22,7 +22,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - create
   - delete

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-view-workspaces.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-view-workspaces.ClusterRole.yaml
@@ -21,7 +21,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - get
   - list

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -24132,7 +24132,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - create
   - delete
@@ -24437,7 +24437,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - get
   - list

--- a/deploy/deployment/openshift/objects/devworkspace-controller-edit-workspaces.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-edit-workspaces.ClusterRole.yaml
@@ -22,7 +22,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - create
   - delete

--- a/deploy/deployment/openshift/objects/devworkspace-controller-view-workspaces.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-view-workspaces.ClusterRole.yaml
@@ -21,7 +21,7 @@ rules:
   - controller.devfile.io
   resources:
   - devworkspaceroutings
-  - components
+  - devworkspaceoperatorconfigs
   verbs:
   - get
   - list

--- a/deploy/templates/components/rbac/edit_workspaces_cluster_role.yaml
+++ b/deploy/templates/components/rbac/edit_workspaces_cluster_role.yaml
@@ -23,7 +23,7 @@ rules:
       - controller.devfile.io
     resources:
       - devworkspaceroutings
-      - components
+      - devworkspaceoperatorconfigs
     verbs:
       - create
       - delete

--- a/deploy/templates/components/rbac/view_workspaces_cluster_role.yaml
+++ b/deploy/templates/components/rbac/view_workspaces_cluster_role.yaml
@@ -22,7 +22,7 @@ rules:
       - controller.devfile.io
     resources:
       - devworkspaceroutings
-      - components
+      - devworkspaceoperatorconfigs
     verbs:
       - get
       - list


### PR DESCRIPTION
### What does this PR do?
The aggregated view an edit clusterroles refer to an old CRD type (components) that has been removed from the DevWorkspace Operator and do not include the DevWorkspaceOperatorConfig resource.


### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
