### PR TITLE
Include parent-imported components in implicit merge targets

### DIFF
--- a/pkg/library/flatten/testdata/implicit-container-contributions/contributes-to-parent.yaml
+++ b/pkg/library/flatten/testdata/implicit-container-contributions/contributes-to-parent.yaml
@@ -1,0 +1,191 @@
+name: "Can contribute to parent devworkspace"
+
+input:
+  devworkspace:
+    parent:
+      uri: parent.yaml
+    components:
+      - name: che-code
+        plugin:
+          uri: che-code.yaml
+
+  devfileResources:
+    parent.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: parent
+      components:
+        - name: tools
+          container:
+            image: quay.io/devfile/universal-developer-image:latest
+            env:
+              - name: GOPATH
+                value: /projects:/home/user/go
+              - name: GOCACHE
+                value: /tmp/.cache
+            endpoints:
+              - name: 8080-tcp
+                targetPort: 8080
+            memoryLimit: 2Gi
+            mountSources: true
+    che-code.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: che-code
+      commands:
+        - id: init-container-command
+          apply:
+            component: che-code-injector
+      events:
+        preStart:
+          - init-container-command
+      components:
+        - name: che-code-runtime-description
+          attributes:
+            app.kubernetes.io/component: che-code-runtime
+            app.kubernetes.io/part-of: che-code.eclipse.org
+            controller.devfile.io/container-contribution: true
+          container:
+            image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+            command:
+              - /checode/entrypoint-volume.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 1024Mi
+            memoryRequest: 256Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+            endpoints:
+              - name: che-code
+                attributes:
+                  type: main
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                path: '?tkn=eclipse-che'
+                secure: false
+                protocol: https
+              - name: code-redirect-1
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13131
+                exposure: public
+                protocol: http
+              - name: code-redirect-2
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13132
+                exposure: public
+                protocol: http
+              - name: code-redirect-3
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13133
+                exposure: public
+                protocol: http
+        - name: checode
+          volume: {}
+        - name: che-code-injector
+          container:
+            image: quay.io/che-incubator/che-code:insiders
+            command:
+              - /entrypoint-init-container.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+
+output:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          app.kubernetes.io/component: che-code-runtime
+          app.kubernetes.io/part-of: che-code.eclipse.org
+          controller.devfile.io/merged-contributions: "che-code"
+          controller.devfile.io/imported-by: "parent"
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          command:
+            - /checode/entrypoint-volume.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 3Gi
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+            - name: che-code
+              attributes:
+                type: main
+                cookiesAuthEnabled: true
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              path: '?tkn=eclipse-che'
+              secure: false
+              protocol: https
+            - name: code-redirect-1
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13131
+              exposure: public
+              protocol: http
+            - name: code-redirect-2
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13132
+              exposure: public
+              protocol: http
+            - name: code-redirect-3
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13133
+              exposure: public
+              protocol: http
+          mountSources: true
+      - name: checode
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        volume: {}
+      - name: che-code-injector
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        container:
+          image: quay.io/che-incubator/che-code:insiders
+          command:
+            - /entrypoint-init-container.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+    commands:
+      - id: init-container-command
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        apply:
+          component: che-code-injector
+    events:
+      preStart:
+          - init-container-command

--- a/pkg/library/flatten/testdata/implicit-container-contributions/prioritizes-parent-components-for-target.yaml
+++ b/pkg/library/flatten/testdata/implicit-container-contributions/prioritizes-parent-components-for-target.yaml
@@ -1,0 +1,201 @@
+name: "Prioritizes contributing to parent components over child components"
+
+input:
+  devworkspace:
+    parent:
+      uri: parent.yaml
+    components:
+      - name: first-child-component
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          memoryLimit: 2Gi
+          mountSources: true
+      - name: che-code
+        plugin:
+          uri: che-code.yaml
+
+  devfileResources:
+    parent.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: parent
+      components:
+        - name: tools
+          container:
+            image: quay.io/devfile/universal-developer-image:latest
+            env:
+              - name: GOPATH
+                value: /projects:/home/user/go
+              - name: GOCACHE
+                value: /tmp/.cache
+            endpoints:
+              - name: 8080-tcp
+                targetPort: 8080
+            memoryLimit: 2Gi
+            mountSources: true
+    che-code.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: che-code
+      commands:
+        - id: init-container-command
+          apply:
+            component: che-code-injector
+      events:
+        preStart:
+          - init-container-command
+      components:
+        - name: che-code-runtime-description
+          attributes:
+            app.kubernetes.io/component: che-code-runtime
+            app.kubernetes.io/part-of: che-code.eclipse.org
+            controller.devfile.io/container-contribution: true
+          container:
+            image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+            command:
+              - /checode/entrypoint-volume.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 1024Mi
+            memoryRequest: 256Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+            endpoints:
+              - name: che-code
+                attributes:
+                  type: main
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                path: '?tkn=eclipse-che'
+                secure: false
+                protocol: https
+              - name: code-redirect-1
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13131
+                exposure: public
+                protocol: http
+              - name: code-redirect-2
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13132
+                exposure: public
+                protocol: http
+              - name: code-redirect-3
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13133
+                exposure: public
+                protocol: http
+        - name: checode
+          volume: {}
+        - name: che-code-injector
+          container:
+            image: quay.io/che-incubator/che-code:insiders
+            command:
+              - /entrypoint-init-container.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+
+output:
+  devworkspace:
+    components:
+      - name: first-child-component
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          memoryLimit: 2Gi
+          mountSources: true
+      - name: tools
+        attributes:
+          app.kubernetes.io/component: che-code-runtime
+          app.kubernetes.io/part-of: che-code.eclipse.org
+          controller.devfile.io/merged-contributions: "che-code"
+          controller.devfile.io/imported-by: "parent"
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          command:
+            - /checode/entrypoint-volume.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 3Gi
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+            - name: che-code
+              attributes:
+                type: main
+                cookiesAuthEnabled: true
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              path: '?tkn=eclipse-che'
+              secure: false
+              protocol: https
+            - name: code-redirect-1
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13131
+              exposure: public
+              protocol: http
+            - name: code-redirect-2
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13132
+              exposure: public
+              protocol: http
+            - name: code-redirect-3
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13133
+              exposure: public
+              protocol: http
+          mountSources: true
+      - name: checode
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        volume: {}
+      - name: che-code-injector
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        container:
+          image: quay.io/che-incubator/che-code:insiders
+          command:
+            - /entrypoint-init-container.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+    commands:
+      - id: init-container-command
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        apply:
+          component: che-code-injector
+    events:
+      preStart:
+          - init-container-command

