### PR TITLE
Update memory limit to 5Gi

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -405,7 +405,7 @@ spec:
                 resources:
                   limits:
                     cpu: "3"
-                    memory: 3Gi
+                    memory: 5Gi
                   requests:
                     cpu: 250m
                     memory: 100Mi

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -25266,7 +25266,7 @@ spec:
         resources:
           limits:
             cpu: 3000m
-            memory: 3Gi
+            memory: 5Gi
           requests:
             cpu: 250m
             memory: 100Mi

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -92,7 +92,7 @@ spec:
         resources:
           limits:
             cpu: 3000m
-            memory: 3Gi
+            memory: 5Gi
           requests:
             cpu: 250m
             memory: 100Mi

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -25268,7 +25268,7 @@ spec:
         resources:
           limits:
             cpu: 3000m
-            memory: 3Gi
+            memory: 5Gi
           requests:
             cpu: 250m
             memory: 100Mi

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -92,7 +92,7 @@ spec:
         resources:
           limits:
             cpu: 3000m
-            memory: 3Gi
+            memory: 5Gi
           requests:
             cpu: 250m
             memory: 100Mi

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
           resources:
             limits:
               cpu: 3000m
-              memory: 3Gi
+              memory: 5Gi
             requests:
               cpu: 250m
               memory: 100Mi


### PR DESCRIPTION
### What does this PR do?
This PR updates the memory limit of the devworkspace-controller container of the devworkspace-controller-manager-* pod from 3Gi to 5Gi.


### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/1345

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
To test, run:
```
DWO_IMG_REPO=quay.io/<username>/<repo>
DWO_IMG_TAG=<tag>
export DWO_BUNDLE_IMG=${DWO_IMG_REPO}/devworkspace-operator-bundle:${DWO_IMG_TAG}
export DWO_INDEX_IMG=${DWO_IMG_REPO}/devworkspace-operator-index:${DWO_IMG_TAG}
export DOCKER=podman 
make generate_olm_bundle_yaml build_bundle_and_index register_catalogsource
```
And install the operator from OperatorHub.

Verify that the resulting devworkspace-controller-manager-* pod in the openshift-operators namespace has the new  memory limit for the devworkspace-controller container.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
