### PR TITLE
Override the default ssh askpass flow on project clone step

### DIFF
--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -185,11 +185,11 @@ Git SSH keys can be configured for DevWorkspaces by mounting secrets to workspac
 
 Prerequisites:
 
-* An SSH keypair with _no passphrase_, with the public key uploaded to the Git provider that stores your repository.
+* An SSH keypair, with the public key uploaded to the Git provider, that stores your repository.
 ** The steps below assume the following environment variables are set:
 *** `$SSH_KEY`: path on disk to private key for SSH keypair (e.g. `~/.ssh/id_ed25519`)
 *** `$SSH_PUB_KEY`: path on disk to public key for SSH keypair (e.g. `~/.ssh/id_ed25519.pub`)
-*** `$PASSPHRASE`: ssh keypair passphrase (optional)
+*** `$PASSPHRASE`: SSH keypair passphrase (optional)
 *** `$NAMESPACE`: namespace where workspaces using the SSH keypair will be started.
 
 Process:

--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -189,6 +189,7 @@ Prerequisites:
 ** The steps below assume the following environment variables are set:
 *** `$SSH_KEY`: path on disk to private key for SSH keypair (e.g. `~/.ssh/id_ed25519`)
 *** `$SSH_PUB_KEY`: path on disk to public key for SSH keypair (e.g. `~/.ssh/id_ed25519.pub`)
+*** `$PASSPHRASE`: ssh keypair passphrase (optional)
 *** `$NAMESPACE`: namespace where workspaces using the SSH keypair will be started.
 
 Process:
@@ -211,7 +212,8 @@ EOF
 kubectl create secret -n "$NAMESPACE" generic git-ssh-key \
   --from-file=dwo_ssh_key="$SSH_KEY" \
   --from-file=dwo_ssh_key.pub="$SSH_PUB_KEY" \
-  --from-file=ssh_config=/tmp/ssh_config
+  --from-file=ssh_config=/tmp/ssh_config \
+  --from-literal=passphrase="$PASSPHRASE"
 ----
 
 3. Annotate the secret to configure automatic mounting to DevWorkspaces

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -44,10 +44,14 @@ COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/proj
 
 ENV USER_UID=1001 \
     USER_NAME=project-clone \
-    HOME=/home/user
+    HOME=/home/user \
+    DISPLAY=":0" \
+    SSH_ASKPASS=/usr/local/bin/ssh-askpass.sh
 
 COPY build/bin /usr/local/bin
+COPY project-clone/ssh-askpass.sh /usr/local/bin
 RUN  /usr/local/bin/user_setup
+RUN chmod +x /usr/local/bin/ssh-askpass.sh
 
 USER ${USER_UID}
 

--- a/project-clone/ssh-askpass.sh
+++ b/project-clone/ssh-askpass.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+PASSPHRASE_FILE_PATH="/etc/ssh/passphrase"
+if [ ! -f $PASSPHRASE_FILE_PATH ]; then
+    echo "Error: passphrase file is missing in the '/etc/ssh/' directory" 1>&2
+    exit 1
+fi
+cat $PASSPHRASE_FILE_PATH


### PR DESCRIPTION
### What does this PR do?
We support [project clone from ssh urls](https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#configuring-devworkspaces-to-use-ssh-keys-for-git-operations), but if the ssh key has a passphrase, the project clone step will fail because the default ssh askpass flow will be invoked, but it does not support any other input then a manual input from keyboard. To override the default flow, a script file is used. The passphrase file must be mounted to `/etc/ssh/` folder. The `SSH_ASKPASS` env variables defines the script file for the ssh flow, see: https://man.openbsd.org/ssh-add#ENVIRONMENT. The current `open-ssh` version does not support the `SSH_ASKPASS_REQUIRE` key, so we need to set the `DISPLAY` env variable as the command process does not have an associated terminal.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6614
Fix https://github.com/devfile/devworkspace-operator/issues/1294

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Setup ssh key with passphrase: https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#configuring-devworkspaces-to-use-ssh-keys-for-git-operations.
2. Try to start a workspace from an ssh url.
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
