### PR TITLE
Fail DevWorkspaces when DevWorkspaceRouting controller sees error

### DIFF
--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/config"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
@@ -185,6 +186,10 @@ func (r *DevWorkspaceRoutingReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	servicesInSync, clusterServices, err := r.syncServices(instance, services)
 	if err != nil {
+		failError := &sync.UnrecoverableSyncError{}
+		if errors.As(err, &failError) {
+			return reconcile.Result{}, r.markRoutingFailed(instance, err.Error())
+		}
 		reqLogger.Error(err, "Error syncing services")
 		return reconcile.Result{Requeue: true}, r.reconcileStatus(instance, nil, nil, false, "Preparing services")
 	} else if !servicesInSync {
@@ -199,6 +204,10 @@ func (r *DevWorkspaceRoutingReconciler) Reconcile(ctx context.Context, req ctrl.
 	if infrastructure.IsOpenShift() {
 		routesInSync, clusterRoutes, err := r.syncRoutes(instance, routes)
 		if err != nil {
+			failError := &sync.UnrecoverableSyncError{}
+			if errors.As(err, &failError) {
+				return reconcile.Result{}, r.markRoutingFailed(instance, err.Error())
+			}
 			reqLogger.Error(err, "Error syncing routes")
 			return reconcile.Result{Requeue: true}, r.reconcileStatus(instance, nil, nil, false, "Preparing routes")
 		} else if !routesInSync {
@@ -209,6 +218,10 @@ func (r *DevWorkspaceRoutingReconciler) Reconcile(ctx context.Context, req ctrl.
 	} else {
 		ingressesInSync, clusterIngresses, err := r.syncIngresses(instance, ingresses)
 		if err != nil {
+			failError := &sync.UnrecoverableSyncError{}
+			if errors.As(err, &failError) {
+				return reconcile.Result{}, r.markRoutingFailed(instance, err.Error())
+			}
 			reqLogger.Error(err, "Error syncing ingresses")
 			return reconcile.Result{Requeue: true}, r.reconcileStatus(instance, nil, nil, false, "Preparing ingresses")
 		} else if !ingressesInSync {

--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller_test.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller_test.go
@@ -32,29 +32,6 @@ import (
 
 var _ = Describe("DevWorkspaceRouting Controller", func() {
 	Context("Basic DevWorkspaceRouting Tests", func() {
-		It("Gets Preparing status", func() {
-			By("Creating a new DevWorkspaceRouting object")
-			dwrNamespacedName := namespacedName(devWorkspaceRoutingName, testNamespace)
-			createdDWR := createPreparingDWR(testWorkspaceID, devWorkspaceRoutingName)
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, dwrNamespacedName, createdDWR)
-				return err == nil
-			}, timeout, interval).Should(BeTrue(), "DevWorkspaceRouting should exist in cluster")
-
-			By("Checking DevWorkspaceRouting Status is updated to preparing")
-			Eventually(func() (phase controllerv1alpha1.DevWorkspaceRoutingPhase, err error) {
-				if err := k8sClient.Get(ctx, dwrNamespacedName, createdDWR); err != nil {
-					return "", err
-				}
-				return createdDWR.Status.Phase, nil
-			}, timeout, interval).Should(Equal(controllerv1alpha1.RoutingPreparing), "DevWorkspaceRouting should have Preparing phase")
-
-			Expect(createdDWR.Status.Message).ShouldNot(BeNil(), "Status message should be set for DevWorkspaceRoutings in Preparing phase")
-
-			deleteDevWorkspaceRouting(devWorkspaceRoutingName)
-			// Services and Ingresses aren't created since the DWR was stuck in preparing phase, no need to clean them up
-		})
-
 		It("Gets Ready Status on OpenShift", func() {
 			By("Setting infrastructure to OpenShift")
 			infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)

--- a/controllers/controller/devworkspacerouting/sync_ingresses.go
+++ b/controllers/controller/devworkspacerouting/sync_ingresses.go
@@ -63,7 +63,7 @@ func (r *DevWorkspaceRoutingReconciler) syncIngresses(routing *controllerv1alpha
 			ingressesInSync = false
 			continue
 		case *sync.UnrecoverableSyncError:
-			return false, nil, t.Cause
+			return false, nil, t
 		default:
 			return false, nil, err
 		}

--- a/controllers/controller/devworkspacerouting/sync_routes.go
+++ b/controllers/controller/devworkspacerouting/sync_routes.go
@@ -62,7 +62,7 @@ func (r *DevWorkspaceRoutingReconciler) syncRoutes(routing *controllerv1alpha1.D
 			routesInSync = false
 			continue
 		case *sync.UnrecoverableSyncError:
-			return false, nil, t.Cause
+			return false, nil, t
 		default:
 			return false, nil, err
 		}

--- a/controllers/controller/devworkspacerouting/sync_services.go
+++ b/controllers/controller/devworkspacerouting/sync_services.go
@@ -62,7 +62,7 @@ func (r *DevWorkspaceRoutingReconciler) syncServices(routing *controllerv1alpha1
 			servicesInSync = false
 			continue
 		case *sync.UnrecoverableSyncError:
-			return false, nil, t.Cause
+			return false, nil, t
 		default:
 			return false, nil, err
 		}

--- a/controllers/controller/devworkspacerouting/util_test.go
+++ b/controllers/controller/devworkspacerouting/util_test.go
@@ -54,39 +54,6 @@ var (
 	ExpectedLabels = map[string]string{constants.DevWorkspaceIDLabel: testWorkspaceID}
 )
 
-func createPreparingDWR(workspaceID string, name string) *controllerv1alpha1.DevWorkspaceRouting {
-	mainAttributes := controllerv1alpha1.Attributes{}
-	mainAttributes.PutString("type", "main")
-	exposedEndpoint := controllerv1alpha1.Endpoint{
-		Name:       exposedEndPointName,
-		Attributes: mainAttributes,
-		// Target port must be within range 1 and 65535
-		// Created service will be invalid on cluster and error will be logged
-		// DWR will continue trying to reconcile however, keeping it stuck in preparing phase
-		TargetPort: 0,
-	}
-	machineEndpointsMap := map[string]controllerv1alpha1.EndpointList{
-		testMachineName: {
-			exposedEndpoint,
-		},
-	}
-
-	dwr := &controllerv1alpha1.DevWorkspaceRouting{
-		Spec: controllerv1alpha1.DevWorkspaceRoutingSpec{
-			DevWorkspaceId: workspaceID,
-			RoutingClass:   controllerv1alpha1.DevWorkspaceRoutingBasic,
-			Endpoints:      machineEndpointsMap,
-			PodSelector: map[string]string{
-				constants.DevWorkspaceIDLabel: workspaceID,
-			},
-		},
-	}
-	dwr.SetName(name)
-	dwr.SetNamespace(testNamespace)
-	Expect(k8sClient.Create(ctx, dwr)).Should(Succeed())
-	return dwr
-}
-
 func createDWR(workspaceID string, name string) *controllerv1alpha1.DevWorkspaceRouting {
 	mainAttributes := controllerv1alpha1.Attributes{}
 	mainAttributes.PutString("type", "main")


### PR DESCRIPTION
### What does this PR do?
Mark DevWorkspaceRoutings as failed if any of the sync operations returns an UnrecoverableSyncError rather than ignoring it and treating it as a transient error (i.e. retrying).

This allows workspaces to fail with a meaningful message more quickly, rather than waiting for timeout and failing then.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1198

### Is it tested? How?
To test, create a resource quota, then create workspaces that would violate that quota and ensure they fail. 

For example, for services, 
1. Create a resource quota specifying e.g. a maximum number of services in a namespace:
    ```yaml
    apiVersion: v1
    kind: ResourceQuota
    metadata:
      name: resource-quota-services
    spec:
      hard:
        count/services: "1"
    ```
2. Create two workspaces that have at least one endpoint (resulting in DWO attempting to create two services)
3. Workspace should fail with message
    ```
    Failed to set up networking for workspace: services "workspace82736d3c797e4150-service" is forbidden: exceeded quota: resource-quota-services, requested: count/services=1, used: count/services=1, limited: count/services=1
    ```

We should verify that such quotas are respected for routes and ingresses as well, as applicable.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
