### PR TITLE
Update Go in e2e test Dockerfile to Go 1.20

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
+FROM registry.ci.openshift.org/openshift/release:golang-1.20
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
### What does this PR do?
Updates Go to v1.20 in the e2e test dockerfile. This is required as e2e tests run on a PR do not include the changes, resulting in e2e tests failing on https://github.com/devfile/devworkspace-operator/pull/1208:
```
+ go mod tidy
go: go.mod file indicates go 1.20, but maximum version supported by tidy is 1.19
```

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
