### PR TITLE
Update kube-rbac-proxy image to quay.io/brancz/kube-rbac-proxy:v0.13.1 

### DIFF
--- a/build/scripts/generate_deployment.sh
+++ b/build/scripts/generate_deployment.sh
@@ -177,7 +177,7 @@ fi
 
 # Run kustomize to build yamls
 echo "Generating config for Kubernetes"
-export RBAC_PROXY_IMAGE="${KUBE_RBAC_PROXY_IMAGE:-gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1}"
+export RBAC_PROXY_IMAGE="${KUBE_RBAC_PROXY_IMAGE:-quay.io/brancz/kube-rbac-proxy:v0.13.1}"
 ${KUSTOMIZE} build "${DEPLOY_DIR}/templates/cert-manager" \
   | envsubst "$SUBST_VARS" \
   > "${KUBERNETES_DIR}/${COMBINED_FILENAME}"
@@ -185,7 +185,7 @@ unset RBAC_PROXY_IMAGE
 echo "File saved to ${KUBERNETES_DIR}/${COMBINED_FILENAME}"
 
 echo "Generating config for OpenShift"
-export RBAC_PROXY_IMAGE="${OPENSHIFT_RBAC_PROXY_IMAGE:-gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1}"
+export RBAC_PROXY_IMAGE="${OPENSHIFT_RBAC_PROXY_IMAGE:-quay.io/brancz/kube-rbac-proxy:v0.13.1}"
 ${KUSTOMIZE} build "${DEPLOY_DIR}/templates/service-ca" \
   | envsubst "$SUBST_VARS" \
   > "${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
@@ -194,7 +194,7 @@ echo "File saved to ${OPENSHIFT_DIR}/${COMBINED_FILENAME}"
 
 if $GEN_OLM; then
   echo "Generating base deployment files for OLM"
-  export RBAC_PROXY_IMAGE="${OPENSHIFT_RBAC_PROXY_IMAGE:-gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1}"
+  export RBAC_PROXY_IMAGE="${OPENSHIFT_RBAC_PROXY_IMAGE:-quay.io/brancz/kube-rbac-proxy:v0.13.1}"
   export NAMESPACE=openshift-operators
   # Generate .spec.relatedImages for CSV based on deployment
   TMPCSV="csv.tmp.yaml"

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -340,7 +340,7 @@ spec:
                 - name: RELATED_IMAGE_devworkspace_webhook_server
                   value: quay.io/devfile/devworkspace-controller:next
                 - name: RELATED_IMAGE_kube_rbac_proxy
-                  value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+                  value: quay.io/brancz/kube-rbac-proxy:v0.13.1
                 - name: RELATED_IMAGE_project_clone
                   value: quay.io/devfile/project-clone:next
                 - name: WATCH_NAMESPACE
@@ -414,7 +414,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+                image: quay.io/brancz/kube-rbac-proxy:v0.13.1
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -481,7 +481,7 @@ spec:
   relatedImages:
   - image: quay.io/devfile/devworkspace-controller:next
     name: devworkspace_webhook_server
-  - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+  - image: quay.io/brancz/kube-rbac-proxy:v0.13.1
     name: kube_rbac_proxy
   - image: quay.io/devfile/project-clone:next
     name: project_clone

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -25313,7 +25313,7 @@ spec:
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
         - name: RELATED_IMAGE_kube_rbac_proxy
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
           value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
@@ -25389,7 +25389,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
         - name: RELATED_IMAGE_kube_rbac_proxy
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
           value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
@@ -105,7 +105,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -25315,7 +25315,7 @@ spec:
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
         - name: RELATED_IMAGE_kube_rbac_proxy
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
           value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
@@ -25391,7 +25391,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: RELATED_IMAGE_devworkspace_webhook_server
           value: quay.io/devfile/devworkspace-controller:next
         - name: RELATED_IMAGE_kube_rbac_proxy
-          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_project_clone
           value: quay.io/devfile/project-clone:next
         - name: WATCH_NAMESPACE
@@ -105,7 +105,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -99,7 +99,7 @@ spec:
   relatedImages:
     - image: quay.io/devfile/devworkspace-controller:next
       name: devworkspace_webhook_server
-    - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+    - image: quay.io/brancz/kube-rbac-proxy:v0.13.1
       name: kube_rbac_proxy
     - image: quay.io/devfile/project-clone:next
       name: project_clone


### PR DESCRIPTION
### What does this PR do?
Updates kube-rbac-proxy image to quay.io/brancz/kube-rbac-proxy:v0.13.1

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/devworkspace-operator/issues/1352

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
