### PR TITLE
Support events.preStop

### DIFF
--- a/docs/unsupported-devfile-api.adoc
+++ b/docs/unsupported-devfile-api.adoc
@@ -10,8 +10,7 @@ The following features of the Devfile API that are not yet supported by the DevW
 | `components.container.dedicatedPod`           |                                                                                                                                                
 | `components.image`                            | https://github.com/eclipse/che/issues/21186[Support Devfile v2 outer loop components of type image and kubernetes]                             
 | `components.custom`                           |                                                                                                                                                
-| `events.postStop`                             |                                                                                                                                                
-| `events.preStop`                              |                                                                                                                                                                                             
+| `events.postStop`                             |                                                  
 |================================================================================================================================================================================================
 
 If there is no corresponding issue for a Devfile feature you'd like to use, please feel free to submit a feature request.

--- a/pkg/library/container/container.go
+++ b/pkg/library/container/container.go
@@ -80,6 +80,10 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, securi
 		return nil, err
 	}
 
+	if err := lifecycle.AddPreStopLifecycleHooks(workspace, podAdditions.Containers); err != nil {
+		return nil, err
+	}
+
 	for _, initComponent := range initComponents {
 		k8sContainer, err := convertContainerToK8s(initComponent, securityContext, pullPolicy, defaultResources)
 		if err != nil {

--- a/pkg/library/lifecycle/prestop_test.go
+++ b/pkg/library/lifecycle/prestop_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type preStopTestCase struct {
+	Name     string            `json:"name,omitempty"`
+	Input    preStopTestInput  `json:"input,omitempty"`
+	Output   preStopTestOutput `json:"output,omitempty"`
+	testPath string
+}
+
+type preStopTestInput struct {
+	Devfile    *dw.DevWorkspaceTemplateSpec `json:"devfile,omitempty"`
+	Containers []corev1.Container           `json:"containers,omitempty"`
+}
+
+type preStopTestOutput struct {
+	Containers []corev1.Container `json:"containers,omitempty"`
+	ErrRegexp  *string            `json:"errRegexp,omitempty"`
+}
+
+func loadPreStopTestCaseOrPanic(t *testing.T, testPath string) preStopTestCase {
+	bytes, err := os.ReadFile(testPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var test preStopTestCase
+	if err := yaml.Unmarshal(bytes, &test); err != nil {
+		t.Fatal(err)
+	}
+	test.testPath = testPath
+	return test
+}
+
+func loadAllPreStopTestCasesOrPanic(t *testing.T, fromDir string) []preStopTestCase {
+	files, err := os.ReadDir(fromDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tests []preStopTestCase
+	for _, file := range files {
+		if file.IsDir() {
+			tests = append(tests, loadAllPreStopTestCasesOrPanic(t, filepath.Join(fromDir, file.Name()))...)
+		} else {
+			tests = append(tests, loadPreStopTestCaseOrPanic(t, filepath.Join(fromDir, file.Name())))
+		}
+	}
+	return tests
+}
+
+func TestAddPreStopLifecycleHooks(t *testing.T) {
+	tests := loadAllPreStopTestCasesOrPanic(t, "./testdata/preStop")
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.testPath), func(t *testing.T) {
+			err := AddPreStopLifecycleHooks(tt.Input.Devfile, tt.Input.Containers)
+			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
+				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
+			} else {
+				if !assert.NoError(t, err, "Should not return error") {
+					return
+				}
+				assert.Equal(t, tt.Output.Containers, tt.Input.Containers, "Containers should be updated to match expected output")
+			}
+		})
+	}
+}

