### PR TITLE
chore: Update devfile/api dependency to upstream commit a6c32fc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export PROJECT_CLONE_IMG ?= quay.io/devfile/project-clone:next
 export PULL_POLICY ?= Always
 export DEFAULT_ROUTING ?= basic
 export KUBECONFIG ?= ${HOME}/.kube/config
-export DEVWORKSPACE_API_VERSION ?= 2568944140c38aa941390d0f8e941534bf88f793
+export DEVWORKSPACE_API_VERSION ?= a6c32fca0dbdcb61454e7bb7ff5b5ef525bbbe86
 
 # Enable using Podman instead of Docker
 export DOCKER ?= docker

--- a/build/scripts/generate_deployment.sh
+++ b/build/scripts/generate_deployment.sh
@@ -120,7 +120,7 @@ if $USE_DEFAULT_ENV; then
   export PROJECT_CLONE_IMG=${PROJECT_CLONE_IMG:-"quay.io/devfile/project-clone:next"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic
-  export DEVWORKSPACE_API_VERSION=2568944140c38aa941390d0f8e941534bf88f793
+  export DEVWORKSPACE_API_VERSION=a6c32fca0dbdcb61454e7bb7ff5b5ef525bbbe86
   export ROUTING_SUFFIX='""'
   export FORCE_DEVWORKSPACE_CRDS_UPDATE=true
 fi

--- a/controllers/workspace/suite_test.go
+++ b/controllers/workspace/suite_test.go
@@ -25,6 +25,7 @@ import (
 	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/controllers/workspace/internal/testutil"
+	kubesync "github.com/devfile/devworkspace-operator/pkg/library/kubernetes"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -108,6 +109,9 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	// Replicate controller setup similarly to how we do for main.go
+	err = kubesync.InitializeDeserializer(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	cacheFunc, err := cache.GetCacheFunc()
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/workspace/testdata/test-devworkspace-duplicate-ports.yaml
+++ b/controllers/workspace/testdata/test-devworkspace-duplicate-ports.yaml
@@ -1,0 +1,51 @@
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  labels:
+    controller.devfile.io/creator: ""
+spec:
+  started: true
+  routingClass: 'basic'
+  template:
+    attributes:
+      controller.devfile.io/storage-type: ephemeral
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+    components:
+      - name: kubernetes-deploy
+        kubernetes:
+          deployByDefault: true
+          endpoints:
+            - name: http-8080
+              path: /
+              targetPort: 8080
+          inlined: |
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: webserver-dwo-deployed
+              namespace: devworkspace-controller
+            spec:
+              containers:
+                - name: webserver
+                  image: nginx:latest
+                  ports:
+                    - containerPort: 8080
+      - name: web-terminal
+        container:
+          image: quay.io/wto/web-terminal-tooling:next
+          memoryRequest: 256Mi
+          memoryLimit: 512Mi
+          mountSources: true
+          command:
+           - "tail"
+           - "-f"
+           - "/dev/null"
+          endpoints:
+            - name: 'http'
+              protocol: http
+              targetPort: 8080
+              exposure: public

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -367,7 +367,7 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                  description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label for this command to be used in Editor UI menus for example
@@ -883,7 +883,7 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                            description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                             type: boolean
                                           label:
                                             description: Optional label that provides a label for this command to be used in Editor UI menus for example

--- a/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
+++ b/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
@@ -261,7 +261,7 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                              description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
@@ -830,7 +830,7 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                        description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
@@ -1461,7 +1461,7 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                  description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                   type: boolean
                                 id:
                                   description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
@@ -2030,7 +2030,7 @@ spec:
                                             - kind
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                            description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                             type: boolean
                                           id:
                                             description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
@@ -3068,7 +3068,7 @@ spec:
                                     type: string
                                 type: object
                               hotReloadCapable:
-                                description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                 type: boolean
                               label:
                                 description: Optional label that provides a label for this command to be used in Editor UI menus for example
@@ -3695,7 +3695,7 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                              description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for this command to be used in Editor UI menus for example
@@ -4260,7 +4260,7 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                        description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides a label for this command to be used in Editor UI menus for example
@@ -4872,7 +4872,7 @@ spec:
                                       type: string
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                  description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label for this command to be used in Editor UI menus for example
@@ -5400,7 +5400,7 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                            description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                             type: boolean
                                           label:
                                             description: Optional label that provides a label for this command to be used in Editor UI menus for example

--- a/deploy/bundle/manifests/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/deploy/bundle/manifests/workspace.devfile.io_devworkspacetemplates.yaml
@@ -241,7 +241,7 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                           type: boolean
                         id:
                           description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
@@ -810,7 +810,7 @@ spec:
                                     - kind
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                     type: boolean
                                   id:
                                     description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
@@ -1441,7 +1441,7 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                              description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
@@ -2010,7 +2010,7 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                        description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.
@@ -3025,7 +3025,7 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                           type: boolean
                         label:
                           description: Optional label that provides a label for this command to be used in Editor UI menus for example
@@ -3590,7 +3590,7 @@ spec:
                                         type: string
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                     type: boolean
                                   label:
                                     description: Optional label that provides a label for this command to be used in Editor UI menus for example
@@ -4202,7 +4202,7 @@ spec:
                                   type: string
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                              description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for this command to be used in Editor UI menus for example
@@ -4730,7 +4730,7 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own. \n Default value is `false`"
+                                        description: "Specify whether the command is restarted or not when the source code changes. If set to `true` the command won't be restarted. A *hotReloadCapable* `run` or `debug` command is expected to handle file changes on its own and won't be restarted. A *hotReloadCapable* `build` command is expected to be executed only once and won't be executed again. This field is taken into account only for commands `build`, `run` and `debug` with `isDefault` set to `true`. \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides a label for this command to be used in Editor UI menus for example

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -571,11 +571,16 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label
@@ -1367,11 +1372,18 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           label:
@@ -7589,11 +7601,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing
@@ -8394,11 +8411,18 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows
@@ -9314,11 +9338,16 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 id:
                                   description: Mandatory identifier that allows referencing
@@ -10141,11 +10170,18 @@ spec:
                                             - kind
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           id:
@@ -11591,11 +11627,16 @@ spec:
                                     type: string
                                 type: object
                               hotReloadCapable:
-                                description: "Whether the command is capable to reload
-                                  itself when source code changes. If set to `true`
-                                  the command won't be restarted and it is expected
-                                  to handle file changes on its own. \n Default value
-                                  is `false`"
+                                description: "Specify whether the command is restarted
+                                  or not when the source code changes. If set to `true`
+                                  the command won't be restarted. A *hotReloadCapable*
+                                  `run` or `debug` command is expected to handle file
+                                  changes on its own and won't be restarted. A *hotReloadCapable*
+                                  `build` command is expected to be executed only
+                                  once and won't be executed again. This field is
+                                  taken into account only for commands `build`, `run`
+                                  and `debug` with `isDefault` set to `true`. \n Default
+                                  value is `false`"
                                 type: boolean
                               label:
                                 description: Optional label that provides a label
@@ -12488,11 +12529,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for
@@ -13311,11 +13357,18 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides
@@ -14262,11 +14315,16 @@ spec:
                                       type: string
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label
@@ -15064,11 +15122,18 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           label:
@@ -16595,10 +16660,15 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself
-                            when source code changes. If set to `true` the command
-                            won't be restarted and it is expected to handle file changes
-                            on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or
+                            not when the source code changes. If set to `true` the
+                            command won't be restarted. A *hotReloadCapable* `run`
+                            or `debug` command is expected to handle file changes
+                            on its own and won't be restarted. A *hotReloadCapable*
+                            `build` command is expected to be executed only once and
+                            won't be executed again. This field is taken into account
+                            only for commands `build`, `run` and `debug` with `isDefault`
+                            set to `true`. \n Default value is `false`"
                           type: boolean
                         id:
                           description: Mandatory identifier that allows referencing
@@ -17380,11 +17450,17 @@ spec:
                                     - kind
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to
-                                      reload itself when source code changes. If set
-                                      to `true` the command won't be restarted and
-                                      it is expected to handle file changes on its
-                                      own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted
+                                      or not when the source code changes. If set
+                                      to `true` the command won't be restarted. A
+                                      *hotReloadCapable* `run` or `debug` command
+                                      is expected to handle file changes on its own
+                                      and won't be restarted. A *hotReloadCapable*
+                                      `build` command is expected to be executed only
+                                      once and won't be executed again. This field
+                                      is taken into account only for commands `build`,
+                                      `run` and `debug` with `isDefault` set to `true`.
+                                      \n Default value is `false`"
                                     type: boolean
                                   id:
                                     description: Mandatory identifier that allows
@@ -18267,11 +18343,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing
@@ -19072,11 +19153,18 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows
@@ -20437,10 +20525,15 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself
-                            when source code changes. If set to `true` the command
-                            won't be restarted and it is expected to handle file changes
-                            on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or
+                            not when the source code changes. If set to `true` the
+                            command won't be restarted. A *hotReloadCapable* `run`
+                            or `debug` command is expected to handle file changes
+                            on its own and won't be restarted. A *hotReloadCapable*
+                            `build` command is expected to be executed only once and
+                            won't be executed again. This field is taken into account
+                            only for commands `build`, `run` and `debug` with `isDefault`
+                            set to `true`. \n Default value is `false`"
                           type: boolean
                         label:
                           description: Optional label that provides a label for this
@@ -21238,11 +21331,17 @@ spec:
                                         type: string
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to
-                                      reload itself when source code changes. If set
-                                      to `true` the command won't be restarted and
-                                      it is expected to handle file changes on its
-                                      own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted
+                                      or not when the source code changes. If set
+                                      to `true` the command won't be restarted. A
+                                      *hotReloadCapable* `run` or `debug` command
+                                      is expected to handle file changes on its own
+                                      and won't be restarted. A *hotReloadCapable*
+                                      `build` command is expected to be executed only
+                                      once and won't be executed again. This field
+                                      is taken into account only for commands `build`,
+                                      `run` and `debug` with `isDefault` set to `true`.
+                                      \n Default value is `false`"
                                     type: boolean
                                   label:
                                     description: Optional label that provides a label
@@ -22147,11 +22246,16 @@ spec:
                                   type: string
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for
@@ -22928,11 +23032,18 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -571,11 +571,16 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label
@@ -1367,11 +1372,18 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           label:

--- a/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -313,11 +313,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing
@@ -1118,11 +1123,18 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows
@@ -2038,11 +2050,16 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 id:
                                   description: Mandatory identifier that allows referencing
@@ -2865,11 +2882,18 @@ spec:
                                             - kind
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           id:
@@ -4315,11 +4339,16 @@ spec:
                                     type: string
                                 type: object
                               hotReloadCapable:
-                                description: "Whether the command is capable to reload
-                                  itself when source code changes. If set to `true`
-                                  the command won't be restarted and it is expected
-                                  to handle file changes on its own. \n Default value
-                                  is `false`"
+                                description: "Specify whether the command is restarted
+                                  or not when the source code changes. If set to `true`
+                                  the command won't be restarted. A *hotReloadCapable*
+                                  `run` or `debug` command is expected to handle file
+                                  changes on its own and won't be restarted. A *hotReloadCapable*
+                                  `build` command is expected to be executed only
+                                  once and won't be executed again. This field is
+                                  taken into account only for commands `build`, `run`
+                                  and `debug` with `isDefault` set to `true`. \n Default
+                                  value is `false`"
                                 type: boolean
                               label:
                                 description: Optional label that provides a label
@@ -5212,11 +5241,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for
@@ -6035,11 +6069,18 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides
@@ -6986,11 +7027,16 @@ spec:
                                       type: string
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label
@@ -7788,11 +7834,18 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           label:

--- a/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -286,10 +286,15 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself
-                            when source code changes. If set to `true` the command
-                            won't be restarted and it is expected to handle file changes
-                            on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or
+                            not when the source code changes. If set to `true` the
+                            command won't be restarted. A *hotReloadCapable* `run`
+                            or `debug` command is expected to handle file changes
+                            on its own and won't be restarted. A *hotReloadCapable*
+                            `build` command is expected to be executed only once and
+                            won't be executed again. This field is taken into account
+                            only for commands `build`, `run` and `debug` with `isDefault`
+                            set to `true`. \n Default value is `false`"
                           type: boolean
                         id:
                           description: Mandatory identifier that allows referencing
@@ -1071,11 +1076,17 @@ spec:
                                     - kind
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to
-                                      reload itself when source code changes. If set
-                                      to `true` the command won't be restarted and
-                                      it is expected to handle file changes on its
-                                      own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted
+                                      or not when the source code changes. If set
+                                      to `true` the command won't be restarted. A
+                                      *hotReloadCapable* `run` or `debug` command
+                                      is expected to handle file changes on its own
+                                      and won't be restarted. A *hotReloadCapable*
+                                      `build` command is expected to be executed only
+                                      once and won't be executed again. This field
+                                      is taken into account only for commands `build`,
+                                      `run` and `debug` with `isDefault` set to `true`.
+                                      \n Default value is `false`"
                                     type: boolean
                                   id:
                                     description: Mandatory identifier that allows
@@ -1958,11 +1969,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing
@@ -2763,11 +2779,18 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows
@@ -4128,10 +4151,15 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself
-                            when source code changes. If set to `true` the command
-                            won't be restarted and it is expected to handle file changes
-                            on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or
+                            not when the source code changes. If set to `true` the
+                            command won't be restarted. A *hotReloadCapable* `run`
+                            or `debug` command is expected to handle file changes
+                            on its own and won't be restarted. A *hotReloadCapable*
+                            `build` command is expected to be executed only once and
+                            won't be executed again. This field is taken into account
+                            only for commands `build`, `run` and `debug` with `isDefault`
+                            set to `true`. \n Default value is `false`"
                           type: boolean
                         label:
                           description: Optional label that provides a label for this
@@ -4929,11 +4957,17 @@ spec:
                                         type: string
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to
-                                      reload itself when source code changes. If set
-                                      to `true` the command won't be restarted and
-                                      it is expected to handle file changes on its
-                                      own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted
+                                      or not when the source code changes. If set
+                                      to `true` the command won't be restarted. A
+                                      *hotReloadCapable* `run` or `debug` command
+                                      is expected to handle file changes on its own
+                                      and won't be restarted. A *hotReloadCapable*
+                                      `build` command is expected to be executed only
+                                      once and won't be executed again. This field
+                                      is taken into account only for commands `build`,
+                                      `run` and `debug` with `isDefault` set to `true`.
+                                      \n Default value is `false`"
                                     type: boolean
                                   label:
                                     description: Optional label that provides a label
@@ -5838,11 +5872,16 @@ spec:
                                   type: string
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for
@@ -6619,11 +6658,18 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -571,11 +571,16 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label
@@ -1367,11 +1372,18 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           label:
@@ -7589,11 +7601,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing
@@ -8394,11 +8411,18 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows
@@ -9314,11 +9338,16 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 id:
                                   description: Mandatory identifier that allows referencing
@@ -10141,11 +10170,18 @@ spec:
                                             - kind
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           id:
@@ -11591,11 +11627,16 @@ spec:
                                     type: string
                                 type: object
                               hotReloadCapable:
-                                description: "Whether the command is capable to reload
-                                  itself when source code changes. If set to `true`
-                                  the command won't be restarted and it is expected
-                                  to handle file changes on its own. \n Default value
-                                  is `false`"
+                                description: "Specify whether the command is restarted
+                                  or not when the source code changes. If set to `true`
+                                  the command won't be restarted. A *hotReloadCapable*
+                                  `run` or `debug` command is expected to handle file
+                                  changes on its own and won't be restarted. A *hotReloadCapable*
+                                  `build` command is expected to be executed only
+                                  once and won't be executed again. This field is
+                                  taken into account only for commands `build`, `run`
+                                  and `debug` with `isDefault` set to `true`. \n Default
+                                  value is `false`"
                                 type: boolean
                               label:
                                 description: Optional label that provides a label
@@ -12488,11 +12529,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for
@@ -13311,11 +13357,18 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides
@@ -14262,11 +14315,16 @@ spec:
                                       type: string
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label
@@ -15064,11 +15122,18 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           label:
@@ -16595,10 +16660,15 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself
-                            when source code changes. If set to `true` the command
-                            won't be restarted and it is expected to handle file changes
-                            on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or
+                            not when the source code changes. If set to `true` the
+                            command won't be restarted. A *hotReloadCapable* `run`
+                            or `debug` command is expected to handle file changes
+                            on its own and won't be restarted. A *hotReloadCapable*
+                            `build` command is expected to be executed only once and
+                            won't be executed again. This field is taken into account
+                            only for commands `build`, `run` and `debug` with `isDefault`
+                            set to `true`. \n Default value is `false`"
                           type: boolean
                         id:
                           description: Mandatory identifier that allows referencing
@@ -17380,11 +17450,17 @@ spec:
                                     - kind
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to
-                                      reload itself when source code changes. If set
-                                      to `true` the command won't be restarted and
-                                      it is expected to handle file changes on its
-                                      own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted
+                                      or not when the source code changes. If set
+                                      to `true` the command won't be restarted. A
+                                      *hotReloadCapable* `run` or `debug` command
+                                      is expected to handle file changes on its own
+                                      and won't be restarted. A *hotReloadCapable*
+                                      `build` command is expected to be executed only
+                                      once and won't be executed again. This field
+                                      is taken into account only for commands `build`,
+                                      `run` and `debug` with `isDefault` set to `true`.
+                                      \n Default value is `false`"
                                     type: boolean
                                   id:
                                     description: Mandatory identifier that allows
@@ -18267,11 +18343,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing
@@ -19072,11 +19153,18 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows
@@ -20437,10 +20525,15 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself
-                            when source code changes. If set to `true` the command
-                            won't be restarted and it is expected to handle file changes
-                            on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or
+                            not when the source code changes. If set to `true` the
+                            command won't be restarted. A *hotReloadCapable* `run`
+                            or `debug` command is expected to handle file changes
+                            on its own and won't be restarted. A *hotReloadCapable*
+                            `build` command is expected to be executed only once and
+                            won't be executed again. This field is taken into account
+                            only for commands `build`, `run` and `debug` with `isDefault`
+                            set to `true`. \n Default value is `false`"
                           type: boolean
                         label:
                           description: Optional label that provides a label for this
@@ -21238,11 +21331,17 @@ spec:
                                         type: string
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to
-                                      reload itself when source code changes. If set
-                                      to `true` the command won't be restarted and
-                                      it is expected to handle file changes on its
-                                      own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted
+                                      or not when the source code changes. If set
+                                      to `true` the command won't be restarted. A
+                                      *hotReloadCapable* `run` or `debug` command
+                                      is expected to handle file changes on its own
+                                      and won't be restarted. A *hotReloadCapable*
+                                      `build` command is expected to be executed only
+                                      once and won't be executed again. This field
+                                      is taken into account only for commands `build`,
+                                      `run` and `debug` with `isDefault` set to `true`.
+                                      \n Default value is `false`"
                                     type: boolean
                                   label:
                                     description: Optional label that provides a label
@@ -22147,11 +22246,16 @@ spec:
                                   type: string
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for
@@ -22928,11 +23032,18 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -571,11 +571,16 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label
@@ -1367,11 +1372,18 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           label:

--- a/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -313,11 +313,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing
@@ -1118,11 +1123,18 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows
@@ -2038,11 +2050,16 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 id:
                                   description: Mandatory identifier that allows referencing
@@ -2865,11 +2882,18 @@ spec:
                                             - kind
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           id:
@@ -4315,11 +4339,16 @@ spec:
                                     type: string
                                 type: object
                               hotReloadCapable:
-                                description: "Whether the command is capable to reload
-                                  itself when source code changes. If set to `true`
-                                  the command won't be restarted and it is expected
-                                  to handle file changes on its own. \n Default value
-                                  is `false`"
+                                description: "Specify whether the command is restarted
+                                  or not when the source code changes. If set to `true`
+                                  the command won't be restarted. A *hotReloadCapable*
+                                  `run` or `debug` command is expected to handle file
+                                  changes on its own and won't be restarted. A *hotReloadCapable*
+                                  `build` command is expected to be executed only
+                                  once and won't be executed again. This field is
+                                  taken into account only for commands `build`, `run`
+                                  and `debug` with `isDefault` set to `true`. \n Default
+                                  value is `false`"
                                 type: boolean
                               label:
                                 description: Optional label that provides a label
@@ -5212,11 +5241,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for
@@ -6035,11 +6069,18 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides
@@ -6986,11 +7027,16 @@ spec:
                                       type: string
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label
@@ -7788,11 +7834,18 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           label:

--- a/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -286,10 +286,15 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself
-                            when source code changes. If set to `true` the command
-                            won't be restarted and it is expected to handle file changes
-                            on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or
+                            not when the source code changes. If set to `true` the
+                            command won't be restarted. A *hotReloadCapable* `run`
+                            or `debug` command is expected to handle file changes
+                            on its own and won't be restarted. A *hotReloadCapable*
+                            `build` command is expected to be executed only once and
+                            won't be executed again. This field is taken into account
+                            only for commands `build`, `run` and `debug` with `isDefault`
+                            set to `true`. \n Default value is `false`"
                           type: boolean
                         id:
                           description: Mandatory identifier that allows referencing
@@ -1071,11 +1076,17 @@ spec:
                                     - kind
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to
-                                      reload itself when source code changes. If set
-                                      to `true` the command won't be restarted and
-                                      it is expected to handle file changes on its
-                                      own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted
+                                      or not when the source code changes. If set
+                                      to `true` the command won't be restarted. A
+                                      *hotReloadCapable* `run` or `debug` command
+                                      is expected to handle file changes on its own
+                                      and won't be restarted. A *hotReloadCapable*
+                                      `build` command is expected to be executed only
+                                      once and won't be executed again. This field
+                                      is taken into account only for commands `build`,
+                                      `run` and `debug` with `isDefault` set to `true`.
+                                      \n Default value is `false`"
                                     type: boolean
                                   id:
                                     description: Mandatory identifier that allows
@@ -1958,11 +1969,16 @@ spec:
                               - kind
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             id:
                               description: Mandatory identifier that allows referencing
@@ -2763,11 +2779,18 @@ spec:
                                         - kind
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       id:
                                         description: Mandatory identifier that allows
@@ -4128,10 +4151,15 @@ spec:
                           - kind
                           type: object
                         hotReloadCapable:
-                          description: "Whether the command is capable to reload itself
-                            when source code changes. If set to `true` the command
-                            won't be restarted and it is expected to handle file changes
-                            on its own. \n Default value is `false`"
+                          description: "Specify whether the command is restarted or
+                            not when the source code changes. If set to `true` the
+                            command won't be restarted. A *hotReloadCapable* `run`
+                            or `debug` command is expected to handle file changes
+                            on its own and won't be restarted. A *hotReloadCapable*
+                            `build` command is expected to be executed only once and
+                            won't be executed again. This field is taken into account
+                            only for commands `build`, `run` and `debug` with `isDefault`
+                            set to `true`. \n Default value is `false`"
                           type: boolean
                         label:
                           description: Optional label that provides a label for this
@@ -4929,11 +4957,17 @@ spec:
                                         type: string
                                     type: object
                                   hotReloadCapable:
-                                    description: "Whether the command is capable to
-                                      reload itself when source code changes. If set
-                                      to `true` the command won't be restarted and
-                                      it is expected to handle file changes on its
-                                      own. \n Default value is `false`"
+                                    description: "Specify whether the command is restarted
+                                      or not when the source code changes. If set
+                                      to `true` the command won't be restarted. A
+                                      *hotReloadCapable* `run` or `debug` command
+                                      is expected to handle file changes on its own
+                                      and won't be restarted. A *hotReloadCapable*
+                                      `build` command is expected to be executed only
+                                      once and won't be executed again. This field
+                                      is taken into account only for commands `build`,
+                                      `run` and `debug` with `isDefault` set to `true`.
+                                      \n Default value is `false`"
                                     type: boolean
                                   label:
                                     description: Optional label that provides a label
@@ -5838,11 +5872,16 @@ spec:
                                   type: string
                               type: object
                             hotReloadCapable:
-                              description: "Whether the command is capable to reload
-                                itself when source code changes. If set to `true`
-                                the command won't be restarted and it is expected
-                                to handle file changes on its own. \n Default value
-                                is `false`"
+                              description: "Specify whether the command is restarted
+                                or not when the source code changes. If set to `true`
+                                the command won't be restarted. A *hotReloadCapable*
+                                `run` or `debug` command is expected to handle file
+                                changes on its own and won't be restarted. A *hotReloadCapable*
+                                `build` command is expected to be executed only once
+                                and won't be executed again. This field is taken into
+                                account only for commands `build`, `run` and `debug`
+                                with `isDefault` set to `true`. \n Default value is
+                                `false`"
                               type: boolean
                             label:
                               description: Optional label that provides a label for
@@ -6619,11 +6658,18 @@ spec:
                                             type: string
                                         type: object
                                       hotReloadCapable:
-                                        description: "Whether the command is capable
-                                          to reload itself when source code changes.
-                                          If set to `true` the command won't be restarted
-                                          and it is expected to handle file changes
-                                          on its own. \n Default value is `false`"
+                                        description: "Specify whether the command
+                                          is restarted or not when the source code
+                                          changes. If set to `true` the command won't
+                                          be restarted. A *hotReloadCapable* `run`
+                                          or `debug` command is expected to handle
+                                          file changes on its own and won't be restarted.
+                                          A *hotReloadCapable* `build` command is
+                                          expected to be executed only once and won't
+                                          be executed again. This field is taken into
+                                          account only for commands `build`, `run`
+                                          and `debug` with `isDefault` set to `true`.
+                                          \n Default value is `false`"
                                         type: boolean
                                       label:
                                         description: Optional label that provides

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -570,11 +570,16 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command is capable to
-                                    reload itself when source code changes. If set
-                                    to `true` the command won't be restarted and it
-                                    is expected to handle file changes on its own.
-                                    \n Default value is `false`"
+                                  description: "Specify whether the command is restarted
+                                    or not when the source code changes. If set to
+                                    `true` the command won't be restarted. A *hotReloadCapable*
+                                    `run` or `debug` command is expected to handle
+                                    file changes on its own and won't be restarted.
+                                    A *hotReloadCapable* `build` command is expected
+                                    to be executed only once and won't be executed
+                                    again. This field is taken into account only for
+                                    commands `build`, `run` and `debug` with `isDefault`
+                                    set to `true`. \n Default value is `false`"
                                   type: boolean
                                 label:
                                   description: Optional label that provides a label
@@ -1366,11 +1371,18 @@ spec:
                                                 type: string
                                             type: object
                                           hotReloadCapable:
-                                            description: "Whether the command is capable
-                                              to reload itself when source code changes.
-                                              If set to `true` the command won't be
-                                              restarted and it is expected to handle
-                                              file changes on its own. \n Default
+                                            description: "Specify whether the command
+                                              is restarted or not when the source
+                                              code changes. If set to `true` the command
+                                              won't be restarted. A *hotReloadCapable*
+                                              `run` or `debug` command is expected
+                                              to handle file changes on its own and
+                                              won't be restarted. A *hotReloadCapable*
+                                              `build` command is expected to be executed
+                                              only once and won't be executed again.
+                                              This field is taken into account only
+                                              for commands `build`, `run` and `debug`
+                                              with `isDefault` set to `true`. \n Default
                                               value is `false`"
                                             type: boolean
                                           label:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/devworkspace-operator
 go 1.18
 
 require (
-	github.com/devfile/api/v2 v2.2.0
+	github.com/devfile/api/v2 v2.2.1-alpha.0.20230413012049-a6c32fca0dbd
 	github.com/go-git/go-git/v5 v5.5.1
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api/v2 v2.2.0 h1:3Mwl/dtT508oU4pNt/v4G8vqvjoZqi9LOInXCNwKMoc=
-github.com/devfile/api/v2 v2.2.0/go.mod h1:dN7xFrOVG+iPqn4UKGibXLd5oVsdE8XyK9OEb5JL3aI=
+github.com/devfile/api/v2 v2.2.1-alpha.0.20230413012049-a6c32fca0dbd h1:HpGR728CfB6BB9ZuFtQb0UeTIYNFgpuGsuoMOJNMUTM=
+github.com/devfile/api/v2 v2.2.1-alpha.0.20230413012049-a6c32fca0dbd/go.mod h1:qp8jcw12y1JdCsxjK/7LJ7uWaJOxcY1s2LUk5PhbkbM=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
### What does this PR do?
Updates the devfile/api dependency to the upstream commit https://github.com/devfile/api/commit/a6c32fca0dbdcb61454e7bb7ff5b5ef525bbbe86. This is required for https://github.com/devfile/devworkspace-operator/issues/1179, as the devfile validation library was previously preventing a deworkspace from having a container component and openshift/kubernetes component from using the same target port on an endpoint. 

 https://github.com/devfile/api/commit/a6c32fca0dbdcb61454e7bb7ff5b5ef525bbbe86 was chosen as it is the same commit [used by the devfile library](https://github.com/devfile/library/blob/main/go.mod#L6), and all commits past a6c32fc were non-function-changing commits: https://github.com/devfile/api/compare/a6c32fca0dbdcb61454e7bb7ff5b5ef525bbbe86...e05a23590d0f820bb7f070d7e782a5f9caf301c5

I also added a controller env test to test the case from https://github.com/devfile/devworkspace-operator/issues/1179, but this might be redundant as this functionality should already be tested in the devfile API repo. 

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1179

### Is it tested? How?
Install DWO with the changes from this PR, and create a devworkspace with a container component and kubernetes (or openshift) component that uses the same endpoint target port, such as the following:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace
spec:
  started: true
  routingClass: 'basic'
  template:
    components:
      - name: kubernetes-deploy
        kubernetes:
          deployByDefault: true
          endpoints:
            - name: http-8080
              path: /
              targetPort: 8080
          inlined: |
            apiVersion: v1
            kind: Pod
            metadata:
              name: webserver-dwo-deployed
              namespace: devworkspace-controller
            spec:
              containers:
                - name: webserver
                  image: nginx:latest
                  ports:
                    - containerPort: 8080
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
          endpoints:
            - name: 'http'
              protocol: http
              targetPort: 8080
              exposure: public
```

Ensure the workspace starts up as expected. You should see a pod get deployed to the `devworkspace-controller` namespace called `webserver-dwo-deployed`. The main thing to ensure is the workspace does not fail to startup with the following reason: `* devfile contains multiple containers with same endpoint targetPort: 8080`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
Signed-off-by: Andrew Obuchowicz <aobuchow@redhat.com>