### PR TITLE
Add installation guides

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,10 @@
+# Installation Guide for DevWorkspace Operator
+
+- **Kind**
+  - [Installation on Kind Without OLM (Linux)](installation/kind-without-olm-linux.md)
+  - [Installation on Kind Without OLM (MacOs)](installation/kind-without-olm-macos.md)
+- **Minikube**
+  - [Installation on Minikube Without OLM](installation/minikube-without-olm.md)
+- **OpenShift**
+  - [Installation on OpenShift With OLM](installation/openshift-with-olm.md)
+  - [Installation on OpenShift Without OLM](installation/openshift-without-olm.md)

--- a/docs/installation/kind-without-olm-linux.md
+++ b/docs/installation/kind-without-olm-linux.md
@@ -180,3 +180,10 @@ You can also check the DevWorkspace status by running:
 ```sh
 kubectl get devworkspace -n default
 ```
+
+When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
+
+```
+NAME                            DEVWORKSPACE ID             PHASE     INFO
+git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
+```

--- a/docs/installation/kind-without-olm-linux.md
+++ b/docs/installation/kind-without-olm-linux.md
@@ -1,0 +1,182 @@
+# Installation on Kind Without OLM (Linux)
+
+## Prerequisites
+
+Before you begin, ensure you have the following tools installed:
+
+*   **kubectl:** The Kubernetes command-line tool.
+*   **kind:** A tool for running Kubernetes locally using Docker.
+*   **Docker** (as a container runtime)
+
+## Steps
+
+### 1. Create Kind Cluster with Extra Port Mappings
+
+Create a Kind cluster with port mappings for HTTP and HTTPS traffic:
+
+```sh
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
+```
+
+### 2. Install NGINX Ingress Controller
+
+Install the NGINX ingress controller:
+
+```sh
+kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+```
+
+Wait until the NGINX ingress controller pods are ready:
+
+```sh
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=90s
+```
+
+Redeploy the `ingress-nginx-controller` service to change its type from `LoadBalancer` to `NodePort`:
+
+```sh
+kubectl delete service ingress-nginx-controller -n ingress-nginx
+```
+
+```sh
+kubectl expose deployment ingress-nginx-controller --name=ingress-nginx-controller --port=80 --type=NodePort -n ingress-nginx
+```
+
+### 3. Create Namespace
+
+Create a dedicated namespace for the DevWorkspace Controller:
+
+```sh
+kubectl create namespace devworkspace-controller
+```
+
+### 4. Install cert-manager
+
+Install cert-manager using the provided manifest:
+
+```sh
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.4/cert-manager.yaml
+```
+
+Wait until cert-manager pods are ready:
+
+```sh
+kubectl wait --namespace cert-manager \
+      --timeout 90s \
+      --for=condition=ready pod \
+      --selector=app.kubernetes.io/instance=cert-manager
+```
+
+### 5. Install the DevWorkspace Operator
+
+Install the DevWorkspace Operator from the given URL:
+
+```sh
+kubectl apply -f https://github.com/devfile/devworkspace-operator/raw/refs/tags/v0.31.2/deploy/deployment/kubernetes/combined.yaml
+```
+
+Wait until the DevWorkspace Operator pods are ready:
+
+```sh
+kubectl wait --namespace devworkspace-controller \
+      --timeout 90s \
+      --for=condition=ready pod \
+      --selector=app.kubernetes.io/part-of=devworkspace-operator
+```
+
+### 6. Create the DevWorkspace Operator Config
+
+#### 6.1 Get Kind Node IP
+
+Get the internal IP address of your Kind control-plane node:
+
+```sh
+kubectl get node -o wide
+```
+Look for the `INTERNAL-IP` of the `kind-control-plane` node. Let's denote this as `<HOST_IP>`. You will use this IP in the next step.
+
+#### 6.2 Create the DevWorkspaceOperatorConfig
+
+Create the `DevWorkspaceOperatorConfig` resource, replacing `<HOST_IP>` with the IP you obtained in the previous step:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: controller.devfile.io/v1alpha1
+kind: DevWorkspaceOperatorConfig
+metadata:
+  name: devworkspace-operator-config
+  namespace: devworkspace-controller
+config:
+  routing:
+    clusterHostSuffix: "<HOST_IP>.nip.io"
+EOF
+```
+
+### 7. Create a Sample DevWorkspace
+
+Create a sample DevWorkspace:
+
+```bash
+kubectl apply -f - <<EOF
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: git-clone-sample-devworkspace
+spec:
+  started: true
+  template:
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+      - name: devworkspace-operator
+        git:
+          checkoutFrom:
+            remote: origin
+            revision: 0.21.x
+          remotes:
+            origin: "https://github.com/devfile/devworkspace-operator.git"
+            amisevsk: "https://github.com/amisevsk/devworkspace-operator.git"
+    commands:
+      - id: say-hello
+        exec:
+          component: che-code-runtime-description
+          commandLine: echo "Hello from $(pwd)"
+          workingDir: ${PROJECT_SOURCE}/app
+  contributions:
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+      components:
+        - name: che-code-runtime-description
+          container:
+            env:
+              - name: CODE_HOST
+                value: 0.0.0.0
+EOF
+```
+
+**Note:** The DevWorkspace creation may fail due to timeout if some container images are large and take longer than 5 minutes to pull. If the DevWorkspace fails, you can restart it by setting `spec.started` to `true`. Use the following command to re-trigger the DevWorkspace start:
+
+```bash
+kubectl patch devworkspace git-clone-sample-devworkspace -n default --type merge -p '{"spec": {"started": true}}'
+```
+You can also check the DevWorkspace status by running:
+```sh
+kubectl get devworkspace -n default
+```

--- a/docs/installation/kind-without-olm-linux.md
+++ b/docs/installation/kind-without-olm-linux.md
@@ -4,9 +4,9 @@
 
 Before you begin, ensure you have the following tools installed:
 
-*   **kubectl:** The Kubernetes command-line tool.
-*   **kind:** A tool for running Kubernetes locally using Docker.
-*   **Docker** (as a container runtime)
+* **kubectl:** The Kubernetes command-line tool.
+* **kind:** A tool for running Kubernetes locally using Docker.
+* **Docker** (as a container runtime)
 
 ## Steps
 
@@ -108,6 +108,7 @@ Get the internal IP address of your Kind control-plane node:
 ```sh
 kubectl get node -o wide
 ```
+
 Look for the `INTERNAL-IP` of the `kind-control-plane` node. Let's denote this as `<HOST_IP>`. You will use this IP in the next step.
 
 #### 6.2 Create the DevWorkspaceOperatorConfig
@@ -176,14 +177,16 @@ EOF
 ```bash
 kubectl patch devworkspace git-clone-sample-devworkspace -n default --type merge -p '{"spec": {"started": true}}'
 ```
+
 You can also check the DevWorkspace status by running:
+
 ```sh
 kubectl get devworkspace -n default
 ```
 
 When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
 
-```
+```sh
 NAME                            DEVWORKSPACE ID             PHASE     INFO
 git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
 ```

