### PR TITLE
Cherry pick healthz retry to 0.31.x

### DIFF
--- a/controllers/workspace/status.go
+++ b/controllers/workspace/status.go
@@ -26,6 +26,7 @@ import (
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/dwerrors"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 
 	"github.com/go-logr/logr"
@@ -211,7 +212,7 @@ func checkServerStatus(workspace *common.DevWorkspaceWithConfig) (ok bool, respo
 
 	resp, err := healthCheckHttpClient.Get(healthz.String())
 	if err != nil {
-		return false, nil, err
+		return false, nil, &dwerrors.RetryError{Err: err, Message: "Failed to check server status", RequeueAfter: 1 * time.Second}
 	}
 	if (resp.StatusCode / 100) == 4 {
 		// Assume endpoint is unimplemented and/or * is covered with authentication.


### PR DESCRIPTION
### What does this PR do?
Cherry pick commit 75c2a6007dbe47f5e198d4194e803e2ada391ce1 to 0.31.x.

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23067

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
