### PR TITLE
Update python-version for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Set up yq
         uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Setup yq
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
### What does this PR do?
Update the python version for the release workflow to 3.8.

This is needed because 3.6 does not exist for ubuntu runner 24.04:
https://github.com/devfile/devworkspace-operator/actions/runs/14937952132

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
