### PR TITLE
Download chectl install script from che-incubator.github.io in tests

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -27,4 +27,4 @@ RUN yum install --assumeyes -d1 python3-pip nodejs && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin && \
     # Install chectl
-    bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
+    bash <(curl -sL https://che-incubator.github.io/chectl/install.sh) --channel=next


### PR DESCRIPTION
### What does this PR do?
Fix URL where E2E tests is downloading chectl install script from.

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/22925

### Is it tested? How?
**_Note_**: OpenShift CI tests will be failing in PR because they are running tests from the "main" branch without fix from this PR.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
