### PR TITLE
Support multi-arch builds in next-build GH Workflow

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -31,6 +31,12 @@ jobs:
       git-sha: ${{ steps.git-sha.outputs.sha }}
 
     steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
     - name: Checkout devworkspace-operator source code
       uses: actions/checkout@v3
 
@@ -50,6 +56,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x
         tags: |
           quay.io/devfile/devworkspace-controller:next
           quay.io/devfile/devworkspace-controller:sha-${{ steps.git-sha.outputs.sha }}
@@ -60,6 +67,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x
         tags: |
           quay.io/devfile/project-clone:next
           quay.io/devfile/project-clone:sha-${{ steps.git-sha.outputs.sha }}

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -183,6 +183,7 @@ jobs:
             --bundle-tag ${DWO_BUNDLE_TAG} \
             --index-image ${DWO_INDEX_IMG} \
             --container-tool docker \
+            --multi-arch \
             --debug \
             --force
 
@@ -193,11 +194,13 @@ jobs:
             --render ./olm-catalog/next-digest/ \
             --push "${DWO_BUNDLE_REPO}:${DWO_DIGEST_BUNDLE_TAG}" \
             --container-tool docker \
+            --multi-arch \
             --debug
 
           cp ./olm-catalog/next/{channel,package}.yaml ./olm-catalog/next-digest
-          docker build . -t ${DWO_DIGEST_INDEX_IMG} -f build/index.next-digest.Dockerfile
-          docker push ${DWO_DIGEST_INDEX_IMG}
+          docker buildx build . -t ${DWO_DIGEST_INDEX_IMG} -f build/index.next-digest.Dockerfile \
+          --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
+          --push
 
           git restore ./olm-catalog/
           git clean -fd ./olm-catalog/

--- a/build/buildkitd.toml
+++ b/build/buildkitd.toml
@@ -1,0 +1,2 @@
+[worker.oci]
+  max-parallelism = 1


### PR DESCRIPTION
### What does this PR do?
This PR extends the Next container build GitHub action to build the devworkspace-controller
 & project-clone images for the following platforms: 
- linux/amd64
- linux/arm64
- linux/ppc64le
- linux/s390x

Support for building the index, bundle and respect digest images for these platforms was also added in https://github.com/devfile/devworkspace-operator/commit/8b8013885b7595a6b367a34f8286ed1e7123790d. However, the implementation is a bit awkward: rather than using the docker buildx action, the buildx builder is manually setup and used in the `build_digests_bundle.sh` and `build_index_image.sh` scripts if the new `--multi-arch` flag is used. 

Additionally, it seems that docker buildx uses a single virtual network layer for all platform builds which are run in parallel. When building the olm images, the [`opm --serve --cache-only`](https://github.com/devfile/devworkspace-operator/blob/main/build/index.next.Dockerfile#L11) command binds to `localhost:6000`, causing the other builds to fail as they cannot bind to the smart address/port. The `quay.io/operator-framework/opm:latest` image does not include a shell, so changing the port used based on the architecture we're building for is not possible (unless we copy over a shell from another image). As a workaround, I'm configuring the buildx builder to disable parallelism in the `buildkitd.toml` to prevent this race condition. 

Che/DevSpaces might not even need the index, bundle and digest images to be built for multiple platforms anyhow -- so this commit could optionally be removed. 

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/559

### Is it tested? How?
Since these changes only get triggered after merging to the main branch, I tested that the [build-next-imgs](https://github.com/AObuchow/devworkspace-operator/actions/runs/7065375032/job/19235255009) & [build-next-olm-imgs](https://github.com/AObuchow/devworkspace-operator/actions/runs/7065375032/job/19236778070) jobs succeeded on my [fork](https://github.com/AObuchow/devworkspace-operator/compare/f4dd02687a08e11686333d71474792004a88f7a2..8c89c193c8bf918dd1f3c756386e4ed9563c3cea). 

The resulting images were build for all 4 architectures and pushed to my quay repo's:
- [deworkspace-operator-bundle:next](https://quay.io/repository/aobuchow/devworkspace-operator-bundle/manifest/sha256:e2f37a06d902a8e3a25b5984772664114813bd7488e66b43508a852c41278f49)
- [deworkspace-operator-bundle:next-digest](https://quay.io/repository/aobuchow/devworkspace-operator-bundle/manifest/sha256:509a3813ba2c330baff6229f91899b00745931421edf29e1c19763120db15b25)
- [devworkspace-operator-index:next](https://quay.io/repository/aobuchow/devworkspace-operator-index/manifest/sha256:cc4d0f2dee75382cf5751f220e72007101dcd50757915eaee32ffa52be1a48b2)
- [devworkspace-operator-index:next-digest](https://quay.io/repository/aobuchow/devworkspace-operator-index/manifest/sha256:21f87a752d8dc42676bc2d6435611ce578f827d23d4bd099baaba0da34a9158f)
- [devworkspace-controller:next](https://quay.io/repository/aobuchow/devworkspace-controller/manifest/sha256:48fb643c02673b3803cad086f62ed51621975b5792e77cccacd797ea587df2bd)
- [project-clone:next](https://quay.io/repository/aobuchow/project-clone/manifest/sha256:3a4a23efd785792628079696987233b0cb9ec1875133b1b0661fe416dead880f)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
