### PR TITLE
Include binaryData when mounting a configmap via subpath volumeMounts

### DIFF
--- a/pkg/provision/automount/configmap.go
+++ b/pkg/provision/automount/configmap.go
@@ -114,9 +114,18 @@ func getAutomountConfigmap(mountPath, mountAs string, accessMode *int32, configm
 		automount.EnvFromSource = []corev1.EnvFromSource{envFromSource}
 	case constants.DevWorkspaceMountAsSubpath:
 		var volumeMounts []corev1.VolumeMount
+		volumeName := common.AutoMountConfigMapVolumeName(configmap.Name)
 		for secretKey := range configmap.Data {
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
-				Name:      common.AutoMountConfigMapVolumeName(configmap.Name),
+				Name:      volumeName,
+				ReadOnly:  true,
+				MountPath: path.Join(mountPath, secretKey),
+				SubPath:   secretKey,
+			})
+		}
+		for secretKey := range configmap.BinaryData {
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      volumeName,
 				ReadOnly:  true,
 				MountPath: path.Join(mountPath, secretKey),
 				SubPath:   secretKey,

--- a/pkg/provision/automount/testdata/testIncludesConfigmapBinaryData.yaml
+++ b/pkg/provision/automount/testdata/testIncludesConfigmapBinaryData.yaml
@@ -1,0 +1,40 @@
+name: Includes configmap's binaryData field when provisioning
+
+input:
+  configmaps:
+    -
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-subpath-configmap
+        labels:
+          controller.devfile.io/mount-to-devworkspace: "true"
+          controller.devfile.io/watch-configmap: 'true'
+        annotations:
+          controller.devfile.io/mount-as: subpath
+          controller.devfile.io/mount-path: /tmp/configmap/subpath
+      data:
+        configmap-key: "This is secret"
+        configmap-key-2: "This is also secret I guess"
+      binaryData:
+        binary-key: aGVsbG8K # "hello"
+
+output:
+  volumes:
+  - name: test-subpath-configmap
+    configmap:
+      name: test-subpath-configmap
+      defaultMode: 0640
+  volumeMounts:
+  - name: test-subpath-configmap
+    readOnly: true
+    mountPath: /tmp/configmap/subpath/configmap-key
+    subpath: configmap-key
+  - name: test-subpath-configmap
+    readOnly: true
+    mountPath: /tmp/configmap/subpath/configmap-key-2
+    subpath: configmap-key-2
+  - name: test-subpath-configmap
+    readOnly: true
+    mountPath: /tmp/configmap/subpath/binary-key
+    subpath: binary-key


### PR DESCRIPTION
### What does this PR do?
Include `binaryData` field when mounting a configmap as subpath volumeMounts

### What issues does this PR fix or reference?
Closes #1155 

### Is it tested? How?
1. Apply configmap
    ```yaml
    kind: ConfigMap
    apiVersion: v1
    metadata:
      name: test-cm
      labels:
        controller.devfile.io/mount-to-devworkspace: 'true'
        controller.devfile.io/watch-configmap: 'true'
      annotations:
        controller.devfile.io/mount-as: subpath
        controller.devfile.io/mount-path: /tmp/
    binaryData:
      testfile: aGVsbG8K # "hello"
    ```
2. Start a workspace
3. Verify that `/tmp/testfile` is mounted and contains text `hello`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
