### PR TITLE
Add nc to project clone image

### DIFF
--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -38,7 +38,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1731593028
-RUN microdnf -y update && microdnf install -y time git git-lfs && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
+RUN microdnf -y update && microdnf install -y time git git-lfs nc && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/project-clone
 


### PR DESCRIPTION
### What does this PR do?
Adds `nc` to the project clone image.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-7860

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Build the project clone image:
```
export PROJECT_CLONE_IMG=quay.io/yourrepo/project-clone:prerelease
# build and push project clone image
podman build -t "$PROJECT_CLONE_IMG" -f ./project-clone/Dockerfile .
```

And verify that the nc tool runs exists, for example:
```
$ podman run -it --rm quay.io/dkwon17/project-clone:prerelease nc --version
Ncat: Version 7.92 ( https://nmap.org/ncat )
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