--- a/docs/installation/kind-without-olm-macos.md
+++ b/docs/installation/kind-without-olm-macos.md
@@ -1,0 +1,220 @@
+# Installation on Kind Without OLM (MacOs)
+
+## Prerequisites
+
+Before you begin, ensure you have the following tools installed:
+
+*   **kubectl:** The Kubernetes command-line tool.
+*   **kind:** A tool for running Kubernetes locally using Docker.
+*   **OrbStack** (as a container runtime)
+
+## Steps
+
+### 1. Create Kind Cluster
+
+Create a Kind cluster:
+
+```sh
+kind create cluster
+```
+
+### 2. Install MetalLB
+
+Install MetalLB using the provided manifest:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.9/config/manifests/metallb-native.yaml
+```
+
+Wait until the MetalLB pods are ready:
+
+```sh
+kubectl wait --namespace metallb-system \
+  --for=condition=ready pod \
+  --selector=app=metallb \
+  --timeout=90s
+```
+
+### 3. Define MetalLB IP Address Pool
+
+Inspect the Docker network to find the subnet range:
+
+```sh
+docker network inspect kind
+```
+
+In the output, look for the `Subnet` entry (e.g., `"Subnet": "192.168.97.0/24"`). Then, define an IP address pool using a range within that subnet.
+
+**Note:** The Subnet will be different on your host, please use your own Subnet!
+For example if you have `"Subnet": "192.168.97.0/24"`, then it could be `192.168.97.100-192.168.97.110`.
+
+Apply the IP address pool and L2 advertisement:
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: ip-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.97.100-192.168.97.110
+EOF
+```
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - ip-pool
+EOF
+```
+
+### 4. Install NGINX Ingress Controller
+
+Install the NGINX ingress controller:
+
+```sh
+kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+```
+
+Wait until the NGINX ingress controller pods are ready:
+
+```sh
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=90s
+```
+
+### 5. Create Namespace
+
+Create a dedicated namespace for the DevWorkspace Controller:
+
+```sh
+kubectl create namespace devworkspace-controller
+```
+
+### 6. Install cert-manager
+
+Install cert-manager using the provided manifest:
+
+```sh
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.4/cert-manager.yaml
+```
+
+Wait until cert-manager pods are ready:
+
+```sh
+kubectl wait --namespace cert-manager \
+      --timeout 90s \
+      --for=condition=ready pod \
+      --selector=app.kubernetes.io/instance=cert-manager
+```
+
+### 7. Install the DevWorkspace Operator
+
+Install the DevWorkspace Operator from the given URL:
+
+```sh
+kubectl apply -f https://github.com/devfile/devworkspace-operator/raw/refs/tags/v0.31.2/deploy/deployment/kubernetes/combined.yaml
+```
+
+Wait until the DevWorkspace Operator pods are ready:
+
+```sh
+kubectl wait --namespace devworkspace-controller \
+      --timeout 90s \
+      --for=condition=ready pod \
+      --selector=app.kubernetes.io/part-of=devworkspace-operator
+```
+
+### 8. Create the DevWorkspace Operator Config
+
+#### 8.1 Get Load Balancer IP
+Get the Load Balancer IP from the `ingress-nginx` service:
+
+```sh
+kubectl get services \
+   --namespace ingress-nginx \
+   ingress-nginx-controller \
+   --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+Let's denote this value as `<HOST_IP>`.
+
+#### 8.2 Create the DevWorkspaceOperatorConfig
+
+Create the `DevWorkspaceOperatorConfig` resource, replacing `<HOST_IP>` with the IP you obtained in the previous step:
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: controller.devfile.io/v1alpha1
+kind: DevWorkspaceOperatorConfig
+metadata:
+  name: devworkspace-operator-config
+  namespace: devworkspace-controller
+config:
+  routing:
+    clusterHostSuffix: "<HOST_IP>.nip.io"
+EOF
+```
+
+### 9. Create a Sample DevWorkspace
+
+Create a sample DevWorkspace:
+
+```sh
+kubectl apply -f - <<EOF
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: git-clone-sample-devworkspace
+spec:
+  started: true
+  template:
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+      - name: devworkspace-operator
+        git:
+          checkoutFrom:
+            remote: origin
+            revision: 0.21.x
+          remotes:
+            origin: "https://github.com/devfile/devworkspace-operator.git"
+            amisevsk: "https://github.com/amisevsk/devworkspace-operator.git"
+    commands:
+      - id: say-hello
+        exec:
+          component: che-code-runtime-description
+          commandLine: echo "Hello from $(pwd)"
+          workingDir: ${PROJECT_SOURCE}/app
+  contributions:
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+      components:
+        - name: che-code-runtime-description
+          container:
+            env:
+              - name: CODE_HOST
+                value: 0.0.0.0
+EOF
+```
+
+**Note:** The DevWorkspace start may fail due to timeout if some container images are large and take longer than 5 minutes to pull. If the DevWorkspace fails, you can restart it by setting `spec.started` to `true`. Use the following command to re-trigger the DevWorkspace start:
+
+```bash
+kubectl patch devworkspace git-clone-sample-devworkspace -n default --type merge -p '{"spec": {"started": true}}'
+```
+You can also check the DevWorkspace status by running:
+```sh
+kubectl get devworkspace -n default
+```

--- a/docs/installation/kind-without-olm-macos.md
+++ b/docs/installation/kind-without-olm-macos.md
@@ -4,9 +4,9 @@
 
 Before you begin, ensure you have the following tools installed:
 
-*   **kubectl:** The Kubernetes command-line tool.
-*   **kind:** A tool for running Kubernetes locally using Docker.
-*   **OrbStack** (as a container runtime)
+* **kubectl:** The Kubernetes command-line tool.
+* **kind:** A tool for running Kubernetes locally using Docker.
+* **OrbStack** (as a container runtime)
 
 ## Steps
 
@@ -138,6 +138,7 @@ kubectl wait --namespace devworkspace-controller \
 ### 8. Create the DevWorkspace Operator Config
 
 #### 8.1 Get Load Balancer IP
+
 Get the Load Balancer IP from the `ingress-nginx` service:
 
 ```sh
