### PR TITLE
Add conditions to the SSH agent post-start command

### DIFF
--- a/pkg/library/ssh/event.go
+++ b/pkg/library/ssh/event.go
@@ -21,12 +21,17 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/library/lifecycle"
 )
 
-const commandLine = `SSH_ENV_PATH=$HOME/ssh-environment \
-&& if [ -f /etc/ssh/passphrase ] && command -v ssh-add >/dev/null; \
-then ssh-agent | sed 's/^echo/#echo/' > $SSH_ENV_PATH \
-&& chmod 600 $SSH_ENV_PATH && source $SSH_ENV_PATH \
-&& ssh-add /etc/ssh/dwo_ssh_key < /etc/ssh/passphrase \
-&& if [ -f $HOME/.bashrc ] && [ -w $HOME/.bashrc ]; then echo "source ${SSH_ENV_PATH}" >> $HOME/.bashrc; fi; fi`
+const commandLine = `(
+SSH_ENV_PATH=$HOME/ssh-environment && \
+if [ -f /etc/ssh/passphrase ] && [ -w $HOME ] && command -v ssh-add >/dev/null && command -v ssh-agent >/dev/null; then
+    ssh-agent | sed 's/^echo/#echo/' > $SSH_ENV_PATH \
+    && chmod 600 $SSH_ENV_PATH \
+    && source $SSH_ENV_PATH \
+    && if timeout 3 ssh-add /etc/ssh/dwo_ssh_key < /etc/ssh/passphrase && [ -f $HOME/.bashrc ] && [ -w $HOME/.bashrc ]; then
+        echo "source ${SSH_ENV_PATH}" >> $HOME/.bashrc
+    fi
+fi
+) || true`
 
 // AddSshAgentPostStartEvent Start ssh-agent and add the default ssh key to it, if the ssh key has a passphrase.
 // Initialise the ssh-agent session env variables in the user .bashrc file.


### PR DESCRIPTION
### What does this PR do?
Add extra conditions to the SSH agent post-start command:
* Check the `$HOME` directory for the write permissions in order to create the `ssh-environment` file in the user home directory.
* Add `timeout` to the `ssh-add <key path> < <passphrase path>` command. If the passphrase is incorrect, then the `ssh-add` asks to input a new password:
```
Enter passphrase for <key path>: 
Bad passphrase, try again for <key path>:
```
The command will stuck to wait the user input, but the timeout will interrupt the command.
### What issues does this PR fix or reference?
fixes https://github.com/devfile/devworkspace-operator/issues/1337 https://github.com/eclipse-che/che/issues/23213

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
see https://github.com/devfile/devworkspace-operator/issues/1337
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
