### PR TITLE
Fix potential nil pointer dereference in reconcile loop

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -443,8 +443,10 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return reconcileResult, reconcileErr
 	}
 
-	allPodAdditions = append(allPodAdditions, *pullSecretPodAdditions)
-	reconcileStatus.setConditionTrue(conditions.PullSecretsReady, "DevWorkspace secrets ready")
+	if pullSecretPodAdditions != nil && pullSecretPodAdditions.PullSecrets != nil {
+		allPodAdditions = append(allPodAdditions, *pullSecretPodAdditions)
+		reconcileStatus.setConditionTrue(conditions.PullSecretsReady, "DevWorkspace secrets ready")
+	}
 
 	if kubesync.HasKubelikeComponent(workspace) {
 		err := kubesync.HandleKubernetesComponents(workspace, clusterAPI)

--- a/pkg/provision/workspace/pull_secret.go
+++ b/pkg/provision/workspace/pull_secret.go
@@ -64,7 +64,7 @@ func PullSecrets(clusterAPI sync.ClusterAPI, serviceAccountName, namespace strin
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			// ServiceAccount does not exist, no pull secrets to extract
-			return nil, nil
+			return &v1alpha1.PodAdditions{}, nil
 		}
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?
Fix potential for a panic due to nil pointer dereference if the workspace ServiceAccount does not exist.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1137

### Is it tested? How?
1. Disable Service Account creation
2. Attempt to start a workspace (workspace expected to fail to start)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
