### PR TITLE
Update metrics doc token creation

### DIFF
--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -15,12 +15,9 @@ To quickly test metrics locally (without installing Prometheus Grafana in the cl
     ```
 2. Get the serviceaccount's token to enable local access to metrics
     ```bash
-    TOKEN=$(kubectl get secrets -o=json -n ${NAMESPACE} | jq -r '[.items[] |
-      select (
-        .type == "kubernetes.io/service-account-token" and
-        .metadata.annotations."kubernetes.io/service-account.name" == "devworkspace-controller-serviceaccount")][0].data.token' \
-      | base64 --decode)
+    TOKEN=$(kubectl create token devworkspace-controller-serviceaccount -n ${NAMESPACE} --duration=1h | base64 --decode)
     ```
+      NOTE: For development purposes, a non-expiring token can be created instead: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount
 3. In another terminal, use `kubectl port-forward` to expose the controller's service locally
     ```bash
     kubectl port-forward service/devworkspace-controller-metrics 8443:8443 &


### PR DESCRIPTION
### What does this PR do?
The PR updates the metrics doc token creation. In recent versions of Kubernetes and OpenShift, token secrets are not automatically created for service accounts: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#manual-secret-management-for-serviceaccounts

This PR updates the instructions to use the token request api.

### What issues does this PR fix or reference?
n/a

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
