### PR TITLE
fix: replace deprecated Ingress annotation

### DIFF
--- a/controllers/controller/devworkspacerouting/solvers/basic_solver.go
+++ b/controllers/controller/devworkspacerouting/solvers/basic_solver.go
@@ -31,7 +31,6 @@ var routeAnnotations = func(endpointName string) map[string]string {
 
 var nginxIngressAnnotations = func(endpointName string) map[string]string {
 	return map[string]string{
-		"kubernetes.io/ingress.class":                "nginx",
 		"nginx.ingress.kubernetes.io/rewrite-target": "/",
 		"nginx.ingress.kubernetes.io/ssl-redirect":   "false",
 		constants.DevWorkspaceEndpointNameAnnotation: endpointName,

--- a/controllers/controller/devworkspacerouting/solvers/common.go
+++ b/controllers/controller/devworkspacerouting/solvers/common.go
@@ -25,6 +25,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 )
 
 type DevWorkspaceMetadata struct {
@@ -223,6 +224,7 @@ func getIngressForEndpoint(routingSuffix string, endpoint controllerv1alpha1.End
 			Annotations: nginxIngressAnnotations(endpoint.Name),
 		},
 		Spec: networkingv1.IngressSpec{
+			IngressClassName: pointer.String("nginx"),
 			Rules: []networkingv1.IngressRule{
 				{
 					Host: hostname,


### PR DESCRIPTION
### What does this PR do?

Before the IngressClass resource and ingressClassName field were added in Kubernetes 1.18, Ingress classes were specified with a kubernetes.io/ingress.class annotation on the Ingress. This annotation was never formally defined, but was widely supported by Ingress controllers.

The newer ingressClassName field on Ingresses is a replacement for that annotation, but is not a direct equivalent. While the annotation was generally used to reference the name of the Ingress controller that should implement the Ingress, the field is a reference to an IngressClass resource that contains additional Ingress configuration, including the name of the Ingress controller.

Cf. https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
