### PR TITLE
Allow pod/container overrides for volumes/volumemounts

### DIFF
--- a/pkg/library/overrides/containers.go
+++ b/pkg/library/overrides/containers.go
@@ -94,9 +94,6 @@ func restrictContainerOverride(override *corev1.Container) error {
 	if override.Ports != nil {
 		invalidField = "ports"
 	}
-	if override.VolumeMounts != nil {
-		invalidField = "volumeMounts"
-	}
 	if override.Env != nil {
 		invalidField = "env"
 	}

--- a/pkg/library/overrides/pods.go
+++ b/pkg/library/overrides/pods.go
@@ -16,9 +16,11 @@ package overrides
 import (
 	"fmt"
 
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
@@ -41,7 +43,7 @@ func NeedsPodOverrides(workspace *common.DevWorkspaceWithConfig) bool {
 }
 
 func ApplyPodOverrides(workspace *common.DevWorkspaceWithConfig, deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
-	overrides, err := getPodOverrides(workspace)
+	overrides, err := getPodOverrides(&workspace.Spec.Template)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +55,6 @@ func ApplyPodOverrides(workspace *common.DevWorkspaceWithConfig, deployment *app
 	originalContainers := patched.Spec.Template.Spec.Containers
 	// Save fields we do not allow to be configured in pod-overrides
 	originalInitContainers := patched.Spec.Template.Spec.InitContainers
-	originalVolumes := patched.Spec.Template.Spec.Volumes
 	patchedTemplateBytes, err := json.Marshal(patched.Spec.Template)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal deployment to yaml: %w", err)
@@ -72,55 +73,68 @@ func ApplyPodOverrides(workspace *common.DevWorkspaceWithConfig, deployment *app
 	patched.Spec.Template = patchedPodSpecTemplate
 	patched.Spec.Template.Spec.Containers = originalContainers
 	patched.Spec.Template.Spec.InitContainers = originalInitContainers
-	patched.Spec.Template.Spec.Volumes = originalVolumes
 	return patched, nil
+}
+
+func GetPodVolumeOverrides(workspace *dw.DevWorkspaceTemplateSpec) (*[]corev1.Volume, error) {
+	var volumeOverrides []corev1.Volume
+	overrides, err := getPodOverrides(workspace)
+	if err != nil {
+		return &volumeOverrides, err
+	}
+
+	for _, override := range overrides {
+		podSpecTemplate := corev1.PodTemplateSpec{}
+		if err := json.Unmarshal(override.Raw, &podSpecTemplate); err != nil {
+			return &volumeOverrides, fmt.Errorf("error unmarshalling: %w", err)
+		}
+
+		if podSpecTemplate.Spec.Volumes != nil {
+			volumeOverrides = append(volumeOverrides, podSpecTemplate.Spec.Volumes...)
+		}
+	}
+	return &volumeOverrides, nil
 }
 
 // getPodOverrides returns PodTemplateSpecOverrides for every instance of the pod overrides attribute
 // present in the DevWorkspace. The order of elements is
 // 1. Pod overrides defined on Container components, in the order they appear in the DevWorkspace
 // 2. Pod overrides defined in the global attributes field (.spec.template.attributes)
-func getPodOverrides(workspace *common.DevWorkspaceWithConfig) ([]apiext.JSON, error) {
+func getPodOverrides(workspace *dw.DevWorkspaceTemplateSpec) ([]apiext.JSON, error) {
 	var allOverrides []apiext.JSON
 
-	for _, component := range workspace.Spec.Template.Components {
+	for _, component := range workspace.Components {
 		if component.Attributes.Exists(constants.PodOverridesAttribute) {
 			override := corev1.PodTemplateSpec{}
 			// Check format of pod-overrides to detect errors early
 			if err := component.Attributes.GetInto(constants.PodOverridesAttribute, &override); err != nil {
 				return nil, fmt.Errorf("failed to parse %s attribute on component %s: %w", constants.PodOverridesAttribute, component.Name, err)
 			}
-			// Do not allow overriding containers or volumes
+			// Do not allow overriding containers
 			if override.Spec.Containers != nil {
 				return nil, fmt.Errorf("cannot use pod-overrides to override pod containers (component %s)", component.Name)
 			}
 			if override.Spec.InitContainers != nil {
 				return nil, fmt.Errorf("cannot use pod-overrides to override pod initContainers (component %s)", component.Name)
 			}
-			if override.Spec.Volumes != nil {
-				return nil, fmt.Errorf("cannot use pod-overrides to override pod volumes (component %s)", component.Name)
-			}
 			patchData := component.Attributes[constants.PodOverridesAttribute]
 			allOverrides = append(allOverrides, patchData)
 		}
 	}
-	if workspace.Spec.Template.Attributes.Exists(constants.PodOverridesAttribute) {
+	if workspace.Attributes.Exists(constants.PodOverridesAttribute) {
 		override := corev1.PodTemplateSpec{}
-		err := workspace.Spec.Template.Attributes.GetInto(constants.PodOverridesAttribute, &override)
+		err := workspace.Attributes.GetInto(constants.PodOverridesAttribute, &override)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse %s attribute for workspace: %w", constants.PodOverridesAttribute, err)
 		}
-		// Do not allow overriding containers or volumes
+		// Do not allow overriding containers
 		if override.Spec.Containers != nil {
 			return nil, fmt.Errorf("cannot use pod-overrides to override pod containers")
 		}
 		if override.Spec.InitContainers != nil {
 			return nil, fmt.Errorf("cannot use pod-overrides to override pod initContainers")
 		}
-		if override.Spec.Volumes != nil {
-			return nil, fmt.Errorf("cannot use pod-overrides to override pod volumes")
-		}
-		patchData := workspace.Spec.Template.Attributes[constants.PodOverridesAttribute]
+		patchData := workspace.Attributes[constants.PodOverridesAttribute]
 		allOverrides = append(allOverrides, patchData)
 	}
 	return allOverrides, nil

--- a/pkg/library/overrides/testdata/container-overrides/container-defines-overrides-volumemount.yaml
+++ b/pkg/library/overrides/testdata/container-overrides/container-defines-overrides-volumemount.yaml
@@ -1,0 +1,23 @@
+name: "Applies volumeMount overrides from container-overrides attribute"
+
+input:
+  component:
+    name: test-component
+    attributes:
+      container-overrides:
+        volumeMounts:
+          - name: test-volume
+            mountPath: /test/path
+    container:
+      image: test-image
+  container:
+    name: test-component
+    image: test-image
+
+output:
+  container:
+    name: test-component
+    image: test-image
+    volumeMounts:
+      - name: test-volume
+        mountPath: /test/path

--- a/pkg/library/overrides/testdata/container-overrides/overrides-can-add-volumemount.yaml
+++ b/pkg/library/overrides/testdata/container-overrides/overrides-can-add-volumemount.yaml
@@ -1,0 +1,28 @@
+name: "Container overrides can add volumeMounts"
+
+input:
+  component:
+    name: test-component
+    attributes:
+      container-overrides:
+        volumeMounts:
+          - name: test-volume
+            mountPath: /test-volume/path
+    container:
+      image: test-image
+  container:
+    name: test-component
+    image: test-image
+    volumeMounts:
+      - name: my-volume
+        mountPath: /my-volume/path
+
+output:
+  container:
+    name: test-component
+    image: test-image
+    volumeMounts:
+      - name: test-volume
+        mountPath: /test-volume/path
+      - name: my-volume
+        mountPath: /my-volume/path

--- a/pkg/library/overrides/testdata/container-overrides/overrides-can-define-volumemount.yaml
+++ b/pkg/library/overrides/testdata/container-overrides/overrides-can-define-volumemount.yaml
@@ -1,4 +1,4 @@
-name: "Container overrides can add define volumeMounts"
+name: "Container overrides can define a volumeMount"
 
 input:
   component:

--- a/pkg/library/overrides/testdata/container-overrides/overrides-can-define-volumemount.yaml
+++ b/pkg/library/overrides/testdata/container-overrides/overrides-can-define-volumemount.yaml
@@ -1,4 +1,4 @@
-name: "Applies volumeMount overrides from container-overrides attribute"
+name: "Container overrides can add define volumeMounts"
 
 input:
   component:

--- a/pkg/library/overrides/testdata/container-overrides/overrides-can-override-volumemount.yaml
+++ b/pkg/library/overrides/testdata/container-overrides/overrides-can-override-volumemount.yaml
@@ -1,0 +1,28 @@
+name: "Container overrides can override existing volumeMounts"
+
+input:
+  component:
+    name: test-component
+    attributes:
+      container-overrides:
+        volumeMounts:
+          # patchMergeKey is mountPath
+          - mountPath: /my-volume/path
+            subPath: test-subpath
+    container:
+      image: test-image
+  container:
+    name: test-component
+    image: test-image
+    volumeMounts:
+      - name: my-volume
+        mountPath: /my-volume/path
+
+output:
+  container:
+    name: test-component
+    image: test-image
+    volumeMounts:
+      - name: my-volume
+        mountPath: /my-volume/path
+        subPath: test-subpath

--- a/pkg/library/overrides/testdata/pod-overrides/overrides-can-add-volumes.yaml
+++ b/pkg/library/overrides/testdata/pod-overrides/overrides-can-add-volumes.yaml
@@ -1,0 +1,37 @@
+name: "Pod overrides can add volumes"
+
+input:
+  workspace:
+    attributes:
+      pod-overrides:
+        spec:
+          volumes:
+            - name: test-volume-1
+    components:
+      - name: test-component
+        container:
+          image: test-image
+
+  podTemplateSpec:
+    metadata:
+      labels:
+        controller.devfile.io/devworkspace-id: test-id
+    spec:
+      containers:
+      - name: test-component
+        image: test-image
+      volumes:
+        - name: test-volume-2
+
+output:
+  podTemplateSpec:
+    metadata:
+      labels:
+        controller.devfile.io/devworkspace-id: test-id
+    spec:
+      containers:
+      - name: test-component
+        image: test-image
+      volumes:
+      - name: test-volume-1
+      - name: test-volume-2

--- a/pkg/library/overrides/testdata/pod-overrides/overrides-can-define-volumes.yaml
+++ b/pkg/library/overrides/testdata/pod-overrides/overrides-can-define-volumes.yaml
@@ -1,4 +1,4 @@
-name: "Returns error when attempting to patch pod volumes"
+name: "Pod overrides can define volumes"
 
 input:
   workspace:
@@ -22,4 +22,13 @@ input:
         image: test-image
 
 output:
-  errRegexp: "cannot use pod-overrides to override pod volumes"
+  podTemplateSpec:
+    metadata:
+      labels:
+        controller.devfile.io/devworkspace-id: test-id
+    spec:
+      containers:
+      - name: test-component
+        image: test-image
+      volumes:
+      - name: test-volume

--- a/pkg/library/overrides/testdata/pod-overrides/overrides-can-override-volumes.yaml
+++ b/pkg/library/overrides/testdata/pod-overrides/overrides-can-override-volumes.yaml
@@ -1,0 +1,53 @@
+name: "Pod overrides can override existing volumes"
+
+input:
+  workspace:
+    attributes:
+      pod-overrides:
+        spec:
+          volumes:
+          - name: config-volume
+            configMap:
+              name: override
+              defaultMode: 420
+    components:
+      - name: test-component
+        container:
+          image: test-image
+
+  podTemplateSpec:
+    metadata:
+      labels:
+        controller.devfile.io/devworkspace-id: test-id
+    spec:
+      containers:
+      - name: test-component
+        image: test-image
+      volumes:
+      - name: config-volume
+        configMap:
+          name: special-config
+          defaultMode: 420
+      - name: other-volume
+        configMap:
+          name: special-config
+          defaultMode: 420
+
+output:
+  podTemplateSpec:
+    metadata:
+      labels:
+        controller.devfile.io/devworkspace-id: test-id
+    spec:
+      containers:
+      - name: test-component
+        image: test-image
+      volumes:
+      - name: config-volume
+        configMap:
+          name: override
+          defaultMode: 420
+      - name: other-volume
+        configMap:
+          name: special-config
+          defaultMode: 420

--- a/pkg/provision/storage/commonStorage.go
+++ b/pkg/provision/storage/commonStorage.go
@@ -31,6 +31,7 @@ import (
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	devfileConstants "github.com/devfile/devworkspace-operator/pkg/library/constants"
+	"github.com/devfile/devworkspace-operator/pkg/library/overrides"
 )
 
 // The CommonStorageProvisioner provisions one PVC per namespace and configures all volumes in a workspace
@@ -142,6 +143,15 @@ func (p *CommonStorageProvisioner) rewriteContainerVolumeMounts(workspaceId, pvc
 	additionalVolumes := map[string]bool{}
 	for _, additionalVolume := range podAdditions.Volumes {
 		additionalVolumes[additionalVolume.Name] = true
+	}
+
+	// Containers in podAdditions may reference volumes defined in pod overrides, and this is not an error
+	overridesVolumes, err := overrides.GetPodVolumeOverrides(workspace)
+	if err != nil {
+		return err
+	}
+	for _, overridesVolume := range *overridesVolumes {
+		additionalVolumes[overridesVolume.Name] = true
 	}
 
 	// Add implicit projects volume to support mountSources, if needed

--- a/pkg/provision/storage/commonStorage.go
+++ b/pkg/provision/storage/commonStorage.go
@@ -146,12 +146,12 @@ func (p *CommonStorageProvisioner) rewriteContainerVolumeMounts(workspaceId, pvc
 	}
 
 	// Containers in podAdditions may reference volumes defined in pod overrides, and this is not an error
-	overridesVolumes, err := overrides.GetPodVolumeOverrides(workspace)
+	overridesVolumes, err := overrides.GetVolumesFromOverrides(workspace)
 	if err != nil {
 		return err
 	}
-	for _, overridesVolume := range *overridesVolumes {
-		additionalVolumes[overridesVolume.Name] = true
+	for key, value := range overridesVolumes {
+		additionalVolumes[key] = value
 	}
 
 	// Add implicit projects volume to support mountSources, if needed

--- a/pkg/provision/storage/commonStorage.go
+++ b/pkg/provision/storage/commonStorage.go
@@ -150,8 +150,8 @@ func (p *CommonStorageProvisioner) rewriteContainerVolumeMounts(workspaceId, pvc
 	if err != nil {
 		return err
 	}
-	for key, value := range overridesVolumes {
-		additionalVolumes[key] = value
+	for volumeName, present := range overridesVolumes {
+		additionalVolumes[volumeName] = present
 	}
 
 	// Add implicit projects volume to support mountSources, if needed

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -111,12 +111,12 @@ func (p *PerWorkspaceStorageProvisioner) rewriteContainerVolumeMounts(workspaceI
 	}
 
 	// Containers in podAdditions may reference volumes defined in pod overrides, and this is not an error
-	overridesVolumes, err := overrides.GetPodVolumeOverrides(workspace)
+	overridesVolumes, err := overrides.GetVolumesFromOverrides(workspace)
 	if err != nil {
 		return err
 	}
-	for _, overridesVolume := range *overridesVolumes {
-		additionalVolumes[overridesVolume.Name] = true
+	for key, value := range overridesVolumes {
+		additionalVolumes[key] = value
 	}
 
 	// Add implicit projects volume to support mountSources, if needed

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -25,6 +25,7 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/dwerrors"
 	devfileConstants "github.com/devfile/devworkspace-operator/pkg/library/constants"
+	"github.com/devfile/devworkspace-operator/pkg/library/overrides"
 	nsconfig "github.com/devfile/devworkspace-operator/pkg/provision/config"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 	corev1 "k8s.io/api/core/v1"
@@ -107,6 +108,15 @@ func (p *PerWorkspaceStorageProvisioner) rewriteContainerVolumeMounts(workspaceI
 	additionalVolumes := map[string]bool{}
 	for _, additionalVolume := range podAdditions.Volumes {
 		additionalVolumes[additionalVolume.Name] = true
+	}
+
+	// Containers in podAdditions may reference volumes defined in pod overrides, and this is not an error
+	overridesVolumes, err := overrides.GetPodVolumeOverrides(workspace)
+	if err != nil {
+		return err
+	}
+	for _, overridesVolume := range *overridesVolumes {
+		additionalVolumes[overridesVolume.Name] = true
 	}
 
 	// Add implicit projects volume to support mountSources, if needed

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -115,8 +115,8 @@ func (p *PerWorkspaceStorageProvisioner) rewriteContainerVolumeMounts(workspaceI
 	if err != nil {
 		return err
 	}
-	for key, value := range overridesVolumes {
-		additionalVolumes[key] = value
+	for volumeName, present := range overridesVolumes {
+		additionalVolumes[volumeName] = present
 	}
 
 	// Add implicit projects volume to support mountSources, if needed


### PR DESCRIPTION
### What does this PR do?
Allows pod overrides for `spec.volumes` and container overrides for `spec.containers[*].volumeMounts`.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/22751

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

Checkout this PR and install DWO on a fresh cluster with [Run controller locally](https://github.com/devfile/devworkspace-operator?tab=readme-ov-file#run-controller-locally). Switch to the `devworkspace-controller` namespace by running `oc project devworkspace-controller`

<details><summary>Mounting secrets to workspace container using overrides
</summary>


1. Create secret to mount:
```
kubectl apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: dotfile-secret
data:
  .secret-file: dmFsdWUtMg0KDQo=
EOF
```

2. Create a devworkspace that uses pod-overrides and container-overrides to mount the secret:
```
curl https://gist.githubusercontent.com/dkwon17/4e698c3dcf6e36fc474eb73f5c20ac7c/raw/e7e4cf11d2081ced4b69e9cf9a230a2c8c30cf0c/che-code-secret-override.yaml | kubectl apply -f -
```

3. Wait until the DevWorkspace's status becomes 'Running'.
4. Check that the volume has been added in the workspace pod. In this case, we should see `secret-volume` in the list of volumes:
```
$ oc get pod <podname> -o=jsonpath='{.spec.volumes[*].name}'
secret-volume checode projects workspace-metadata kube-api-access-hcdjv
```
5. Check that the volumeMount has been added in the workspace pod's `tools` container:
```
$oc get pod <podname> -o=jsonpath='{.spec.containers[1].volumeMounts[*].name}'
secret-volume projects workspace-metadata kube-api-access-hcdjv
```

6. Run the following in the workspace `tools` container to check that the secret has been mounted:
```
$ cat /etc/secret-volume/.secret-file 
value-2
```
7. Stop the workspace and update the `storage-type` to `per-user`:
``` 
oc patch dw secret-volume-override --type merge -p '{"spec":{"template":{"att
ributes":{"controller.devfile.io/storage-type":"per-user"}}}}'
```
8. Start the workspace, and recheck steps 3-6.
9. Stop the workspace and update the `storage-type` to `per-workspace`, start the workspace and recheck steps 3-6 again.

</details>

The feature also works for adding PVC volumes:
```
      pod-overrides:
        spec:
          volumes:
            - name: my-pv
              persistentVolumeClaim:
                claimName: my-pvc
```

### Caveat of this feature
When introducing a new volumes using pod-overrides, the new volume must contain all fields that Kubernetes may add. For example, pods that specify configmap and secret volumes have a `defaultMode: 420` added to the yaml even if it's not originally provided in the pod's yaml.

Therefore when introducing a new configmap/secret volumes using pod-overrides, the `defaultMode` field must be provided  along with the configmap/secret details.

For example:
```
      pod-overrides:
        spec:
          volumes:
            - name: secret-volume
              secret:
                secretName: dotfile-secret
                defaultMode: 420
```

If the `defaultMode` is missing in the pod overrides, the DevWorkspace will never reach the `Running` state because the new volume in the pod will have the `defaultMode: 420` added by default. At the same time, the DWO will try to remove `defaultMode` if it doesn't exist in pod overrides. To clarify, from my testing this only happens when introducing new volumes through pod-overrides. This logic causes reconciliation until workspace start fails with this message:
```
The workspace status remains "Starting" in the last 300 seconds.
```
  

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
