### PR TITLE
Mark the injection of the SSH agent postStart event as experimental feature

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -281,9 +281,12 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	workspace.Spec.Template = *flattenedWorkspace
 
-	err = ssh.AddSshAgentPostStartEvent(&workspace.Spec.Template)
-	if err != nil {
-		return r.failWorkspace(workspace, "Failed to add ssh-agent post start event", metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus), nil
+	// Include to experimental features list because it is not clear how to handle post start events in containers without sh.
+	if *workspace.Config.EnableExperimentalFeatures {
+		err = ssh.AddSshAgentPostStartEvent(&workspace.Spec.Template)
+		if err != nil {
+			return r.failWorkspace(workspace, "Failed to add ssh-agent post start event", metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus), nil
+		}
 	}
 
 	reconcileStatus.setConditionTrue(conditions.DevWorkspaceResolved, "Resolved plugins and parents from DevWorkspace")

--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -225,6 +225,7 @@ you must add the following in your `~/.bashrc`:
 ----
 [ -f $HOME/ssh-environment ] && source $HOME/ssh-environment
 ----
+*Note:*  This is an experimental feature and is controlled by the `DevWorkspaceOperatorConfig.EnableExperimentalFeatures` option.
 
 3. Annotate the secret to configure automatic mounting to DevWorkspaces
 +


### PR DESCRIPTION
### What does this PR do?
Wrap the `AddSshAgentPostStartEvent` function into the `EnableExperimentalFeatures` condition. 

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1337

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Create a workspace with a container without sh:
```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: plain-devworkspace
spec:
  routingClass: che
  started: true
  template:
    components:
      - container:
          image: 'quay.io/devfile/universal-developer-image:ubi8-latest'
        name: universal-developer-image
      - container:
          image: 'ghcr.io/l0rd/outyet@sha256:3ab91b5801ab2e2a6147cab5d4a959838d9318921298e84cf7b6d19a3359e496'
        name: test
```
See: workspace starts successfully.
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
