### PR TITLE
Revert oci.Dockerfile changes; attempt to install nodejs 16 there

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,31 +13,18 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi9/nodejs-18:1
-# hadolint ignore=DL3002
-USER 0
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
-ENV GOCACHE="/home/.cache/go-build"
+SHELL ["/bin/bash", "-c"]
 
-# hadolint ignore=DL3041
-RUN dnf install -y -q --allowerasing --nobest nodejs-devel nodejs-libs \
-  # already installed or installed as deps:
-  openssl openssl-devel ca-certificates make cmake cpp gcc gcc-c++ zlib zlib-devel brotli brotli-devel python3 nodejs-packaging && \
-  dnf update -y && dnf clean all && \
-  npm install -g yarn@1.22 npm@9 && \
-  echo -n "node version: "; node -v; \
-  echo -n "npm  version: "; npm -v; \
-  echo -n "yarn version: "; yarn -v
-
-RUN dnf -y install go && \
-  mkdir -p /home/.cache/go-build && \
-  dnf update -y && dnf clean all && \
-  echo -n "go version: "; go version && \
-  dnf install --assumeyes -d1 python3-pip && \
-  # Need to pin yq version due to version 3.2.0 requiring python 3.6 and above
-  pip3 install yq==v3.1.1 && \
-  # install kubectl
-  curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
-  chmod +x ./kubectl && \
-  mv ./kubectl /usr/local/bin && \
-  bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
+RUN yum install --assumeyes -d1 python3-pip nodejs && \
+    pip3 install --upgrade pip && \
+    pip3 install --upgrade setuptools && \
+    # Install yq
+    pip3 install yq && \
+    # Install kubectl
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin && \
+    # Install chectl
+    bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next


### PR DESCRIPTION
### What does this PR do?
Revert changes from https://github.com/devfile/devworkspace-operator/pull/1176 and instead try to install nodejs in the previous `oci.Dockerfile`. This is the approach taken by e.g. the [Che Operator](https://github.com/eclipse-che/che-operator/blob/main/.ci/openshift-ci/Dockerfile) which does not seem to have the same issue we do despite using the same machinery.

If this works, it would be a lot easier than trying to install golang into a node container in a way the openshift CI tests can handle.

### What issues does this PR fix or reference?
Failing e2e tests on all PRs

### Is it tested? How?
Due to how e2e tests are run, it's not possible to test this change without first merging it; the e2e test will run using the dockerfile that is present in `main` rather than the PR one. 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
