### PR TITLE
Add timeout to health checks to avoid very long reconciles

### DIFF
--- a/controllers/workspace/http.go
+++ b/controllers/workspace/http.go
@@ -17,6 +17,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"golang.org/x/net/http/httpproxy"
@@ -60,5 +61,6 @@ func setupHttpClients() {
 	}
 	healthCheckHttpClient = &http.Client{
 		Transport: healthCheckTransport,
+		Timeout:   500 * time.Millisecond,
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Adds a timeout (500ms) to the health check HTTP client. This hopefully avoids cases where the controller effectively idles for long periods while the health check server is being started (i.e. the server is not ready and is not sending a response)

### What issues does this PR fix or reference?
Haven't created an issue yet, need to do a bit more diagnosing.

### Is it tested? How?
Also hard to test -- it's hard to trigger a slow response from the editor server manually. Regular workspace startup should not be impacted by this change, however.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
