### PR TITLE
Disable automount resources for the `init-container-home` init container

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -353,7 +353,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Add automount resources into devfile containers
-	err = automount.ProvisionAutoMountResourcesInto(devfilePodAdditions, clusterAPI, workspace.Namespace)
+	err = automount.ProvisionAutoMountResourcesInto(devfilePodAdditions, clusterAPI, workspace.Namespace, home.PersistUserHomeEnabled(workspace))
 	if shouldReturn, reconcileResult, reconcileErr := r.checkDWError(workspace, err, "Failed to process automount resources", metrics.ReasonBadRequest, reqLogger, &reconcileStatus); shouldReturn {
 		return reconcileResult, reconcileErr
 	}

--- a/pkg/library/home/persistentHome.go
+++ b/pkg/library/home/persistentHome.go
@@ -92,10 +92,7 @@ func AddPersistentHomeVolume(workspace *common.DevWorkspaceWithConfig) (*v1alpha
 // - Persistent storage is required for the DevWorkspace
 // Returns false otherwise.
 func NeedsPersistentHomeDirectory(workspace *common.DevWorkspaceWithConfig) bool {
-	if !pointer.BoolDeref(workspace.Config.Workspace.PersistUserHome.Enabled, false) {
-		return false
-	}
-	if !storageStrategySupportsPersistentHome(workspace) {
+	if !PersistUserHomeEnabled(workspace) || !storageStrategySupportsPersistentHome(workspace) {
 		return false
 	}
 	for _, component := range workspace.Spec.Template.Components {
@@ -111,6 +108,10 @@ func NeedsPersistentHomeDirectory(workspace *common.DevWorkspaceWithConfig) bool
 		}
 	}
 	return storage.WorkspaceNeedsStorage(&workspace.Spec.Template)
+}
+
+func PersistUserHomeEnabled(workspace *common.DevWorkspaceWithConfig) bool {
+	return pointer.BoolDeref(workspace.Config.Workspace.PersistUserHome.Enabled, false)
 }
 
 // Returns true if the workspace's storage strategy supports persisting the user home directory.

--- a/pkg/library/lifecycle/prestart_test.go
+++ b/pkg/library/lifecycle/prestart_test.go
@@ -56,6 +56,9 @@ func TestGetInitContainers(t *testing.T) {
 		loadPreStartTestCaseOrPanic(t, "prestart_exec_command.yaml"),
 		loadPreStartTestCaseOrPanic(t, "prestart_apply_command.yaml"),
 		loadPreStartTestCaseOrPanic(t, "init_and_main_container.yaml"),
+		loadPreStartTestCaseOrPanic(t, "persistent_home_initcontainer_first_initcontainer.yaml"),
+		loadPreStartTestCaseOrPanic(t, "persistent_home_initcontainer_second_initcontainer.yaml"),
+		loadPreStartTestCaseOrPanic(t, "persistent_home_initcontainer_only_initcontainer.yaml"),
 	}
 
 	for _, tt := range tests {

--- a/pkg/library/lifecycle/testdata/prestart/persistent_home_initcontainer_first_initcontainer.yaml
+++ b/pkg/library/lifecycle/testdata/prestart/persistent_home_initcontainer_first_initcontainer.yaml
@@ -1,0 +1,45 @@
+name: "Should set the init-persistent-home init container when init-persistent-home is the first preStart event"
+
+input:
+  components:
+    - name: test-container1
+      container:
+        image: my-image
+    - name: test-container2
+      container:
+        image: my-image
+    - name: init-persistent-home
+      container:
+        image: my-image
+  commands:
+    - id: test_preStart_command
+      apply:
+        component: test-container1
+    - id: test_regular_command
+      exec:
+        component: test-container1
+        command: "test_command"
+    - id: init-persistent-home
+      apply:
+        component: init-persistent-home
+  events:
+    preStart:
+      - "init-persistent-home"
+      - "test_preStart_command"
+
+output:
+  initContainers:
+    - name: init-persistent-home
+      container:
+        image: my-image
+    - name: test-container1
+      container:
+        image: my-image
+  mainContainers:
+    - name: test-container1
+      container:
+        image: my-image
+    - name: test-container2
+      container:
+        image: my-image
+  errRegexp:

--- a/pkg/library/lifecycle/testdata/prestart/persistent_home_initcontainer_only_initcontainer.yaml
+++ b/pkg/library/lifecycle/testdata/prestart/persistent_home_initcontainer_only_initcontainer.yaml
@@ -1,0 +1,38 @@
+name: "Should set the init-persistent-home init container when it is the only init container"
+
+input:
+  components:
+    - name: test-container1
+      container:
+        image: my-image
+    - name: test-container2
+      container:
+        image: my-image
+    - name: init-persistent-home
+      container:
+        image: my-image
+  commands:
+    - id: test_regular_command
+      exec:
+        component: test-container1
+        command: "test_command"
+    - id: init-persistent-home
+      apply:
+        component: init-persistent-home
+  events:
+    preStart:
+      - "init-persistent-home"
+
+output:
+  initContainers:
+    - name: init-persistent-home
+      container:
+        image: my-image
+  mainContainers:
+    - name: test-container1
+      container:
+        image: my-image
+    - name: test-container2
+      container:
+        image: my-image
+  errRegexp:

--- a/pkg/library/lifecycle/testdata/prestart/persistent_home_initcontainer_second_initcontainer.yaml
+++ b/pkg/library/lifecycle/testdata/prestart/persistent_home_initcontainer_second_initcontainer.yaml
@@ -1,0 +1,45 @@
+name: "Should set the init-persistent-home init container when init-persistent-home is the second preStart event"
+
+input:
+  components:
+    - name: test-container1
+      container:
+        image: my-image
+    - name: test-container2
+      container:
+        image: my-image
+    - name: init-persistent-home
+      container:
+        image: my-image
+  commands:
+    - id: test_preStart_command
+      apply:
+        component: test-container1
+    - id: test_regular_command
+      exec:
+        component: test-container1
+        command: "test_command"
+    - id: init-persistent-home
+      apply:
+        component: init-persistent-home
+  events:
+    preStart:
+      - "test_preStart_command"
+      - "init-persistent-home"
+
+output:
+  initContainers:
+    - name: init-persistent-home
+      container:
+        image: my-image
+    - name: test-container1
+      container:
+        image: my-image
+  mainContainers:
+    - name: test-container1
+      container:
+        image: my-image
+    - name: test-container2
+      container:
+        image: my-image
+  errRegexp:

--- a/pkg/provision/automount/common_persistenthome_test.go
+++ b/pkg/provision/automount/common_persistenthome_test.go
@@ -1,0 +1,93 @@
+//
+// Copyright (c) 2019-2024 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package automount
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+)
+
+func TestProvisionAutomountResourcesIntoPersistentHomeEnabled(t *testing.T) {
+	tests := []testCase{
+		loadTestCaseOrPanic(t, "testdata/testProvisionsConfigmaps.yaml"),
+		loadTestCaseOrPanic(t, "testdata/testProvisionsProjectedVolumes.yaml"),
+		loadTestCaseOrPanic(t, "testdata/testProvisionsSecrets.yaml"),
+	}
+
+	testPodAdditions := &v1alpha1.PodAdditions{
+		Containers: []corev1.Container{{
+			Name:  "test-container",
+			Image: "test-image",
+		}},
+		InitContainers: []corev1.Container{{
+			Name:  "init-persistent-home",
+			Image: "test-image",
+		}, {
+			Name:  "test-container",
+			Image: "test-image",
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.TestPath), func(t *testing.T) {
+			podAdditions := testPodAdditions.DeepCopy()
+			testAPI := sync.ClusterAPI{
+				Client: fake.NewClientBuilder().WithObjects(tt.Input.allObjects...).Build(),
+			}
+
+			err := ProvisionAutoMountResourcesInto(podAdditions, testAPI, testNamespace, true)
+
+			if !assert.NoError(t, err, "Unexpected error") {
+				return
+			}
+			assert.Truef(t, cmp.Equal(tt.Output.Volumes, podAdditions.Volumes, testDiffOpts),
+				"Volumes should match expected output:\n%s",
+				cmp.Diff(tt.Output.Volumes, podAdditions.Volumes, testDiffOpts))
+
+			for _, container := range podAdditions.Containers {
+				assert.Truef(t, cmp.Equal(tt.Output.VolumeMounts, container.VolumeMounts, testDiffOpts),
+					"Container VolumeMounts should match expected output:\n%s",
+					cmp.Diff(tt.Output.VolumeMounts, container.VolumeMounts, testDiffOpts))
+				assert.Truef(t, cmp.Equal(tt.Output.EnvFrom, container.EnvFrom, testDiffOpts),
+					"Container EnvFrom should match expected output:\n%s",
+					cmp.Diff(tt.Output.EnvFrom, container.EnvFrom, testDiffOpts))
+			}
+
+			for _, container := range podAdditions.InitContainers {
+				if container.Name == "init-persistent-home" {
+					assert.Truef(t, container.VolumeMounts == nil || len(container.VolumeMounts) == 0,
+						"The init-persistent-home container should not have any volume mounts if persistent home is enabled")
+				} else {
+					assert.Truef(t, cmp.Equal(tt.Output.VolumeMounts, container.VolumeMounts, testDiffOpts),
+						"Container VolumeMounts should match expected output:\n%s",
+						cmp.Diff(tt.Output.VolumeMounts, container.VolumeMounts, testDiffOpts))
+					assert.Truef(t, cmp.Equal(tt.Output.EnvFrom, container.EnvFrom, testDiffOpts),
+						"Container EnvFrom should match expected output:\n%s",
+						cmp.Diff(tt.Output.EnvFrom, container.EnvFrom, testDiffOpts))
+				}
+			}
+
+		})
+	}
+}

--- a/pkg/provision/automount/common_test.go
+++ b/pkg/provision/automount/common_test.go
@@ -125,7 +125,7 @@ func TestProvisionAutomountResourcesInto(t *testing.T) {
 			}
 			// Note: this test does not allow for returning AutoMountError with isFatal: false (i.e. no retrying)
 			// and so is not suitable for testing automount features that provision cluster resources (yet)
-			err := ProvisionAutoMountResourcesInto(podAdditions, testAPI, testNamespace)
+			err := ProvisionAutoMountResourcesInto(podAdditions, testAPI, testNamespace, false)
 			if tt.Output.ErrRegexp != nil {
 				if !assert.Error(t, err, "Expected an error but got none") {
 					return


### PR DESCRIPTION
### What does this PR do?
Disable automount resources for the `init-persistent-home` initcontainer (an not the other initcontainers) if persistent home is enabled.


### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1257


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

1. Deploy DWO:
```
export DWO_IMG=quay.io/dkwon17/devworkspace-controller:init-container-mount
make install
```

2. In the DWOC named `devworkspace-operator-config`, enable persistent storage.
```
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
  namespace: eclipse-che
config:
  workspace:
    persistUserHome:
      enabled: true
``` 
3. Create a configmap that mounts to any directory:
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: storageconf
  labels:
    controller.devfile.io/mount-to-devworkspace: 'true'
    controller.devfile.io/watch-configmap: 'true'
  annotations:
    controller.devfile.io/mount-as: subpath
    controller.devfile.io/mount-path: /home/user/.config/containers
data:
  storage.conf: test1234
```
4. Create a workspace and wait for it to start:
```
oc apply -f ./samples/code-latest.yaml
```
5. Verify that the first initcontainer is `init-persistent-home`, and that the configmap is mounted in all containers except for `init-persistent-home`:
```
$ oc get pod <pod name> -o jsonpath='{.spec.initContainers[0].name}'
init-persistent-home

$ oc get pod <pod name> -o jsonpath='{.spec.initContainers[0].volumeMounts}' | grep storageconf
// no match exists

$ oc get pod <pod name> -o jsonpath='{.spec.initContainers[1].volumeMounts}' | grep storageconf
// match exists

$ oc get pod <pod name> -o jsonpath='{.spec.initContainers[2].volumeMounts}' | grep storageconf
// match exists

$ oc get pod <pod name> -o jsonpath='{.spec.containers[*].volumeMounts}' | grep storageconf
// match exists
```

6. Verify that stow has run successfully in the `dev` container:
```
sh-4.4$ cat ~/.stow.log | tail -n 10 
LINK: go/pkg/mod/mvdan.cc/xurls/v2@v2.5.0/xurls_test.go => ../../../../../../../tooling/go/pkg/mod/mvdan.cc/xurls/v2@v2.5.0/xurls_test.go
    level of go/pkg/sumdb is 2
MKDIR: go/pkg/sumdb
    level of go/pkg/sumdb/sum.golang.org is 3
MKDIR: go/pkg/sumdb/sum.golang.org
    level of go/pkg/sumdb/sum.golang.org/latest is 4
LINK: go/pkg/sumdb/sum.golang.org/latest => ../../../../../tooling/go/pkg/sumdb/sum.golang.org/latest
Planning stow of package .... done
Processing tasks...
Processing tasks... done
```


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
