### PR TITLE
feat : [CRW-5722] Add configuration option in DevWorkspaceOperatorConfig for storage access mode (#1019)

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -135,6 +135,9 @@ type WorkspaceConfig struct {
 	// DefaultStorageSize defines an optional struct with fields to specify the sizes of Persistent Volume Claims for storage
 	// classes used by DevWorkspaces.
 	DefaultStorageSize *StorageSizes `json:"defaultStorageSize,omitempty"`
+	// StorageAccessMode are the desired access modes the volume should have. It defaults
+	// to ReadWriteOnce if not specified
+	StorageAccessMode []corev1.PersistentVolumeAccessMode `json:"storageAccessMode,omitempty"`
 	// PersistUserHome defines configuration options for persisting the `/home/user/`
 	// directory in workspaces.
 	PersistUserHome *PersistentHomeConfig `json:"persistUserHome,omitempty"`

--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -731,6 +731,11 @@ func (in *WorkspaceConfig) DeepCopyInto(out *WorkspaceConfig) {
 		*out = new(StorageSizes)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.StorageAccessMode != nil {
+		in, out := &in.StorageAccessMode, &out.StorageAccessMode
+		*out = make([]v1.PersistentVolumeAccessMode, len(*in))
+		copy(*out, *in)
+	}
 	if in.PersistUserHome != nil {
 		in, out := &in.PersistUserHome, &out.PersistUserHome
 		*out = new(PersistentHomeConfig)

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -2988,6 +2988,13 @@ spec:
                           type: object
                         type: array
                     type: object
+                  storageAccessMode:
+                    description: |-
+                      StorageAccessMode are the desired access modes the volume should have. It defaults
+                      to ReadWriteOnce if not specified
+                    items:
+                      type: string
+                    type: array
                   storageClassName:
                     description: |-
                       StorageClassName defines an optional storageClass to use for persistent

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -3139,6 +3139,13 @@ spec:
                           type: object
                         type: array
                     type: object
+                  storageAccessMode:
+                    description: |-
+                      StorageAccessMode are the desired access modes the volume should have. It defaults
+                      to ReadWriteOnce if not specified
+                    items:
+                      type: string
+                    type: array
                   storageClassName:
                     description: |-
                       StorageClassName defines an optional storageClass to use for persistent

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -3139,6 +3139,13 @@ spec:
                           type: object
                         type: array
                     type: object
+                  storageAccessMode:
+                    description: |-
+                      StorageAccessMode are the desired access modes the volume should have. It defaults
+                      to ReadWriteOnce if not specified
+                    items:
+                      type: string
+                    type: array
                   storageClassName:
                     description: |-
                       StorageClassName defines an optional storageClass to use for persistent

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -3139,6 +3139,13 @@ spec:
                           type: object
                         type: array
                     type: object
+                  storageAccessMode:
+                    description: |-
+                      StorageAccessMode are the desired access modes the volume should have. It defaults
+                      to ReadWriteOnce if not specified
+                    items:
+                      type: string
+                    type: array
                   storageClassName:
                     description: |-
                       StorageClassName defines an optional storageClass to use for persistent

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -3139,6 +3139,13 @@ spec:
                           type: object
                         type: array
                     type: object
+                  storageAccessMode:
+                    description: |-
+                      StorageAccessMode are the desired access modes the volume should have. It defaults
+                      to ReadWriteOnce if not specified
+                    items:
+                      type: string
+                    type: array
                   storageClassName:
                     description: |-
                       StorageClassName defines an optional storageClass to use for persistent

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -3137,6 +3137,13 @@ spec:
                           type: object
                         type: array
                     type: object
+                  storageAccessMode:
+                    description: |-
+                      StorageAccessMode are the desired access modes the volume should have. It defaults
+                      to ReadWriteOnce if not specified
+                    items:
+                      type: string
+                    type: array
                   storageClassName:
                     description: |-
                       StorageClassName defines an optional storageClass to use for persistent

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -341,6 +341,9 @@ func mergeConfig(from, to *controller.OperatorConfiguration) {
 		if from.Workspace.ContainerSecurityContext != nil {
 			to.Workspace.ContainerSecurityContext = mergeContainerSecurityContext(to.Workspace.ContainerSecurityContext, from.Workspace.ContainerSecurityContext)
 		}
+		if from.Workspace.StorageAccessMode != nil {
+			to.Workspace.StorageAccessMode = from.Workspace.StorageAccessMode
+		}
 		if from.Workspace.DefaultStorageSize != nil {
 			if to.Workspace.DefaultStorageSize == nil {
 				to.Workspace.DefaultStorageSize = &controller.StorageSizes{}

--- a/pkg/config/sync_test.go
+++ b/pkg/config/sync_test.go
@@ -440,6 +440,24 @@ func TestMergeConfigLooksAtAllFields(t *testing.T) {
 	assert.Equal(t, expectedConfig, actualConfig, "merging configs should merge all fields")
 }
 
+func TestMergeConfigMergesStorageAccessMode(t *testing.T) {
+	// Given
+	expectedConfig := &v1alpha1.OperatorConfiguration{
+		Workspace: &v1alpha1.WorkspaceConfig{
+			StorageAccessMode: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteMany,
+			},
+		},
+	}
+	actualConfig := &v1alpha1.OperatorConfiguration{}
+
+	// When
+	mergeConfig(expectedConfig, actualConfig)
+
+	// Then
+	assert.Equal(t, expectedConfig.Workspace.StorageAccessMode, actualConfig.Workspace.StorageAccessMode)
+}
+
 func fuzzQuantity(q *resource.Quantity, c fuzz.Continue) {
 	q.Set(c.Int63n(999))
 	q.Format = resource.DecimalSI

--- a/pkg/provision/storage/commonStorage_test.go
+++ b/pkg/provision/storage/commonStorage_test.go
@@ -130,13 +130,13 @@ func TestUseCommonStorageProvisionerForPerUserStorageClass(t *testing.T) {
 func TestProvisionStorageForCommonStorageClass(t *testing.T) {
 	tests := loadAllTestCasesOrPanic(t, "testdata/common-storage")
 	commonStorage := CommonStorageProvisioner{}
-	commonPVC, err := getPVCSpec("claim-devworkspace", "test-namespace", nil, resource.MustParse("10Gi"))
+	commonPVC, err := getPVCSpec("claim-devworkspace", "test-namespace", nil, resource.MustParse("10Gi"), nil)
 	if err != nil {
 		t.Fatalf("Failure during setup: %s", err)
 	}
 	commonPVC.Status.Phase = corev1.ClaimBound
 	clusterAPI := sync.ClusterAPI{
-		Client: fake.NewFakeClientWithScheme(scheme, commonPVC),
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(commonPVC).Build(),
 		Logger: zap.New(),
 	}
 
@@ -166,7 +166,7 @@ func TestProvisionStorageForCommonStorageClass(t *testing.T) {
 
 func TestTerminatingPVC(t *testing.T) {
 	commonStorage := CommonStorageProvisioner{}
-	commonPVC, err := getPVCSpec("claim-devworkspace", "test-namespace", nil, resource.MustParse("10Gi"))
+	commonPVC, err := getPVCSpec("claim-devworkspace", "test-namespace", nil, resource.MustParse("10Gi"), nil)
 	if err != nil {
 		t.Fatalf("Failure during setup: %s", err)
 	}
@@ -174,7 +174,7 @@ func TestTerminatingPVC(t *testing.T) {
 	commonPVC.SetDeletionTimestamp(&testTime)
 
 	clusterAPI := sync.ClusterAPI{
-		Client: fake.NewFakeClientWithScheme(scheme, commonPVC),
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(commonPVC).Build(),
 		Logger: zap.New(),
 	}
 	testCase := loadTestCaseOrPanic(t, "testdata/common-storage/rewrites-volumes-for-common-pvc-strategy.yaml")

--- a/pkg/provision/storage/perWorkspaceStorage.go
+++ b/pkg/provision/storage/perWorkspaceStorage.go
@@ -219,7 +219,7 @@ func syncPerWorkspacePVC(workspace *common.DevWorkspaceWithConfig, clusterAPI sy
 	}
 
 	storageClass := workspace.Config.Workspace.StorageClassName
-	pvc, err := getPVCSpec(common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId), workspace.Namespace, storageClass, *pvcSize)
+	pvc, err := getPVCSpec(common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId), workspace.Namespace, storageClass, *pvcSize, workspace.Config.Workspace.StorageAccessMode)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provision/storage/shared_test.go
+++ b/pkg/provision/storage/shared_test.go
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2019-2025 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetPVCSpecWithDefaultStorageAccessMode(t *testing.T) {
+	// Given
+	name := "test-pvc"
+	namespace := "default"
+	storageClass := "standard"
+
+	// When
+	pvc, err := getPVCSpec(name, namespace, &storageClass, resource.MustParse("5Gi"), nil)
+
+	// Then
+	assert.NoError(t, err, "Expected no error")
+	assert.Equal(t, name, pvc.Name, "PVC name should match")
+	assert.Equal(t, namespace, pvc.Namespace, "PVC namespace should match")
+	assert.Equal(t, storageClass, *pvc.Spec.StorageClassName, "Storage class should match")
+	assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, pvc.Spec.AccessModes, "Access modes should match")
+	assert.Equal(t, "5Gi", pvc.Spec.Resources.Requests.Storage().String(), "Storage size should match")
+}
+
+func TestGetPVCSpecWithCustomStorageAccessMode(t *testing.T) {
+	// Given
+	name := "test-pvc"
+	namespace := "default"
+	storageClass := "standard"
+	storageAccessMode := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod}
+
+	// When
+	pvc, err := getPVCSpec(name, namespace, &storageClass, resource.MustParse("5Gi"), storageAccessMode)
+
+	// Then
+	assert.NoError(t, err, "Expected no error")
+	assert.Equal(t, name, pvc.Name, "PVC name should match")
+	assert.Equal(t, namespace, pvc.Namespace, "PVC namespace should match")
+	assert.Equal(t, storageClass, *pvc.Spec.StorageClassName, "Storage class should match")
+	assert.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod}, pvc.Spec.AccessModes, "Access modes should match")
+	assert.Equal(t, "5Gi", pvc.Spec.Resources.Requests.Storage().String(), "Storage size should match")
+}


### PR DESCRIPTION
### What does this PR do?
- Add a configuration option named StorageAccessMode in WorkspaceConfig struct
- Set PVC accessMode if the above-mentioned option is set in WorkspaceConfig, default to ReadWriteOnce

### What issues does this PR fix or reference?
Fix #1019

Related to https://issues.redhat.com/browse/CRW-5722

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- Create this DevWorkspaceConfig that provides storageAccessMode for `ReadWriteMany`
```yaml
apiVersion: controller.devfile.io/v1alpha1
config:
  enableExperimentalFeatures: true
  routing:
    clusterHostSuffix: 127.0.0.1.nip.io
    defaultRoutingClass: basic
  workspace:
    imagePullPolicy: Always
    storageAccessMode:
    - ReadWriteMany
kind: DevWorkspaceOperatorConfig
metadata:
  name: external-dwoc-test

```
- Create a DevWorkspace using abovementioned workspace config:
```yaml
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: theia-next-external-dwoc
spec:
  started: true
  template:
    attributes:
        controller.devfile.io/storage-type: common
        controller.devfile.io/devworkspace-config:
          name: external-dwoc-test
          namespace: devworkspace-controller
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
    - name: tools
      container:
        image: quay.io/devfile/universal-developer-image:ubi9-latest
        memoryLimit: 256Mi
        mountSources: true
    commands:
      - id: say-hello
        exec:
          component: theia-ide
          commandLine: echo "Hello world"
```

- After applying these manifests, check the PVC created should have the same accessMode as specified in DevWorkspaceConfig:
```
oc get pvc external-dwoc-pvc -o=jsonpath='{.status.accessModes}'
["ReadWriteMany"]
```
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
