### PR TITLE
fix: workspace config not found

### DIFF
--- a/controllers/cleanupcronjob/cleanupcronjob_controller.go
+++ b/controllers/cleanupcronjob/cleanupcronjob_controller.go
@@ -163,14 +163,25 @@ func (r *CleanupCronJobReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	cleanupConfig := dwOperatorConfig.Config.Workspace.CleanupCronJob
-	log = log.WithValues("CleanupCronJob", cleanupConfig)
-
-	if cleanupConfig == nil {
-		log.Info("DevWorkspaceOperatorConfig does not have cleanup configuration, stopping cron schedler and skipping reconciliation")
+	if dwOperatorConfig.Config == nil {
+		log.Info("DevWorkspaceOperatorConfig does not have config, stopping cron scheduler and skipping reconciliation")
 		r.stopCron(log)
 		return ctrl.Result{}, nil
 	}
+	if dwOperatorConfig.Config.Workspace == nil {
+		log.Info("DevWorkspaceOperatorConfig does not have workspace config, stopping cron scheduler and skipping reconciliation")
+		r.stopCron(log)
+		return ctrl.Result{}, nil
+	}
+	if dwOperatorConfig.Config.Workspace.CleanupCronJob == nil {
+		log.Info("DevWorkspaceOperatorConfig does not have cleanup configuration, stopping cron scheduler and skipping reconciliation")
+		r.stopCron(log)
+		return ctrl.Result{}, nil
+	}
+
+	cleanupConfig := dwOperatorConfig.Config.Workspace.CleanupCronJob
+	log = log.WithValues("CleanupCronJob", cleanupConfig)
+
 	if cleanupConfig.Enable == nil || !*cleanupConfig.Enable {
 		log.Info("DevWorkspace pruning is disabled, stopping cron scheduler and skipping reconciliation")
 		r.stopCron(log)

--- a/controllers/cleanupcronjob/cleanupcronjob_controller_test.go
+++ b/controllers/cleanupcronjob/cleanupcronjob_controller_test.go
@@ -148,6 +148,34 @@ var _ = Describe("CleanupCronJobReconciler", func() {
 			Expect(reconciler.cron.Entries()).To(BeEmpty())
 		})
 
+		It("Should not start cron if dwOperatorConfig.Config is nil", func() {
+			dwoc := &controllerv1alpha1.DevWorkspaceOperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: nameNamespace.Name, Namespace: nameNamespace.Namespace},
+				Config:     nil,
+			}
+			Expect(fakeClient.Create(ctx, dwoc)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nameNamespace})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(reconciler.cron.Entries()).To(BeEmpty())
+		})
+
+		It("Should not start cron if dwOperatorConfig.Config.Workspace is nil", func() {
+			dwoc := &controllerv1alpha1.DevWorkspaceOperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: nameNamespace.Name, Namespace: nameNamespace.Namespace},
+				Config: &controllerv1alpha1.OperatorConfiguration{
+					Workspace: nil,
+				},
+			}
+			Expect(fakeClient.Create(ctx, dwoc)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: nameNamespace})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(reconciler.cron.Entries()).To(BeEmpty())
+		})
+
 		It("Should not start cron if received event from different namespace", func() {
 			dwoc := &controllerv1alpha1.DevWorkspaceOperatorConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: nameNamespace.Name, Namespace: "other-namespace"},
@@ -185,7 +213,7 @@ var _ = Describe("CleanupCronJobReconciler", func() {
 			Expect(reconciler.cron.Entries()).To(BeEmpty())
 		})
 
-		It("Should do not start cron if pruning is disabled", func() {
+		It("Should not start cron if pruning is disabled", func() {
 			enabled := false
 			dwoc := &controllerv1alpha1.DevWorkspaceOperatorConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: nameNamespace.Name, Namespace: nameNamespace.Namespace},
@@ -205,7 +233,7 @@ var _ = Describe("CleanupCronJobReconciler", func() {
 			Expect(reconciler.cron.Entries()).To(BeEmpty())
 		})
 
-		It("Should do not start cron if schedule is missing", func() {
+		It("Should not start cron if schedule is missing", func() {
 			enabled := true
 			dwoc := &controllerv1alpha1.DevWorkspaceOperatorConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: nameNamespace.Name, Namespace: nameNamespace.Namespace},


### PR DESCRIPTION
### What does this PR do?

This PR adds checks for essential configuration fields within the `DevWorkspaceOperatorConfig` custom resource.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse-che/che/issues/23418

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

Unit tests.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
