### PR TITLE
Project-clone multiarch support

### DIFF
--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -16,6 +16,8 @@
 # Build the manager binary
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
 FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1739267472 as builder
+ARG TARGETARCH
+ARG TARGETOS
 ENV GOPATH=/go/
 USER root
 WORKDIR /project-clone
@@ -30,7 +32,7 @@ RUN go mod download
 COPY . .
 
 # compile workspace controller binaries
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build \
   -a -o _output/bin/project-clone \
   -gcflags all=-trimpath=/ \
   -asmflags all=-trimpath=/ \


### PR DESCRIPTION
Changed the Dockerfile to support multiarch golang builds.

### What does this PR do?
- Add support to multi-arch builds of project-clone image.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- Tested locally by checking `printf` of the args.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
