### PR TITLE
chore: Update actions/cache to v3.4.3

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,7 +26,7 @@ jobs:
     -
       name: Cache go modules
       id: cache-mod
-      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
+      uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
 
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         id: cache-operator-sdk
         with:
           path: ~/cache
@@ -107,7 +107,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Cache OPM ${{ env.OPM_VERSION }}
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         id: cache-opm
         with:
           path: ~/cache

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
 
     -
       name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
+      uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
       id: cache-operator-sdk
       with:
         path: ~/cache
@@ -49,7 +49,7 @@ jobs:
     -
       name: Cache go modules
       id: cache-mod
-      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.0
+      uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        uses: actions/cache@v3.4.3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         id: cache-operator-sdk
         with:
           path: ~/cache
@@ -80,7 +80,7 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Cache OPM ${{ env.OPM_VERSION }}
-        uses: actions/cache@v3.4.3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         id: cache-opm
         with:
           path: ~/cache


### PR DESCRIPTION
### What does this PR do?
Updates the actions/cache github action to v3.4.3 (the latest version for major version 3) by pinning the hash to the latest commit of the v3.4.3 branch:
https://github.com/actions/cache/tree/v3.4.3

### What issues does this PR fix or reference?
Fix failing jobs due to deprecation: https://github.com/devfile/devworkspace-operator/actions/runs/13797182618/job/38591517958?pr=1399

More about the deprecation: https://github.com/actions/cache/discussions/1510

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
