### PR TITLE
add SSH agent postStart event only if SSH key has a passphrase & experimental features enabled

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -286,7 +286,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			reqLogger.Error(err, "Error retrieving SSH secret")
 		} else if needsSSHAgentPostStartEvent {
 			if err = ssh.AddSshAgentPostStartEvent(&workspace.Spec.Template); err != nil {
-				return r.failWorkspace(workspace, "Failed to add ssh-agent post start event", metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus), nil
+				return r.failWorkspace(workspace, "Failed to add ssh-agent initialization postStart event", metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus), nil
 			}
 		}
 	}

--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -189,7 +189,7 @@ Prerequisites:
 ** The steps below assume the following environment variables are set:
 *** `$SSH_KEY`: path on disk to private key for SSH keypair (e.g. `~/.ssh/id_ed25519`)
 *** `$SSH_PUB_KEY`: path on disk to public key for SSH keypair (e.g. `~/.ssh/id_ed25519.pub`)
-*** `$PASSPHRASE`: SSH keypair passphrase (optional)
+*** `$PASSPHRASE`: SSH keypair passphrase (optional). *Note:* requires setting `config.enableExperimentalFeatures: true` in the DevWorkspaceOperatorConfig.
 *** `$NAMESPACE`: namespace where workspaces using the SSH keypair will be started.
 
 Process:
@@ -225,6 +225,8 @@ you must add the following in your `~/.bashrc`:
 ----
 [ -f $HOME/ssh-environment ] && source $HOME/ssh-environment
 ----
++
+*Note:*  Specifying a passphrase for an SSH key is an experimental feature and is controlled by the DevWorkspaceOperatorConfig's `config.enableExperimentalFeatures` field.
 
 3. Annotate the secret to configure automatic mounting to DevWorkspaces
 +

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -87,6 +87,15 @@ const (
 	// in a given namespace. It is used when e.g. adding Git credentials via secret
 	GitCredentialsConfigMapName = "devworkspace-gitconfig"
 
+	// SSHSecretName is the name used for the secret that stores the SSH key data for workspaces in a given namespace.
+	// TODO: This is a workaround for https://github.com/devfile/devworkspace-operator/issues/1340.
+	// We do not enforce the SSH secret to have this name, but it is used by the Che Dashboard and this allows us
+	// to detect if the user has provided an SSH key with a passhprase.
+	SSHSecretName = "git-ssh-key"
+
+	// SSHSecretPassphraseKey is the key used to retrieve the optional passphrase stored inside the SSH secret.
+	SSHSecretPassphraseKey = "passphrase"
+
 	SshAskPassConfigMapName = "devworkspace-ssh-askpass"
 
 	// GitCredentialsMergedSecretName is the name for the merged Git credentials secret that is mounted to workspaces

--- a/pkg/library/ssh/event.go
+++ b/pkg/library/ssh/event.go
@@ -19,6 +19,10 @@ import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/devfile/devworkspace-operator/pkg/library/lifecycle"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const commandLine = `SSH_ENV_PATH=$HOME/ssh-environment \
@@ -57,4 +61,30 @@ func AddSshAgentPostStartEvent(spec *v1alpha2.DevWorkspaceTemplateSpec) error {
 		spec.Events.PostStart = append(spec.Events.PostStart, commandId)
 	}
 	return err
