### PR TITLE
feat: set defaults for ignoredUnrecoverableEvents operator config

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -118,10 +118,11 @@ type WorkspaceConfig struct {
 	// "15m", "20s", "1h30m", etc. If not specified, the default value of "5m" is used.
 	ProgressTimeout string `json:"progressTimeout,omitempty"`
 	// IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
-	// be ignored when deciding to fail a DevWorkspace startup. This option should be used
-	// if a transient cluster issue is triggering false-positives (for example, if
-	// the cluster occasionally encounters FailedScheduling events). Events listed
-	// here will not trigger DevWorkspace failures.
+	// be ignored when deciding to fail a DevWorkspace startup.
+	// For example, a FailedScheduling event, that occurs when workspace cannot start
+	// due to exceeding available resources, should not fail the workspace startup, if there is
+	// an autoscaler configured on the cluster, and we want to wait until it provisions additional resources.
+	// FailedScheduling event can also occur as a false-positive, as a result of a transient cluster issue.
 	IgnoredUnrecoverableEvents []string `json:"ignoredUnrecoverableEvents,omitempty"`
 	// CleanupOnStop governs how the Operator handles stopped DevWorkspaces. If set to
 	// true, additional resources associated with a DevWorkspace (e.g. services, deployments,

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -76,6 +76,7 @@ var defaultConfig = &v1alpha1.OperatorConfiguration{
 				corev1.ResourceMemory: resource.MustParse("64Mi"),
 			},
 		},
+		IgnoredUnrecoverableEvents: []string {"FailedScheduling"},
 	},
 }
 


### PR DESCRIPTION
### What does this PR do?
Add FailedScheduling event to the default list of ignoredUnrecoverableEvents list in operator config.

(this PR is an alternative to https://github.com/devfile/devworkspace-operator/pull/1306)

the relevant docs should also be updated:
https://eclipse.dev/che/docs/stable/administration-guide/configuring-machine-autoscaling/#_when_the_autoscaler_adds_a_new_node

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1280
### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
create a workspace with exceeding resource requests/limits (modified samples/plain.yaml):
```
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace
spec:
  started: true
  routingClass: 'basic'
  template:
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 1000Gi
          memoryLimit: 1000Gi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
```

check the workspace status, which will keep trying to start workspace, until it times out in 5 minutes:
```
$ kdw get dw
NAME                 DEVWORKSPACE ID             PHASE    INFO
plain-devworkspace   workspace8e15dba59ab04607   Failed   DevWorkspace failed to progress past step 'Waiting for workspace deployment' for longer than timeout (5m). Ignored events: Detected unrecoverable event FailedScheduling: 0/1 nodes are available: 1 Insufficient memory. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod...
```
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