@@ -146,6 +147,7 @@ kubectl get services \
    ingress-nginx-controller \
    --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ```
+
 Let's denote this value as `<HOST_IP>`.
 
 #### 8.2 Create the DevWorkspaceOperatorConfig
@@ -214,14 +216,16 @@ EOF
 ```bash
 kubectl patch devworkspace git-clone-sample-devworkspace -n default --type merge -p '{"spec": {"started": true}}'
 ```
+
 You can also check the DevWorkspace status by running:
+
 ```sh
 kubectl get devworkspace -n default
 ```
 
 When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
 
-```
+```sh
 NAME                            DEVWORKSPACE ID             PHASE     INFO
 git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
 ```

--- a/docs/installation/kind-without-olm-macos.md
+++ b/docs/installation/kind-without-olm-macos.md
@@ -218,3 +218,10 @@ You can also check the DevWorkspace status by running:
 ```sh
 kubectl get devworkspace -n default
 ```
+
+When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
+
+```
+NAME                            DEVWORKSPACE ID             PHASE     INFO
+git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
+```

--- a/docs/installation/minikube-without-olm.md
+++ b/docs/installation/minikube-without-olm.md
@@ -149,3 +149,10 @@ You can also check the DevWorkspace status by running:
 ```sh
 kubectl get devworkspace -n default
 ```
