### PR TITLE
feat: configure securityContext for che-gateway container

### DIFF
--- a/pkg/provision/workspace/routing.go
+++ b/pkg/provision/workspace/routing.go
@@ -56,6 +56,7 @@ func SyncRoutingToCluster(
 		return nil, nil, statusMsg, &dwerrors.RetryError{Message: statusMsg, RequeueAfter: 5 * time.Second}
 	}
 
+	// Configure securityContext for pod additions, for example che-gateway container
 	// https://github.com/eclipse-che/che/issues/22747
 	if clusterRouting.Status.PodAdditions != nil {
 		for i, container := range clusterRouting.Status.PodAdditions.Containers {

--- a/pkg/provision/workspace/routing.go
+++ b/pkg/provision/workspace/routing.go
@@ -58,11 +58,12 @@ func SyncRoutingToCluster(
 
 	// Configure securityContext for pod additions, for example che-gateway container
 	// https://github.com/eclipse-che/che/issues/22747
-	if clusterRouting.Status.PodAdditions != nil {
+	if clusterRouting.Status.PodAdditions != nil &&
+		workspace.Config.Workspace != nil &&
+		workspace.Config.Workspace.ContainerSecurityContext != nil {
+
 		for i, container := range clusterRouting.Status.PodAdditions.Containers {
-			if container.SecurityContext == nil &&
-				workspace.Config.Workspace != nil &&
-				workspace.Config.Workspace.ContainerSecurityContext != nil {
+			if container.SecurityContext == nil {
 				clusterRouting.Status.PodAdditions.Containers[i].SecurityContext = workspace.Config.Workspace.ContainerSecurityContext
 			}
 		}

--- a/pkg/provision/workspace/routing.go
+++ b/pkg/provision/workspace/routing.go
@@ -56,6 +56,17 @@ func SyncRoutingToCluster(
 		return nil, nil, statusMsg, &dwerrors.RetryError{Message: statusMsg, RequeueAfter: 5 * time.Second}
 	}
 
+	// https://github.com/eclipse-che/che/issues/22747
+	if clusterRouting.Status.PodAdditions != nil {
+		for i, container := range clusterRouting.Status.PodAdditions.Containers {
+			if container.SecurityContext == nil &&
+				workspace.Config.Workspace != nil &&
+				workspace.Config.Workspace.ContainerSecurityContext != nil {
+				clusterRouting.Status.PodAdditions.Containers[i].SecurityContext = workspace.Config.Workspace.ContainerSecurityContext
+			}
+		}
+	}
+
 	return clusterRouting.Status.PodAdditions, clusterRouting.Status.ExposedEndpoints, statusMsg, nil
 }
 


### PR DESCRIPTION
### What does this PR do?
feat: configure securityContext for che-gateway container

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/22747

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Configure CheCluster 
```yaml
spec:
  devEnvironments:
    security:
      containerSecurityContext:
        <...>
```

2. Start a workspace
3. Check security context in the gateway container

### PR Checklist

- [x] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [x] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [x] `v8-che-happy-path`: Happy path for verification integration with Che
