### PR TITLE
fix: temporarily pin goimports in GH Actions to v0.24.0

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -40,7 +40,7 @@ jobs:
       name: Run Go Tests
       run: |
         python -m pip install --upgrade pip yq
-        go install golang.org/x/tools/cmd/goimports@latest
+        go install golang.org/x/tools/cmd/goimports@v0.24.0
         go install github.com/onsi/ginkgo/v2/ginkgo@v2.0.0
         make update_devworkspace_crds test
     -

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,7 +73,7 @@ jobs:
       name: Check format
       run: |
         go install github.com/google/addlicense@latest
-        go install golang.org/x/tools/cmd/goimports@latest
+        go install golang.org/x/tools/cmd/goimports@v0.24.0
         if ! make check_fmt; then
           echo "not well formatted sources are found:"
           git --no-pager diff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           # Need to grab goimports otherwise formatting after this step will fail
           # PR checks.
-          go install golang.org/x/tools/cmd/goimports@latest
+          go install golang.org/x/tools/cmd/goimports@v0.24.0
 
           git config --global user.name "Andrew Obuchowicz"
           git config --global user.email "aobuchow@redhat.com"


### PR DESCRIPTION
### What does this PR do?
The latest version of goimports (v0.25.0) requires go >= 1.22.0.

Since we are about to do the upstream release of DWO 0.31.0, we are temporarily pinning goimports to the last working version (v0.24.0).

After the 0.31.0 release of DWO, we can safely upgrade the entire repo to go 1.22.0, and use the latest version of goimports again.


### What issues does this PR fix or reference?
Part of #1314 (initial, temporary fix)

### Is it tested? How?
CI checks should pass (hopefully, if they run off my fork).
I tested installing goimports@v0.25.0 and goimports@v0.24.0 in Che to see the required version of go for goimports v0.25.0:

```
projects $ go install golang.org/x/tools/cmd/goimports@latest
go: downloading golang.org/x/tools v0.25.0
go: golang.org/x/tools/cmd/goimports@latest: golang.org/x/tools@v0.25.0 requires go >= 1.22.0 (running go 1.21.11; GOTOOLCHAIN=local)
projects $ go install golang.org/x/tools/cmd/goimports@v0.24.0
go: downloading golang.org/x/mod v0.20.0
go: downloading golang.org/x/sync v0.8.0
```

Since the formating checks that install the latest version of goimports were succeeding [last week ](https://github.com/devfile/devworkspace-operator/actions/runs/10745761086), and goimports v0.25.0 was just released [yesterday](https://pkg.go.dev/golang.org/x/tools/cmd/goimports?tab=versions), I'm hopeful that this PR should work as expected to temporarily resolve #1314

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