+
+When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
+
+```
+NAME                            DEVWORKSPACE ID             PHASE     INFO
+git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
+```

--- a/docs/installation/minikube-without-olm.md
+++ b/docs/installation/minikube-without-olm.md
@@ -4,8 +4,8 @@
 
 Before you begin, ensure you have the following tools installed:
 
-*   **kubectl:** The Kubernetes command-line tool.
-*   **minikube:** A tool for running Kubernetes locally.
+* **kubectl:** The Kubernetes command-line tool.
+* **minikube:** A tool for running Kubernetes locally.
 
 ## Steps
 
@@ -152,7 +152,7 @@ kubectl get devworkspace -n default
 
 When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
 
-```
+```sh
 NAME                            DEVWORKSPACE ID             PHASE     INFO
 git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
 ```

--- a/docs/installation/openshift-with-olm.md
+++ b/docs/installation/openshift-with-olm.md
@@ -125,3 +125,10 @@ You can also check the DevWorkspace status by running:
 ```sh
 oc get devworkspace -n devworkspace-samples
 ```
+
+When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
+
+```
+NAME                            DEVWORKSPACE ID             PHASE     INFO
+git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
+```

--- a/docs/installation/openshift-with-olm.md
+++ b/docs/installation/openshift-with-olm.md
@@ -4,8 +4,8 @@
 
 Before you begin, ensure you have the following tools installed:
 
-*   **oc:** The OpenShift command-line tool.
-*   Access to an OpenShift cluster.
+* **oc:** The OpenShift command-line tool.
+* Access to an OpenShift cluster.
 
 ## Steps
 
@@ -122,13 +122,14 @@ oc patch devworkspace git-clone-sample-devworkspace -n devworkspace-samples --ty
 ```
 
 You can also check the DevWorkspace status by running:
+
 ```sh
 oc get devworkspace -n devworkspace-samples
 ```
 
 When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
 
