### PR TITLE
chore: Replace deprecated `ioutil.ReadFile` and `ioutil.ReadDir` in workspaceenv_test

### DIFF
--- a/pkg/library/env/workspaceenv_test.go
+++ b/pkg/library/env/workspaceenv_test.go
@@ -14,7 +14,7 @@
 package env
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -61,7 +61,7 @@ type TestOutput struct {
 }
 
 func loadTestCaseOrPanic(t *testing.T, testFilepath string) TestCase {
-	bytes, err := ioutil.ReadFile(testFilepath)
+	bytes, err := os.ReadFile(testFilepath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func loadTestCaseOrPanic(t *testing.T, testFilepath string) TestCase {
 }
 
 func loadAllTestsOrPanic(t *testing.T, fromDir string) []TestCase {
-	files, err := ioutil.ReadDir(fromDir)
+	files, err := os.ReadDir(fromDir)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### What does this PR do?

Updated code to use `os.ReadFile` and `os.ReadDir`, as `ioutil` package was deprecated in Go 1.16 (See [ioutil godoc](https://pkg.go.dev/io/ioutil)).
> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code.

### What issues does this PR fix or reference?
This is just a minor code smell fix, it is not related to any issue.


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
I've only verified it via IDE that code is not breaking any build. 

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
