### PR TITLE
[project-clone] Initialize and update submodules when present in project

### DIFF
--- a/project-clone/internal/git/operations.go
+++ b/project-clone/internal/git/operations.go
@@ -18,6 +18,8 @@ package git
 import (
 	"fmt"
 	"log"
+	"os"
+	"path"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/go-git/go-git/v5"
@@ -114,6 +116,18 @@ func SetupRemotes(repo *git.Repository, project *dw.Project, projectPath string)
 			return fmt.Errorf("failed to fetch from remote %s: %s", remoteUrl, err)
 		}
 		log.Printf("Fetched remote %s at %s", remoteName, remoteUrl)
+	}
+	return nil
+}
+
+func SetupSubmodules(project *dw.Project, projectPath string) error {
+	if _, err := os.Stat(path.Join(projectPath, ".gitmodules")); os.IsNotExist(err) {
+		// No submodules; do nothing
+		return nil
+	}
+	log.Printf("Initializing submodules for project %s", project.Name)
+	if err := shell.GitInitSubmodules(projectPath); err != nil {
+		return fmt.Errorf("git submodule update --init --recursive failed: %s", err)
 	}
 	return nil
 }

--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -71,6 +71,10 @@ func doInitialGitClone(project *dw.Project) error {
 		return fmt.Errorf("failed to checkout revision: %s", err)
 	}
 
+	if err := SetupSubmodules(project, tmpClonePath); err != nil {
+		log.Printf("Failed to set up submodules in project: %s", err)
+	}
+
 	if err := copyProjectFromTmpDir(project, tmpClonePath); err != nil {
 		return err
 	}

--- a/project-clone/internal/shell/execute.go
+++ b/project-clone/internal/shell/execute.go
@@ -99,6 +99,10 @@ func GitResolveReference(projectPath, remote, revision string) (GitRefType, erro
 	return GitRefUnknown, nil
 }
 
+func GitInitSubmodules(projectPath string) error {
+	return executeCommand("git", "-C", projectPath, "submodule", "update", "--init", "--recursive")
+}
+
 func executeCommand(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Stderr = log.Writer()


### PR DESCRIPTION
### What does this PR do?
If a cloned-and-checked-out project has a `.gitmodules` file in the root of the repo, run `git submodule update --init --recursive` inside the project to clone all submodules.

Failures in setting up submodules result only in a warning log and do not prevent the project from being 'set up', as the user can later initialize submodules manually.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/949

### Is it tested? How?
Can be tested by cloning https://github.com/dkwon17/submodule-test

Changes are built and pushed to `quay.io/amisevsk/project-clone:submodules`. To test changes with an existing DevWorkspace Operator, set the `RELATED_IMAGE_project_clone` environment variable to `quay.io/amisevsk/project-clone:submodules`
* Kubernetes/OpenShift manual install: update the devworkspace-controller deployment directly
* OpenShift Operator subscription: update the devworkspace-operator CSV `.spec.install.spec.deployments[0]` and wait for the controller to roll out

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