+}
+
+// Determines whether an SSH key with a passphrase is provided for the namespace where the workspace exists.
+// If an SSH key with a passphrase is used, then the SSH Agent Post Start event is needed for it to automatically
+// be used by the workspace's SSH agent.
+// If no SSH key is provided, or the SSH key does not provide a passphrase, then the SSH Agent Post Start event is not required.
+func NeedsSSHPostStartEvent(api sync.ClusterAPI, namespace string) (bool, error) {
+	secretNN := types.NamespacedName{
+		Name:      constants.SSHSecretName,
+		Namespace: namespace,
+	}
+	sshSecret := &corev1.Secret{}
+	if err := api.Client.Get(api.Ctx, secretNN, sshSecret); err != nil {
+		if k8sErrors.IsNotFound(err) {
+			// No SSH secret found
+			return false, nil
+		}
+		return false, err
+	}
+
+	if _, ok := sshSecret.Data[constants.SSHSecretPassphraseKey]; ok {
+		// SSH secret exists and has a passphrase set
+		return true, nil
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
### What does this PR do?
The SSH agent initialization postStart event is now only injected under the following conditions:
- A secret named `git-ssh-key` exists in the workspace's namespace
- The `git-ssh-key` contains a data key called `passphrase`
- `config.enableExperimentalFeatures: true` is set in an [external](https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#setting-an-alternate-configuration-for-a-workspace) DWOC used by the workspace, or in the global DWOC.

The intention of this PR is to ensure the SSH agent initialization postStart event is only injected if user's opt-in by configuring the DWOC accordingly, and provide a passphrase in their SSH key.

However, this is only a temporary workaround for DWO 0.31.2. After this PR, we should reconsider how this postStart event should be injected. I've mentioned 2 potential ideas in the long-term solution section of https://github.com/devfile/devworkspace-operator/issues/1340

### What issues does this PR fix or reference?
#1340

### Is it tested? How?
First deploy DWO with the changes from this PR.

There are 4 scenarios to test: 
1. Starting a devworkspace with no SSH secret configured, and experimental features disabled in the DWOC. The SSH agent postStart event should not be injected, and this can be observed from the workspace pod's Kubernetes PostStart lifecycle hook.
2. Starting a devworkspace with a passphrase-less SSH secret configured, and experimental features disabled in the DWOC. The SSH agent postStart event should not be injected.
3. Starting a devworkspace with an SSH secret that contains a passphrase and experimental features disabled in the DWOC.  The SSH agent postStart event should not be injected.
4. Starting a devworkspace with an SSH secret that contains a passphrase and **experimental features enabled** in the DWOC. The SSH agent postStart event should be injected.

I recommend testing all 4 scenarios in order.

#### Scenario 1: no SSH secret configured; experimental features disabled
1. Create a devworkspace:

```YAML
cat <<'EOF' | kubectl apply -n $NAMESPACE -f - 
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: plain-devworkspace
spec:
  started: true
  routingClass: 'basic'
  template:
    components:
      - name: web-terminal
        container:
          image: quay.io/wto/web-terminal-tooling:next
          memoryRequest: 256Mi
          memoryLimit: 512Mi
          mountSources: true
          command:
           - "tail"
           - "-f"
           - "/dev/null"
EOF
```

2. Ensure the devworkspace starts up successfully.
3. Verify that the devworkspace's pod does not have the SSH agent command in its PostStart lifecycle hook. The result of  `oc get pod <workspace-pod-name> -n $NAMESPACE -o json | jq '.spec.containers[0].lifecycle.postStart'` should be `null`.
4. You can now delete your devworkspace: `oc delete dw plain-devworkspace -n $NAMESPACE`

#### Scenario 2: SSH secret configured with no passphrase; experimental features disabled
1. [Configure an SSH key](https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#configuring-devworkspaces-to-use-ssh-keys-for-git-operations) in the same namespace that you will create your devworkspace. Make sure you do not set the `$PASSPHRASE` environment variable when creating the SSH secret.
2. Create a devworkspace.
3. Ensure the devworkspace starts up successfully.
5. Verify that the devworkspace's pod does not have the SSH agent command in its PostStart lifecycle hook.
6. You can now delete your devworkspace: `oc delete dw plain-devworkspace -n $NAMESPACE`

#### Scenario 3: SSH secret configured with a passphrase; experimental features disabled
1. Delete your SSH secret from Scenario 2:` oc delete secret git-ssh-key -n $NAMESPACE`
2. [Configure an SSH key](https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#configuring-devworkspaces-to-use-ssh-keys-for-git-operations) in the same namespace that you will create your devworkspace. **Make sure you set the `$PASSPHRASE` environment variable when creating the SSH secret.**
3. Create a devworkspace.
5. Ensure the devworkspace starts up successfully.
7. Verify that the devworkspace's pod does not have the SSH agent command in its PostStart lifecycle hook.
8. You can now delete your devworkspace: `oc delete dw plain-devworkspace -n $NAMESPACE`

#### Scenario 4: SSH secret configured with a passphrase; experimental features enabled
1. After testing Scenario 3, enable experimental features in the DWOC: `oc edit dwoc -n $NAMESPACE`

```diff
kind: DevWorkspaceOperatorConfig
apiVersion: controller.devfile.io/v1alpha1
config:
+  enableExperimentalFeatures: true
  routing:
    clusterHostSuffix: 192.168.49.2.nip.io
    defaultRoutingClass: basic
  workspace:
    imagePullPolicy: Always
```
2. Create a devworkspace
3. Ensure the devworkspace starts up successfully.
4.  Verify that the devworkspace's pod **does have the SSH agent command in its PostStart lifecycle hook:** `oc get pod <workspace-pod-name> -n $NAMESPACE -o json | jq '.spec.containers[0].lifecycle.postStart'`

```json
{
  "exec": {
    "command": [
      "/bin/sh",
      "-c",
      "{\nSSH_ENV_PATH=$HOME/ssh-environment \\\n&& if [ -f /etc/ssh/passphrase ] && command -v ssh-add >/dev/null; \\\nthen ssh-agent | sed 's/^echo/#echo/' > $SSH_ENV_PATH \\\n&& chmod 600 $SSH_ENV_PATH && source $SSH_ENV_PATH \\\n&& ssh-add /etc/ssh/dwo_ssh_key < /etc/ssh/passphrase \\\n&& if [ -f $HOME/.bashrc ] && [ -w $HOME/.bashrc ]; then echo \"source ${SSH_ENV_PATH}\" >> $HOME/.bashrc; fi; fi\n} 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt\n"
    ]
  }
}
```






### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