--- a/pkg/library/lifecycle/testdata/preStop/adds_all_preStop_commands.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/adds_all_preStop_commands.yaml
@@ -1,0 +1,57 @@
+name: "Adds all preStop events to containers"
+
+input:
+  devfile:
+    commands:
+      - id: test-preStop-1
+        exec:
+          component: test-component-1
+          commandLine: "echo 'hello world 1'"
+      - id: test-preStop-2
+        exec:
+          component: test-component-2
+          commandLine: "echo 'hello world 2'"
+          workingDir: "/tmp/test-dir"
+    events:
+      preStop:
+        - test-preStop-1
+        - test-preStop-2
+
+  containers:
+    - name: test-component-1
+      image: test-img
+    - name: test-component-2
+      image: test-img
+    - name: test-component-3
+      image: test-img
+
+output:
+  containers:
+    - name: test-component-1
+      image: test-img
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - "/bin/sh"
+              - "-c"
+              - |
+                {
+                echo 'hello world 1'
+                }
+    - name: test-component-2
+      image: test-img
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - "/bin/sh"
+              - "-c"
+              - |
+                {
+                cd /tmp/test-dir
+                echo 'hello world 2'
+                }
+
+    - name: test-component-3
+      image: test-img

--- a/pkg/library/lifecycle/testdata/preStop/basic_preStop.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/basic_preStop.yaml
@@ -1,0 +1,30 @@
+name: "Should add preStop lifecycle hook for basic event"
+
+input:
+  devfile:
+    commands:
+      - id: test-preStop
+        exec:
+          component: test-component
+          commandLine: "echo 'hello world'"
+    events:
+      preStop:
+        - test-preStop
+  containers:
+    - name: test-component
+      image: test-img
+
+output:
+  containers:
+    - name: test-component
+      image: test-img
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - "/bin/sh"
+              - "-c"
+              - |
+                {
+                echo 'hello world'
+                }

--- a/pkg/library/lifecycle/testdata/preStop/error_command_has_env.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/error_command_has_env.yaml
@@ -1,0 +1,21 @@
+name: "Returns error when preStop command requires env vars"
+
+input:
+  devfile:
+    commands:
+      - id: test-cmd
+        exec:
+          component: test-component
+          commandLine: "echo hello world ${MY_ENV}"
+          env:
+            - name: MY_ENV
+              value: /projects
+    events:
+      preStop:
+        - test-cmd
+  containers:
+    - name: test-component
+      image: test-img
+
+output:
+  errRegexp: ".*env vars in preStop command test-cmd are unsupported.*"

--- a/pkg/library/lifecycle/testdata/preStop/error_preStop_cmd_is_not_exec.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/error_preStop_cmd_is_not_exec.yaml
@@ -1,0 +1,14 @@
+name: "Returns error when preStop command is not exec-type"
+
+input:
+  devfile:
+    commands:
+      - id: test-command
+        apply:
+          component: my-component
+    events:
+      preStop:
+        - test-command
+
+output:
+  errRegexp: "can not use Apply-type command in preStop lifecycle event"

--- a/pkg/library/lifecycle/testdata/preStop/error_preStop_command_does_not_exist.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/error_preStop_command_does_not_exist.yaml
@@ -1,0 +1,10 @@
+name: "Returns error when preStop command does not exist"
+
+input:
+  devfile:
+    events:
+      preStop:
+        - test-cmd
+
+output:
+  errRegexp: ".*could not resolve command for preStop event 'test-cmd'.*"

--- a/pkg/library/lifecycle/testdata/preStop/error_preStop_command_uses_nonexistent_container.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/error_preStop_command_uses_nonexistent_container.yaml
@@ -1,0 +1,18 @@
+name: "Returns error when preStop command requires nonexistent container"
+
+input:
+  devfile:
+    commands:
+      - id: test-cmd
+        exec:
+          component: test-component-wrong-name
+          commandLine: "echo hello world"
+    events:
+      preStop:
+        - test-cmd
+  containers:
+    - name: test-component
+      image: test-img
+
+output:
+  errRegexp: ".*failed to process preStop event 'test-cmd':.*container component with name .* not found.*"

