### PR TITLE
Switch from using hub to gh in GitHub actions

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -194,8 +194,7 @@ git_commit_and_push() {
     git checkout "${PR_BRANCH}"
     git pull origin "${PR_BRANCH}" || true
     $DRY_RUN git push origin "${PR_BRANCH}"
-    lastCommitComment="$(git log -1 --pretty=%B)"
-    $DRY_RUN hub pull-request -f -m "${lastCommitComment}" -b "${CURRENT_BRANCH}" -h "${PR_BRANCH}"
+    $DRY_RUN gh pr create -f -B "${CURRENT_BRANCH}" -H "${PR_BRANCH}"
   fi
   git checkout "${CURRENT_BRANCH}"
 }


### PR DESCRIPTION
### What does this PR do?
The `hub` CLI has been removed from the Ubuntu 20.04 runner and is intended to be replaced with the 'gh' CLI. This commit adapts the previous hub command to open a PR into a gh command that does the same.

A note on arguments:
* There's no `-f` (force, even if not all commits are pushed to remote) equivalent in `gh`. This shouldn't be an issue because the prior command is `git push origin ${PR_BRANCH}`
    * Instead, `-f` in `gh` means "create PR description from last commit", which should duplicate what the `-m` was doing in `hub`
* `-b` (base branch) and `-h` (head branch) are replaced with `-B` and `-H`

### What issues does this PR fix or reference?
`release` GH action is failing.

### Is it tested? How?
I haven't directly tested, will probably have to wait for the next release to see if everything works appropriately. 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
