### PR TITLE
Wrap git credential helper to ignore 'store' and 'erase' operations

### DIFF
--- a/pkg/provision/automount/templates.go
+++ b/pkg/provision/automount/templates.go
@@ -41,8 +41,12 @@ const gitLFSConfig = `[filter "lfs"]
     required = true
 `
 
+// Since we're mounting the credentials file read-only, we need to ignore 'store'
+// and 'erase' commands to the credential helper (will print an error about being
+// unable to get a lock on the credentials file). This snippet effectively wraps
+// only 'git credential-store get' to make it read-only.
 const credentialTemplate = `[credential]
-    helper = store --file %s
+    helper = "!f() { test \"$1\" = get && git credential-store --file %s \"$@\"; }; f"
 `
 
 const gitServerTemplate = `[http "%s"]


### PR DESCRIPTION
### What does this PR do?
Since the credentials file is mounted read-only to the filesystem, we need to configure a git credential helper that ignores 'store' and 'erase' operations in order to avoid printing error messages around getting a lock on the credentials file:

```
fatal: unable to get credential storage lock in 1000 ms: Read-only file system
```

In order to do this, we wrap the existing 'store' credential helper to effectively be read-only.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1121

### Is it tested? How?
To test:
1. Configure a personal access token secret in the test namespace
2. Start a workspace that clones a project that uses that token

Verify:
1. Project clone container logs do not contain error message above
2. Execing into the container and running git commands that require credentials (e.g. git pull) do not show the error message.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