--- a/pkg/library/lifecycle/testdata/preStop/multiple_prestop_commands.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/multiple_prestop_commands.yaml
@@ -1,0 +1,36 @@
+name: "Multiple preStop commands use same component"
+
+input:
+  devfile:
+    commands:
+      - id: test-cmd-1
+        exec:
+          component: test-component
+          commandLine: "echo 'hello world 1'"
+      - id: test-cmd-2
+        exec:
+          component: test-component
+          commandLine: "echo 'hello world 2'"
+    events:
+      preStop:
+        - test-cmd-1
+        - test-cmd-2
+  containers:
+    - name: test-component
+      image: test-img
+
+output:
+  containers:
+    - name: test-component
+      image: test-img
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - "/bin/sh"
+              - "-c"
+              - |
+                {
+                echo 'hello world 1'
+                echo 'hello world 2'
+                }

--- a/pkg/library/lifecycle/testdata/preStop/no_events.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/no_events.yaml
@@ -1,0 +1,12 @@
+name: "Should do nothing when devfile does not specify events"
+
+input:
+  devfile: {}
+  containers:
+    - name: test-container
+      image: my-test-image
+
+output:
+  containers:
+    - name: test-container
+      image: my-test-image

--- a/pkg/library/lifecycle/testdata/preStop/no_preStop.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/no_preStop.yaml
@@ -1,0 +1,20 @@
+name: "Should do nothing when devfile does not include preStop events"
+
+input:
+  devfile:
+    commands:
+      - id: prestart-cmd
+        exec:
+          component: test-component
+          commandLine: echo "Hello from $(pwd)"
+    events:
+      preStart:
+        - prestart-cmd
+  containers:
+    - name: test-container
+      image: my-test-image
+
+output:
+  containers:
+    - name: test-container
+      image: my-test-image

--- a/pkg/library/lifecycle/testdata/preStop/workingDir_preStop.yaml
+++ b/pkg/library/lifecycle/testdata/preStop/workingDir_preStop.yaml
@@ -1,0 +1,32 @@
+name: "Should add preStop lifecycle hook for event with workingDir"
+
+input:
+  devfile:
+    commands:
+      - id: test-preStop
+        exec:
+          component: test-component
+          commandLine: "echo 'hello world'"
+          workingDir: "/tmp/test-dir"
+    events:
+      preStop:
+        - test-preStop
+  containers:
+    - name: test-component
+      image: test-img
+
+output:
+  containers:
+    - name: test-component
+      image: test-img
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - "/bin/sh"
+              - "-c"
+              - |
+                {
+                cd /tmp/test-dir
+                echo 'hello world'
+                }

--- a/pkg/library/lifecycle/util.go
+++ b/pkg/library/lifecycle/util.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func getContainerWithName(name string, containers []corev1.Container) (*corev1.Container, error) {
+	for idx, container := range containers {
+		if container.Name == name {
+			return &containers[idx], nil
+		}
+	}
+	return nil, fmt.Errorf("container component with name %s not found", name)
+}

--- a/webhook/workspace/handler/testdata/warning/add-all-unsupported-features.yaml
+++ b/webhook/workspace/handler/testdata/warning/add-all-unsupported-features.yaml
@@ -53,5 +53,5 @@ input:
         - eventF
 
 output:
-  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.annotation.service, used by components: testing-container-1; components[].container.endpoints[].annotations, used by components: testing-container-1; components[].container.dedicatedPod, used by components: testing-container-1; components[].image, used by components: image-component; components[].custom, used by components: custom-component; events.postStop: eventD, eventE, eventF; events.preStop: eventA, eventB, eventC"
+  expectedWarning: "Unsupported Devfile features are present in this workspace. The following features will have no effect: components[].container.annotation.service, used by components: testing-container-1; components[].container.endpoints[].annotations, used by components: testing-container-1; components[].container.dedicatedPod, used by components: testing-container-1; components[].image, used by components: image-component; components[].custom, used by components: custom-component; events.postStop: eventD, eventE, eventF"
   newWarningsPresent: true

--- a/webhook/workspace/handler/warning.go
+++ b/webhook/workspace/handler/warning.go
@@ -30,7 +30,6 @@ type unsupportedWarnings struct {
 	imageComponent      map[string]bool
 	customComponent     map[string]bool
 	eventPostStop       map[string]bool
-	eventPreStop        map[string]bool
 }
 
 // Returns an initialized unsupportedWarnings struct
