### PR TITLE
Set up gitconfig extra properties from the specified secret

### DIFF
--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -93,6 +93,18 @@ const (
 	// to detect if the user has provided an SSH key with a passhprase.
 	SSHSecretName = "git-ssh-key"
 
+	// DevWorkspaceGitconfigExtraPropertiesSecretName is the name of the secret that is used to define custom gitconfig
+	// properties that will be mounted to the /etc/gitconfig file. The secret's data map is parsed as a key value structure,
+	// where each key is a gitconfig section, and value is a property definition. For example, secret's data map is set to
+	// key:"http", value:"extraHeader = Basic token-content", so the gitconfig file will include next content:
+	// [http]
+	//     extraHeader = Basic token-content
+	// The 'git config list' command will reveal the property as: http.extraheader=Basic token-content.
+	// The secret's data map key must not contain any special characters and whitespaces, and the value must match the
+	// format: <property> = <value>, otherwise the custom property will be ignored.
+	// Multiple properties per section are supported, each property set must start from the new line in this case.
+	DevWorkspaceGitconfigExtraPropertiesSecretName = "devworkspace-gitconfig-extra-properties"
+
 	// SSHSecretPassphraseKey is the key used to retrieve the optional passphrase stored inside the SSH secret.
 	SSHSecretPassphraseKey = "passphrase"
 


### PR DESCRIPTION
### What does this PR do?
Add a way to setup extra properties to the dev-container's system scope gitconfig file (`etc/gitconfig`).

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23306

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Add a secret to the user namespace with the next content:
```yaml
kind: Secret
apiVersion: v1
metadata:
  name: devworkspace-gitconfig-extra-properties
  labels:
    controller.devfile.io/mount-to-devworkspace: 'true'
    controller.devfile.io/watch-secret: 'true'
stringData:
  http: extraHeader = some-value
type: Opaque
```
2. Start a dev-workspace and `cat` the `etc/gitconfig` file.

See: the gitconfig file contains the `extraHeader` property:
```
...
[http]
	extraHeader = some-value
```
run `git config --list` and see:
```
...
http.extraheader=some-value
```
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
