### PR TITLE
Set default container security context on OpenShift

### DIFF
--- a/pkg/config/common_test.go
+++ b/pkg/config/common_test.go
@@ -55,6 +55,7 @@ func setupForTest(t *testing.T) {
 	}
 	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
 	setDefaultPodSecurityContext()
+	setDefaultContainerSecurityContext()
 	configNamespace = testNamespace
 	originalDefaultConfig := defaultConfig.DeepCopy()
 	t.Cleanup(func() {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -49,8 +49,8 @@ var defaultConfig = &v1alpha1.OperatorConfiguration{
 		IdleTimeout:              "15m",
 		ProgressTimeout:          "5m",
 		CleanupOnStop:            pointer.Bool(false),
-		PodSecurityContext:       nil,
-		ContainerSecurityContext: &corev1.SecurityContext{},
+		PodSecurityContext:       nil, // Set per-platform in setDefaultPodSecurityContext()
+		ContainerSecurityContext: nil, // Set per-platform in setDefaultContainerSecurityContext()
 		DefaultTemplate:          nil,
 		ProjectCloneConfig: &v1alpha1.ProjectCloneConfig{
 			Resources: &corev1.ResourceRequirements{
@@ -75,14 +75,26 @@ var defaultConfig = &v1alpha1.OperatorConfiguration{
 	},
 }
 
-var defaultKubernetesPodSecurityContext = &corev1.PodSecurityContext{
-	RunAsUser:    pointer.Int64(1234),
-	RunAsGroup:   pointer.Int64(0),
-	RunAsNonRoot: pointer.Bool(true),
-	FSGroup:      pointer.Int64(1234),
-}
-
-var defaultOpenShiftPodSecurityContext = &corev1.PodSecurityContext{}
+var (
+	defaultKubernetesPodSecurityContext = &corev1.PodSecurityContext{
+		RunAsUser:    pointer.Int64(1234),
+		RunAsGroup:   pointer.Int64(0),
+		RunAsNonRoot: pointer.Bool(true),
+		FSGroup:      pointer.Int64(1234),
+	}
+	defaultKubernetesContainerSecurityContext = &corev1.SecurityContext{}
+	defaultOpenShiftPodSecurityContext        = &corev1.PodSecurityContext{}
+	defaultOpenShiftContainerSecurityContext  = &corev1.SecurityContext{
+		ReadOnlyRootFilesystem:   pointer.Bool(false),
+		RunAsNonRoot:             pointer.Bool(true),
+		AllowPrivilegeEscalation: pointer.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+	}
+)
 
 // Necessary variables for setting pointer values
 var (
@@ -98,6 +110,18 @@ func setDefaultPodSecurityContext() error {
 		defaultConfig.Workspace.PodSecurityContext = defaultOpenShiftPodSecurityContext
 	} else {
 		defaultConfig.Workspace.PodSecurityContext = defaultKubernetesPodSecurityContext
+	}
+	return nil
+}
+
+func setDefaultContainerSecurityContext() error {
+	if !infrastructure.IsInitialized() {
+		return fmt.Errorf("can not set default container security context, infrastructure not detected")
+	}
+	if infrastructure.IsOpenShift() {
+		defaultConfig.Workspace.ContainerSecurityContext = defaultOpenShiftContainerSecurityContext
+	} else {
+		defaultConfig.Workspace.ContainerSecurityContext = defaultKubernetesContainerSecurityContext
 	}
 	return nil
 }

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -100,6 +100,7 @@ func SetGlobalConfigForTesting(testConfig *controller.OperatorConfiguration) {
 	configMutex.Lock()
 	defer configMutex.Unlock()
 	setDefaultPodSecurityContext()
+	setDefaultContainerSecurityContext()
 	internalConfig = defaultConfig.DeepCopy()
 	mergeConfig(testConfig, internalConfig)
 }
@@ -109,6 +110,9 @@ func SetupControllerConfig(client crclient.Client) error {
 		return fmt.Errorf("internal controller configuration is already set up")
 	}
 	if err := setDefaultPodSecurityContext(); err != nil {
+		return err
+	}
+	if err := setDefaultContainerSecurityContext(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?
Set the default value for `ContainerSecurityContext` to match the security context required by OpenShift's `restricted-v2` SCC. This ensures that workspaces don't accidentally use a higher-priority, lower-permission SCC (e.g. one that requires `readOnlyRootFilesystem: true`)

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1170

### Is it tested? How?
I haven't had a chance to test it yet (to come, tomorrow)

To verify:
* On Kubernetes, behavior is unchanged, containers do not get anything set for container security context
* On OpenShift, verify that #1170 cannot be reproduced; pod/container spec should look the same as before as the restricted-v2 SCC sets fields matching the default
* Also necessary to verify that this change does not interfere with how Eclipse Che sets the default security context to allow for `podman build`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