@@ -42,7 +41,6 @@ func newUnsupportedWarnings() *unsupportedWarnings {
 		imageComponent:      make(map[string]bool),
 		customComponent:     make(map[string]bool),
 		eventPostStop:       make(map[string]bool),
-		eventPreStop:        make(map[string]bool),
 	}
 }
 
@@ -76,12 +74,6 @@ func checkUnsupportedFeatures(devWorkspaceSpec dwv2.DevWorkspaceTemplateSpec) (w
 				warnings.eventPostStop[event] = true
 			}
 		}
-		if len(devWorkspaceSpec.Events.PreStop) > 0 {
-			for _, event := range devWorkspaceSpec.Events.PreStop {
-				warnings.eventPreStop[event] = true
-			}
-
-		}
 	}
 	return warnings
 }
@@ -92,8 +84,7 @@ func unsupportedWarningsPresent(warnings *unsupportedWarnings) bool {
 		len(warnings.dedicatedPod) > 0 ||
 		len(warnings.imageComponent) > 0 ||
 		len(warnings.customComponent) > 0 ||
-		len(warnings.eventPostStop) > 0 ||
-		len(warnings.eventPreStop) > 0
+		len(warnings.eventPostStop) > 0
 }
 
 func formatUnsupportedFeaturesWarning(warnings *unsupportedWarnings) string {
@@ -133,10 +124,6 @@ func formatUnsupportedFeaturesWarning(warnings *unsupportedWarnings) string {
 		eventPostStopMsg := "events.postStop: " + strings.Join(getWarningNames(warnings.eventPostStop), ", ")
 		msg = append(msg, eventPostStopMsg)
 	}
-	if len(warnings.eventPreStop) > 0 {
-		eventPreStopMsg := "events.preStop: " + strings.Join(getWarningNames(warnings.eventPreStop), ", ")
-		msg = append(msg, eventPreStopMsg)
-	}
 	return fmt.Sprintf("Unsupported Devfile features are present in this workspace. The following features will have no effect: %s", strings.Join(msg, "; "))
 }
 
@@ -162,7 +149,6 @@ func checkForAddedUnsupportedFeatures(oldWksp, newWksp *dwv2.DevWorkspace) *unsu
 	addedWarnings.dedicatedPod = getAddedWarnings(oldWarnings.dedicatedPod, newWarnings.dedicatedPod)
 	addedWarnings.imageComponent = getAddedWarnings(oldWarnings.imageComponent, newWarnings.imageComponent)
 	addedWarnings.customComponent = getAddedWarnings(oldWarnings.customComponent, newWarnings.customComponent)
-	addedWarnings.eventPreStop = getAddedWarnings(oldWarnings.eventPreStop, newWarnings.eventPreStop)
 	addedWarnings.eventPostStop = getAddedWarnings(oldWarnings.eventPostStop, newWarnings.eventPostStop)
 	return addedWarnings
 }


### PR DESCRIPTION
### What does this PR do?
Adds support for `events.preStop` in devworkspaces. Only exec type commands are supported.

