### PR TITLE
Change location of GO cache folder for avoiding permition conflicts

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -17,7 +17,7 @@ FROM registry.access.redhat.com/ubi9/nodejs-18:1
 # hadolint ignore=DL3002
 USER 0
 
-ENV GOCACHE="/home/.cache/go-build"
+ENV GOCACHE="/home/user/.cache/go-build"
 
 # hadolint ignore=DL3041
 RUN dnf install -y -q --allowerasing --nobest nodejs-devel nodejs-libs \
@@ -30,7 +30,7 @@ RUN dnf install -y -q --allowerasing --nobest nodejs-devel nodejs-libs \
   echo -n "yarn version: "; yarn -v
 
 RUN dnf -y install go && \
-  mkdir -p /home/.cache/go-build && \
+  mkdir -p $GOCACHE && \
   dnf update -y && dnf clean all && \
   echo -n "go version: "; go version && \
   dnf install --assumeyes -d1 python3-pip && \


### PR DESCRIPTION
### What does this PR do?
Add changes to avoid conflicts with folder creation  like: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/devfile_devworkspace-operator/1180/pull-ci-devfile-devworkspace-operator-main-v8-devworkspace-operator-e2e/1709310058111700992/build-log.txt (ailed to initialize build cache at /home/.cache/go-build: mkdir /home/.cache/go-build/00: permission denied string)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22535

### Is it tested? How?
Was checked on the local machine:
```
[+] Building 86.0s (7/7) FINISHED                                                                                                                        docker:default
 => [internal] load build definition from oci.Dockerfile                                                                                                           0.0s
 => => transferring dockerfile: 1.89kB                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                  0.0s
 => => transferring context: 131B                                                                                                                                  0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi9/nodejs-18:1                                                                                       0.4s
 => CACHED [1/3] FROM registry.access.redhat.com/ubi9/nodejs-18:1@sha256:78e32c4f667bfb736564f5e3f4e52124a9e2eeab79acb17b0d795526ff7b41a6                          0.0s
 => [2/3] RUN dnf install -y -q --allowerasing --nobest nodejs-devel nodejs-libs   openssl openssl-devel ca-certificates make cmake cpp gcc gcc-c++ zlib zlib-de  20.8s
 => [3/3] RUN dnf -y install go &&   mkdir -p /home/user/.cache/go-build &&   dnf update -y && dnf clean all &&   echo -n "go version: "; go version &&   dnf in  51.1s 
 => exporting to image                                                                                                                                            13.6s 
 => => exporting layers                                                                                                                                           13.6s 
 => => writing image sha256:9db28d5ea32ee92250893b173cb72217092312b55d26a3e63ac3abc766f1ed2a                                                                       0.0s 
 => => naming to quay.io/mmusiien/dwo-test:latest    
 ```
 The folder in the image is created successfully:
 ```
 docker exec -ti sleepy_spence /bin/bash
bash-5.1# св ʼ
bash: $'\321\201\320\262': command not found
bash-5.1# cd ~
bash-5.1# ls
chectl-install.log
bash-5.1# cd /home/user/.
./      ../     .cache/ 
bash-5.1# cd /home/user/.
./      ../     .cache/ 
bash-5.1# cd /home/user/.cache/go-build/
```


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
