### PR TITLE
fix: pin setup-envtest to v0.0.0-20240320141353-395cfc7486e6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ $(LOCALBIN):
 ## Tool Binaries
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 CONTROLLER_GEN_VERSION = v0.6.1
+ENVTEST_VERSION = v0.0.0-20240320141353-395cfc7486e6
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 ENVTEST_K8S_VERSION = 1.24.2
 
@@ -256,4 +257,4 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)


### PR DESCRIPTION
### What does this PR do?
Versions of envtest >= v0.0.0-20240322105421-affb96708000 [require using go >= 1.22](https://github.com/kubernetes-sigs/controller-runtime/blob/affb9670800090d6ef8c450c84ec79075b43fe4f/tools/setup-envtest/go.mod). As go 1.22 is only coming to Fedora 40 on April 16th 2024, we are pinning the version of env-test used for the DWO test suite to v0.0.0-20240320141353-395cfc7486e6 which [requires go 1.20](https://github.com/kubernetes-sigs/controller-runtime/blob/395cfc7486e652d19fe1b544a436f9852ba26e4f/tools/setup-envtest/go.mod).

### What issues does this PR fix or reference?
Fix https://github.com/devfile/devworkspace-operator/issues/1242

### Is it tested? How?
For local testing, delete the `/bin` directory from the root of the repo and run `make test`. The required testing binaries (including setup-envtest) will be downloaded and the test suite should run successfully.

Also, ensure Check Sources GH action succeeds on this PR. 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
