### PR TITLE
feat: turn healthCheckHttpClient timeout from 500ms to 3s

### DIFF
--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -26,6 +26,7 @@ import (
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/dwerrors"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 
 	"github.com/go-logr/logr"
@@ -211,7 +212,7 @@ func checkServerStatus(workspace *common.DevWorkspaceWithConfig) (ok bool, respo
 
 	resp, err := healthCheckHttpClient.Get(healthz.String())
 	if err != nil {
-		return false, nil, err
+		return false, nil, &dwerrors.RetryError{Err: err, Message: "Failed to check server status", RequeueAfter: 1 * time.Second}
 	}
 	if (resp.StatusCode / 100) == 4 {
 		// Assume endpoint is unimplemented and/or * is covered with authentication.


### PR DESCRIPTION
### What does this PR do?

It change the timeout of the healthcheck client from 500ms to 3s

### What issues does this PR fix or reference?

Linked to https://github.com/eclipse-che/che/issues/23067
Fixes https://github.com/devfile/devworkspace-operator/issues/1325

### Is it tested? How?

In progress

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
