### PR TITLE
Update Go version in actions, go.mod to 1.19

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,12 +14,12 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.19.10
     -
-      name: Set up Python 3.8
+      name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.11
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,12 +15,12 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.19.10
     -
-      name: Set up Python 3.8
+      name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.11
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.4
+          go-version: 1.19.10
 
       - name: Clone source code
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/devworkspace-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/devfile/api/v2 v2.2.0


### PR DESCRIPTION
### What does this PR do?
Updates GitHub actions, CI checks, and go.mod to use Go 1.19 in order to match what's in use in dockerfiles.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