-```
+```sh
 NAME                            DEVWORKSPACE ID             PHASE     INFO
 git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
 ```

--- a/docs/installation/openshift-with-olm.md
+++ b/docs/installation/openshift-with-olm.md
@@ -1,0 +1,127 @@
+# Installation on OpenShift With OLM
+
+## Prerequisites
+
+Before you begin, ensure you have the following tools installed:
+
+*   **oc:** The OpenShift command-line tool.
+*   Access to an OpenShift cluster.
+
+## Steps
+
+### 1. Add the DevWorkspace Operator CatalogSource
+
+Add the DevWorkspace Operator `CatalogSource` to the `openshift-marketplace` namespace:
+
+```sh
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: devworkspace-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/devfile/devworkspace-operator-index:next
+  publisher: Red Hat
+  displayName: DevWorkspace Operator Catalog
+  updateStrategy:
+    registryPoll:
+      interval: 5m
+EOF
+```
+
+### 2. Create the DevWorkspace Operator Subscription
+
+Create the DevWorkspace Operator `Subscription` in the `openshift-operators` namespace:
+
+```sh
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: devworkspace-operator
+  namespace: openshift-operators
+spec:
+  channel: next
+  installPlanApproval: Automatic
+  name: devworkspace-operator
+  source: devworkspace-operator-catalog
+  sourceNamespace: openshift-marketplace
+EOF
+```
+
+### 3. Wait for Operator to be Ready
+
+Wait until the DevWorkspace Operator pods are ready:
+
+```sh
+oc wait --namespace openshift-operators \
+      --timeout 90s \
+      --for=condition=ready pod \
+      --selector=app.kubernetes.io/part-of=devworkspace-operator
+```
+
+### 4. Create DevWorkspaces Namespace
+
+Create a namespace for the DevWorkspace sample:
+
+```sh
+oc create namespace devworkspace-samples
+```
+
+### 5. Create a Sample DevWorkspace
+
+Create a sample DevWorkspace in the `devworkspace-samples` namespace:
+
+```sh
+oc apply -f - <<EOF
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: git-clone-sample-devworkspace
+  namespace: devworkspace-samples
+spec:
+  started: true
+  template:
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+      - name: devworkspace-operator
+        git:
+          checkoutFrom:
+            remote: origin
+            revision: 0.21.x
+          remotes:
+            origin: "https://github.com/devfile/devworkspace-operator.git"
+            amisevsk: "https://github.com/amisevsk/devworkspace-operator.git"
+    commands:
+      - id: say-hello
+        exec:
+          component: che-code-runtime-description
+          commandLine: echo "Hello from $(pwd)"
+          workingDir: ${PROJECT_SOURCE}/app
+  contributions:
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+      components:
+        - name: che-code-runtime-description
+          container:
+            env:
+              - name: CODE_HOST
+                value: 0.0.0.0
+EOF
+```
+
+**Note:** The DevWorkspace creation may fail due to timeout if some container images are large and take longer than 5 minutes to pull. If the DevWorkspace fails, you can restart it by setting `spec.started` to `true`. Use the following command to re-trigger the DevWorkspace start:
+
+```sh
+oc patch devworkspace git-clone-sample-devworkspace -n devworkspace-samples --type merge -p '{"spec": {"started": true}}'
+```
+
+You can also check the DevWorkspace status by running:
+```sh
+oc get devworkspace -n devworkspace-samples
+```

--- a/docs/installation/openshift-without-olm.md
+++ b/docs/installation/openshift-without-olm.md
@@ -97,3 +97,10 @@ You can also check the DevWorkspace status by running:
 ```sh
 oc get devworkspace -n devworkspace-samples
 ```
+
+When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
+
+```
+NAME                            DEVWORKSPACE ID             PHASE     INFO
+git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
+```

--- a/docs/installation/openshift-without-olm.md
+++ b/docs/installation/openshift-without-olm.md
@@ -4,8 +4,8 @@
 
 Before you begin, ensure you have the following tools installed:
 
-*   **oc:** The OpenShift command-line tool.
-*   Access to an OpenShift cluster.
+* **oc:** The OpenShift command-line tool.
+* Access to an OpenShift cluster.
 
 ## Steps
 
@@ -41,7 +41,6 @@ Create a namespace for the DevWorkspace sample:
 ```sh
 oc create namespace devworkspace-samples
 ```
-
 
 ### 4. Create a Sample DevWorkspace
 
@@ -93,14 +92,16 @@ EOF
 ```sh
 oc patch devworkspace git-clone-sample-devworkspace -n devworkspace-samples --type merge -p '{"spec": {"started": true}}'
 ```
+
 You can also check the DevWorkspace status by running:
+
 ```sh
 oc get devworkspace -n devworkspace-samples
 ```
 
 When the DevWorkspace is running according to the status, open the editor by accesssing the URL from the `INFO` column in a web browser. For example:
 
-```
+```sh
 NAME                            DEVWORKSPACE ID             PHASE     INFO
 git-clone-sample-devworkspace   workspace0196ce197f0b4e90   Running   <URL>
 ```

