### PR TITLE
Improve process for clearing 'started-at' annotations from workspaces

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -621,8 +621,14 @@ func (r *DevWorkspaceReconciler) syncStartedAtToCluster(
 func (r *DevWorkspaceReconciler) removeStartedAtFromCluster(
 	ctx context.Context, workspace *common.DevWorkspaceWithConfig, reqLogger logr.Logger) {
 	if workspace.Annotations == nil {
-		workspace.Annotations = map[string]string{}
+		// No annotations, nothing to do
+		return
 	}
+	if _, ok := workspace.Annotations[constants.DevWorkspaceStartedAtAnnotation]; !ok {
+		// Annotation has already been deleted
+		return
+	}
+
 	delete(workspace.Annotations, constants.DevWorkspaceStartedAtAnnotation)
 	if err := r.Update(ctx, workspace.DevWorkspace); err != nil {
 		if k8sErrors.IsConflict(err) {


### PR DESCRIPTION
### What does this PR do?
Avoid attempting to update stopped workspaces to remove started-at annotations if the annotation is not present on the workspace.

### What issues does this PR fix or reference?
Minor fix to avoid sending unnecessary update requests.

### Is it tested? How?
Should be no functional change -- annotations should still be removed from stopped workspaces.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
