### PR TITLE
fix: don't abort PVC size calculation early if volume size not defined

### DIFF
--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -170,7 +170,7 @@ func getPVCSize(workspace *common.DevWorkspaceWithConfig, namespacedConfig *nsco
 
 			if component.Volume.Size == "" {
 				allVolumeSizesDefined = false
-				break
+				continue
 			}
 
 			volumeSize, err := resource.ParseQuantity(component.Volume.Size)

--- a/pkg/provision/storage/testdata/perWorkspace-storage/uses-calculated-pvc-size-when-greater-than-default.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/uses-calculated-pvc-size-when-greater-than-default.yaml
@@ -1,4 +1,4 @@
-name: "Calculates PVC size when all volumes define their size"
+name: "Calculates PVC size when sum of volumes with defined size is greater than default PVC size"
 
 input:
   devworkspaceId: "test-workspaceid"
@@ -26,6 +26,8 @@ input:
         container:
           image: testing-image-1
           sourceMapping: "/plugins-mountpath"
+      - name: plugins
+        volume: {} # Size is not defined, but calculated PVC size will be greater than default 5Gi so, calculated size should be used
       - name: volume-1
         volume:
           size: 1Gi
@@ -38,8 +40,6 @@ input:
       - name: volume-4
         volume:
           size: 248Mi
-      - name: plugins
-        volume: {} # Size is not defined, but calculated PVC size will be greater than default 5Gi so, calculated size should be used
 
 output:
   pvcSize: 5880Mi


### PR DESCRIPTION
### What does this PR do?
The following rules are supposed to be used when computing the per-workspace PVC size:
1. If all volumes in a devworkspace specify their size, the computed PVC size will be used.
2. If all volumes in a devworkspace either specify their size or are ephemeral, the computed PVC size will be used.
3. If at least one volume in a devworkspace specifies its size, and the computed PVC size is greater than the default per-workspace PVC size, the computed PVC size will be used.

Prior to this PR, rule 3 was not being respected in cases where a volume did not define its size, but later volumes (in the volume array) did define their sizes.

This commit prevents aborting the PVC size calculation too early, and modifies the test case that was relevant to rule 3 to ensure the case from https://github.com/devfile/devworkspace-operator/issues/1162 is accounted for.


### What issues does this PR fix or reference?
Fix #1162

### Is it tested? How?
1. Install DWO using the changes from this PR
2. Apply the following reproducer devworkspace:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: pvc-size-reproducer
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
        controller.devfile.io/storage-type: per-workspace
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
          volumeMounts:
            - name: no-size-volume
              path: /home/user/no-size-volume
            - name: sized-volume
              path: /home/user/sized-volume
      - name: no-size-volume
        volume: {}
      - name: sized-volume
        volume:
          size: 10Gi
```

3. Verify that the PVC created for the devworkspace has a claim size of 10Gi rather than the default 5Gi.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
