### PR TITLE
Fix: fix broken olm 0.27.0 digest channel entry (on 0.28.x branch)

### DIFF
--- a/olm-catalog/release-digest/channel.yaml
+++ b/olm-catalog/release-digest/channel.yaml
@@ -18,5 +18,5 @@ entries:
     replaces: devworkspace-operator.v0.24.0
   - name: devworkspace-operator.v0.26.0
     replaces: devworkspace-operator.v0.25.0
-  - name: devworkspace-operator.v0.27.
+  - name: devworkspace-operator.v0.27.0
     replaces: devworkspace-operator.v0.26.0


### PR DESCRIPTION
### What does this PR do?
When adding the 0.28.0 olm digest bundle, the channel entry for 0.27.0 was mistakenly entered as `0.27.` instead of `0.27.0`, causing `opm validate` to [fail](https://github.com/devfile/devworkspace-operator/actions/runs/9248400987/job/25438649172#step:16:3451). This PR fixes the typo so that the 0.28.0 release can succeed.

### What issues does this PR fix or reference?
n/a

### Is it tested? How?
Run `opm validate olm-catalog/release-digest/`. No error output should be shown.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
