### PR TITLE
update ubuntu runner from 20 to latest

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   coverage-report:
     name: Check Code Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     -
       name: Set up Go 1.x

--- a/.github/workflows/devtools-image-build.yml
+++ b/.github/workflows/devtools-image-build.yml
@@ -23,7 +23,7 @@ jobs:
   
   build-devtools-img:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     outputs:
       git-sha: ${{ steps.git-sha.outputs.sha }}

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
 
   build-next-imgs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     outputs:
       git-sha: ${{ steps.git-sha.outputs.sha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   go:
     name: Check sources
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       OPERATOR_SDK_VERSION: v1.8.0
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       OPERATOR_SDK_VERSION: v1.8.0
       OPM_VERSION: v1.19.5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0


### PR DESCRIPTION
### What does this PR do?
Update ubuntu runner for the jobs from 20 to latest (unless it should be a fixed version like 22?)

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23344

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