--- a/pkg/library/flatten/testdata/implicit-spec-contributions/contributes-to-parent.yaml
+++ b/pkg/library/flatten/testdata/implicit-spec-contributions/contributes-to-parent.yaml
@@ -1,0 +1,190 @@
+name: "Can contribute to parent devworkspace"
+
+input:
+  devworkspace:
+    parent:
+      uri: parent.yaml
+  contributions:
+    - name: che-code
+      uri: che-code.yaml
+
+  devfileResources:
+    parent.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: parent
+      components:
+        - name: tools
+          container:
+            image: quay.io/devfile/universal-developer-image:latest
+            env:
+              - name: GOPATH
+                value: /projects:/home/user/go
+              - name: GOCACHE
+                value: /tmp/.cache
+            endpoints:
+              - name: 8080-tcp
+                targetPort: 8080
+            memoryLimit: 2Gi
+            mountSources: true
+    che-code.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: che-code
+      commands:
+        - id: init-container-command
+          apply:
+            component: che-code-injector
+      events:
+        preStart:
+          - init-container-command
+      components:
+        - name: che-code-runtime-description
+          attributes:
+            app.kubernetes.io/component: che-code-runtime
+            app.kubernetes.io/part-of: che-code.eclipse.org
+            controller.devfile.io/container-contribution: true
+          container:
+            image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+            command:
+              - /checode/entrypoint-volume.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 1024Mi
+            memoryRequest: 256Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+            endpoints:
+              - name: che-code
+                attributes:
+                  type: main
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                path: '?tkn=eclipse-che'
+                secure: false
+                protocol: https
+              - name: code-redirect-1
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13131
+                exposure: public
+                protocol: http
+              - name: code-redirect-2
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13132
+                exposure: public
+                protocol: http
+              - name: code-redirect-3
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13133
+                exposure: public
+                protocol: http
+        - name: checode
+          volume: {}
+        - name: che-code-injector
+          container:
+            image: quay.io/che-incubator/che-code:insiders
+            command:
+              - /entrypoint-init-container.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+
+output:
+  devworkspace:
+    components:
+      - name: tools
+        attributes:
+          app.kubernetes.io/component: che-code-runtime
+          app.kubernetes.io/part-of: che-code.eclipse.org
+          controller.devfile.io/merged-contributions: "che-code"
+          controller.devfile.io/imported-by: "parent"
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          command:
+            - /checode/entrypoint-volume.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 3Gi
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+            - name: che-code
+              attributes:
+                type: main
+                cookiesAuthEnabled: true
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              path: '?tkn=eclipse-che'
+              secure: false
+              protocol: https
+            - name: code-redirect-1
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13131
+              exposure: public
+              protocol: http
+            - name: code-redirect-2
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13132
+              exposure: public
+              protocol: http
+            - name: code-redirect-3
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13133
+              exposure: public
+              protocol: http
+          mountSources: true
+      - name: checode
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        volume: {}
+      - name: che-code-injector
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        container:
+          image: quay.io/che-incubator/che-code:insiders
+          command:
+            - /entrypoint-init-container.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+    commands:
+      - id: init-container-command
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        apply:
+          component: che-code-injector
+    events:
+      preStart:
+          - init-container-command

