### PR TITLE
Handle failures in routing reconciler in recoverable way

### DIFF
--- a/apis/controller/v1alpha1/devworkspacerouting_types.go
+++ b/apis/controller/v1alpha1/devworkspacerouting_types.go
@@ -62,6 +62,7 @@ const (
 	RoutingReady     DevWorkspaceRoutingPhase = "Ready"
 	RoutingPreparing DevWorkspaceRoutingPhase = "Preparing"
 	RoutingFailed    DevWorkspaceRoutingPhase = "Failed"
+	RoutingStopped   DevWorkspaceRoutingPhase = "Stopped"
 )
 
 type ExposedEndpoint struct {

--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
@@ -108,6 +108,9 @@ func (r *DevWorkspaceRoutingReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	if instance.Annotations != nil && instance.Annotations[constants.DevWorkspaceStartedStatusAnnotation] == "false" {
+		if err := r.setStatusStopped(instance); err != nil {
+			return reconcile.Result{}, err
+		}
 		return reconcile.Result{}, nil
 	}
 
@@ -288,6 +291,14 @@ func (r *DevWorkspaceRoutingReconciler) reconcileStatus(
 	instance.Status.Message = "DevWorkspaceRouting prepared"
 	instance.Status.PodAdditions = routingObjects.PodAdditions
 	instance.Status.ExposedEndpoints = exposedEndpoints
+	return r.Status().Update(context.TODO(), instance)
+}
+
+func (r *DevWorkspaceRoutingReconciler) setStatusStopped(instance *controllerv1alpha1.DevWorkspaceRouting) error {
+	instance.Status.Phase = controllerv1alpha1.RoutingStopped
+	instance.Status.Message = "DevWorkspace is not started"
+	instance.Status.PodAdditions = nil
+	instance.Status.ExposedEndpoints = nil
 	return r.Status().Update(context.TODO(), instance)
 }
 


### PR DESCRIPTION
### What does this PR do?
When a DevWorkspaceRouting fails to provision objects, it enters the 'Failed' phase. In order to prevent repeated unnecessary reconciles, the controller ignores DWRs that are already Failed, which leads to the 'Failed' phase being permanent.

To avoid this, we instead set a Stopped phase when the parent workspace is stopped. This will clear the Failed phase and any message that was set, so the DevWorkspace controller will need to propagate it into the DevWorkspace object to allow it to be shown.

### What issues does this PR fix or reference?
Closes #923 

### Is it tested? How?
To test, follow the reproducer in #923 and verify this PR fixes the issue (allows failed workspaces to be restarted):

1. Install DWO and the Eclipse Che operator in a cluster
2. Create two CheCluster CRs in the cluster and wait for them to be set up. This will cause all routingClass: che DWRs to fail during reconcile.
3. Create a DevWorkspace with routingClass: che. Workspace will fail to start
4. Delete one of the two CheClusters. While new routingClass: che workspaces will start successfully, it's not possible to restart the failed workspace.

alternatively, this PR can be tested by patching the DevWorkspace controller pod to mark routing objects as failed instead of ready by replacing [this block](https://github.com/devfile/devworkspace-operator/blob/65bdb9e652d16e1f8d413ae77e92a01464f43c7c/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go#L287-L291) with
```go
r.markRoutingFailed(instance, "testing failure")
```
in order to get a failed DevWorkspaceRouting. Then undo the patch and retest to ensure workspace can be restarted after failure.

In testing, when the DevWorkspaceRouting fails, the DevWorkspace should also be marked as failed, and the failure message on the DevWorkspace should include all applicable context from the DevWorkspaceRouting.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
