### PR TITLE
fix: update Dockerfile to support multiple architectures

### DIFF
--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -30,7 +30,7 @@ RUN go mod download
 COPY . .
 
 # compile workspace controller binaries
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
+RUN CGO_ENABLED=0 GO111MODULE=on go build \
   -a -o _output/bin/project-clone \
   -gcflags all=-trimpath=/ \
   -asmflags all=-trimpath=/ \
@@ -43,11 +43,11 @@ WORKDIR /
 COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/project-clone
 
 ENV USER_UID=1001 \
-    USER_NAME=project-clone \
-    HOME=/home/user
+  USER_NAME=project-clone \
+  HOME=/home/user
 
 COPY build/bin /usr/local/bin
-RUN  /usr/local/bin/user_setup
+RUN /usr/local/bin/user_setup
 
 USER ${USER_UID}
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue with compiling the project-clone binary. Previously, it could only run in a linux/amd64 environment.

<img width="672" alt="企业微信截图_56672fc5-5e45-4a7c-a10f-8a6be19d5acb" src="https://github.com/user-attachments/assets/29604eee-7c5c-4e56-bce0-25054c72c3b7" />


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
