### PR TITLE
Update images to ubi9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22.7-5 as builder
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.7-1733160835 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /devworkspace-operator
@@ -33,8 +33,8 @@ COPY . .
 RUN make compile-devworkspace-controller
 RUN make compile-webhook-server
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.10-1130
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
+FROM registry.access.redhat.com/ubi9-minimal:9.5-1731593028
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /devworkspace-operator/_output/bin/devworkspace-controller /usr/local/bin/devworkspace-controller

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -368,7 +368,7 @@ spec:
                 - name: WEBHOOKS_SERVER_CPU_REQUEST
                   value: 100m
                 - name: RELATED_IMAGE_pvc_cleanup_job
-                  value: registry.access.redhat.com/ubi8-micro:8.8-1
+                  value: registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
                 - name: RELATED_IMAGE_async_storage_server
                   value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
                 - name: RELATED_IMAGE_async_storage_sidecar
@@ -485,7 +485,7 @@ spec:
     name: kube_rbac_proxy
   - image: quay.io/devfile/project-clone:next
     name: project_clone
-  - image: registry.access.redhat.com/ubi8-micro:8.8-1
+  - image: registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
     name: pvc_cleanup_job
   - image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
     name: async_storage_server

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -25229,7 +25229,7 @@ spec:
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: registry.access.redhat.com/ubi8-micro:8.8-1
+          value: registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: registry.access.redhat.com/ubi8-micro:8.8-1
+          value: registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -25231,7 +25231,7 @@ spec:
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: registry.access.redhat.com/ubi8-micro:8.8-1
+          value: registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: WEBHOOKS_SERVER_CPU_REQUEST
           value: 100m
         - name: RELATED_IMAGE_pvc_cleanup_job
-          value: registry.access.redhat.com/ubi8-micro:8.8-1
+          value: registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
         - name: RELATED_IMAGE_async_storage_server
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -103,7 +103,7 @@ spec:
       name: kube_rbac_proxy
     - image: quay.io/devfile/project-clone:next
       name: project_clone
-    - image: registry.access.redhat.com/ubi8-micro:8.8-1
+    - image: registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
       name: pvc_cleanup_job
     - image: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
       name: async_storage_server

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -85,7 +85,7 @@ spec:
             - name: RELATED_IMAGE_devworkspace_webhook_server
               value: "quay.io/devfile/devworkspace-controller:next"
             - name: RELATED_IMAGE_pvc_cleanup_job
-              value: "registry.access.redhat.com/ubi8-micro:8.8-1"
+              value: "registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338"
             - name: RELATED_IMAGE_async_storage_server
               value: "quay.io/eclipse/che-workspace-data-sync-storage:0.0.1"
             - name: RELATED_IMAGE_async_storage_sidecar

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -14,8 +14,8 @@
 #
 
 # Build the manager binary
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22.7-5 as builder
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.7-1733160835 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /project-clone
@@ -36,8 +36,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
   -asmflags all=-trimpath=/ \
   project-clone/main.go
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.10-1130
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
+FROM registry.access.redhat.com/ubi9-minimal:9.5-1731593028
 RUN microdnf -y update && microdnf install -y time git git-lfs && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/project-clone


### PR DESCRIPTION
### What does this PR do?
Updates ubi8 images to ubi9 images for the conteroller and project-clone images.
Also updates the PVC cleanup pod image to ubi9/ubi-micro.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-7863 & https://github.com/devfile/devworkspace-operator/issues/1356

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Build the DWO image and the project clone image:

```
export DWO_IMG=quay.io/yourrepo/devworkspace-controller:prerelease
export PROJECT_CLONE_IMG=quay.io/yourrepo/project-clone:prerelease
# build and push project clone image
podman build -t "$PROJECT_CLONE_IMG" -f ./project-clone/Dockerfile .
podman push "$PROJECT_CLONE_IMG"
# build and push DevWorkspace Operator image
make docker
# deploy DevWorkspace Operator using these images
make install
```

Successfully follow section 3 from this doc:  https://gist.github.com/amisevsk/1bdfa7b063e4c1a0cb420314a9c14ae6/66213a41c408554cdae23918796525c5db924d06#3-test-devworkspace-flow-in-the-new-version

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
