### PR TITLE
Feat: support multi-arch builds for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           go-version: 1.20.10
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Clone source code
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### What does this PR do?
Uses docker buildx for building the devworkspace-controller image and project clone image in the release script. 
Also sets up QEMU and a docker buildx builder in the `release.yml` workflow so that buildx will have a multi-arch builder setup prior to running `make-release.sh`

Note: excuse the merge commit, I'll remove it and rebase this PR before merging. 

### What issues does this PR fix or reference?
Part of https://github.com/devfile/devworkspace-operator/issues/559

### Is it tested? How?
Not tested as it requires running the release github action. Though I will try and simulate this on my fork and report back before having this merged, just wanted to get @amisevsk's eyes on it incase there's something that I'm missing in this fix. 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
