### PR TITLE
Fix: disable persistent home when ephemeral storage used; persistent home volume shouldn't use capital letters

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -291,7 +291,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus), nil
 	}
 
-	if home.NeedsPersistentHomeDirectory(workspace) {
+	if storageProvisioner.NeedsStorage(&workspace.Spec.Template) && home.NeedsPersistentHomeDirectory(workspace) {
 		workspaceWithHomeVolume, err := home.AddPersistentHomeVolume(workspace)
 		if err != nil {
 			reconcileStatus.addWarning(fmt.Sprintf("Info: default persistentHome volume is not being used: %s", err.Error()))

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -39,7 +39,7 @@ const (
 
 	HomeUserDirectory = "/home/user/"
 
-	HomeVolumeName = "persistentHome"
+	HomeVolumeName = "persistent-home"
 
 	ServiceAccount = "devworkspace"
 

--- a/pkg/library/home/testdata/persistent-home/creates-home-vm-when-enabled.yaml
+++ b/pkg/library/home/testdata/persistent-home/creates-home-vm-when-enabled.yaml
@@ -26,9 +26,9 @@ output:
           volumeMounts:
             - name: my-defined-volume
               path: /my-defined-volume-path
-            - name: persistentHome
+            - name: persistent-home
               path: /home/user/
       - name: my-defined-volume
         volume: {}
-      - name: persistentHome
+      - name: persistent-home
         volume: {}

--- a/pkg/library/home/testdata/persistent-home/noop-if-home-vm-name-used.yaml
+++ b/pkg/library/home/testdata/persistent-home/noop-if-home-vm-name-used.yaml
@@ -1,4 +1,4 @@
-name: "Does not create persistent home volume if a volume already named 'persistentHome'"
+name: "Does not create persistent home volume if a volume is already named 'persistent-home'"
 
 input:
   devworkspaceId: "test-workspaceid"
@@ -14,7 +14,7 @@ input:
           volumeMounts:
             - name: my-defined-volume
               path: /my-defined-volume-path
-            - name: persistentHome
+            - name: persistent-home
               path: /some/path
       - name: testing-container-2
         container:
@@ -24,11 +24,11 @@ input:
               path: /my-defined-volume-path
       - name: my-defined-volume
         volume: {}
-      - name: persistentHome
+      - name: persistent-home
         volume: {}
 
 output:
-  error: "addition of persistentHome volume would render DevWorkspace invalid: 1 error occurred:\n\t* duplicate key: persistentHome\n\n"
+  error: "addition of persistent-home volume would render DevWorkspace invalid: 1 error occurred:\n\t* duplicate key: persistent-home\n\n"
   workspace:
     components:
       - name: testing-container-1
@@ -37,7 +37,7 @@ output:
           volumeMounts:
             - name: my-defined-volume
               path: /my-defined-volume-path
-            - name: persistentHome
+            - name: persistent-home
               path: /some/path
       - name: testing-container-2
         container:
@@ -47,5 +47,5 @@ output:
               path: /my-defined-volume-path
       - name: my-defined-volume
         volume: {}
-      - name: persistentHome
+      - name: persistent-home
         volume: {}


### PR DESCRIPTION
### What does this PR do?
This PR makes 2 fixes to the $HOME persistence feature in DWO:
- The persistent home devfile volume is now only added if the DWOC's `workspace.persistUserHome.enabled: true` field is set, _and_ the workspace requires persistent storage (i.e. it uses the uses async, per-workspace or per-user storage strategy and has at least one-non ephemeral volume or has mount-sources enabled).
- The persistent home volume name was changed from `persistentHome` -> `persistent-home` to be a [valid Kubernetes name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names). 

(Sorry for putting 2 bug fixes in a single PR - it seemed to make sense since they're both related) 

### What issues does this PR fix or reference?
#1200 & #1203

### Is it tested? How?
#### Initial setup
1. Set the $DWO_IMG environment variable to point to your quay repository for DWO, e.g: `export DWO_IMG=quay.io/<your-username>/devworkspace-controller:next`
2. Run `make install_cert_manager docker install` if testing on Minikube. For openshift, run `make docker install`
3. Enable persistUserHome in the DWOC: `kubectl edit dwoc -n $NAMESPACE`

```diff
apiVersion: controller.devfile.io/v1alpha1                                                                                                                                 
config:                                                                                                                                                                    
  routing:                                                                                                                                                                 
    clusterHostSuffix: 192.168.49.2.nip.io                                                                                                                                 
    defaultRoutingClass: basic                                                                                                                                             
  workspace:                                                                                                                                                               
    imagePullPolicy: Always                                                                                                                                                
+    persistUserHome:                                                                                                                                                       
+      enabled: true                                                                                                                                                        
kind: DevWorkspaceOperatorConfig
```
#### Testing fix for #1200 
1. Create a devworkspace that uses persistent storage. The plain-devworkspace sample will suffice: `kubectl apply -f ./samples/plain.yaml`
2. Ensure the workspace starts up successfully with `kubectl get dw -n $NAMESPACE -w`
3. Check the workspace pod's spec, and verify it has a volumeMount with a subPath set to <workspace-id>/persistent-home. For example:


```YAML
(...)
        volumeMounts:                                                                                                                                                                                                                                                                            
        - mountPath: /home/user/                                                                                                                                           
          name: claim-devworkspace                                                                                                                                         
          subPath: workspace1835a0b4d9f04fd2/persistent-home   
(...)
```

#### Testing fix for #1203 
1. Create a devworkspace that uses ephemeral storage. The following devworkspace can be used:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace-ephemeral
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
        controller.devfile.io/storage-type: ephemeral
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
```
2. Ensure the workspace starts up successfully with `kubectl get dw -n $NAMESPACE -w`

```bash
$ kubectl get dw -n $NAMESPACE -w
NAME                           DEVWORKSPACE ID             PHASE     INFO
plain-devworkspace-ephemeral   workspace03197f210f9247e4   Running   Workspace is running
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
