### PR TITLE
Remove aobuchow from code-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @AObuchow @dkwon17 @ibuziuk
+* @dkwon17 @ibuziuk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,8 +123,8 @@ jobs:
           # PR checks.
           go install golang.org/x/tools/cmd/goimports@v0.24.0
 
-          git config --global user.name "Andrew Obuchowicz"
-          git config --global user.email "aobuchow@redhat.com"
+          git config --global user.name "David Kwon"
+          git config --global user.email "dakwon@redhat.com"
 
           export GITHUB_TOKEN=${{ secrets.CHE_INCUBATOR_BOT_GITHUB_TOKEN }}
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,5 @@
 reviewers:
-  - AObuchow
   - dkwon17
 approvers:
-  - AObuchow
   - dkwon17
 component: DevWorkspace Operator

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -470,8 +470,8 @@ spec:
   - name: Devworkspace Operator
     url: https://github.com/devfile/devworkspace-operator
   maintainers:
-  - email: aobuchow@redhat.com
-    name: Andrew Obuchowicz
+  - email: dakwon@redhat.com
+    name: David Kwon
   - email: ibuziuk@redhat.com
     name: Ilya Buziuk
   maturity: alpha

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -87,8 +87,8 @@ spec:
     - name: Devworkspace Operator
       url: https://github.com/devfile/devworkspace-operator
   maintainers:
-    - email: aobuchow@redhat.com
-      name: Andrew Obuchowicz
+    - email: dakwon@redhat.com
+      name: David Kwon
     - email: ibuziuk@redhat.com
       name: Ilya Buziuk
   maturity: alpha


### PR DESCRIPTION
### What does this PR do?
- Removing myself as a code-owner of this repo & passing the torch to @dkwon17 :)
- Replacing myself with David in the release GH action workflow
- Replacing myself with David as the maintainer of DWO in the clusterserviceversion template (and the resulting generated file)

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
