### PR TITLE
chore: fix Dockerfile warnings reported during docker build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1739267472 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1739267472 AS builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /devworkspace-operator
@@ -35,7 +35,12 @@ RUN make compile-webhook-server
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1739420147
-RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
+RUN microdnf -y update && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum && \
+    echo "Installed Packages" && \
+    rpm -qa | sort -V && \
+    echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /devworkspace-operator/_output/bin/devworkspace-controller /usr/local/bin/devworkspace-controller
 COPY --from=builder /devworkspace-operator/_output/bin/webhook-server /usr/local/bin/webhook-server
@@ -49,6 +54,6 @@ RUN  /usr/local/bin/user_setup
 USER ${USER_UID}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
-CMD /usr/local/bin/devworkspace-controller
+CMD ["/usr/local/bin/devworkspace-controller"]
 
 # append Brew metadata here


### PR DESCRIPTION


### What does this PR do?
This PR tries to fix build warnings seen during `make docker` command invocation:
```
 2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 17)
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 52)
```

- Use uppercase keyword in dockerfile as per convention
- Split long RUN instruction into multiple lines for clarity
- Use exec form for CMD instruction as done in ENTRYPOINT

### What issues does this PR fix or reference?
It doesn't fix any related issue. It's only a minor cleanup task.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Without these changes you'd see the warnings reported above when running `make docker`. 

I've verified that after making changes, I don't see any warnings.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
