### PR TITLE
Update cpu and memory limit for devworkspace-controller

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -404,8 +404,8 @@ spec:
                   timeoutSeconds: 5
                 resources:
                   limits:
-                    cpu: "1"
-                    memory: 1Gi
+                    cpu: "3"
+                    memory: 3Gi
                   requests:
                     cpu: 250m
                     memory: 100Mi

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -25251,8 +25251,8 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 3000m
+            memory: 3Gi
           requests:
             cpu: 250m
             memory: 100Mi

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -91,8 +91,8 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 3000m
+            memory: 3Gi
           requests:
             cpu: 250m
             memory: 100Mi

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -25253,8 +25253,8 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 3000m
+            memory: 3Gi
           requests:
             cpu: 250m
             memory: 100Mi

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -91,8 +91,8 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 3000m
+            memory: 3Gi
           requests:
             cpu: 250m
             memory: 100Mi

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -54,8 +54,8 @@ spec:
             - "--metrics-addr=127.0.0.1:8080"
           resources:
             limits:
-              cpu: 1000m
-              memory: 1Gi
+              cpu: 3000m
+              memory: 3Gi
             requests:
               cpu: 250m
               memory: 100Mi


### PR DESCRIPTION
### What does this PR do?
This PR updates the CPU and memory limit of the `devworkspace-controller` container of the `devworkspace-controller-manager-*` pod from `1000m` to `3000m` and `1Gi` to `3Gi` respectively.

### What issues does this PR fix or reference?
Part of https://issues.redhat.com/browse/CRW-6889
Fix https://github.com/devfile/devworkspace-operator/issues/1299


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
To test, run:
```
DWO_IMG_REPO=quay.io/<username>/<repo>
DWO_IMG_TAG=<tag>
export DWO_BUNDLE_IMG=${DWO_IMG_REPO}/devworkspace-operator-bundle:${DWO_IMG_TAG}
export DWO_INDEX_IMG=${DWO_IMG_REPO}/devworkspace-operator-index:${DWO_IMG_TAG}
export DOCKER=podman 
make generate_olm_bundle_yaml build_bundle_and_index register_catalogsource
```
And install the operator from OperatorHub.

Verify that the resulting `devworkspace-controller-manager-*` pod in the openshift-operators namespace has the new CPU and memory limit for the `devworkspace-controller` container.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