Multiple preStop commands may be executed, following a similar format to [postStart events](https://github.com/devfile/devworkspace-operator/pull/1081), the difference being that the output of the commands are redirected to` /proc/1/fd/1`  (for stdout) and `/proc/1/fd/2` for stderr. This allows reading the output of preStop commands in the kubernetes logs after pod termination. 

The webhook warning against the usage of `events.preStop` was removed, as well as the mention of `events.preStop` in the unsupported devfile API doc.

### What issues does this PR fix or reference?
Fix #1139

### Is it tested? How?
Some automated tests (based on the postStart test cases) were added.

To manually test:
1. Install DWO using the changes from this PR. Make sure the webhook is also built from this PR, otherwise you'll get the old warning about using `events.preStop`
2. Apply a DevWorkspace that uses preStop events. I tested with the following:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: pre-stop-test
spec:
  started: true
  routingClass: 'basic'
  template:
    projects:
    - name: web-nodejs-sample
      git:
        remotes:
          origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
    commands:
    - id: failing-command
      exec:
        component: web-terminal
        commandLine: ./not-a-script.sh
        workingDir: /tmp/
    - id: list-in-project
      exec:
        component: web-terminal
        commandLine: ls -al
        workingDir: ${PROJECT_SOURCE}
    - id: long-command
      exec:
        component: web-terminal
        commandLine: |
          date
          pwd
          sleep 5s
          echo "done sleeping"
        workingDir: $HOME
    - id: output-to-file
      exec:
        component: web-terminal
        commandLine: echo "writing to a file" > output-to-file.log
        workingDir: ${PROJECT_SOURCE}
    - id: multi-line-command
      exec:
        component: web-terminal
        commandLine: |
          echo "date: $(date)" > multi-line-command.log
          pwd >> multi-line-command.log
          sleep 5s
          echo "done sleeping: $(date)" >> multi-line-command.log
        workingDir: $HOME
    - id: background-longrunning
      exec:
        component: web-terminal
        commandLine: |
          nohup sh -c '{
            for i in {1..500}; do
              echo "background: $i"
              sleep 1
            done
          }' &
    events:
      preStop:
        - long-command
        - background-longrunning
        - output-to-file
        - failing-command
        - multi-line-command
        - list-in-project
```
3. After the Devworkspace starts up, find the workspace pod's name. In my case, workspace623a8f20aa6442f3-6dccd76799-mqnt5 :
```
$ kubectl get pods -n $NAMESPACE
NAME                                           READY   STATUS    RESTARTS   AGE
devworkspace-webhook-server-7ff4b8d7bf-szb8f   2/2     Running   0          89s
workspace623a8f20aa6442f3-6dccd76799-mqnt5     1/1     Running   0          63s
```
4. Open another terminal and monitor the logs of the workspace pod: `kubectl logs -f workspace623a8f20aa6442f3-6dccd76799-mqnt5 -n $NAMESPACE`

5. In another terminal, delete the DevWorkspace: `kubectl delete dw pre-stop-test -n $NAMESPACE`

6. In the terminal that you're monitoring the logs, you should see the output of all preStop event commands:

```
$ kubectl logs -f workspace623a8f20aa6442f3-6dccd76799-mqnt5 -n $NAMESPACE
Defaulted container "web-terminal" out of: web-terminal, project-clone (init)
Wed Aug 23 15:56:13 UTC 2023
/home/user
done sleeping
/bin/sh: line 17: ./not-a-script.sh: No such file or directory
background: 1
background: 2
background: 3
background: 4
background: 5
total 56
drwxr-xr-x. 1 1234 root   240 Aug 23 15:56 .
drwxrwxrwx. 1 root root    34 Aug 23 15:52 ..
drwxr-xr-x. 1 1234 root   158 Aug 23 15:52 .git
-rw-r--r--. 1 1234 root    25 Aug 23 15:52 .gitattributes
drwxr-xr-x. 1 1234 root    20 Aug 23 15:52 .github
-rw-r--r--. 1 1234 root    14 Aug 23 15:52 .gitignore
drwxr-xr-x. 1 1234 root    52 Aug 23 15:52 .vscode
-rw-r--r--. 1 1234 root 14197 Aug 23 15:52 LICENSE
-rw-r--r--. 1 1234 root   449 Aug 23 15:52 README.md
drwxr-xr-x. 1 1234 root    12 Aug 23 15:52 app
-rw-r--r--. 1 1234 root  1384 Aug 23 15:52 devfile.yaml
-rw-r--r--. 1 1234 root    18 Aug 23 15:56 output-to-file.log
-rw-r--r--. 1 1234 root 14289 Aug 23 15:52 package-lock.json
-rw-r--r--. 1 1234 root   265 Aug 23 15:52 package.json
background: 6
background: 7
background: 8
background: 9
background: 10
background: 11
background: 12
background: 13
background: 14
background: 15
$ # Pod has fully terminated and preStop events have finished
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
