### PR TITLE
Add ability for project clone to 'bootstrap' devworkspaces

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -326,7 +326,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Add init container to clone projects
 	projectCloneOptions := projects.Options{
 		Image:     workspace.Config.Workspace.ProjectCloneConfig.Image,
-		Env:       workspace.Config.Workspace.ProjectCloneConfig.Env,
+		Env:       env.GetEnvironmentVariablesForProjectClone(workspace),
 		Resources: workspace.Config.Workspace.ProjectCloneConfig.Resources,
 	}
 	if workspace.Config.Workspace.ProjectCloneConfig.ImagePullPolicy != "" {

--- a/pkg/constants/attributes.go
+++ b/pkg/constants/attributes.go
@@ -145,4 +145,10 @@ const (
 	// StarterProjectAttribute is an attribute applied to the top-level attributes in a DevWorkspace to specify which
 	// starterProject in the workspace should be cloned.
 	StarterProjectAttribute = "controller.devfile.io/use-starter-project"
+
+	// BootstrapDevWorkspaceAttribute is an attribute applied to the top-level attributes in a DevWorkspace to configure
+	// the project-clone container to "bootstrap" the DevWorkspace from a devfile.yaml or .devfile.yaml file at the root
+	// of a cloned project. If the bootstrap process is successful, project-clone will automatically remove this attribute
+	// from the DevWorkspace
+	BootstrapDevWorkspaceAttribute = "controller.devfile.io/bootstrap-devworkspace"
 )

--- a/pkg/library/projects/clone.go
+++ b/pkg/library/projects/clone.go
@@ -22,7 +22,6 @@ import (
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	devfileConstants "github.com/devfile/devworkspace-operator/pkg/library/constants"
-	"github.com/devfile/devworkspace-operator/pkg/library/env"
 	dwResources "github.com/devfile/devworkspace-operator/pkg/library/resources"
 	corev1 "k8s.io/api/core/v1"
 
@@ -68,15 +67,6 @@ func GetProjectCloneInitContainer(workspace *dw.DevWorkspaceTemplateSpec, option
 		return nil, nil
 	}
 
-	cloneEnv := []corev1.EnvVar{
-		{
-			Name:  devfileConstants.ProjectsRootEnvVar,
-			Value: constants.DefaultProjectsSourcesRoot,
-		},
-	}
-	cloneEnv = append(cloneEnv, env.GetProxyEnvVars(proxyConfig)...)
-	cloneEnv = append(cloneEnv, options.Env...)
-
 	resources := dwResources.FilterResources(options.Resources)
 	if err := dwResources.ValidateResources(resources); err != nil {
 		return nil, fmt.Errorf("invalid resources for project clone container: %w", err)
@@ -85,7 +75,7 @@ func GetProjectCloneInitContainer(workspace *dw.DevWorkspaceTemplateSpec, option
 	return &corev1.Container{
 		Name:      projectClonerContainerName,
 		Image:     cloneImage,
-		Env:       cloneEnv,
+		Env:       options.Env,
 		Resources: *resources,
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/project-clone/internal/bootstrap/bootstrap.go
+++ b/project-clone/internal/bootstrap/bootstrap.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/attributes"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+)
+
+var devfileNames = []string{"devfile.yaml", ".devfile.yaml"}
+
+func NeedsBootstrap(dw *dw.DevWorkspaceTemplateSpec) (bool, error) {
+	if dw.Attributes == nil {
+		return false, nil
+	}
+	if !dw.Attributes.Exists(constants.BootstrapDevWorkspaceAttribute) {
+		return false, nil
+	}
+	var attrErr error
+	needBootstrap := dw.Attributes.GetBoolean(constants.BootstrapDevWorkspaceAttribute, &attrErr)
+	if attrErr != nil {
+		return false, attrErr
+	}
+	return needBootstrap, nil
+}
+
+func BootstrapWorkspace(flattenedWorkspace *dw.DevWorkspaceTemplateSpec) error {
+	devfile, projectName, err := getBootstrapDevfile(flattenedWorkspace.Projects)
+	if err != nil {
+		return err
+	}
+	log.Printf("Updating current DevWorkspace with content from devfile found in project %s", projectName)
+
+	kubeclient, err := setupKubeClient()
+	if err != nil {
+		return err
+	}
+
+	workspaceNN, err := getWorkspaceNamespacedName()
+	if err != nil {
+		return err
+	}
+
+	clusterWorkspace := &dw.DevWorkspace{}
+	if err := kubeclient.Get(context.Background(), workspaceNN, clusterWorkspace); err != nil {
+		return fmt.Errorf("failed to read DevWorkspace from cluster: %w", err)
+	}
+
+	updatedWorkspace := updateWorkspaceFromDevfile(clusterWorkspace, devfile)
+
+	if err := kubeclient.Update(context.Background(), updatedWorkspace); err != nil {
+		return fmt.Errorf("failed to update DevWorkspace on cluster: %w", err)
+	}
+
+	log.Printf("Successfully updated DevWorkspace. Workspace may restart")
+
+	return nil
+}
+
+func updateWorkspaceFromDevfile(workspace *dw.DevWorkspace, devfile *dw.DevWorkspaceTemplateSpec) *dw.DevWorkspace {
+	updated := workspace.DeepCopy()
+
+	// Use devfile contents for this DevWorkspace instead of whatever is there
+	updated.Spec.Template = *devfile
+
+	// Add attributes from original DevWorkspace, since it's assumed they're more relevant than the devfile's attributes
+	// This will override any attributes present in both the devfile and DevWorkspace with the latter's value
+	if updated.Spec.Template.Attributes == nil {
+		updated.Spec.Template.Attributes = attributes.Attributes{}
+	}
+	for key, value := range workspace.Spec.Template.Attributes {
+		updated.Spec.Template.Attributes[key] = value
+	}
+
+	// Merge projects; we want the DevWorkspace's projects to not be dropped from the workspace, but also want to add any projects
+	// present in the devfile. We also want workspace projects first in this list, since this is the order they're bootstrapped from
+	updated.Spec.Template.Projects = mergeProjects(workspace.Spec.Template.Projects, devfile.Projects)
+
+	// Remove bootstrap attribute to avoid unnecessarily doing this process in the future
+	delete(updated.Spec.Template.Attributes, constants.BootstrapDevWorkspaceAttribute)
+
+	return updated
+}
+
+func mergeProjects(workspaceProjects, devfileProjects []dw.Project) []dw.Project {
+	var allProjects []dw.Project
+
+	// Bookkeeping structs to avoid adding identical projects. We want to avoid an issue where DevWorkspace and devfile
+	// contain the same project; adding both to the workspace will cause the workspace to be invalid.
+	// An additional improvement in the future would be to avoid adding two very similar projects (e.g. identical projects
+	// with different names)
+	projectNames := map[string]bool{}
+
+	for _, project := range workspaceProjects {
+		projectNames[project.Name] = true
+		allProjects = append(allProjects, project)
+	}
+
+	for _, project := range devfileProjects {
+		if !projectNames[project.Name] {
+			projectNames[project.Name] = true
+			allProjects = append(allProjects, project)
+		}
+	}
+
+	return allProjects
+}

--- a/project-clone/internal/bootstrap/cluster.go
+++ b/project-clone/internal/bootstrap/cluster.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"fmt"
+	"os"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func setupKubeClient() (client.Client, error) {
+	scheme := k8sruntime.NewScheme()
+
+	if err := dw.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to set up Kubernetes client: %w", err)
+	}
+
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read in-cluster Kubernetes configuration: %w", err)
+	}
+
+	kubeClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	return kubeClient, nil
+}
+
+func getWorkspaceNamespacedName() (types.NamespacedName, error) {
+	name := os.Getenv(constants.DevWorkspaceName)
+	namespace := os.Getenv(constants.DevWorkspaceNamespace)
+
+	namespacedName := types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	if name == "" || namespace == "" {
+		return namespacedName, fmt.Errorf("could not get workspace name or namespace from environment variables")
+	}
+	return namespacedName, nil
+}

--- a/project-clone/internal/bootstrap/util.go
+++ b/project-clone/internal/bootstrap/util.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/devworkspace-operator/pkg/library/projects"
+	"github.com/devfile/devworkspace-operator/project-clone/internal"
+	"sigs.k8s.io/yaml"
+)
+
+func getBootstrapDevfile(projects []dw.Project) (devfile *dw.DevWorkspaceTemplateSpec, projectName string, err error) {
+	var devfileBytes []byte
+	var devfileProject string
+	for _, project := range projects {
+		bytes, err := getDevfileFromProject(project)
+		if err == nil && len(bytes) > 0 {
+			devfileBytes = bytes
+			devfileProject = project.Name
+			break
+		}
+	}
+	if len(devfileBytes) == 0 {
+		return nil, "", fmt.Errorf("could not find devfile in any project")
+	}
+
+	devfile = &dw.DevWorkspaceTemplateSpec{}
+	if err := yaml.Unmarshal(devfileBytes, devfile); err != nil {
+		return nil, "", fmt.Errorf("failed to read devfile in project %s: %s", devfileProject, err)
+	}
+	return devfile, devfileProject, nil
+}
+
+func getDevfileFromProject(project dw.Project) ([]byte, error) {
+	clonePath := projects.GetClonePath(&project)
+	for _, devfileName := range devfileNames {
+		if bytes, err := os.ReadFile(path.Join(internal.ProjectsRoot, clonePath, devfileName)); err == nil {
+			return bytes, nil
+		}
+	}
+	return nil, fmt.Errorf("no devfile found")
+}

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -27,6 +27,7 @@ import (
 
 	projectslib "github.com/devfile/devworkspace-operator/pkg/library/projects"
 	"github.com/devfile/devworkspace-operator/project-clone/internal"
+	"github.com/devfile/devworkspace-operator/project-clone/internal/bootstrap"
 	"github.com/devfile/devworkspace-operator/project-clone/internal/git"
 	"github.com/devfile/devworkspace-operator/project-clone/internal/zip"
 	gitclient "github.com/go-git/go-git/v5/plumbing/transport/client"
@@ -114,6 +115,18 @@ func main() {
 	}
 	if encounteredError {
 		copyLogFileToProjectsRoot()
+		os.Exit(0)
+	}
+
+	needBootstrap, err := bootstrap.NeedsBootstrap(workspace)
+	if err != nil {
+		log.Printf("Encountered error reading DevWorkspace attributes: %s", err)
+		copyLogFileToProjectsRoot()
+	} else if needBootstrap {
+		if err := bootstrap.BootstrapWorkspace(workspace); err != nil {
+			log.Printf("Encountered error setting up DevWorkspace from devfile: %s", err)
+			copyLogFileToProjectsRoot()
+		}
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Adds DevWorkspace attribute `controller.devfile.io/bootstrap-devworkspace`. If set to `true`, this attribute will configure project clone to do the following:

1. Clone all projects in the DevWorkspace as normal
2. Search cloned projects for a devfile.yaml or .devfile.yaml
3. Merge contents of this devfile into the DevWorkspace
   * Projects are merged (i.e. both devfile and DevWorkspace projects
     are used)
   * Attributes from the DevWorkspace override attributes from the
     devfile
   * Components, commands, events, etc. from the Devfile are used.
4. Apply the updated DevWorkspace to the cluster, automatically
   restarting the workspace.

### What issues does this PR fix or reference?
Closes #1192 

### Is it tested? How?
Basic testing of this PR is to create a DevWorkspace that uses the attribute and imports a project with a devfile.yaml at its root:
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
      controller.devfile.io/bootstrap-devworkspace: true
    projects:
      - name: che-dashboard
        git:
          remotes:
            origin: "https://github.com/eclipse-che/che-dashboard.git"
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
```
After starting, the workspace should update so that the `.spec.template` of the workspace matches the devfile of the imported project, with the merge process above (attributes, projects are merged instead of overwritten)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
