### PR TITLE
Add gettext

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -20,7 +20,7 @@ SHELL ["/bin/bash", "-c"]
 # Temporary workaround since mirror.centos.org is down and can be replaced with vault.centos.org
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-RUN yum install --assumeyes -d1 python3-pip nodejs && \
+RUN yum install --assumeyes -d1 python3-pip nodejs gettext && \
     pip3 install --upgrade pip && \
     pip3 install --upgrade setuptools && \
     # Install yq


### PR DESCRIPTION
### What does this PR do?
Installs `gettext` so that `envsubst` is available in the e2e test image.

### What issues does this PR fix or reference?

Fixes error in the e2e tests:
```
ERROR: Program envsubst is required for this script
```
https://github.com/devfile/devworkspace-operator/pull/1369#issuecomment-2670383916

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
