### PR TITLE
fix: auto-mount path collisions

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -371,7 +371,9 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Add automount resources into devfile containers
-	err = automount.ProvisionAutoMountResourcesInto(devfilePodAdditions, clusterAPI, workspace.Namespace, home.PersistUserHomeEnabled(workspace))
+	if err := automount.ProvisionAutoMountResourcesInto(devfilePodAdditions, clusterAPI, workspace.Namespace, home.PersistUserHomeEnabled(workspace)); err != nil {
+		return r.failWorkspace(workspace, fmt.Sprintf("Failed to mount automount resources to workspace: %s", err), metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus), nil
+	}
 	if shouldReturn, reconcileResult, reconcileErr := r.checkDWError(workspace, err, "Failed to process automount resources", metrics.ReasonBadRequest, reqLogger, &reconcileStatus); shouldReturn {
 		return reconcileResult, reconcileErr
 	}

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -371,9 +371,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Add automount resources into devfile containers
-	if err := automount.ProvisionAutoMountResourcesInto(devfilePodAdditions, clusterAPI, workspace.Namespace, home.PersistUserHomeEnabled(workspace)); err != nil {
-		return r.failWorkspace(workspace, fmt.Sprintf("Failed to mount automount resources to workspace: %s", err), metrics.ReasonWorkspaceEngineFailure, reqLogger, &reconcileStatus), nil
-	}
+	err = automount.ProvisionAutoMountResourcesInto(devfilePodAdditions, clusterAPI, workspace.Namespace, home.PersistUserHomeEnabled(workspace))
 	if shouldReturn, reconcileResult, reconcileErr := r.checkDWError(workspace, err, "Failed to process automount resources", metrics.ReasonBadRequest, reqLogger, &reconcileStatus); shouldReturn {
 		return reconcileResult, reconcileErr
 	}

--- a/pkg/provision/automount/projected.go
+++ b/pkg/provision/automount/projected.go
@@ -55,6 +55,7 @@ func mergeProjectedVolumes(resources *Resources) (*Resources, error) {
 	}
 
 	// Map of merged volume names -> bool, for not merging the same volume twice
+	// This can happen due to different subpath volume mounts, where the mount path is the same. In this case, there should be only one volume.
 	mergedVolumeNames := map[string]bool{}
 	for _, mountPath := range mountPathOrder {
 		volumeMounts := mountPathToVolumeMounts[mountPath]

--- a/pkg/provision/automount/projected.go
+++ b/pkg/provision/automount/projected.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/dwerrors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 )
@@ -164,7 +165,9 @@ func checkCanUseProjectedVolumes(volumeMounts []corev1.VolumeMount, volumeNameTo
 		for _, vm := range volumeMounts {
 			problemNames = append(problemNames, formatVolumeDescription(volumeNameToVolume[vm.Name]))
 		}
-		return fmt.Errorf("auto-mounted volumes from (%s) have the same mount path", strings.Join(problemNames, ", "))
+		return &dwerrors.FailError{
+			Message: fmt.Sprintf("auto-mounted volumes from (%s) have the same mount path", strings.Join(problemNames, ", ")),
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR makes DWO handle auto-mount path collisions and fails the workspace with the error message.


### What issues does this PR fix or reference?

fixes https://github.com/devfile/devworkspace-operator/issues/1194

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
