### PR TITLE
Pin version for all actions via SHA rather than floating tag

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,21 +12,21 @@ jobs:
     steps:
     -
       name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version: 1.20.10
     -
       name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
       with:
         python-version: 3.11
     -
       name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     -
       name: Cache go modules
       id: cache-mod
-      uses: actions/cache@v3
+      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -45,6 +45,6 @@ jobs:
         make update_devworkspace_crds test
     -
       name: Build Codecov report
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       with:
         files: ./cover.out,./controller.cover.out

--- a/.github/workflows/devtools-image-build.yml
+++ b/.github/workflows/devtools-image-build.yml
@@ -30,27 +30,27 @@ jobs:
 
     steps:
       - name: Checkout devworkspace-operator source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Set output for Git short SHA
         id: git-sha
         run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Login to quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc #v2.2.0
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
           registry: quay.io
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 #v2.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 #v2.10.0
 
       - name: Build and push devworkspace-devtools image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 #v4.2.1
         with:
           context: .
           push: true

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -32,27 +32,27 @@ jobs:
 
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 #v2.2.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 #v2.10.0
 
     - name: Checkout devworkspace-operator source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Set output for Git short SHA
       id: git-sha
       run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Login to quay.io
-      uses: docker/login-action@v2
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc #v2.2.0
       with:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
 
     - name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 #v4.2.1
       with:
         context: .
         push: true
@@ -63,7 +63,7 @@ jobs:
         file: ./build/Dockerfile
 
     - name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 #v4.2.1
       with:
         context: .
         push: true
@@ -87,7 +87,7 @@ jobs:
     steps:
 
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        uses: actions/cache@v3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
         id: cache-operator-sdk
         with:
           path: ~/cache
@@ -107,7 +107,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Cache OPM ${{ env.OPM_VERSION }}
-        uses: actions/cache@v3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
         id: cache-opm
         with:
           path: ~/cache
@@ -128,10 +128,10 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Checkout devworkspace-operator source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Login to quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc #v2.2.0
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,21 +13,21 @@ jobs:
     steps:
     -
       name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version: 1.20.10
     -
       name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
       with:
         python-version: 3.11
     -
       name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     -
       name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-      uses: actions/cache@v3
+      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
       id: cache-operator-sdk
       with:
         path: ~/cache
@@ -49,7 +49,7 @@ jobs:
     -
       name: Cache go modules
       id: cache-mod
-      uses: actions/cache@v3
+      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -111,7 +111,7 @@ jobs:
         make test
     -
       name: Build Codecov report
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       with:
         files: ./cover.out,./controller.cover.out
 
@@ -123,7 +123,7 @@ jobs:
     steps:
     -
       name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     -
       name: Check if dockerimage build is working
       run: docker build -f ./build/Dockerfile .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,18 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: 1.20.10
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 #v2.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 #v2.10.0
 
       - name: Clone source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        uses: actions/cache@v3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
         id: cache-operator-sdk
         with:
           path: ~/cache
@@ -80,7 +80,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Cache OPM ${{ env.OPM_VERSION }}
-        uses: actions/cache@v3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
         id: cache-opm
         with:
           path: ~/cache
@@ -100,14 +100,14 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Login to quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc #v2.2.0
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
           registry: quay.io
 
       - name: Set up yq
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
           python-version: 3.6
       - name: Setup yq
@@ -139,18 +139,3 @@ jobs:
             RELEASE_COMMAND="$RELEASE_COMMAND --dry-run"
           fi
           $RELEASE_COMMAND
-
-      - name: Create failure MM message
-        if: ${{ failure() }}
-        run: |
-          echo "{\"text\":\":no_entry_sign: DevWorkspace Operator ${{ github.event.inputs.version }} release has failed: https://github.com/devfile/devworkspace-operator/actions/workflows/release.yml\"}" > mattermost.json
-      - name: Create success MM message
-        run: |
-          echo "{\"text\":\":white_check_mark: DevWorkspace Operator ${{ github.event.inputs.version }} has been released: https://quay.io/devfile/devworkspace-operator:${{ github.event.inputs.version }}\"}" > mattermost.json
-      - name: Send MM message
-        if: ${{ github.event.inputs.dryrun != true && github.event.inputs.prerelease == false && (success() || failure()) }}
-        uses: mattermost/action-mattermost-notify@1.1.0
-        env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          MATTERMOST_CHANNEL: eclipse-che-releases
-          MATTERMOST_USERNAME: che-bot


### PR DESCRIPTION
### What does this PR do?
* Pin all actions used in workflows to the current latest bugfix release within their major version (e.g. v3 -> [hash for] v3.6.1)
* Update all instances of `docker/build-push-action` to use latest v4 release instead of a mix of v3 and v4
* Remove mattermost message steps from release job, as mattermost is gone now.

Note: in most cases, there's a new major version for our actions (usually around switching from Node 16 -> 20. This PR does not switch major versions (except for some instances of `docker/build-push-action`) to avoid any risk of breaking anything -- ideally these are the exact same versions of each action we're using right now.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
