### PR TITLE
fix: Ensure $PROJECT_SOURCE and $PROJECT_ROOT are first environment variables in workspace containers

### DIFF
--- a/pkg/library/container/mountSources.go
+++ b/pkg/library/container/mountSources.go
@@ -81,13 +81,17 @@ func handleMountSources(k8sContainer *corev1.Container, devfileContainer *dw.Con
 		return err
 	}
 
-	k8sContainer.Env = append(k8sContainer.Env, corev1.EnvVar{
-		Name:  devfileConstants.ProjectsRootEnvVar,
-		Value: sourceMapping,
-	}, corev1.EnvVar{
-		Name:  devfileConstants.ProjectsSourceEnvVar,
-		Value: path.Join(sourceMapping, projectsSourcePath),
-	})
+	// The $PROJECT_ROOT and $PROJECT_SOURCE environment variables must be the first
+	// environment variables defined in the container so that other environment variables can reference them.
+	k8sContainer.Env = append([]corev1.EnvVar{
+		{
+			Name:  devfileConstants.ProjectsRootEnvVar,
+			Value: sourceMapping,
+		},
+		{
+			Name:  devfileConstants.ProjectsSourceEnvVar,
+			Value: path.Join(sourceMapping, projectsSourcePath),
+		}}, k8sContainer.Env...)
 
 	return nil
 }

--- a/pkg/library/container/testdata/component/converts-all-fields.yaml
+++ b/pkg/library/container/testdata/component/converts-all-fields.yaml
@@ -51,14 +51,14 @@ output:
             memory: "-1"
             cpu: "-1"
         env:
-          - name: "DEVWORKSPACE_COMPONENT_NAME"
-            value: "testing-container-1"
-          - name: "TEST_ENVVAR"
-            value: "TEST_VALUE"
           - name: "PROJECTS_ROOT"
             value: "/source-mapping"
           - name: "PROJECT_SOURCE"
             value: "/source-mapping"
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-1"
+          - name: "TEST_ENVVAR"
+            value: "TEST_VALUE"
         command:
           - "test"
           - "command"

--- a/pkg/library/container/testdata/mountsources/projects-source-and-root-first-env-vars.yaml.yaml
+++ b/pkg/library/container/testdata/mountsources/projects-source-and-root-first-env-vars.yaml.yaml
@@ -1,6 +1,9 @@
-name: "Handle mountSources correctly"
+name: "Ensures  PROJECT_ROOT and PROJECT_SOURCE env vars are first in list of env vars"
 
 input:
+  projects:
+  - name: test_project
+    clonePath: clone-path
   components:
     - name: testing-container-1
       container:
@@ -9,8 +12,12 @@ input:
         memoryLimit: "-1"  # isolate test to not include this field
         cpuRequest: "-1"  # isolate test to not include this field
         cpuLimit: "-1"  # isolate test to not include this field
-        sourceMapping: "/testdir1"
         # no mountSources defined -> should mount sources
+        env:
+          - name: user-env-var-1
+            value: value1
+          - name: user-env-var-1
+            value: value1
     - name: testing-container-2
       container:
         image: testing-image-2
@@ -20,6 +27,11 @@ input:
         cpuLimit: "-1"  # isolate test to not include this field
         # No sourceMapping -> defaults to "/projects"
         mountSources: true # mountSources: true -> should mount sources
+        env:
+          - name: user-env-var-2
+            value: value1
+          - name: user-env-var-3
+            value: value1
     - name: testing-container-3
       container:
         image: testing-image-3
@@ -29,6 +41,11 @@ input:
         cpuLimit: "-1"  # isolate test to not include this field
         sourceMapping: "/projects"
         mountSources: false # mountSources: false -> should not mount sources
+        env:
+          - name: user-env-var-4
+            value: value1
+          - name: user-env-var-5
+            value: value1
 output:
   podAdditions:
     containers:
@@ -44,14 +61,18 @@ output:
             cpu: "-1"
         volumeMounts:
           - name: "projects"
-            mountPath: "/testdir1"
+            mountPath: "/projects"
         env:
           - name: "PROJECTS_ROOT"
-            value: "/testdir1"
+            value: "/projects"
           - name: "PROJECT_SOURCE"
-            value: "/testdir1"
+            value: "/projects/clone-path"
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-1"
+          - name: user-env-var-1
+            value: value1
+          - name: user-env-var-1
+            value: value1
       - name: testing-container-2
         image: testing-image-2
         imagePullPolicy: Always
@@ -69,15 +90,23 @@ output:
           - name: "PROJECTS_ROOT"
             value: "/projects"
           - name: "PROJECT_SOURCE"
