### PR TITLE
fix: remove dummy caBundle from CRDs

### DIFF
--- a/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
+++ b/deploy/bundle/manifests/workspace.devfile.io_devworkspaces.yaml
@@ -11,7 +11,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: system

--- a/deploy/bundle/manifests/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/deploy/bundle/manifests/workspace.devfile.io_devworkspacetemplates.yaml
@@ -11,7 +11,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: system

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -7495,7 +7495,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: devworkspace-controller
@@ -16750,7 +16749,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: devworkspace-controller

--- a/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: devworkspace-controller

--- a/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: devworkspace-controller

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -7495,7 +7495,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: devworkspace-controller
@@ -16750,7 +16749,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: devworkspace-controller

--- a/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: devworkspace-controller

--- a/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml
@@ -12,7 +12,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: devworkspace-controller-manager-service
           namespace: devworkspace-controller

--- a/deploy/templates/cert-manager/crd_webhooks_patch.yaml
+++ b/deploy/templates/cert-manager/crd_webhooks_patch.yaml
@@ -17,7 +17,6 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by cert-manager on creation
-        # caBundle: Cg==
 ---
 # Add webhooks to the devfile/api CRDs
 apiVersion: apiextensions.k8s.io/v1
@@ -38,4 +37,3 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by cert-manager on creation
-        # caBundle: Cg==

--- a/deploy/templates/cert-manager/crd_webhooks_patch.yaml
+++ b/deploy/templates/cert-manager/crd_webhooks_patch.yaml
@@ -17,7 +17,7 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by cert-manager on creation
-        caBundle: Cg==
+        # caBundle: Cg==
 ---
 # Add webhooks to the devfile/api CRDs
 apiVersion: apiextensions.k8s.io/v1
@@ -38,4 +38,4 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by cert-manager on creation
-        caBundle: Cg==
+        # caBundle: Cg==

--- a/deploy/templates/olm/crd_webhooks_patch.yaml
+++ b/deploy/templates/olm/crd_webhooks_patch.yaml
@@ -15,7 +15,6 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by Service CA operator
-        # caBundle: Cg==
 ---
 # Add webhooks to the devfile/api CRDs
 apiVersion: apiextensions.k8s.io/v1
@@ -34,4 +33,3 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by Service CA operator
-        # caBundle: Cg==

--- a/deploy/templates/olm/crd_webhooks_patch.yaml
+++ b/deploy/templates/olm/crd_webhooks_patch.yaml
@@ -15,7 +15,7 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by Service CA operator
-        caBundle: Cg==
+        # caBundle: Cg==
 ---
 # Add webhooks to the devfile/api CRDs
 apiVersion: apiextensions.k8s.io/v1
@@ -34,4 +34,4 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by Service CA operator
-        caBundle: Cg==
+        # caBundle: Cg==

--- a/deploy/templates/service-ca/crd_webhooks_patch.yaml
+++ b/deploy/templates/service-ca/crd_webhooks_patch.yaml
@@ -17,7 +17,7 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by Service CA operator
-        caBundle: Cg==
+        # caBundle: Cg==
 ---
 # Add webhooks to the devfile/api CRDs
 apiVersion: apiextensions.k8s.io/v1
@@ -38,4 +38,4 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by Service CA operator
-        caBundle: Cg==
+        # caBundle: Cg==

--- a/deploy/templates/service-ca/crd_webhooks_patch.yaml
+++ b/deploy/templates/service-ca/crd_webhooks_patch.yaml
@@ -17,7 +17,6 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by Service CA operator
-        # caBundle: Cg==
 ---
 # Add webhooks to the devfile/api CRDs
 apiVersion: apiextensions.k8s.io/v1
@@ -38,4 +37,3 @@ spec:
           path: /convert
           port: 443
         # caBundle will be filled by Service CA operator
-        # caBundle: Cg==


### PR DESCRIPTION
### What does this PR do?
Removes `webhook.clientConfig.caBundle: Cg==` from the DevWorkspace and DevWorkspaceTemplate CRDs.

### What issues does this PR fix or reference?
For Kubernetes version 1.31 and later, CRDs with `clientConfig.caBundle: Cg==` cannot be applied anymore:
https://github.com/kubernetes/kubernetes/issues/125569#issuecomment-2261245120

This PR fixes https://github.com/redhat-developer/web-terminal-operator/issues/171, https://github.com/devfile/devworkspace-operator/issues/1327

### Is it tested? How?
Create a bundle and apply the catalog source to the cluster and install the DWO version provided from the catalog source:
```
export DWO_BUNDLE_IMG=quay.io/<username>/devworkspace-operator-bundle:removeCaBundle
export DWO_INDEX_IMG=quay.io/<username>/devworkspace-operator-index:removeCaBundle
make generate_olm_bundle_yaml build_bundle_and_index register_catalogsource
```

DWO installation should be successful.

To test even further, you can try creating a DevWorkspace and use conversion webhooks by retrieving the v1alpha1 version:
```
$ kubectl apply -f ./samples/code-latest.yaml 
$ kubectl get devworkspace.v1alpha1.workspace.devfile.io code-latest
```
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
