### PR TITLE
Bump Go version to 1.19

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,12 +14,12 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18.4
+        go-version: 1.19.10
     -
-      name: Set up Python 3.8
+      name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.11
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,12 +15,12 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18.4
+        go-version: 1.19.10
     -
-      name: Set up Python 3.8
+      name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.11
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18.4
+          go-version: 1.19.10
 
       - name: Clone source code
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/devworkspace-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/devfile/api/v2 v2.2.0


### PR DESCRIPTION
### What does this PR do?
Update GH actions, go.mod, etc. to use Go 1.19 (1.19.10, to match the builder Dockerfile). Also bumps Python to 3.11

### What issues does this PR fix or reference?
The `check-sources` GH action is currently failing due to dependency issues

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
