### PR TITLE
chore: add the workflow_dispatch event into devtools container build

### DIFF
--- a/.github/workflows/devtools-image-build.yml
+++ b/.github/workflows/devtools-image-build.yml
@@ -18,6 +18,7 @@ name: Devtools container build
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   


### PR DESCRIPTION
### What does this PR do?

This PR supports manually triggering the devtools container build workflow via the GitHub UI. 