--- a/pkg/library/flatten/testdata/implicit-spec-contributions/prioritizes-parent-components-for-target.yaml
+++ b/pkg/library/flatten/testdata/implicit-spec-contributions/prioritizes-parent-components-for-target.yaml
@@ -1,0 +1,202 @@
+name: "Prioritizes contributing to parent components over child components"
+
+input:
+  devworkspace:
+    parent:
+      uri: parent.yaml
+    components:
+      - name: first-child-component
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          memoryLimit: 2Gi
+          mountSources: true
+  
+  contributions:
+    - name: che-code
+      uri: che-code.yaml
+
+  devfileResources:
+    parent.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: parent
+      components:
+        - name: tools
+          container:
+            image: quay.io/devfile/universal-developer-image:latest
+            env:
+              - name: GOPATH
+                value: /projects:/home/user/go
+              - name: GOCACHE
+                value: /tmp/.cache
+            endpoints:
+              - name: 8080-tcp
+                targetPort: 8080
+            memoryLimit: 2Gi
+            mountSources: true
+    che-code.yaml:
+      schemaVersion: 2.1.0
+      metadata:
+        name: che-code
+      commands:
+        - id: init-container-command
+          apply:
+            component: che-code-injector
+      events:
+        preStart:
+          - init-container-command
+      components:
+        - name: che-code-runtime-description
+          attributes:
+            app.kubernetes.io/component: che-code-runtime
+            app.kubernetes.io/part-of: che-code.eclipse.org
+            controller.devfile.io/container-contribution: true
+          container:
+            image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+            command:
+              - /checode/entrypoint-volume.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 1024Mi
+            memoryRequest: 256Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+            endpoints:
+              - name: che-code
+                attributes:
+                  type: main
+                  cookiesAuthEnabled: true
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 3100
+                exposure: public
+                path: '?tkn=eclipse-che'
+                secure: false
+                protocol: https
+              - name: code-redirect-1
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13131
+                exposure: public
+                protocol: http
+              - name: code-redirect-2
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13132
+                exposure: public
+                protocol: http
+              - name: code-redirect-3
+                attributes:
+                  discoverable: false
+                  urlRewriteSupported: true
+                targetPort: 13133
+                exposure: public
+                protocol: http
+        - name: checode
+          volume: {}
+        - name: che-code-injector
+          container:
+            image: quay.io/che-incubator/che-code:insiders
+            command:
+              - /entrypoint-init-container.sh
+            volumeMounts:
+              - name: checode
+                path: /checode
+            memoryLimit: 128Mi
+            memoryRequest: 32Mi
+            cpuLimit: 500m
+            cpuRequest: 30m
+
+output:
+  devworkspace:
+    components:
+      - name: first-child-component
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          memoryLimit: 2Gi
+          mountSources: true
+      - name: tools
+        attributes:
+          app.kubernetes.io/component: che-code-runtime
+          app.kubernetes.io/part-of: che-code.eclipse.org
+          controller.devfile.io/merged-contributions: "che-code"
+          controller.devfile.io/imported-by: "parent"
+        container:
+          image: quay.io/devfile/universal-developer-image:latest
+          command:
+            - /checode/entrypoint-volume.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 3Gi
+          env:
+            - name: GOPATH
+              value: /projects:/home/user/go
+            - name: GOCACHE
+              value: /tmp/.cache
+          endpoints:
+            - name: 8080-tcp
+              targetPort: 8080
+            - name: che-code
+              attributes:
+                type: main
+                cookiesAuthEnabled: true
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 3100
+              exposure: public
+              path: '?tkn=eclipse-che'
+              secure: false
+              protocol: https
+            - name: code-redirect-1
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13131
+              exposure: public
+              protocol: http
+            - name: code-redirect-2
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13132
+              exposure: public
+              protocol: http
+            - name: code-redirect-3
+              attributes:
+                discoverable: false
+                urlRewriteSupported: true
+              targetPort: 13133
+              exposure: public
+              protocol: http
+          mountSources: true
+      - name: checode
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        volume: {}
+      - name: che-code-injector
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        container:
+          image: quay.io/che-incubator/che-code:insiders
+          command:
+            - /entrypoint-init-container.sh
+          volumeMounts:
+            - name: checode
+              path: /checode
+          memoryLimit: 128Mi
+          memoryRequest: 32Mi
+          cpuLimit: 500m
+          cpuRequest: 30m
+    commands:
+      - id: init-container-command
+        attributes:
+          controller.devfile.io/imported-by: che-code
+        apply:
+          component: che-code-injector
+    events:
+      preStart:
+          - init-container-command


### PR DESCRIPTION
### What does this PR do?
Include components that were imported by a parent in potential targets for implicit merging of container contributions

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1158

### Is it tested? How?
I haven't had time to test this PR thoroughly; it should be ensured that including parents in merge targets still behaves as expected:
* What happens if a devfile contains both a component and a parent? Is the merge processed on the "expected" component?
  * E.g. if we have a parent devfile and add e.g. a 'database' container, is merging still processed as expected?

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