--- a/docs/installation/openshift-without-olm.md
+++ b/docs/installation/openshift-without-olm.md
@@ -1,0 +1,99 @@
+# Installation on OpenShift Without OLM
+
+## Prerequisites
+
+Before you begin, ensure you have the following tools installed:
+
+*   **oc:** The OpenShift command-line tool.
+*   Access to an OpenShift cluster.
+
+## Steps
+
+### 1. Create Namespace for Operator
+
+Create a dedicated namespace for the DevWorkspace Controller:
+
+```sh
+oc create namespace devworkspace-controller
+```
+
+### 2. Install the DevWorkspace Operator
+
+Install the DevWorkspace Operator using the OpenShift-specific bundle:
+
+```sh
+oc apply -f https://raw.githubusercontent.com/devfile/devworkspace-operator/refs/heads/main/deploy/deployment/openshift/combined.yaml
+```
+
+Wait until the DevWorkspace Operator pods are ready:
+
+```sh
+oc wait --namespace devworkspace-controller \
+    --timeout 90s \
+    --for=condition=ready pod \
+    --selector=app.kubernetes.io/part-of=devworkspace-operator
+```
+
+### 3. Create DevWorkspaces Namespace
+
+Create a namespace for the DevWorkspace sample:
+
+```sh
+oc create namespace devworkspace-samples
+```
+
+
+### 4. Create a Sample DevWorkspace
+
+Create a sample DevWorkspace in the `devworkspace-samples` namespace:
+
+```sh
+oc apply -f - <<EOF
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: git-clone-sample-devworkspace
+  namespace: devworkspace-samples
+spec:
+  started: true
+  template:
+    projects:
+      - name: web-nodejs-sample
+        git:
+          remotes:
+            origin: "https://github.com/che-samples/web-nodejs-sample.git"
+      - name: devworkspace-operator
+        git:
+          checkoutFrom:
+            remote: origin
+            revision: 0.21.x
+          remotes:
+            origin: "https://github.com/devfile/devworkspace-operator.git"
+            amisevsk: "https://github.com/amisevsk/devworkspace-operator.git"
+    commands:
+      - id: say-hello
+        exec:
+          component: che-code-runtime-description
+          commandLine: echo "Hello from $(pwd)"
+          workingDir: ${PROJECT_SOURCE}/app
+  contributions:
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+      components:
+        - name: che-code-runtime-description
+          container:
+            env:
+              - name: CODE_HOST
+                value: 0.0.0.0
+EOF
+```
+
+**Note:** The DevWorkspace creation may fail due to timeout if some container images are large and take longer than 5 minutes to pull. If the DevWorkspace fails, you can restart it by setting `spec.started` to `true`. Use the following command to re-trigger the DevWorkspace start:
+
+```sh
+oc patch devworkspace git-clone-sample-devworkspace -n devworkspace-samples --type merge -p '{"spec": {"started": true}}'
+```
+You can also check the DevWorkspace status by running:
+```sh
+oc get devworkspace -n devworkspace-samples
+```


### PR DESCRIPTION
### What does this PR do?

This PR adds installation guides for installing the DWO on Kind, minikube, and Openshift.

### What issues does this PR fix or reference?

resolves https://github.com/devfile/devworkspace-operator/issues/1335

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
n/a

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
