### PR TITLE
Update Devfile API dependency to v2.2.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export PROJECT_CLONE_IMG ?= quay.io/devfile/project-clone:next
 export PULL_POLICY ?= Always
 export DEFAULT_ROUTING ?= basic
 export KUBECONFIG ?= ${HOME}/.kube/config
-export DEVWORKSPACE_API_VERSION ?= 1ae41b52c5f2bea1031b16277666e1b6baa0358c
+export DEVWORKSPACE_API_VERSION ?= a6ec0a38307b63a29fad2eea945cc69bee97a683
 
 # Enable using Podman instead of Docker
 export DOCKER ?= docker

--- a/build/scripts/generate_deployment.sh
+++ b/build/scripts/generate_deployment.sh
@@ -120,7 +120,7 @@ if $USE_DEFAULT_ENV; then
   export PROJECT_CLONE_IMG=${PROJECT_CLONE_IMG:-"quay.io/devfile/project-clone:next"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic
-  export DEVWORKSPACE_API_VERSION=1ae41b52c5f2bea1031b16277666e1b6baa0358c
+  export DEVWORKSPACE_API_VERSION=a6ec0a38307b63a29fad2eea945cc69bee97a683
   export ROUTING_SUFFIX='""'
   export FORCE_DEVWORKSPACE_CRDS_UPDATE=true
 fi

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -1307,6 +1307,74 @@ spec:
                           - name
                           type: object
                         type: array
+                      dependentProjects:
+                        description: Additional projects related to the main project in the devfile, contianing names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used as init. Required if there are more than one remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       events:
                         description: Bindings of commands to events. Each command is referred-to by its name.
                         properties:

--- a/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
+++ b/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
@@ -4717,6 +4717,81 @@ spec:
                       - name
                       type: object
                     type: array
+                  dependentProjects:
+                    description: Additional projects related to the main project in the devfile, contianing names and sources locations
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      - required:
+                        - custom
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
+                          type: string
+                        custom:
+                          description: Project's Custom source
+                          properties:
+                            embeddedResource:
+                              type: object
+                              x-kubernetes-embedded-resource: true
+                              x-kubernetes-preserve-unknown-fields: true
+                            projectSourceClass:
+                              type: string
+                          required:
+                          - embeddedResource
+                          - projectSourceClass
+                          type: object
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init. Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                              type: object
+                          required:
+                          - remotes
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          - Custom
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   events:
                     description: Bindings of commands to events. Each command is referred-to by its name.
                     properties:
@@ -5849,6 +5924,63 @@ spec:
                                   type: boolean
                                 size:
                                   description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dependentProjects:
+                        description: Overrides of dependentProjects encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.
+                        items:
+                          oneOf:
+                          - required:
+                            - git
+                          - required:
+                            - zip
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used as init. Required if there are more than one remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                                  type: object
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH
                                   type: string
                               type: object
                           required:

--- a/deploy/bundle/manifests/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/deploy/bundle/manifests/workspace.devfile.io_devworkspacetemplates.yaml
@@ -4047,6 +4047,81 @@ spec:
                   - name
                   type: object
                 type: array
+              dependentProjects:
+                description: Additional projects related to the main project in the devfile, contianing names and sources locations
+                items:
+                  oneOf:
+                  - required:
+                    - git
+                  - required:
+                    - zip
+                  - required:
+                    - custom
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    clonePath:
+                      description: Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
+                      type: string
+                    custom:
+                      description: Project's Custom source
+                      properties:
+                        embeddedResource:
+                          type: object
+                          x-kubernetes-embedded-resource: true
+                          x-kubernetes-preserve-unknown-fields: true
+                        projectSourceClass:
+                          type: string
+                      required:
+                      - embeddedResource
+                      - projectSourceClass
+                      type: object
+                    git:
+                      description: Project's Git source
+                      properties:
+                        checkoutFrom:
+                          description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                          properties:
+                            remote:
+                              description: The remote name should be used as init. Required if there are more than one remote configured
+                              type: string
+                            revision:
+                              description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                              type: string
+                          type: object
+                        remotes:
+                          additionalProperties:
+                            type: string
+                          description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                          type: object
+                      required:
+                      - remotes
+                      type: object
+                    name:
+                      description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    sourceType:
+                      description: Type of project source
+                      enum:
+                      - Git
+                      - Zip
+                      - Custom
+                      type: string
+                    zip:
+                      description: Project's Zip source
+                      properties:
+                        location:
+                          description: Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               events:
                 description: Bindings of commands to events. Each command is referred-to by its name.
                 properties:
@@ -5179,6 +5254,63 @@ spec:
                               type: boolean
                             size:
                               description: Size of the volume
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  dependentProjects:
+                    description: Overrides of dependentProjects encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
+                          type: string
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be checked out. Required if there are more than one remote configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init. Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized in the git project. Projects must have at least one remote configured while StarterProjects & Image Component's Git source can only have at most one remote configured.
+                              type: object
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH
                               type: string
                           type: object
                       required:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -2126,6 +2126,93 @@ spec:
                           - name
                           type: object
                         type: array
+                      dependentProjects:
+                        description: Additional projects related to the main project
+                          in the devfile, contianing names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       events:
                         description: Bindings of commands to events. Each command
                           is referred-to by its name.
@@ -14108,6 +14195,98 @@ spec:
                       - name
                       type: object
                     type: array
+                  dependentProjects:
+                    description: Additional projects related to the main project in
+                      the devfile, contianing names and sources locations
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      - required:
+                        - custom
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to
+                            which this project should be cloned into. This is a unix-style
+                            relative path (i.e. uses forward slashes). The path is
+                            invalid if it is absolute or tries to escape the project
+                            root through the usage of '..'. If not specified, defaults
+                            to the project name.
+                          type: string
+                        custom:
+                          description: Project's Custom source
+                          properties:
+                            embeddedResource:
+                              type: object
+                              x-kubernetes-embedded-resource: true
+                              x-kubernetes-preserve-unknown-fields: true
+                            projectSourceClass:
+                              type: string
+                          required:
+                          - embeddedResource
+                          - projectSourceClass
+                          type: object
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be
+                                checked out. Required if there are more than one remote
+                                configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init.
+                                    Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should
+                                    be branch name, tag or commit id. Default branch
+                                    is used if missing or specified revision is not
+                                    found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized
+                                in the git project. Projects must have at least one
+                                remote configured while StarterProjects & Image Component's
+                                Git source can only have at most one remote configured.
+                              type: object
+                          required:
+                          - remotes
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          - Custom
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address.
+                                Should be file path of the archive, e.g. file://$FILE_PATH
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   events:
                     description: Bindings of commands to events. Each command is referred-to
                       by its name.
@@ -15901,6 +16080,83 @@ spec:
                                   type: boolean
                                 size:
                                   description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dependentProjects:
+                        description: Overrides of dependentProjects encapsulated in
+                          a parent devfile. Overriding is done according to K8S strategic
+                          merge patch standard rules.
+                        items:
+                          oneOf:
+                          - required:
+                            - git
+                          - required:
+                            - zip
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
                                   type: string
                               type: object
                           required:
@@ -22047,6 +22303,95 @@ spec:
                   - name
                   type: object
                 type: array
+              dependentProjects:
+                description: Additional projects related to the main project in the
+                  devfile, contianing names and sources locations
+                items:
+                  oneOf:
+                  - required:
+                    - git
+                  - required:
+                    - zip
+                  - required:
+                    - custom
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML
+                        attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    clonePath:
+                      description: Path relative to the root of the projects to which
+                        this project should be cloned into. This is a unix-style relative
+                        path (i.e. uses forward slashes). The path is invalid if it
+                        is absolute or tries to escape the project root through the
+                        usage of '..'. If not specified, defaults to the project name.
+                      type: string
+                    custom:
+                      description: Project's Custom source
+                      properties:
+                        embeddedResource:
+                          type: object
+                          x-kubernetes-embedded-resource: true
+                          x-kubernetes-preserve-unknown-fields: true
+                        projectSourceClass:
+                          type: string
+                      required:
+                      - embeddedResource
+                      - projectSourceClass
+                      type: object
+                    git:
+                      description: Project's Git source
+                      properties:
+                        checkoutFrom:
+                          description: Defines from what the project should be checked
+                            out. Required if there are more than one remote configured
+                          properties:
+                            remote:
+                              description: The remote name should be used as init.
+                                Required if there are more than one remote configured
+                              type: string
+                            revision:
+                              description: The revision to checkout from. Should be
+                                branch name, tag or commit id. Default branch is used
+                                if missing or specified revision is not found.
+                              type: string
+                          type: object
+                        remotes:
+                          additionalProperties:
+                            type: string
+                          description: The remotes map which should be initialized
+                            in the git project. Projects must have at least one remote
+                            configured while StarterProjects & Image Component's Git
+                            source can only have at most one remote configured.
+                          type: object
+                      required:
+                      - remotes
+                      type: object
+                    name:
+                      description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    sourceType:
+                      description: Type of project source
+                      enum:
+                      - Git
+                      - Zip
+                      - Custom
+                      type: string
+                    zip:
+                      description: Project's Zip source
+                      properties:
+                        location:
+                          description: Zip project's source location address. Should
+                            be file path of the archive, e.g. file://$FILE_PATH
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               events:
                 description: Bindings of commands to events. Each command is referred-to
                   by its name.
@@ -23775,6 +24120,81 @@ spec:
                               type: boolean
                             size:
                               description: Size of the volume
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  dependentProjects:
+                    description: Overrides of dependentProjects encapsulated in a
+                      parent devfile. Overriding is done according to K8S strategic
+                      merge patch standard rules.
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to
+                            which this project should be cloned into. This is a unix-style
+                            relative path (i.e. uses forward slashes). The path is
+                            invalid if it is absolute or tries to escape the project
+                            root through the usage of '..'. If not specified, defaults
+                            to the project name.
+                          type: string
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be
+                                checked out. Required if there are more than one remote
+                                configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init.
+                                    Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should
+                                    be branch name, tag or commit id. Default branch
+                                    is used if missing or specified revision is not
+                                    found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized
+                                in the git project. Projects must have at least one
+                                remote configured while StarterProjects & Image Component's
+                                Git source can only have at most one remote configured.
+                              type: object
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address.
+                                Should be file path of the archive, e.g. file://$FILE_PATH
                               type: string
                           type: object
                       required:

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2126,6 +2126,93 @@ spec:
                           - name
                           type: object
                         type: array
+                      dependentProjects:
+                        description: Additional projects related to the main project
+                          in the devfile, contianing names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       events:
                         description: Bindings of commands to events. Each command
                           is referred-to by its name.

--- a/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -6820,6 +6820,98 @@ spec:
                       - name
                       type: object
                     type: array
+                  dependentProjects:
+                    description: Additional projects related to the main project in
+                      the devfile, contianing names and sources locations
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      - required:
+                        - custom
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to
+                            which this project should be cloned into. This is a unix-style
+                            relative path (i.e. uses forward slashes). The path is
+                            invalid if it is absolute or tries to escape the project
+                            root through the usage of '..'. If not specified, defaults
+                            to the project name.
+                          type: string
+                        custom:
+                          description: Project's Custom source
+                          properties:
+                            embeddedResource:
+                              type: object
+                              x-kubernetes-embedded-resource: true
+                              x-kubernetes-preserve-unknown-fields: true
+                            projectSourceClass:
+                              type: string
+                          required:
+                          - embeddedResource
+                          - projectSourceClass
+                          type: object
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be
+                                checked out. Required if there are more than one remote
+                                configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init.
+                                    Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should
+                                    be branch name, tag or commit id. Default branch
+                                    is used if missing or specified revision is not
+                                    found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized
+                                in the git project. Projects must have at least one
+                                remote configured while StarterProjects & Image Component's
+                                Git source can only have at most one remote configured.
+                              type: object
+                          required:
+                          - remotes
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          - Custom
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address.
+                                Should be file path of the archive, e.g. file://$FILE_PATH
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   events:
                     description: Bindings of commands to events. Each command is referred-to
                       by its name.
@@ -8613,6 +8705,83 @@ spec:
                                   type: boolean
                                 size:
                                   description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dependentProjects:
+                        description: Overrides of dependentProjects encapsulated in
+                          a parent devfile. Overriding is done according to K8S strategic
+                          merge patch standard rules.
+                        items:
+                          oneOf:
+                          - required:
+                            - git
+                          - required:
+                            - zip
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
                                   type: string
                               type: object
                           required:

--- a/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -5673,6 +5673,95 @@ spec:
                   - name
                   type: object
                 type: array
+              dependentProjects:
+                description: Additional projects related to the main project in the
+                  devfile, contianing names and sources locations
+                items:
+                  oneOf:
+                  - required:
+                    - git
+                  - required:
+                    - zip
+                  - required:
+                    - custom
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML
+                        attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    clonePath:
+                      description: Path relative to the root of the projects to which
+                        this project should be cloned into. This is a unix-style relative
+                        path (i.e. uses forward slashes). The path is invalid if it
+                        is absolute or tries to escape the project root through the
+                        usage of '..'. If not specified, defaults to the project name.
+                      type: string
+                    custom:
+                      description: Project's Custom source
+                      properties:
+                        embeddedResource:
+                          type: object
+                          x-kubernetes-embedded-resource: true
+                          x-kubernetes-preserve-unknown-fields: true
+                        projectSourceClass:
+                          type: string
+                      required:
+                      - embeddedResource
+                      - projectSourceClass
+                      type: object
+                    git:
+                      description: Project's Git source
+                      properties:
+                        checkoutFrom:
+                          description: Defines from what the project should be checked
+                            out. Required if there are more than one remote configured
+                          properties:
+                            remote:
+                              description: The remote name should be used as init.
+                                Required if there are more than one remote configured
+                              type: string
+                            revision:
+                              description: The revision to checkout from. Should be
+                                branch name, tag or commit id. Default branch is used
+                                if missing or specified revision is not found.
+                              type: string
+                          type: object
+                        remotes:
+                          additionalProperties:
+                            type: string
+                          description: The remotes map which should be initialized
+                            in the git project. Projects must have at least one remote
+                            configured while StarterProjects & Image Component's Git
+                            source can only have at most one remote configured.
+                          type: object
+                      required:
+                      - remotes
+                      type: object
+                    name:
+                      description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    sourceType:
+                      description: Type of project source
+                      enum:
+                      - Git
+                      - Zip
+                      - Custom
+                      type: string
+                    zip:
+                      description: Project's Zip source
+                      properties:
+                        location:
+                          description: Zip project's source location address. Should
+                            be file path of the archive, e.g. file://$FILE_PATH
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               events:
                 description: Bindings of commands to events. Each command is referred-to
                   by its name.
@@ -7401,6 +7490,81 @@ spec:
                               type: boolean
                             size:
                               description: Size of the volume
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  dependentProjects:
+                    description: Overrides of dependentProjects encapsulated in a
+                      parent devfile. Overriding is done according to K8S strategic
+                      merge patch standard rules.
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to
+                            which this project should be cloned into. This is a unix-style
+                            relative path (i.e. uses forward slashes). The path is
+                            invalid if it is absolute or tries to escape the project
+                            root through the usage of '..'. If not specified, defaults
+                            to the project name.
+                          type: string
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be
+                                checked out. Required if there are more than one remote
+                                configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init.
+                                    Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should
+                                    be branch name, tag or commit id. Default branch
+                                    is used if missing or specified revision is not
+                                    found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized
+                                in the git project. Projects must have at least one
+                                remote configured while StarterProjects & Image Component's
+                                Git source can only have at most one remote configured.
+                              type: object
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address.
+                                Should be file path of the archive, e.g. file://$FILE_PATH
                               type: string
                           type: object
                       required:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -2126,6 +2126,93 @@ spec:
                           - name
                           type: object
                         type: array
+                      dependentProjects:
+                        description: Additional projects related to the main project
+                          in the devfile, contianing names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       events:
                         description: Bindings of commands to events. Each command
                           is referred-to by its name.
@@ -14108,6 +14195,98 @@ spec:
                       - name
                       type: object
                     type: array
+                  dependentProjects:
+                    description: Additional projects related to the main project in
+                      the devfile, contianing names and sources locations
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      - required:
+                        - custom
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to
+                            which this project should be cloned into. This is a unix-style
+                            relative path (i.e. uses forward slashes). The path is
+                            invalid if it is absolute or tries to escape the project
+                            root through the usage of '..'. If not specified, defaults
+                            to the project name.
+                          type: string
+                        custom:
+                          description: Project's Custom source
+                          properties:
+                            embeddedResource:
+                              type: object
+                              x-kubernetes-embedded-resource: true
+                              x-kubernetes-preserve-unknown-fields: true
+                            projectSourceClass:
+                              type: string
+                          required:
+                          - embeddedResource
+                          - projectSourceClass
+                          type: object
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be
+                                checked out. Required if there are more than one remote
+                                configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init.
+                                    Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should
+                                    be branch name, tag or commit id. Default branch
+                                    is used if missing or specified revision is not
+                                    found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized
+                                in the git project. Projects must have at least one
+                                remote configured while StarterProjects & Image Component's
+                                Git source can only have at most one remote configured.
+                              type: object
+                          required:
+                          - remotes
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          - Custom
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address.
+                                Should be file path of the archive, e.g. file://$FILE_PATH
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   events:
                     description: Bindings of commands to events. Each command is referred-to
                       by its name.
@@ -15901,6 +16080,83 @@ spec:
                                   type: boolean
                                 size:
                                   description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dependentProjects:
+                        description: Overrides of dependentProjects encapsulated in
+                          a parent devfile. Overriding is done according to K8S strategic
+                          merge patch standard rules.
+                        items:
+                          oneOf:
+                          - required:
+                            - git
+                          - required:
+                            - zip
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
                                   type: string
                               type: object
                           required:
@@ -22047,6 +22303,95 @@ spec:
                   - name
                   type: object
                 type: array
+              dependentProjects:
+                description: Additional projects related to the main project in the
+                  devfile, contianing names and sources locations
+                items:
+                  oneOf:
+                  - required:
+                    - git
+                  - required:
+                    - zip
+                  - required:
+                    - custom
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML
+                        attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    clonePath:
+                      description: Path relative to the root of the projects to which
+                        this project should be cloned into. This is a unix-style relative
+                        path (i.e. uses forward slashes). The path is invalid if it
+                        is absolute or tries to escape the project root through the
+                        usage of '..'. If not specified, defaults to the project name.
+                      type: string
+                    custom:
+                      description: Project's Custom source
+                      properties:
+                        embeddedResource:
+                          type: object
+                          x-kubernetes-embedded-resource: true
+                          x-kubernetes-preserve-unknown-fields: true
+                        projectSourceClass:
+                          type: string
+                      required:
+                      - embeddedResource
+                      - projectSourceClass
+                      type: object
+                    git:
+                      description: Project's Git source
+                      properties:
+                        checkoutFrom:
+                          description: Defines from what the project should be checked
+                            out. Required if there are more than one remote configured
+                          properties:
+                            remote:
+                              description: The remote name should be used as init.
+                                Required if there are more than one remote configured
+                              type: string
+                            revision:
+                              description: The revision to checkout from. Should be
+                                branch name, tag or commit id. Default branch is used
+                                if missing or specified revision is not found.
+                              type: string
+                          type: object
+                        remotes:
+                          additionalProperties:
+                            type: string
+                          description: The remotes map which should be initialized
+                            in the git project. Projects must have at least one remote
+                            configured while StarterProjects & Image Component's Git
+                            source can only have at most one remote configured.
+                          type: object
+                      required:
+                      - remotes
+                      type: object
+                    name:
+                      description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    sourceType:
+                      description: Type of project source
+                      enum:
+                      - Git
+                      - Zip
+                      - Custom
+                      type: string
+                    zip:
+                      description: Project's Zip source
+                      properties:
+                        location:
+                          description: Zip project's source location address. Should
+                            be file path of the archive, e.g. file://$FILE_PATH
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               events:
                 description: Bindings of commands to events. Each command is referred-to
                   by its name.
@@ -23775,6 +24120,81 @@ spec:
                               type: boolean
                             size:
                               description: Size of the volume
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  dependentProjects:
+                    description: Overrides of dependentProjects encapsulated in a
+                      parent devfile. Overriding is done according to K8S strategic
+                      merge patch standard rules.
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to
+                            which this project should be cloned into. This is a unix-style
+                            relative path (i.e. uses forward slashes). The path is
+                            invalid if it is absolute or tries to escape the project
+                            root through the usage of '..'. If not specified, defaults
+                            to the project name.
+                          type: string
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be
+                                checked out. Required if there are more than one remote
+                                configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init.
+                                    Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should
+                                    be branch name, tag or commit id. Default branch
+                                    is used if missing or specified revision is not
+                                    found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized
+                                in the git project. Projects must have at least one
+                                remote configured while StarterProjects & Image Component's
+                                Git source can only have at most one remote configured.
+                              type: object
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address.
+                                Should be file path of the archive, e.g. file://$FILE_PATH
                               type: string
                           type: object
                       required:

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2126,6 +2126,93 @@ spec:
                           - name
                           type: object
                         type: array
+                      dependentProjects:
+                        description: Additional projects related to the main project
+                          in the devfile, contianing names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       events:
                         description: Bindings of commands to events. Each command
                           is referred-to by its name.

--- a/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -6820,6 +6820,98 @@ spec:
                       - name
                       type: object
                     type: array
+                  dependentProjects:
+                    description: Additional projects related to the main project in
+                      the devfile, contianing names and sources locations
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      - required:
+                        - custom
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to
+                            which this project should be cloned into. This is a unix-style
+                            relative path (i.e. uses forward slashes). The path is
+                            invalid if it is absolute or tries to escape the project
+                            root through the usage of '..'. If not specified, defaults
+                            to the project name.
+                          type: string
+                        custom:
+                          description: Project's Custom source
+                          properties:
+                            embeddedResource:
+                              type: object
+                              x-kubernetes-embedded-resource: true
+                              x-kubernetes-preserve-unknown-fields: true
+                            projectSourceClass:
+                              type: string
+                          required:
+                          - embeddedResource
+                          - projectSourceClass
+                          type: object
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be
+                                checked out. Required if there are more than one remote
+                                configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init.
+                                    Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should
+                                    be branch name, tag or commit id. Default branch
+                                    is used if missing or specified revision is not
+                                    found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized
+                                in the git project. Projects must have at least one
+                                remote configured while StarterProjects & Image Component's
+                                Git source can only have at most one remote configured.
+                              type: object
+                          required:
+                          - remotes
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          - Custom
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address.
+                                Should be file path of the archive, e.g. file://$FILE_PATH
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   events:
                     description: Bindings of commands to events. Each command is referred-to
                       by its name.
@@ -8613,6 +8705,83 @@ spec:
                                   type: boolean
                                 size:
                                   description: Size of the volume
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      dependentProjects:
+                        description: Overrides of dependentProjects encapsulated in
+                          a parent devfile. Overriding is done according to K8S strategic
+                          merge patch standard rules.
+                        items:
+                          oneOf:
+                          - required:
+                            - git
+                          - required:
+                            - zip
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
                                   type: string
                               type: object
                           required:

--- a/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -5673,6 +5673,95 @@ spec:
                   - name
                   type: object
                 type: array
+              dependentProjects:
+                description: Additional projects related to the main project in the
+                  devfile, contianing names and sources locations
+                items:
+                  oneOf:
+                  - required:
+                    - git
+                  - required:
+                    - zip
+                  - required:
+                    - custom
+                  properties:
+                    attributes:
+                      description: Map of implementation-dependant free-form YAML
+                        attributes.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    clonePath:
+                      description: Path relative to the root of the projects to which
+                        this project should be cloned into. This is a unix-style relative
+                        path (i.e. uses forward slashes). The path is invalid if it
+                        is absolute or tries to escape the project root through the
+                        usage of '..'. If not specified, defaults to the project name.
+                      type: string
+                    custom:
+                      description: Project's Custom source
+                      properties:
+                        embeddedResource:
+                          type: object
+                          x-kubernetes-embedded-resource: true
+                          x-kubernetes-preserve-unknown-fields: true
+                        projectSourceClass:
+                          type: string
+                      required:
+                      - embeddedResource
+                      - projectSourceClass
+                      type: object
+                    git:
+                      description: Project's Git source
+                      properties:
+                        checkoutFrom:
+                          description: Defines from what the project should be checked
+                            out. Required if there are more than one remote configured
+                          properties:
+                            remote:
+                              description: The remote name should be used as init.
+                                Required if there are more than one remote configured
+                              type: string
+                            revision:
+                              description: The revision to checkout from. Should be
+                                branch name, tag or commit id. Default branch is used
+                                if missing or specified revision is not found.
+                              type: string
+                          type: object
+                        remotes:
+                          additionalProperties:
+                            type: string
+                          description: The remotes map which should be initialized
+                            in the git project. Projects must have at least one remote
+                            configured while StarterProjects & Image Component's Git
+                            source can only have at most one remote configured.
+                          type: object
+                      required:
+                      - remotes
+                      type: object
+                    name:
+                      description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    sourceType:
+                      description: Type of project source
+                      enum:
+                      - Git
+                      - Zip
+                      - Custom
+                      type: string
+                    zip:
+                      description: Project's Zip source
+                      properties:
+                        location:
+                          description: Zip project's source location address. Should
+                            be file path of the archive, e.g. file://$FILE_PATH
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               events:
                 description: Bindings of commands to events. Each command is referred-to
                   by its name.
@@ -7401,6 +7490,81 @@ spec:
                               type: boolean
                             size:
                               description: Size of the volume
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  dependentProjects:
+                    description: Overrides of dependentProjects encapsulated in a
+                      parent devfile. Overriding is done according to K8S strategic
+                      merge patch standard rules.
+                    items:
+                      oneOf:
+                      - required:
+                        - git
+                      - required:
+                        - zip
+                      properties:
+                        attributes:
+                          description: Map of implementation-dependant free-form YAML
+                            attributes.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        clonePath:
+                          description: Path relative to the root of the projects to
+                            which this project should be cloned into. This is a unix-style
+                            relative path (i.e. uses forward slashes). The path is
+                            invalid if it is absolute or tries to escape the project
+                            root through the usage of '..'. If not specified, defaults
+                            to the project name.
+                          type: string
+                        git:
+                          description: Project's Git source
+                          properties:
+                            checkoutFrom:
+                              description: Defines from what the project should be
+                                checked out. Required if there are more than one remote
+                                configured
+                              properties:
+                                remote:
+                                  description: The remote name should be used as init.
+                                    Required if there are more than one remote configured
+                                  type: string
+                                revision:
+                                  description: The revision to checkout from. Should
+                                    be branch name, tag or commit id. Default branch
+                                    is used if missing or specified revision is not
+                                    found.
+                                  type: string
+                              type: object
+                            remotes:
+                              additionalProperties:
+                                type: string
+                              description: The remotes map which should be initialized
+                                in the git project. Projects must have at least one
+                                remote configured while StarterProjects & Image Component's
+                                Git source can only have at most one remote configured.
+                              type: object
+                          type: object
+                        name:
+                          description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sourceType:
+                          description: Type of project source
+                          enum:
+                          - Git
+                          - Zip
+                          type: string
+                        zip:
+                          description: Project's Zip source
+                          properties:
+                            location:
+                              description: Zip project's source location address.
+                                Should be file path of the archive, e.g. file://$FILE_PATH
                               type: string
                           type: object
                       required:

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -2125,6 +2125,93 @@ spec:
                           - name
                           type: object
                         type: array
+                      dependentProjects:
+                        description: Additional projects related to the main project
+                          in the devfile, contianing names and sources locations
+                        items:
+                          properties:
+                            attributes:
+                              description: Map of implementation-dependant free-form
+                                YAML attributes.
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            clonePath:
+                              description: Path relative to the root of the projects
+                                to which this project should be cloned into. This
+                                is a unix-style relative path (i.e. uses forward slashes).
+                                The path is invalid if it is absolute or tries to
+                                escape the project root through the usage of '..'.
+                                If not specified, defaults to the project name.
+                              type: string
+                            custom:
+                              description: Project's Custom source
+                              properties:
+                                embeddedResource:
+                                  type: object
+                                  x-kubernetes-embedded-resource: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                                projectSourceClass:
+                                  type: string
+                              required:
+                              - embeddedResource
+                              - projectSourceClass
+                              type: object
+                            git:
+                              description: Project's Git source
+                              properties:
+                                checkoutFrom:
+                                  description: Defines from what the project should
+                                    be checked out. Required if there are more than
+                                    one remote configured
+                                  properties:
+                                    remote:
+                                      description: The remote name should be used
+                                        as init. Required if there are more than one
+                                        remote configured
+                                      type: string
+                                    revision:
+                                      description: The revision to checkout from.
+                                        Should be branch name, tag or commit id. Default
+                                        branch is used if missing or specified revision
+                                        is not found.
+                                      type: string
+                                  type: object
+                                remotes:
+                                  additionalProperties:
+                                    type: string
+                                  description: The remotes map which should be initialized
+                                    in the git project. Projects must have at least
+                                    one remote configured while StarterProjects &
+                                    Image Component's Git source can only have at
+                                    most one remote configured.
+                                  type: object
+                              required:
+                              - remotes
+                              type: object
+                            name:
+                              description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            sourceType:
+                              description: Type of project source
+                              enum:
+                              - Git
+                              - Zip
+                              - Custom
+                              type: string
+                            zip:
+                              description: Project's Zip source
+                              properties:
+                                location:
+                                  description: Zip project's source location address.
+                                    Should be file path of the archive, e.g. file://$FILE_PATH
+                                  type: string
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       events:
                         description: Bindings of commands to events. Each command
                           is referred-to by its name.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/devworkspace-operator
 go 1.19
 
 require (
-	github.com/devfile/api/v2 v2.2.1
+	github.com/devfile/api/v2 v2.2.2
 	github.com/go-git/go-git/v5 v5.5.1
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api/v2 v2.2.1 h1:VSX297YqY4C4j4uhn7M0RdZeBaeWqyVi4NnagzEmxu0=
-github.com/devfile/api/v2 v2.2.1/go.mod h1:qp8jcw12y1JdCsxjK/7LJ7uWaJOxcY1s2LUk5PhbkbM=
+github.com/devfile/api/v2 v2.2.2 h1:DXRCPWFlZhTIE38Of2jzTRjQHadfbxBC8GS+m+EjoCU=
+github.com/devfile/api/v2 v2.2.2/go.mod h1:qp8jcw12y1JdCsxjK/7LJ7uWaJOxcY1s2LUk5PhbkbM=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
### What does this PR do?
Update the devfile/api dependency to [v2.2.2](https://github.com/devfile/api/releases/tag/v2.2.2) and regenerate templates.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1201

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
