### PR TITLE
fix: common PVC cleanup job to be assigned to a correct node

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -96,3 +96,8 @@ const (
 	// ProjectCloneDisable specifies that project cloning should be disabled.
 	ProjectCloneDisable = "disable"
 )
+
+const (
+	// This annotation is added to a PVC that is triggered by a scheduler to be dynamically provisioned. Its value is the name of the selected node.
+	SelectedNodeAnnotation = "volume.kubernetes.io/selected-node"
+)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -98,6 +98,6 @@ const (
 )
 
 const (
-	// This annotation is added to a PVC that is triggered by a scheduler to be dynamically provisioned. Its value is the name of the selected node.
+	// SelectedNodeAnnotation annotation is added to a PVC that is triggered by a scheduler to be dynamically provisioned. Its value is the name of the selected node.
 	SelectedNodeAnnotation = "volume.kubernetes.io/selected-node"
 )

--- a/pkg/provision/storage/cleanup.go
+++ b/pkg/provision/storage/cleanup.go
@@ -120,6 +120,13 @@ func getSpecCommonPVCCleanupJob(workspace *common.DevWorkspaceWithConfig, cluste
 		pvcName = workspace.Config.Workspace.PVCName
 	}
 
+	targetNode, err := getCommonPVCTargetNode(workspace, clusterAPI)
+	if err != nil {
+		clusterAPI.Logger.Info("Error getting target node for PVC", "PVC", fmt.Sprintf("%s/%s", workspace.Namespace, workspace.Config.Workspace.PVCName), "error", err)
+	} else if targetNode == "" {
+		clusterAPI.Logger.Info("PVC does not have a target node annotation", "PVC", fmt.Sprintf("%s/%s", workspace.Namespace, workspace.Config.Workspace.PVCName))
+	}
+
 	jobLabels := map[string]string{
 		constants.DevWorkspaceIDLabel:      workspaceId,
 		constants.DevWorkspaceNameLabel:    workspace.Name,
@@ -189,9 +196,28 @@ func getSpecCommonPVCCleanupJob(workspace *common.DevWorkspaceWithConfig, cluste
 							},
 						},
 					},
+					Affinity: &corev1.Affinity{},
 				},
 			},
 		},
+	}
+
+	if targetNode != "" {
+		job.Spec.Template.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "kubernetes.io/hostname",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{targetNode},
+							},
+						},
+					},
+				},
+			},
+		}
 	}
 
 	podTolerations, nodeSelector, err := nsconfig.GetNamespacePodTolerationsAndNodeSelector(workspace.Namespace, clusterAPI)
@@ -225,4 +251,23 @@ func commonPVCExists(workspace *common.DevWorkspaceWithConfig, clusterAPI sync.C
 		return false, err
 	}
 	return true, nil
+}
+
+func getCommonPVCTargetNode(workspace *common.DevWorkspaceWithConfig, clusterAPI sync.ClusterAPI) (string, error) {
+	namespacedName := types.NamespacedName{
+		Name:      workspace.Config.Workspace.PVCName,
+		Namespace: workspace.Namespace,
+	}
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := clusterAPI.Client.Get(clusterAPI.Ctx, namespacedName, pvc)
+	if err != nil {
+		return "", err
+	}
+
+	targetNode := ""
+	if pvc.Annotations != nil {
+		targetNode = pvc.Annotations[constants.SelectedNodeAnnotation]
+	}
+
+	return targetNode, nil
 }

--- a/pkg/provision/storage/cleanup.go
+++ b/pkg/provision/storage/cleanup.go
@@ -209,7 +209,7 @@ func getSpecCommonPVCCleanupJob(workspace *common.DevWorkspaceWithConfig, cluste
 					{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
-								Key:      "kubernetes.io/hostname",
+								Key:      corev1.LabelHostname,
 								Operator: corev1.NodeSelectorOpIn,
 								Values:   []string{targetNode},
 							},


### PR DESCRIPTION
### What does this PR do?

This pull request enhances the common PVC cleanup job by adding node affinity rule.

This change modifies the cleanup job creation logic to:
1.  Read the `volume.kubernetes.io/selected-node` annotation from the common PVC associated with the DevWorkspace.
2.  If the annotation exists, add a `requiredDuringSchedulingIgnoredDuringExecution` node affinity rule to the cleanup job's pod spec, targeting the specified node.

This ensures that the cleanup job pod runs on the same node as the volume. If the annotation is not present, no node affinity is added.

### What issues does this PR fix or reference?

resolves https://github.com/devfile/devworkspace-operator/issues/1269

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

1. Create at least two DevWorkspaces; at least one should be running.
2. Verify that the PVC has the `volume.kubernetes.io/selected-node` annotation. Note the node name specified in the annotation value.
    ```bash
    kubectl get pvc -n <namespace> claim-devworkspace -o jsonpath='{.metadata.annotations.volume\.kubernetes\.io/selected-node}'
    ```  
3. Delete a DevWorkspace, and leave at least one running DevWorkspace untouched.
4. Inspect the cleanup job to verify that the node affinity rule was added:
    ```bash
    kubectl get job -n <namespace> <job-name> -o jsonpath='{.spec.template.spec.affinity.nodeAffinity}'
    ```
    Check that the `nodeSelectorTerms` target the node name noted in step 2 via the `kubernetes.io/hostname` key.
5. Ensure the cleanup Job completes successfully and the DevWorkspace is deleted.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
