### PR TITLE
fix: account for mountSources when calculating per-workspace PVC size

### DIFF
--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -166,6 +166,14 @@ func (p *PerWorkspaceStorageProvisioner) rewriteContainerVolumeMounts(workspaceI
 	return nil
 }
 
+// Calculates the per-workspace PVC size required for the given devworkspace based on the following rules:
+//
+// 1. If all volumes in the devworkspace specify their size, the computed PVC size will be used.
+//
+// 2. If all volumes in the devworkspace either specify their size or are ephemeral, the computed PVC size will be used.
+//
+//  3. If at least one volume in the devworkspace specifies its size, and the computed PVC size is greater
+//     than the default per-workspace PVC size, the computed PVC size will be used.
 func getPVCSize(workspace *common.DevWorkspaceWithConfig, namespacedConfig *nsconfig.NamespacedConfig) (*resource.Quantity, error) {
 	defaultPVCSize := *workspace.Config.Workspace.DefaultStorageSize.PerWorkspace
 

--- a/pkg/provision/storage/testdata/perWorkspace-storage/use-default-size-when-mount-sources-used.yaml
+++ b/pkg/provision/storage/testdata/perWorkspace-storage/use-default-size-when-mount-sources-used.yaml
@@ -1,0 +1,39 @@
+name: "Uses default PVC size when no volumes define their size but mountSources used"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: "projects"
+            mountPath: "/projects-mountpath"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+
+  workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          mountSources: true
+
+output:
+  podAdditions:
+    containers:
+      - name: testing-container-1
+        image: testing-image
+        volumeMounts:
+          - name: storage-test-workspaceid
+            subPath: "projects"
+            mountPath: "/projects-mountpath"
+    initContainers:
+      - name: testing-initContainer-1
+        image: testing-image
+
+    volumes:
+      - name: storage-test-workspaceid
+        persistentVolumeClaim:
+          claimName: storage-test-workspaceid


### PR DESCRIPTION
### What does this PR do?

When calculating the per-workspace PVC size, container components in a devworkspace are now treated as if they were volume components with no size specified. 

This change was made to address an edge case in the per-workspace PVC size calculation where a  devworkspace that has no volume components, but has a container component with `mountSources` enabled will request a PVC size of 0. 

When `mountSources` is used,  the devworkspace [requires storage](https://github.com/devfile/devworkspace-operator/blob/main/pkg/provision/storage/shared.go#L59-L60) to store the project sources. However, it's ambiguous as to _how much_ storage is required for the project sources. Thus, the best we can do is to treat container components with `mountSources` enabled as if they were volume components with an unspecified size.

I also documented the original 3 rules that were followed when calculating the per-workspace PVC size (mentioned in this [PR](https://github.com/devfile/devworkspace-operator/pull/1163)) and added a 4th rule regarding the mountSources edge case.

### What issues does this PR fix or reference?
Fix https://github.com/devfile/devworkspace-operator/issues/1239

### Is it tested? How?
1. Install DWO built from this PR
2. Apply the following DevWorkspace, which used to fail in the [original issue](https://github.com/devfile/devworkspace-operator/issues/1239):

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-per-workspace
spec:
  started: true
  routingClass: 'basic'
  template:
    attributes:
        controller.devfile.io/storage-type: per-workspace
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
```

3. Ensure the devworkspace starts up successfully. 
4. Ensure the devworkspace's PVC size is the default 5Gi

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
