### PR TITLE
Ensure home persistence can only be enabled when workspace requires persistent storage

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -291,7 +291,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus), nil
 	}
 
-	if storageProvisioner.NeedsStorage(&workspace.Spec.Template) && home.NeedsPersistentHomeDirectory(workspace) {
+	if home.StorageStrategySupportsPersistentHome(workspace) && home.NeedsPersistentHomeDirectory(workspace) {
 		workspaceWithHomeVolume, err := home.AddPersistentHomeVolume(workspace)
 		if err != nil {
 			reconcileStatus.addWarning(fmt.Sprintf("Info: default persistentHome volume is not being used: %s", err.Error()))

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -291,7 +291,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.failWorkspace(workspace, fmt.Sprintf("Error provisioning storage: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus), nil
 	}
 
-	if home.StorageStrategySupportsPersistentHome(workspace) && home.NeedsPersistentHomeDirectory(workspace) {
+	if home.NeedsPersistentHomeDirectory(workspace) {
 		workspaceWithHomeVolume, err := home.AddPersistentHomeVolume(workspace)
 		if err != nil {
 			reconcileStatus.addWarning(fmt.Sprintf("Info: default persistentHome volume is not being used: %s", err.Error()))

--- a/pkg/library/home/persistentHome.go
+++ b/pkg/library/home/persistentHome.go
@@ -59,6 +59,14 @@ func AddPersistentHomeVolume(workspace *common.DevWorkspaceWithConfig) (*v1alpha
 	return dwTemplateSpecCopy, nil
 }
 
+// Returns true if the workspace's storage strategy supports persisting the user home directory.
+// The storage strategies which support home persistence are: per-user/common, per-workspace & async.
+// The ephemeral storage strategy does not support home persistence.
+func StorageStrategySupportsPersistentHome(workspace *common.DevWorkspaceWithConfig) bool {
+	storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
+	return storageClass != constants.EphemeralStorageClassType
+}
+
 // Returns true if `persistUserHome` is enabled in the DevWorkspaceOperatorConfig
 // and none of the container components in the DevWorkspace mount a volume to `/home/user/`.
 // Returns false otherwise.

--- a/pkg/library/home/persistentHome.go
+++ b/pkg/library/home/persistentHome.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfilevalidation "github.com/devfile/api/v2/pkg/validation"
+	"github.com/devfile/devworkspace-operator/pkg/provision/storage"
 	"k8s.io/utils/pointer"
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
@@ -67,8 +68,10 @@ func StorageStrategySupportsPersistentHome(workspace *common.DevWorkspaceWithCon
 	return storageClass != constants.EphemeralStorageClassType
 }
 
-// Returns true if `persistUserHome` is enabled in the DevWorkspaceOperatorConfig
-// and none of the container components in the DevWorkspace mount a volume to `/home/user/`.
+// Returns true if the following criteria is met:
+// - `persistUserHome` is enabled in the DevWorkspaceOperatorConfig
+// - None of the container components in the DevWorkspace mount a volume to `/home/user/`.
+// - Persistent storage is required for the DevWorkspace
 // Returns false otherwise.
 func NeedsPersistentHomeDirectory(workspace *common.DevWorkspaceWithConfig) bool {
 	if !pointer.BoolDeref(workspace.Config.Workspace.PersistUserHome.Enabled, false) {
@@ -86,5 +89,5 @@ func NeedsPersistentHomeDirectory(workspace *common.DevWorkspaceWithConfig) bool
 			}
 		}
 	}
-	return true
+	return storage.WorkspaceNeedsStorage(&workspace.Spec.Template)
 }

--- a/pkg/provision/storage/asyncStorage.go
+++ b/pkg/provision/storage/asyncStorage.go
@@ -45,7 +45,7 @@ type AsyncStorageProvisioner struct{}
 var _ Provisioner = (*AsyncStorageProvisioner)(nil)
 
 func (*AsyncStorageProvisioner) NeedsStorage(workspace *dw.DevWorkspaceTemplateSpec) bool {
-	return needsStorage(workspace)
+	return WorkspaceNeedsStorage(workspace)
 }
 
 func (p *AsyncStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspace *common.DevWorkspaceWithConfig, clusterAPI sync.ClusterAPI) error {

--- a/pkg/provision/storage/commonStorage.go
+++ b/pkg/provision/storage/commonStorage.go
@@ -41,7 +41,7 @@ type CommonStorageProvisioner struct{}
 var _ Provisioner = (*CommonStorageProvisioner)(nil)
 
 func (*CommonStorageProvisioner) NeedsStorage(workspace *dw.DevWorkspaceTemplateSpec) bool {
-	return needsStorage(workspace)
+	return WorkspaceNeedsStorage(workspace)
 }
 
 func (p *CommonStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1.PodAdditions, workspace *common.DevWorkspaceWithConfig, clusterAPI sync.ClusterAPI) error {

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -288,9 +288,9 @@ func TestNeedsStorage(t *testing.T) {
 			workspace := &dw.DevWorkspaceTemplateSpec{}
 			workspace.Components = tt.Components
 			if tt.NeedsStorage {
-				assert.True(t, needsStorage(workspace), tt.Explanation)
+				assert.True(t, WorkspaceNeedsStorage(workspace), tt.Explanation)
 			} else {
-				assert.False(t, needsStorage(workspace), tt.Explanation)
+				assert.False(t, WorkspaceNeedsStorage(workspace), tt.Explanation)
 			}
 		})
 	}

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -53,7 +53,7 @@ func (p *PerWorkspaceStorageProvisioner) ProvisionStorage(podAdditions *v1alpha1
 	}
 
 	// If persistent storage is not needed, we're done
-	if !needsStorage(&workspace.Spec.Template) {
+	if !WorkspaceNeedsStorage(&workspace.Spec.Template) {
 		return nil
 	}
 

--- a/pkg/provision/storage/perWorkspaceStorage_test.go
+++ b/pkg/provision/storage/perWorkspaceStorage_test.go
@@ -60,7 +60,7 @@ func TestRewriteContainerVolumeMountsForPerWorkspaceStorageClass(t *testing.T) {
 				Logger: zap.New(),
 			}
 
-			if needsStorage(&workspace.Spec.Template) {
+			if WorkspaceNeedsStorage(&workspace.Spec.Template) {
 				err := perWorkspaceStorage.ProvisionStorage(tt.Input.PodAdditions.DeepCopy(), workspace, clusterAPI)
 				if !assert.Error(t, err, "Should get a NotReady error when creating PVC") {
 					return


### PR DESCRIPTION
### What does this PR do?
This PR makes 2 changes:
####  Ensure only the storage strategies which support home persistence result in the persistent home devfile volume being added to a devworkspace.


The storage strategies which support home persistence are: per-user/common, perworkspace & async. The ephemeral storage strategy does not support home persistence.

Previously, we were trying to disable home persistence for the ephemeral storage strategy by calling [`provisioner.NeedsStorage()`](https://github.com/devfile/devworkspace-operator/blob/067847d900c18a3fe0d47de920a9ce77af29e722/pkg/provision/storage/provisioner.go#L40), however, the [implementation](https://github.com/devfile/devworkspace-operator/blob/067847d900c18a3fe0d47de920a9ce77af29e722/pkg/provision/storage/perWorkspaceStorage.go#L42-L47) of this function for the per-workspace PVC strategy always returns false and thus disabled home persistence when using per-workspace storage. 

Now, we simply disable home persistence if the devworkspace is using the ephemeral storage strategy.

#### Ensure home persistence is only enabled for workspaces which actually require persistent storage.
There are cases where a devworkspace could use the per-workspace, per-user or async storage strategy, but not actually require persistent storage. For example, a devworkspace with no volume components and no components which mount project sources. In these cases, we should not add a persistent home devfile volume to the devworkspace.

### What issues does this PR fix or reference?
Fix #1238

### Is it tested? How?
#### Test the per-workspace storage strategy can be used with persistUserHome
1. Set `config.workspace.persistUserHome: true` in the DWOC: `kubectl edit dwoc -n $NAMESPACE`

```diff
apiVersion: controller.devfile.io/v1alpha1                                                                                                                                 
config:                                                                                                                                                                    
  routing:                                                                                                                                                                 
    clusterHostSuffix: 192.168.49.2.nip.io                                                                                                                                 
    defaultRoutingClass: basic                                                                                                                                             
  workspace:                                                                                                                                                               
    imagePullPolicy: Always                                                                                                                                                
+    persistUserHome:                                                                                                                                                       
+      enabled: true                                                                                                                                                        
kind: DevWorkspaceOperatorConfig 
```
2. Create a devworkspace that uses the per-workspace storage strategy, for example: kubectl apply -f ./samples/per-workspace-storage.yaml
3. Once the devworkspace deployment is created, ensure the the workspace's pod has the persistent home volumeMount:

```diff
(...)
    volumeMounts:                                                                                                                                                          
    - mountPath: /checode                                                                                                                                                  
      name: storage-workspace4915e1b2cc1e4575                                                                                                                              
      subPath: checode                                                                                                                                                     
+    - mountPath: /home/user/                                                                                                                                               
+      name: storage-workspace4915e1b2cc1e4575                                                                                                                              
      subPath: persistent-home                                                                                                                                             
    - mountPath: /projects                                                                                                                                                 
      name: storage-workspace4915e1b2cc1e4575                                                                                                                              
      subPath: projects                                                                                                                                                    
    - mountPath: /devworkspace-metadata                                                                                                                                    
      name: workspace-metadata                                                                                                                                             
      readOnly: true                                                                                                                                                       
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount                                                                                                             
      name: kube-api-access-8bmpn                                                                                                                                          
      readOnly: true   
(...)
````

#### Ensure persistent home volumeMount is not created when the workspace does not need storage
1. Set `config.workspace.persistUserHome: true` in the DWOC: `kubectl edit dwoc -n $NAMESPACE`
2. Apply a devworkspace that uses the per-user or per-workspace storage strategy, but does not need need persistent storage. It should have no devfile volumes, and none of it's components have `mountSources: true`. For example:

```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
        controller.devfile.io/storage-type: per-workspace
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: false
          command:
           - "tail"
           - "-f"
           - "/dev/null"

```
3. After the devworkspace deployment is created, ensure the devworkspace pod does not have a volumeMount for `/home/user/`:

```yaml
    volumeMounts:                                                                                                                                                          
    - mountPath: /devworkspace-metadata                                                                                                                                    
      name: workspace-metadata                                                                                                                                             
      readOnly: true                                                                                                                                                       
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount                                                                                                             
      name: kube-api-access-x4g72                                                                                                                                          
      readOnly: true     
```



### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
