### PR TITLE
Improve documentation for Webhook deployment configuration

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -37,7 +37,7 @@ type OperatorConfiguration struct {
 	// Note: In order for changes made to the webhook configuration to take effect:
 	//
 	// - The changes must be made in the global DevWorkspaceOperatorConfig, which has the
-	//   name 'devworkspace-operator-config' and exists in the same namespace where the 
+	//   name 'devworkspace-operator-config' and exists in the same namespace where the
 	//   DevWorkspaceOperator is deployed.
 	//
 	// - The devworkspace-controller-manager pod must be terminated and recreated for the

--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -34,6 +34,14 @@ type OperatorConfiguration struct {
 	// managed
 	Workspace *WorkspaceConfig `json:"workspace,omitempty"`
 	// Webhook defines configuration options for the DevWorkspace Webhook Server.
+	// Note: In order for changes made to the webhook configuration to take effect:
+	//
+	// - The changes must be made in the global DevWorkspaceOperatorConfig, which has the
+	//   name 'devworkspace-operator-config' and exists in the same namespace where the 
+	//   DevWorkspaceOperator is deployed.
+	//
+	// - The devworkspace-controller-manager pod must be terminated and recreated for the
+	//   DevWorkspace Webhook Server deployment to be updated.
 	Webhook *WebhookConfig `json:"webhook,omitempty"`
 	// EnableExperimentalFeatures turns on in-development features of the controller.
 	// This option should generally not be enabled, as any capabilites are subject

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -70,7 +70,7 @@ spec:
                     type: object
                 type: object
               webhook:
-                description: Webhook defines configuration options for the DevWorkspace Webhook Server.
+                description: "Webhook defines configuration options for the DevWorkspace Webhook Server. Note: In order for changes made to the webhook configuration to take effect: \n - The changes must be made in the global DevWorkspaceOperatorConfig, which has the   name 'devworkspace-operator-config' and exists in the same namespace where the   DevWorkspaceOperator is deployed. \n - The devworkspace-controller-manager pod must be terminated and recreated for the   DevWorkspace Webhook Server deployment to be updated."
                 properties:
                   nodeSelector:
                     additionalProperties:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -108,8 +108,14 @@ spec:
                     type: object
                 type: object
               webhook:
-                description: Webhook defines configuration options for the DevWorkspace
-                  Webhook Server.
+                description: "Webhook defines configuration options for the DevWorkspace
+                  Webhook Server. Note: In order for changes made to the webhook configuration
+                  to take effect: \n - The changes must be made in the global DevWorkspaceOperatorConfig,
+                  which has the   name 'devworkspace-operator-config' and exists in
+                  the same namespace where the   DevWorkspaceOperator is deployed.
+                  \n - The devworkspace-controller-manager pod must be terminated
+                  and recreated for the   DevWorkspace Webhook Server deployment to
+                  be updated."
                 properties:
                   nodeSelector:
                     additionalProperties:

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -108,8 +108,14 @@ spec:
                     type: object
                 type: object
               webhook:
-                description: Webhook defines configuration options for the DevWorkspace
-                  Webhook Server.
+                description: "Webhook defines configuration options for the DevWorkspace
+                  Webhook Server. Note: In order for changes made to the webhook configuration
+                  to take effect: \n - The changes must be made in the global DevWorkspaceOperatorConfig,
+                  which has the   name 'devworkspace-operator-config' and exists in
+                  the same namespace where the   DevWorkspaceOperator is deployed.
+                  \n - The devworkspace-controller-manager pod must be terminated
+                  and recreated for the   DevWorkspace Webhook Server deployment to
+                  be updated."
                 properties:
                   nodeSelector:
                     additionalProperties:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -108,8 +108,14 @@ spec:
                     type: object
                 type: object
               webhook:
-                description: Webhook defines configuration options for the DevWorkspace
-                  Webhook Server.
+                description: "Webhook defines configuration options for the DevWorkspace
+                  Webhook Server. Note: In order for changes made to the webhook configuration
+                  to take effect: \n - The changes must be made in the global DevWorkspaceOperatorConfig,
+                  which has the   name 'devworkspace-operator-config' and exists in
+                  the same namespace where the   DevWorkspaceOperator is deployed.
+                  \n - The devworkspace-controller-manager pod must be terminated
+                  and recreated for the   DevWorkspace Webhook Server deployment to
+                  be updated."
                 properties:
                   nodeSelector:
                     additionalProperties:

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -108,8 +108,14 @@ spec:
                     type: object
                 type: object
               webhook:
-                description: Webhook defines configuration options for the DevWorkspace
-                  Webhook Server.
+                description: "Webhook defines configuration options for the DevWorkspace
+                  Webhook Server. Note: In order for changes made to the webhook configuration
+                  to take effect: \n - The changes must be made in the global DevWorkspaceOperatorConfig,
+                  which has the   name 'devworkspace-operator-config' and exists in
+                  the same namespace where the   DevWorkspaceOperator is deployed.
+                  \n - The devworkspace-controller-manager pod must be terminated
+                  and recreated for the   DevWorkspace Webhook Server deployment to
+                  be updated."
                 properties:
                   nodeSelector:
                     additionalProperties:

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -107,8 +107,14 @@ spec:
                     type: object
                 type: object
               webhook:
-                description: Webhook defines configuration options for the DevWorkspace
-                  Webhook Server.
+                description: "Webhook defines configuration options for the DevWorkspace
+                  Webhook Server. Note: In order for changes made to the webhook configuration
+                  to take effect: \n - The changes must be made in the global DevWorkspaceOperatorConfig,
+                  which has the   name 'devworkspace-operator-config' and exists in
+                  the same namespace where the   DevWorkspaceOperator is deployed.
+                  \n - The devworkspace-controller-manager pod must be terminated
+                  and recreated for the   DevWorkspace Webhook Server deployment to
+                  be updated."
                 properties:
                   nodeSelector:
                     additionalProperties:

--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -351,3 +351,25 @@ spec:
 ----
 
 For documentation on Runtime Classes, see https://kubernetes.io/docs/concepts/containers/runtime-class/
+
+## Configuring the Webhook deployment
+The `devworkspace-webhook-server` deployment can be configured in the global DevWorkspaceOperatorConfig (DWOC). The configuration options include: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas[replicas], https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[pod tolerations] and https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector[nodeSelector]. 
+
+These configuration options exist in the **global** DWOC's `config.webhook`  field:
+[source,yaml]
+----
+apiVersion: controller.devfile.io/v1alpha1
+kind: DevWorkspaceOperatorConfig
+metadata:
+  name: devworkspace-operator-config
+  namespace: $OPERATOR_INSTALL_NAMESPACE
+config:
+ webhook:
+   nodeSelector:  <string, string>
+   tolerations: <[]tolerations>
+   replicas: <int32>
+----
+**Note:** In order for the `devworkspace-webhook-server` configuration options to take effect:
+
+- You must place them in the https://github.com/devfile/devworkspace-operator?tab=readme-ov-file#global-configuration-for-the-devworkspace-operator[global DWOC], which has the name `devworkspace-operator-config` and exists in the namespace where the DevWorkspaceOperator is installed. If it does not already exist on the cluster, you must create it.
+- You'll need to terminate the `devworkspace-controller-manager` pod so that the replicaset can recreate it. The new pod will update the `devworkspace-webhook-server` deployment.


### PR DESCRIPTION
### What does this PR do?
- Add documentation to the DWOC CRD about requirements for configuring the webhook (must use the global DWOC and restart the devworkspace-controller-manager pod for changes to take effect)
- Add documentation about configuration the webhook in the Additional Docs

### What issues does this PR fix or reference?
Fix https://github.com/devfile/devworkspace-operator/issues/1289

### Is it tested? How?
1. Install DWO with the changes from this PR and login to your cluster with oc
2. Do a `kubectl explain dwoc.config.webhook`. The DESCRIPTION field should show the new mentions of needing to use the global DWOC and restarting the devworkspace-controller-manager pod
3. Check the additional docs (here's a [link](https://github.com/AObuchow/devworkspace-operator/blob/webhook-config-docs/docs/additional-configuration.adoc#configuring-the-webhook-deployment) to them on my fork to easily view the changes)

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
