### PR TITLE
Extend workspace SA permissions to all secrets/configmaps in namespace

### DIFF
--- a/docs/workspace-capabilities.md
+++ b/docs/workspace-capabilities.md
@@ -33,8 +33,6 @@ rules:
   - watch
 - apiGroups:
   - ""
-  resourceNames:
-  - workspace-credentials-secret
   resources:
   - secrets
   verbs:
@@ -44,8 +42,6 @@ rules:
   - delete
 - apiGroups:
   - ""
-  resourceNames:
-  - workspace-preferences-configmap
   resources:
   - configmaps
   verbs:

--- a/docs/workspace-capabilities.md
+++ b/docs/workspace-capabilities.md
@@ -37,8 +37,10 @@ rules:
   - secrets
   verbs:
   - get
+  - list
   - create
   - patch
+  - update
   - delete
 - apiGroups:
   - ""
@@ -46,8 +48,10 @@ rules:
   - configmaps
   verbs:
   - get
+  - list
   - create
   - patch
+  - update
   - delete
 - apiGroups:
   - workspace.devfile.io

--- a/pkg/provision/workspace/rbac/role.go
+++ b/pkg/provision/workspace/rbac/role.go
@@ -95,12 +95,12 @@ func generateDefaultRole(namespace string) *rbacv1.Role {
 			{
 				Resources: []string{"secrets"},
 				APIGroups: []string{""},
-				Verbs:     []string{"get", "create", "patch", "delete"},
+				Verbs:     []string{"get", "list", "create", "patch", "update", "delete"},
 			},
 			{
 				Resources: []string{"configmaps"},
 				APIGroups: []string{""},
-				Verbs:     []string{"get", "create", "patch", "delete"},
+				Verbs:     []string{"get", "list", "create", "patch", "update", "delete"},
 			},
 			{
 				Resources: []string{"devworkspaces"},

--- a/pkg/provision/workspace/rbac/role.go
+++ b/pkg/provision/workspace/rbac/role.go
@@ -93,16 +93,14 @@ func generateDefaultRole(namespace string) *rbacv1.Role {
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
-				Resources:     []string{"secrets"},
-				APIGroups:     []string{""},
-				Verbs:         []string{"get", "create", "patch", "delete"},
-				ResourceNames: []string{"workspace-credentials-secret"},
+				Resources: []string{"secrets"},
+				APIGroups: []string{""},
+				Verbs:     []string{"get", "create", "patch", "delete"},
 			},
 			{
-				Resources:     []string{"configmaps"},
-				APIGroups:     []string{""},
-				Verbs:         []string{"get", "create", "patch", "delete"},
-				ResourceNames: []string{"workspace-preferences-configmap"},
+				Resources: []string{"configmaps"},
+				APIGroups: []string{""},
+				Verbs:     []string{"get", "create", "patch", "delete"},
 			},
 			{
 				Resources: []string{"devworkspaces"},


### PR DESCRIPTION
### What does this PR do?
Update the default permissions granted to DevWorkspaces to allow read/write access for all secrets/configmaps in the workspace's namespace.

We should decide if the privilege escalation here represents an issue before merging this PR. With this change, permissions to create DevWorkspaces = permissions to read/write all secrets/configmaps in the current namespace.

### What issues does this PR fix or reference?
No issue currently.

### Is it tested? How?
Changes are pushed to `quay.io/amisevsk/devworkspace-controller:workspace-permissions`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