-            value: "/projects"
+            value: "/projects/clone-path"
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-2"
+          - name: user-env-var-2
+            value: value1
+          - name: user-env-var-3
+            value: value1
       - name: testing-container-3
         image: testing-image-3
         imagePullPolicy: Always
         env:
           - name: "DEVWORKSPACE_COMPONENT_NAME"
             value: "testing-container-3"
+          - name: user-env-var-4
+            value: value1
+          - name: user-env-var-5
+            value: value1
         resources:
           requests:
             memory: "-1"

--- a/pkg/library/container/testdata/mountsources/projects-source-is-set-correctly-from-clonepath.yaml
+++ b/pkg/library/container/testdata/mountsources/projects-source-is-set-correctly-from-clonepath.yaml
@@ -51,12 +51,12 @@ output:
           - name: "projects"
             mountPath: "/testdir1"
         env:
-          - name: "DEVWORKSPACE_COMPONENT_NAME"
-            value: "testing-container-1"
           - name: "PROJECTS_ROOT"
             value: "/testdir1"
           - name: "PROJECT_SOURCE"
             value: "/testdir1/clone-path"
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-1"
       - name: testing-container-2
         image: testing-image-2
         imagePullPolicy: Always
@@ -71,12 +71,12 @@ output:
           - name: "projects"
             mountPath: "/projects"
         env:
-          - name: "DEVWORKSPACE_COMPONENT_NAME"
-            value: "testing-container-2"
           - name: "PROJECTS_ROOT"
             value: "/projects"
           - name: "PROJECT_SOURCE"
             value: "/projects/clone-path"
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-2"
       - name: testing-container-3
         image: testing-image-3
         imagePullPolicy: Always

--- a/pkg/library/container/testdata/mountsources/projects-source-is-set-correctly-from-project-name.yaml
+++ b/pkg/library/container/testdata/mountsources/projects-source-is-set-correctly-from-project-name.yaml
@@ -50,12 +50,12 @@ output:
           - name: "projects"
             mountPath: "/testdir1"
         env:
-          - name: "DEVWORKSPACE_COMPONENT_NAME"
-            value: "testing-container-1"
           - name: "PROJECTS_ROOT"
             value: "/testdir1"
           - name: "PROJECT_SOURCE"
             value: "/testdir1/test_project"
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-1"
       - name: testing-container-2
         image: testing-image-2
         imagePullPolicy: Always
@@ -70,12 +70,12 @@ output:
           - name: "projects"
             mountPath: "/projects"
         env:
-          - name: "DEVWORKSPACE_COMPONENT_NAME"
-            value: "testing-container-2"
           - name: "PROJECTS_ROOT"
             value: "/projects"
           - name: "PROJECT_SOURCE"
             value: "/projects/test_project"
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-2"
       - name: testing-container-3
         image: testing-image-3
         imagePullPolicy: Always

--- a/pkg/library/container/testdata/volume/container-that-mounts-projects-directly.yaml
+++ b/pkg/library/container/testdata/volume/container-that-mounts-projects-directly.yaml
@@ -35,9 +35,9 @@ output:
           - name: "projects"
             mountPath: "/not-source-mapping"
         env:
-          - name: "DEVWORKSPACE_COMPONENT_NAME"
-            value: "testing-container-1"
           - name: "PROJECTS_ROOT"
             value: "/not-source-mapping"
           - name: "PROJECT_SOURCE"
             value: "/not-source-mapping"
+          - name: "DEVWORKSPACE_COMPONENT_NAME"
+            value: "testing-container-1"


### PR DESCRIPTION
### What does this PR do?

Environment variables defined in a Kubernetes container can only reference other variables declared earlier in the list of container environment variables. See the second note from the [Kubernetes docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#define-an-environment-variable-for-a-container) on environment variables.
    
This change ensures that the $PROJECT_SOURCE and $PROJECT_ROOT devfile environment variables are the first environment variables defined in all workspace pod containers so that devfile environment variables can reference $PROJECT_SOURCE and $PROJECT_ROOT.

Instead of appending $PROJECT_SOURCE and $PROJECT_ROOT to all workspace containers, we are now prepending them.

Additionally, existing tests were modified to accommodate this change in the list of container environment variables ordering, and a new test was added for this change.


### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1274

### Is it tested? How?
1. Install DWO with the changes made from this PR. I've pushed to `quay.io/aobuchow/devworkspace-controller:project-source-first` for ease of testing.
2. Apply the following devworkspace:

```YAML
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace-env-test
spec:
  started: true
  routingClass: 'basic'
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
          env:
           - name: ENV_TEST
             value: $(PROJECT_SOURCE)/hey-there
```
3. Once the workspace starts up, exec into the workspace pod and run `echo $ENV_TEST`. The output should be `/projects/web-nodejs-sample/hey-there` -- in other words, `$(PROJECT_SOURCE)` will get evaluated to `/projects/web-nodejs-sample/`.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
