### PR TITLE
chore: temporarily set actions/cache version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
+        uses: actions/cache@v3.4.3
         id: cache-operator-sdk
         with:
           path: ~/cache
@@ -80,7 +80,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Cache OPM ${{ env.OPM_VERSION }}
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
+        uses: actions/cache@v3.4.3
         id: cache-opm
         with:
           path: ~/cache


### PR DESCRIPTION
### What does this PR do?
Temporarily set the actions/cache action version to 3.4.3 to unblock release action.

The release action has this error:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: e12d46a63a90f2fae62d114769bbf2a179198b5c`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```


https://github.com/devfile/devworkspace-operator/actions/runs/13727867119/job/38398330515


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
