### PR TITLE
Update Go in e2e test Dockerfile to Go 1.22

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.20
+FROM registry.ci.openshift.org/openshift/release:golang-1.22
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
### What does this PR do?
Updates Go to v1.22 in the e2e test dockerfile. This PR is based on what was done previously for v1.20: https://github.com/devfile/devworkspace-operator/pull/1209.

### What issues does this PR fix or reference?
Fix e2e test check for https://github.com/devfile/devworkspace-operator/pull/1369

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
