### PR TITLE
Cherry-pick #1138 to 0.21.x branch

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -431,8 +431,10 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return reconcileResult, reconcileErr
 	}
 
-	allPodAdditions = append(allPodAdditions, *pullSecretPodAdditions)
-	reconcileStatus.setConditionTrue(conditions.PullSecretsReady, "DevWorkspace secrets ready")
+	if pullSecretPodAdditions != nil && pullSecretPodAdditions.PullSecrets != nil {
+		allPodAdditions = append(allPodAdditions, *pullSecretPodAdditions)
+		reconcileStatus.setConditionTrue(conditions.PullSecretsReady, "DevWorkspace secrets ready")
+	}
 
 	if kubesync.HasKubelikeComponent(workspace) {
 		err := kubesync.HandleKubernetesComponents(workspace, clusterAPI)

--- a/pkg/provision/workspace/pull_secret.go
+++ b/pkg/provision/workspace/pull_secret.go
@@ -64,7 +64,7 @@ func PullSecrets(clusterAPI sync.ClusterAPI, serviceAccountName, namespace strin
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			// ServiceAccount does not exist, no pull secrets to extract
-			return nil, nil
+			return &v1alpha1.PodAdditions{}, nil
 		}
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?
Cherry-pick changes from https://github.com/devfile/devworkspace-operator/pull/1138 to the 0.21.x branch

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1137 in v0.21

### Is it tested? How?
Tested as part of https://github.com/devfile/devworkspace-operator/issues/1138

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
