### PR TITLE
Update project to go 1.23

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.22
+FROM registry.ci.openshift.org/openshift/release:golang-1.23
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,7 +14,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.22.10
+        go-version: 1.23.6
     -
       name: Set up Python 3.11
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.22.10
+        go-version: 1.23.6
     -
       name: Set up Python 3.11
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.22.10
+          go-version: 1.23.6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 #v2.2.0

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1739267472 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745328278 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /devworkspace-operator

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/devfile/devworkspace-operator
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23.0
 
 require (
 	github.com/devfile/api/v2 v2.2.2

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -15,7 +15,7 @@
 
 # Build the manager binary
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1739267472 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745328278 as builder
 ARG TARGETARCH
 ARG TARGETOS
 ENV GOPATH=/go/


### PR DESCRIPTION
### What does this PR do?
Updates project to use go 1.23

### What issues does this PR fix or reference?
Update to go 1.23 is needed to fix CVEs:
[cve-2025-22869](https://access.redhat.com/security/cve/cve-2025-22869) which has a CVSS score of 7.5.
[cve-2025-22872](https://access.redhat.com/security/cve/cve-2025-22872) which has a CVSS score of 6.5.


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
