### PR TITLE
Change runner image to use nodejs18+go

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,16 +13,28 @@
 # limitations under the License.
 #
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.access.redhat.com/ubi9/nodejs-18:1
+# hadolint ignore=DL3002
+USER 0
 
-SHELL ["/bin/bash", "-c"]
+# hadolint ignore=DL3041
+RUN dnf install -y -q --allowerasing --nobest nodejs-devel nodejs-libs \
+  # already installed or installed as deps:
+  openssl openssl-devel ca-certificates make cmake cpp gcc gcc-c++ zlib zlib-devel brotli brotli-devel python3 nodejs-packaging && \
+  dnf update -y && dnf clean all && \
+  npm install -g yarn@1.22 npm@9 && \
+  echo -n "node version: "; node -v; \
+  echo -n "npm  version: "; npm -v; \
+  echo -n "yarn version: "; yarn -v
 
-RUN yum install --assumeyes -d1 python3-pip && \
-    pip3 install --upgrade setuptools && \
-    # Need to pin yq version due to version 3.2.0 requiring python 3.6 and above
-    pip3 install yq==v3.1.1 && \
-    # install kubectl
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
-    chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin && \
-    bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
+RUN dnf -y install go && \
+  dnf update -y && dnf clean all && \
+  echo -n "go version: "; go version && \
+  dnf install --assumeyes -d1 python3-pip && \
+  # Need to pin yq version due to version 3.2.0 requiring python 3.6 and above
+  pip3 install yq==v3.1.1 && \
+  # install kubectl
+  curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+  chmod +x ./kubectl && \
+  mv ./kubectl /usr/local/bin && \
+  bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next


### PR DESCRIPTION
### What does this PR do?
Try to fix the problem described here: https://github.com/eclipse/che/issues/22535

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22535

### Is it tested? How?
merge to main branch and check results

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
