### PR TITLE
Add support for dependentProjects in devfiles

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -323,6 +323,10 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.failWorkspace(workspace, fmt.Sprintf("Failed to process workspace environment variables: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus), nil
 	}
 
+	// Validate that projects, dependentProjects, and starterProjects do not collide
+	if err := projects.ValidateAllProjects(&workspace.Spec.Template); err != nil {
+		return r.failWorkspace(workspace, fmt.Sprintf("Invalid devfile: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus), nil
+	}
 	// Add init container to clone projects
 	projectCloneOptions := projects.Options{
 		Image:     workspace.Config.Workspace.ProjectCloneConfig.Image,

--- a/pkg/library/annotate/plugins.go
+++ b/pkg/library/annotate/plugins.go
@@ -49,4 +49,10 @@ func AddSourceAttributesForTemplate(sourceID string, template *dw.DevWorkspaceTe
 		}
 		template.StarterProjects[idx].Attributes.PutString(constants.PluginSourceAttribute, sourceID)
 	}
+	for idx, project := range template.DependentProjects {
+		if project.Attributes == nil {
+			template.DependentProjects[idx].Attributes = attributes.Attributes{}
+		}
+		template.DependentProjects[idx].Attributes.PutString(constants.PluginSourceAttribute, sourceID)
+	}
 }

--- a/pkg/library/container/mountSources.go
+++ b/pkg/library/container/mountSources.go
@@ -102,7 +102,9 @@ func handleMountSources(k8sContainer *corev1.Container, devfileContainer *dw.Con
 //
 //  2. If the workspace has a starter project that is selected, its name will be used as the project source path.
 //
-//  3. Otherwise, the returned project source path will be an empty string.
+//  3. If the workspace has any dependentProjects, the first one will be selected.
+//
+//  4. Otherwise, the returned project source path will be an empty string.
 func getProjectSourcePath(workspace *dw.DevWorkspaceTemplateSpec) (string, error) {
 	projects := workspace.Projects
 	// If there are any projects, return the first one's clone path
@@ -118,6 +120,12 @@ func getProjectSourcePath(workspace *dw.DevWorkspaceTemplateSpec) (string, error
 		// Starter projects do not allow specifying a clone path, so use the name
 		return selectedStarterProject.Name, nil
 	}
+
+	// Finally, check if there are any dependent projects
+	if len(workspace.DependentProjects) > 0 {
+		return projectslib.GetClonePath(&workspace.DependentProjects[0]), nil
+	}
+
 	return "", nil
 }
 

--- a/pkg/library/defaults/helper.go
+++ b/pkg/library/defaults/helper.go
@@ -28,8 +28,10 @@ func ApplyDefaultTemplate(workspace *common.DevWorkspaceWithConfig) {
 	}
 	defaultCopy := workspace.Config.Workspace.DefaultTemplate.DeepCopy()
 	originalProjects := workspace.Spec.Template.Projects
+	originalDependentProjects := workspace.Spec.Template.DependentProjects
 	workspace.Spec.Template.DevWorkspaceTemplateSpecContent = *defaultCopy
 	workspace.Spec.Template.Projects = append(workspace.Spec.Template.Projects, originalProjects...)
+	workspace.Spec.Template.DependentProjects = append(workspace.Spec.Template.DependentProjects, originalDependentProjects...)
 }
 
 func NeedsDefaultTemplate(workspace *common.DevWorkspaceWithConfig) bool {

--- a/pkg/library/projects/clone.go
+++ b/pkg/library/projects/clone.go
@@ -46,7 +46,7 @@ func GetProjectCloneInitContainer(workspace *dw.DevWorkspaceTemplateSpec, option
 	if err != nil {
 		return nil, err
 	}
-	if len(workspace.Projects) == 0 && starterProject == nil {
+	if len(workspace.Projects) == 0 && len(workspace.DependentProjects) == 0 && starterProject == nil {
 		return nil, nil
 	}
 	if workspace.Attributes.GetString(constants.ProjectCloneAttribute, nil) == constants.ProjectCloneDisable {

--- a/project-clone/main.go
+++ b/project-clone/main.go
@@ -65,6 +65,7 @@ func main() {
 	}
 
 	projects := workspace.Projects
+	projects = append(projects, workspace.DependentProjects...)
 
 	starterProject, err := projectslib.GetStarterProject(workspace)
 	if err != nil {

--- a/webhook/workspace/handler/validate.go
+++ b/webhook/workspace/handler/validate.go
@@ -40,6 +40,7 @@ func (h *WebhookHandler) ValidateDevfile(ctx context.Context, req admission.Requ
 	events := workspace.Events
 	projects := workspace.Projects
 	starterProjects := workspace.StarterProjects
+	dependentProjects := workspace.DependentProjects
 
 	var devfileErrors []string
 
@@ -56,6 +57,13 @@ func (h *WebhookHandler) ValidateDevfile(ctx context.Context, req admission.Requ
 		projectsErrors := devfilevalidation.ValidateProjects(projects)
 		if projectsErrors != nil {
 			devfileErrors = append(devfileErrors, projectsErrors.Error())
+		}
+	}
+
+	if dependentProjects != nil {
+		dependentProjectsErrors := devfilevalidation.ValidateProjects(dependentProjects)
+		if dependentProjectsErrors != nil {
+			devfileErrors = append(devfileErrors, dependentProjectsErrors.Error())
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?
Adds support for dependentProjects as part of a DevWorkspace. As part of this, this PR also adds an additional validation step, to ensure no two projects:
* Have the same name (possible now since dependentProjects are a separate field)
* Have the same clone path (and would thus collide).

### What issues does this PR fix or reference?
Closes https://github.com/devfile/devworkspace-operator/issues/1204

### Is it tested? How?
Note: testing this PR requires running `make install` from the PR changes to ensure the updated DevWorkspace CRDs are installed.

Can be tested via the following devfile:
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: dependentprojects-test
spec:
  started: true
  template:
    attributes:
      controller.devfile.io/use-starter-project: test-starter-project-2
    projects:
      - name: test-regular-project-1
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
      - name: test-regular-project-2
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    dependentProjects:
      - name: test-dependent-project-1
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
      - name: test-dependent-project-2
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    starterProjects: 
      - name: test-starter-project-1
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
      - name: test-starter-project-2
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
          memoryLimit: 512Mi
          memoryRequest: 256Mi
          cpuRequest: 1000m
  contributions:
    - name: che-code
      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
      components:
        - name: che-code-runtime-description
          container:
            env:
              - name: CODE_HOST
                value: 0.0.0.0
```
This workspace should clone five projects:
```
projects $ ls -l /projects
total 20
drwxr-sr-x. 6 user user 4096 Nov 16 22:03 test-dependent-project-1
drwxr-sr-x. 6 user user 4096 Nov 16 22:03 test-dependent-project-2
drwxr-sr-x. 6 user user 4096 Nov 16 22:03 test-regular-project-1
drwxr-sr-x. 6 user user 4096 Nov 16 22:03 test-regular-project-2
drwxr-sr-x. 6 user user 4096 Nov 16 22:03 test-starter-project-2
```
To verify the validation steps, project names/clonePaths can be changed.


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
