### PR TITLE
Fix Start ssh-agent post start event

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -45,7 +45,7 @@ const (
 
 	HomeInitEventId = "init-persistent-home"
 
-	SshAgentStartEventId = "init-ssh-agent"
+	SshAgentStartEventId = "init-ssh-agent-command"
 
 	ServiceAccount = "devworkspace"
 

--- a/pkg/library/ssh/event.go
+++ b/pkg/library/ssh/event.go
@@ -14,6 +14,8 @@
 package ssh
 
 import (
+	"fmt"
+
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/library/lifecycle"
@@ -38,12 +40,13 @@ func AddSshAgentPostStartEvent(spec *v1alpha2.DevWorkspaceTemplateSpec) error {
 	}
 
 	_, mainComponents, err := lifecycle.GetInitContainers(spec.DevWorkspaceTemplateSpecContent)
-	for _, component := range mainComponents {
+	for id, component := range mainComponents {
 		if component.Container == nil {
 			continue
 		}
+		commandId := fmt.Sprintf("%s-%d", constants.SshAgentStartEventId, id)
 		spec.Commands = append(spec.Commands, v1alpha2.Command{
-			Id: constants.SshAgentStartEventId,
+			Id: commandId,
 			CommandUnion: v1alpha2.CommandUnion{
 				Exec: &v1alpha2.ExecCommand{
 					CommandLine: commandLine,
@@ -51,7 +54,7 @@ func AddSshAgentPostStartEvent(spec *v1alpha2.DevWorkspaceTemplateSpec) error {
 				},
 			},
 		})
+		spec.Events.PostStart = append(spec.Events.PostStart, commandId)
 	}
-	spec.Events.PostStart = append(spec.Events.PostStart, constants.SshAgentStartEventId)
 	return err
 }


### PR DESCRIPTION
### What does this PR do?
Fix a bug when the ssh agent post start event command is present only in the first component of the workspace pod yaml.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-6614
Fix https://github.com/devfile/devworkspace-operator/issues/1330

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Start a workspace with more than one component e.g:
```yaml
schemaVersion: 2.3.0
metadata:
  name: test local
components:
  - name: component-1
    container:
      image: quay.io/devfile/universal-developer-image:ubi8-latest
  - name: component-2
    container:
      image: quay.io/devfile/universal-developer-image:ubi8-latest
```
2. See: the ssh agent post start event command is present in both components of the workspace pod yaml:
```yaml
spec:
  containers:
    - lifecycle:
        postStart:
          exec:
            command:
              - /bin/sh
              - '-c'
              - |
                {
                nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt 2>&1 &
                SSH_ENV_PATH=$HOME/ssh-environment \
                && if [ -f /etc/ssh/passphrase ] && command -v ssh-add >/dev/null; \
                then ssh-agent | sed 's/^echo/#echo/' > $SSH_ENV_PATH \
                && chmod 600 $SSH_ENV_PATH && source $SSH_ENV_PATH \
                && ssh-add /etc/ssh/dwo_ssh_key < /etc/ssh/passphrase \
                && if [ -f $HOME/.bashrc ] && [ -w $HOME/.bashrc ]; then echo "source ${SSH_ENV_PATH}" >> $HOME/.bashrc; fi; fi
                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt
      name: component-1
```
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
