### PR TITLE
fix: stop using mirror.centos.org repo in e2e tests

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -17,6 +17,9 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.20
 
 SHELL ["/bin/bash", "-c"]
 
+# Temporary workaround since mirror.centos.org is down and can be replaced with vault.centos.org
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 RUN yum install --assumeyes -d1 python3-pip nodejs && \
     pip3 install --upgrade pip && \
     pip3 install --upgrade setuptools && \


### PR DESCRIPTION
### What does this PR do?
Replaces usage of `http://mirrorlist.centos.org/` repo with `http://vault.centos.org/` as `http://mirrorlist.centos.org/`  is now down that Centos 7 is EOL as of July 1st 2024.

Without this fix, the e2e Dockerfile [fails](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/devfile_devworkspace-operator/1282/pull-ci-devfile-devworkspace-operator-main-v14-images/1808613067668328448) to build with:
```
Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error" 
```

This is more of a temporary work-around as the issue probably should be fixed in the image being used: http://registry.ci.openshift.org/openshift/release:golang-1.20

### What issues does this PR fix or reference?


### Is it tested? How?
n/a, fixes e2e tests

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
