### PR TITLE
[project-clone] Read additional certs from /public-certs at start

### DIFF
--- a/project-clone/internal/global.go
+++ b/project-clone/internal/global.go
@@ -32,6 +32,7 @@ import (
 const (
 	credentialsMountPath = "/.git-credentials/credentials"
 	sshConfigMountPath   = "/etc/ssh/ssh_config"
+	publicCertsDir       = "/public-certs"
 )
 
 var (

--- a/project-clone/internal/zip/setup.go
+++ b/project-clone/internal/zip/setup.go
@@ -35,7 +35,7 @@ const (
 )
 
 // SetupZipProject downloads and extracts a zip-type project to the corresponding clonePath.
-func SetupZipProject(project v1alpha2.Project) error {
+func SetupZipProject(project v1alpha2.Project, httpClient *http.Client) error {
 	if project.Zip == nil {
 		return fmt.Errorf("project has no 'zip' source")
 	}
@@ -54,7 +54,7 @@ func SetupZipProject(project v1alpha2.Project) error {
 
 	zipFilePath := path.Join(tmpDir, fmt.Sprintf("%s.zip", clonePath))
 	log.Printf("Downloading project archive from %s", url)
-	err := downloadZip(url, zipFilePath)
+	err := downloadZip(url, zipFilePath, httpClient)
 	if err != nil {
 		return fmt.Errorf("failed to download archive: %s", err)
 	}
@@ -83,9 +83,8 @@ func SetupZipProject(project v1alpha2.Project) error {
 //
 // Adapted from the Che plugin broker:
 // https://github.com/eclipse/che-plugin-broker/blob/27e7c6953c92633cbe7e8ce746a16ca10d240ea2/utils/ioutil.go#L67
-func downloadZip(url, destPath string) error {
-	client := http.DefaultClient
-	resp, err := client.Get(url)
+func downloadZip(url, destPath string, httpClient *http.Client) error {
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return err
 	}

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -29,6 +29,8 @@ import (
 	"github.com/devfile/devworkspace-operator/project-clone/internal"
 	"github.com/devfile/devworkspace-operator/project-clone/internal/git"
 	"github.com/devfile/devworkspace-operator/project-clone/internal/zip"
+	gitclient "github.com/go-git/go-git/v5/plumbing/transport/client"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
 const (
@@ -89,6 +91,7 @@ func main() {
 				},
 			},
 		}
+		gitclient.InstallProtocol("https", githttp.NewClient(httpClient))
 	}
 
 	encounteredError := false


### PR DESCRIPTION
### What does this PR do?
Configures the project-clone init container to read any `.crt` or `.pem` files stored in `/public-certs`. These certificates are added to the HTTP client used for preparing zip-based projects in a DevWorkspace, and allows for downloading project zips from default-untrusted sources by e.g. auto-mounting certificates to `/public-certs` in the container.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1160
Related: https://github.com/eclipse/che/issues/22393

### Is it tested? How?
A project-clone image for this PR is available at `quay.io/amisevsk/project-clone:self-signed`

It's easiest to test this PR via the reproducer in https://github.com/eclipse/che/issues/22393

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
