### PR TITLE
Update oci.Dockerfile

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -22,7 +22,7 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && sed
 
 RUN yum install --assumeyes -d1 python3-pip nodejs gettext && \
     pip3 install --upgrade pip && \
-    pip3 install --upgrade setuptools && \
+    pip3 install --ignore-installed --upgrade setuptools && \
     # Install yq
     pip3 install yq && \
     # Install kubectl


### PR DESCRIPTION
### What does this PR do?
Updates oci.Dockerfile to fix this error:
```
Installing collected packages: setuptools
  Attempting uninstall: setuptools
    Found existing installation: setuptools 53.0.0
error: uninstall-no-record-file
× Cannot uninstall setuptools 53.0.0
╰─> The package's contents are unknown: no RECORD file was found for setuptools.
```
in for example: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/devfile_devworkspace-operator/1419/pull-ci-devfile-devworkspace-operator-main-v14-devworkspace-operator-e2e/1916784079701807104

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
