### PR TITLE
chore: Update actions/cache to v4

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
 
     -
       name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       id: cache-operator-sdk
       with:
         path: ~/cache

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
 
     -
       name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-      uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
+      uses: actions/cache@v4
       id: cache-operator-sdk
       with:
         path: ~/cache


### PR DESCRIPTION
### What does this PR do?
Update actions/cache to v4

### What issues does this PR fix or reference?
PR check fails 
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: e12d46a63a90f2fae62d114769bbf2a179198b5c`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
