### PR TITLE
[Devtools] Add Security Insights for CNCF

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,32 @@
+header:
+  schema-version: 1.0.0
+  last-updated: '2024-03-01'
+  last-reviewed: '2024-03-01'
+  expiration-date: '2025-03-01T10:00:00.000Z'
+  project-url: https://github.com/devfile/devworkspace-operator
+  project-release: '0.26.0'
+  commit-hash: '067847d900c18a3fe0d47de920a9ce77af29e722'
+  license: 'https://github.com/devfile/devworkspace-operator/blob/main/LICENSE'
+project-lifecycle:
+  status: active
+  bug-fixes-only: false
+  core-maintainers:
+  - github:AObuchow
+  - github:dkwon17
+  release-cycle: https://github.com/devfile/devworkspace-operator/blob/main/docs/release/README.md
+security-testing:
+- tool-type: sca
+  tool-name: Dependabot
+  comment: |
+    Dependabot is enabled for this repo.
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: true
+  contributing-policy: https://github.com/devfile/devworkspace-operator/blob/main/CONTRIBUTING.md
+  code-of-conduct: https://github.com/devfile/api/blob/main/CODE_OF_CONDUCT.md
+documentation:
+- https://github.com/devfile/devworkspace-operator/blob/main/README.md
+dependencies:
+  third-party-packages: true
+  dependencies-lists:
+  - https://github.com/devfile/devworkspace-operator/blob/main/go.mod


### PR DESCRIPTION
### What does this PR do?
This PR adds the `SECURITY-INSIGHTS.yml` file that is required as part of https://github.com/devfile/api/issues/1396. This is due to an effort to increase our score on the [CLOMonitor](https://clomonitor.io/projects/cncf/devfile#devworkspace-operator) where we are actively trying to improve our repositories and adhere to open source best practices. The addition of this file will provide the monitor with valuable information such as current release, licensing, repo activity status, current maintainers, contributing policy and dependencies. 

### What issues does this PR fix or reference?
fixes https://github.com/devfile/api/issues/1396

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
No testing required the file does not alter the way the project works.
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
