### PR TITLE
Update project to use Go 1.20

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
+FROM registry.ci.openshift.org/openshift/release:golang-1.20
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,7 +14,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.10
+        go-version: 1.20.10
     -
       name: Set up Python 3.11
       uses: actions/setup-python@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.10
+        go-version: 1.20.10
     -
       name: Set up Python 3.11
       uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.10
+          go-version: 1.20.10
 
       - name: Clone source code
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/devworkspace-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/devfile/api/v2 v2.2.2


### PR DESCRIPTION
### What does this PR do?
Update DWO actions/CI to use Go 1.20

### What issues does this PR fix or reference?
Follow on from https://github.com/devfile/devworkspace-operator/pull/1206 that got lost when that PR was closed.

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
