### PR TITLE
feat: remove FailedScheduling event from list of unrecoverable worksp…

### DIFF
--- a/pkg/library/status/check.go
+++ b/pkg/library/status/check.go
@@ -44,7 +44,6 @@ var containerFailureStateReasons = []string{
 var unrecoverablePodEventReasons = map[string]int32{
 	"FailedPostStartHook":   1,
 	"FailedMount":           3,
-	"FailedScheduling":      1,
 	"FailedCreate":          1,
 	"ReplicaSetCreateError": 1,
 }


### PR DESCRIPTION
…ace pod events

### What does this PR do?

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1280

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
create a workspace with exceeding resource requests/limits (modified samples/plain.yaml):
```
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace
spec:
  started: true
  routingClass: 'basic'
  template:
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 1000Gi
          memoryLimit: 1000Gi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
```

check the workspace status, which will keep trying to start workspace, until it times out in 5 minutes:

```
[16:41:05] mykhailo@~/projects/devworkspace-operator$ kubectl get dw
plain-devworkspace   workspaceb6a633cbe27141fe   Failed   DevWorkspace failed to progress past step 'Waiting for workspace deployment' for longer than timeout (5m)
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
