### PR TITLE
Fix: include starter projects for $PROJECT_SOURCE path selection

### DIFF
--- a/pkg/library/container/container.go
+++ b/pkg/library/container/container.go
@@ -27,12 +27,11 @@ package container
 import (
 	"fmt"
 
-	"github.com/devfile/devworkspace-operator/pkg/library/overrides"
-
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/library/flatten"
 	"github.com/devfile/devworkspace-operator/pkg/library/lifecycle"
+	"github.com/devfile/devworkspace-operator/pkg/library/overrides"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -65,7 +64,9 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, securi
 		if err != nil {
 			return nil, err
 		}
-		handleMountSources(k8sContainer, component.Container, workspace.Projects)
+		if err := handleMountSources(k8sContainer, component.Container, workspace); err != nil {
+			return nil, err
+		}
 		if overrides.NeedsContainerOverride(&component) {
 			patchedContainer, err := overrides.ApplyContainerOverrides(&component, k8sContainer)
 			if err != nil {
@@ -89,7 +90,9 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, securi
 		if err != nil {
 			return nil, err
 		}
-		handleMountSources(k8sContainer, initComponent.Container, workspace.Projects)
+		if err := handleMountSources(k8sContainer, initComponent.Container, workspace); err != nil {
+			return nil, err
+		}
 		if overrides.NeedsContainerOverride(&initComponent) {
 			patchedContainer, err := overrides.ApplyContainerOverrides(&initComponent, k8sContainer)
 			if err != nil {

--- a/pkg/library/projects/clone.go
+++ b/pkg/library/projects/clone.go
@@ -115,6 +115,14 @@ func GetStarterProject(workspace *dw.DevWorkspaceTemplateSpec) (*dw.StarterProje
 	return nil, fmt.Errorf("selected starter project %s not found in workspace starterProjects", selectedStarterProject)
 }
 
+// GetClonePath gets the correct clonePath for a project, given the semantics in devfile/api
+func GetClonePath(project *dw.Project) string {
+	if project.ClonePath != "" {
+		return project.ClonePath
+	}
+	return project.Name
+}
+
 func hasContainerComponents(workspace *dw.DevWorkspaceTemplateSpec) bool {
 	for _, component := range workspace.Components {
 		if component.Container != nil {

--- a/project-clone/internal/devfile.go
+++ b/project-clone/internal/devfile.go
@@ -32,14 +32,6 @@ const (
 	ProjectSubDir         = "subDir"
 )
 
-// GetClonePath gets the correct clonePath for a project, given the semantics in devfile/api
-func GetClonePath(project *dw.Project) string {
-	if project.ClonePath != "" {
-		return project.ClonePath
-	}
-	return project.Name
-}
-
 // ReadFlattenedDevWorkspace reads the flattened DevWorkspaceTemplateSpec from disk. The location of the flattened
 // yaml is determined from the DevWorkspace Operator-provisioned environment variable.
 func ReadFlattenedDevWorkspace() (*dw.DevWorkspaceTemplateSpec, error) {

--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	projectslib "github.com/devfile/devworkspace-operator/pkg/library/projects"
 
 	"github.com/devfile/devworkspace-operator/project-clone/internal"
 )
@@ -44,7 +45,7 @@ func SetupGitProject(project dw.Project) error {
 func doInitialGitClone(project *dw.Project) error {
 	// Clone into a temp dir and then move set up project to PROJECTS_ROOT to try and make clone atomic in case
 	// project-clone container is terminated
-	tmpClonePath := path.Join(internal.CloneTmpDir, internal.GetClonePath(project))
+	tmpClonePath := path.Join(internal.CloneTmpDir, projectslib.GetClonePath(project))
 	err := CloneProject(project, tmpClonePath)
 	if err != nil {
 		return fmt.Errorf("failed to clone project: %s", err)
@@ -83,7 +84,7 @@ func doInitialGitClone(project *dw.Project) error {
 }
 
 func setupRemotesForExistingProject(project *dw.Project) error {
-	projectPath := path.Join(internal.ProjectsRoot, internal.GetClonePath(project))
+	projectPath := path.Join(internal.ProjectsRoot, projectslib.GetClonePath(project))
 	repo, err := internal.OpenRepo(projectPath)
 	if err != nil {
 		return fmt.Errorf("failed to open existing project in filesystem: %s", err)
@@ -105,13 +106,13 @@ func copyProjectFromTmpDir(project *dw.Project, tmpClonePath string) error {
 			return fmt.Errorf("failed to process subDir on project: %w", err)
 		}
 		subDirPath := path.Join(tmpClonePath, subDirSubPath)
-		projectPath := path.Join(internal.ProjectsRoot, internal.GetClonePath(project))
+		projectPath := path.Join(internal.ProjectsRoot, projectslib.GetClonePath(project))
 		log.Printf("Moving subdirectory %s in project %s from temporary directory to %s", subDirSubPath, project.Name, projectPath)
 		if err := os.Rename(subDirPath, projectPath); err != nil {
 			return fmt.Errorf("failed to move subdirectory of cloned project to %s: %w", internal.ProjectsRoot, err)
 		}
 	} else {
-		projectPath := path.Join(internal.ProjectsRoot, internal.GetClonePath(project))
+		projectPath := path.Join(internal.ProjectsRoot, projectslib.GetClonePath(project))
 		log.Printf("Moving cloned project %s from temporary directory %s to %s", project.Name, tmpClonePath, projectPath)
 		if err := os.Rename(tmpClonePath, projectPath); err != nil {
 			return fmt.Errorf("failed to move cloned project to %s: %w", internal.ProjectsRoot, err)

--- a/project-clone/internal/utils.go
+++ b/project-clone/internal/utils.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	projectslib "github.com/devfile/devworkspace-operator/pkg/library/projects"
 	"github.com/go-git/go-git/v5"
 )
 
@@ -37,7 +38,7 @@ func CheckProjectState(project *dw.Project) (needClone, needRemotes bool, err er
 	if project.Attributes.Exists(ProjectSubDir) {
 		return checkSubPathProjectState(project)
 	}
-	repo, err := OpenRepo(path.Join(ProjectsRoot, GetClonePath(project)))
+	repo, err := OpenRepo(path.Join(ProjectsRoot, projectslib.GetClonePath(project)))
 	if err != nil {
 		return false, false, err
 	}
@@ -105,7 +106,7 @@ func checkSubPathProjectState(project *dw.Project) (needClone, needRemotes bool,
 	}
 
 	// Result here won't be a git repository, so we only check whether the directory exists
-	clonePath := path.Join(ProjectsRoot, GetClonePath(project))
+	clonePath := path.Join(ProjectsRoot, projectslib.GetClonePath(project))
 	stat, err := os.Stat(clonePath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/project-clone/internal/zip/setup.go
+++ b/project-clone/internal/zip/setup.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 
+	projectslib "github.com/devfile/devworkspace-operator/pkg/library/projects"
 	"github.com/devfile/devworkspace-operator/project-clone/internal"
 )
 
@@ -40,7 +41,7 @@ func SetupZipProject(project v1alpha2.Project, httpClient *http.Client) error {
 		return fmt.Errorf("project has no 'zip' source")
 	}
 	url := project.Zip.Location
-	clonePath := internal.GetClonePath(&project)
+	clonePath := projectslib.GetClonePath(&project)
 	projectPath := path.Join(internal.ProjectsRoot, clonePath)
 	if exists, err := internal.DirExists(projectPath); exists {
 		// Assume project is already set up

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -38,7 +38,6 @@ const (
 	tmpLogFilePath = "/tmp/" + logFileName
 )
 
-// TODO: Handle sparse checkout
 func main() {
 	f, err := os.Create(tmpLogFilePath)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR adds all starterProjects to the list of projects used [when determining](https://github.com/devfile/devworkspace-operator/blob/main/pkg/library/container/mountSources.go#L90-L101) the value of the `$PROJECT_SOURCE` environment variable used in workspace deployments. 

Now, when determining the value of `$PROJECT_SOURCE`, the following rules are considered (in order of priority):

1. If the workspace has at least one regular project, the first one will be selected. If the first project has a clone path, it will be used, otherwise the project's name will be used for the project source path. This was the default behaviour prior to this PR.

2. If the workspace has a starter project that is selected using the `controller.devfile.io/use-starter-project` workspace attribute, its name will be used for project source path.

3. Otherwise, the returned project source path will be an empty string, i.e. `$PROJECT_SOURCE = /projects/`

I also removed a completed TODO comment about adding sparseCheckout support to the project clone container and moved the `GetClonePath()` function to be accessible from other packages. 


### What issues does this PR fix or reference?
#1189

### Is it tested? How?
There are 4 cases to test, each is described below. 

#### devworkspace with only starter projects
1. Apply a devworkspace that has at least one starter project, and no regular projects, such as the following:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-starter-projects
spec:
  started: true
  routingClass: 'basic'
  template:
    starterProjects:
    - name: community
      zip:
        location: https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile
    - name: redhat-product
      zip:
        location: https://code.quarkus.redhat.com/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
```

2. Ensure the workspace pod's spec has the `$PROJECT_SOURCE` environment variable set to `/projects/` as no starter project has been selected. For the previously given devworkspace, we should have:

```YAML
spec:
(...)
  containers:
    - name: web-terminal
      env:
        - name: PROJECTS_ROOT
          value: /projects
        - name: PROJECT_SOURCE
          value: /projects/
(...)
```


#### devworkspace with starter projects and regular projects
1. Apply a devworkspace that has a regular project as well as starter projects. For example:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-starter-projects
spec:
  started: true
  routingClass: 'basic'
  template:
    starterProjects:
    - name: community
      zip:
        location: https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile
    - name: redhat-product
      zip:
        location: https://code.quarkus.redhat.com/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
```

2. Ensure the workspace pod's spec has the `$PROJECT_SOURCE` environment variable set to `/projects/<first-project-name>`. For the previously given devworkspace, we should have:

```YAML
spec:
(...)
  containers:
    - name: web-terminal
      env:
        - name: PROJECTS_ROOT
          value: /projects
        - name: PROJECT_SOURCE
          value: /projects/web-nodejs-sample
(...)
```

#### devworkspace with only starter projects, with a starter project being selected
1. Apply a devworkspace that has at least two starter projects, where one of the starter projects is selected using the  `controller.devfile.io/use-starter-project` attribute, such as the following:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-starter-projects
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
      controller.devfile.io/use-starter-project: redhat-product
    starterProjects:
    - name: community
      zip:
        location: https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile
    - name: redhat-product
      zip:
        location: https://code.quarkus.redhat.com/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
```

2. Ensure the workspace pod's spec has the `$PROJECT_SOURCE` environment variable set to the starter project that was selected. For the previously given devworkspace, we should have:


```YAML
spec:
(...)
  containers:
    - name: web-terminal
      env:
        - name: PROJECTS_ROOT
          value: /projects
        - name: PROJECT_SOURCE
          value: /projects/redhat-product
(...)
```

#### devworkspace with regular and starter projects, with a selected starter project
1. Apply a devworkspace that has a regular and starter project, and the starter project is selected using the  `controller.devfile.io/use-starter-project` attribute, such as the following:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-starter-projects
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
      controller.devfile.io/use-starter-project: redhat-product
    starterProjects:
    - name: community
      zip:
        location: https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile
    - name: redhat-product
      zip:
        location: https://code.quarkus.redhat.com/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"

```

2. Ensure the workspace pod's spec has the `$PROJECT_SOURCE` environment variable set to `/projects/<first-project-name>`. The regular project takes priority over the selected starter project when setting `$PROJECT_SOURCE`. For the previously given devworkspace, we should have:

```YAML
spec:
(...)
  containers:
    - name: web-terminal
      env:
        - name: PROJECTS_ROOT
          value: /projects
        - name: PROJECT_SOURCE
          value: /projects/web-nodejs-sample
(...)
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
