### PR TITLE
postStart hook commands timeout

### DIFF
--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -192,12 +192,10 @@ type WorkspaceConfig struct {
 	// PostStartTimeout defines the maximum duration the PostStart hook can run
 	// before it is automatically failed. This timeout is used for the postStart lifecycle hook
 	// that is used to run commands in the workspace container. The timeout is specified in seconds.
-	// If not specified, the timeout is disabled (0 seconds).
-	// +kubebuilder:validation:Minimum=0
+	// Duration should be specified in a format parseable by Go's time package, e.g. "20s", "2m".
+	// If not specified or "0", the timeout is disabled.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Type=integer
-	// +kubebuilder:validation:Format=int32
-	PostStartTimeout *int32 `json:"postStartTimeout,omitempty"`
+	PostStartTimeout string `json:"postStartTimeout,omitempty"`
 }
 
 type WebhookConfig struct {

--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -189,6 +189,16 @@ type WorkspaceConfig struct {
 	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
 	// CleanupCronJobConfig defines configuration options for a cron job that automatically cleans up stale DevWorkspaces.
 	CleanupCronJob *CleanupCronJobConfig `json:"cleanupCronJob,omitempty"`
+	// PostStartTimeout defines the maximum duration the PostStart hook can run
+	// before it is automatically failed. This timeout is used for the postStart lifecycle hook
+	// that is used to run commands in the workspace container. The timeout is specified in seconds.
+	// If not specified, the timeout is disabled (0 seconds).
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default:=0
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Type=integer
+	// +kubebuilder:validation:Format=int32
+	PostStartTimeout *int32 `json:"postStartTimeout,omitempty"`
 }
 
 type WebhookConfig struct {

--- a/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -194,7 +194,6 @@ type WorkspaceConfig struct {
 	// that is used to run commands in the workspace container. The timeout is specified in seconds.
 	// If not specified, the timeout is disabled (0 seconds).
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:default:=0
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=integer
 	// +kubebuilder:validation:Format=int32

--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ package v1alpha1
 
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -787,11 +787,6 @@ func (in *WorkspaceConfig) DeepCopyInto(out *WorkspaceConfig) {
 		in, out := &in.CleanupCronJob, &out.CleanupCronJob
 		*out = new(CleanupCronJobConfig)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.PostStartTimeout != nil {
-		in, out := &in.PostStartTimeout, &out.PostStartTimeout
-		*out = new(int32)
-		**out = **in
 	}
 }
 

--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ package v1alpha1
 
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ package v1alpha1
 
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -787,6 +787,11 @@ func (in *WorkspaceConfig) DeepCopyInto(out *WorkspaceConfig) {
 		in, out := &in.CleanupCronJob, &out.CleanupCronJob
 		*out = new(CleanupCronJobConfig)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.PostStartTimeout != nil {
+		in, out := &in.PostStartTimeout, &out.PostStartTimeout
+		*out = new(int32)
+		**out = **in
 	}
 }
 

--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -327,7 +327,9 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		&workspace.Spec.Template,
 		workspace.Config.Workspace.ContainerSecurityContext,
 		workspace.Config.Workspace.ImagePullPolicy,
-		workspace.Config.Workspace.DefaultContainerResources)
+		workspace.Config.Workspace.DefaultContainerResources,
+		workspace.Config.Workspace.PostStartTimeout,
+	)
 	if err != nil {
 		return r.failWorkspace(workspace, fmt.Sprintf("Error processing devfile: %s", err), metrics.ReasonBadRequest, reqLogger, &reconcileStatus), nil
 	}

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -2769,10 +2769,9 @@ spec:
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook
                       that is used to run commands in the workspace container. The timeout is specified in seconds.
-                      If not specified, the timeout is disabled (0 seconds).
-                    format: int32
-                    minimum: 0
-                    type: integer
+                      Duration should be specified in a format parseable by Go's time package, e.g. "20s", "2m".
+                      If not specified or "0", the timeout is disabled.
+                    type: string
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -2764,6 +2764,16 @@ spec:
                             type: string
                         type: object
                     type: object
+                  postStartTimeout:
+                    default: 0
+                    description: |-
+                      PostStartTimeout defines the maximum duration the PostStart hook can run
+                      before it is automatically failed. This timeout is used for the postStart lifecycle hook
+                      that is used to run commands in the workspace container. The timeout is specified in seconds.
+                      If not specified, the timeout is disabled (0 seconds).
+                    format: int32
+                    minimum: 0
+                    type: integer
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/bundle/manifests/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -2765,7 +2765,6 @@ spec:
                         type: object
                     type: object
                   postStartTimeout:
-                    default: 0
                     description: |-
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -2905,10 +2905,9 @@ spec:
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook
                       that is used to run commands in the workspace container. The timeout is specified in seconds.
-                      If not specified, the timeout is disabled (0 seconds).
-                    format: int32
-                    minimum: 0
-                    type: integer
+                      Duration should be specified in a format parseable by Go's time package, e.g. "20s", "2m".
+                      If not specified or "0", the timeout is disabled.
+                    type: string
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -2900,6 +2900,16 @@ spec:
                             type: string
                         type: object
                     type: object
+                  postStartTimeout:
+                    default: 0
+                    description: |-
+                      PostStartTimeout defines the maximum duration the PostStart hook can run
+                      before it is automatically failed. This timeout is used for the postStart lifecycle hook
+                      that is used to run commands in the workspace container. The timeout is specified in seconds.
+                      If not specified, the timeout is disabled (0 seconds).
+                    format: int32
+                    minimum: 0
+                    type: integer
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -2901,7 +2901,6 @@ spec:
                         type: object
                     type: object
                   postStartTimeout:
-                    default: 0
                     description: |-
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2905,10 +2905,9 @@ spec:
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook
                       that is used to run commands in the workspace container. The timeout is specified in seconds.
-                      If not specified, the timeout is disabled (0 seconds).
-                    format: int32
-                    minimum: 0
-                    type: integer
+                      Duration should be specified in a format parseable by Go's time package, e.g. "20s", "2m".
+                      If not specified or "0", the timeout is disabled.
+                    type: string
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2900,6 +2900,16 @@ spec:
                             type: string
                         type: object
                     type: object
+                  postStartTimeout:
+                    default: 0
+                    description: |-
+                      PostStartTimeout defines the maximum duration the PostStart hook can run
+                      before it is automatically failed. This timeout is used for the postStart lifecycle hook
+                      that is used to run commands in the workspace container. The timeout is specified in seconds.
+                      If not specified, the timeout is disabled (0 seconds).
+                    format: int32
+                    minimum: 0
+                    type: integer
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2901,7 +2901,6 @@ spec:
                         type: object
                     type: object
                   postStartTimeout:
-                    default: 0
                     description: |-
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -2905,10 +2905,9 @@ spec:
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook
                       that is used to run commands in the workspace container. The timeout is specified in seconds.
-                      If not specified, the timeout is disabled (0 seconds).
-                    format: int32
-                    minimum: 0
-                    type: integer
+                      Duration should be specified in a format parseable by Go's time package, e.g. "20s", "2m".
+                      If not specified or "0", the timeout is disabled.
+                    type: string
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -2900,6 +2900,16 @@ spec:
                             type: string
                         type: object
                     type: object
+                  postStartTimeout:
+                    default: 0
+                    description: |-
+                      PostStartTimeout defines the maximum duration the PostStart hook can run
+                      before it is automatically failed. This timeout is used for the postStart lifecycle hook
+                      that is used to run commands in the workspace container. The timeout is specified in seconds.
+                      If not specified, the timeout is disabled (0 seconds).
+                    format: int32
+                    minimum: 0
+                    type: integer
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -2901,7 +2901,6 @@ spec:
                         type: object
                     type: object
                   postStartTimeout:
-                    default: 0
                     description: |-
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2905,10 +2905,9 @@ spec:
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook
                       that is used to run commands in the workspace container. The timeout is specified in seconds.
-                      If not specified, the timeout is disabled (0 seconds).
-                    format: int32
-                    minimum: 0
-                    type: integer
+                      Duration should be specified in a format parseable by Go's time package, e.g. "20s", "2m".
+                      If not specified or "0", the timeout is disabled.
+                    type: string
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2900,6 +2900,16 @@ spec:
                             type: string
                         type: object
                     type: object
+                  postStartTimeout:
+                    default: 0
+                    description: |-
+                      PostStartTimeout defines the maximum duration the PostStart hook can run
+                      before it is automatically failed. This timeout is used for the postStart lifecycle hook
+                      that is used to run commands in the workspace container. The timeout is specified in seconds.
+                      If not specified, the timeout is disabled (0 seconds).
+                    format: int32
+                    minimum: 0
+                    type: integer
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/devworkspaceoperatorconfigs.controller.devfile.io.CustomResourceDefinition.yaml
@@ -2901,7 +2901,6 @@ spec:
                         type: object
                     type: object
                   postStartTimeout:
-                    default: 0
                     description: |-
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -2903,10 +2903,9 @@ spec:
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook
                       that is used to run commands in the workspace container. The timeout is specified in seconds.
-                      If not specified, the timeout is disabled (0 seconds).
-                    format: int32
-                    minimum: 0
-                    type: integer
+                      Duration should be specified in a format parseable by Go's time package, e.g. "20s", "2m".
+                      If not specified or "0", the timeout is disabled.
+                    type: string
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -2899,7 +2899,6 @@ spec:
                         type: object
                     type: object
                   postStartTimeout:
-                    default: 0
                     description: |-
                       PostStartTimeout defines the maximum duration the PostStart hook can run
                       before it is automatically failed. This timeout is used for the postStart lifecycle hook

--- a/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
+++ b/deploy/templates/crd/bases/controller.devfile.io_devworkspaceoperatorconfigs.yaml
@@ -2898,6 +2898,16 @@ spec:
                             type: string
                         type: object
                     type: object
+                  postStartTimeout:
+                    default: 0
+                    description: |-
+                      PostStartTimeout defines the maximum duration the PostStart hook can run
+                      before it is automatically failed. This timeout is used for the postStart lifecycle hook
+                      that is used to run commands in the workspace container. The timeout is specified in seconds.
+                      If not specified, the timeout is disabled (0 seconds).
+                    format: int32
+                    minimum: 0
+                    type: integer
                   progressTimeout:
                     description: |-
                       ProgressTimeout determines the maximum duration a DevWorkspace can be in

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -432,7 +432,7 @@ func mergeConfig(from, to *controller.OperatorConfiguration) {
 			}
 		}
 
-		if from.Workspace.PostStartTimeout != nil {
+		if from.Workspace.PostStartTimeout != "" {
 			to.Workspace.PostStartTimeout = from.Workspace.PostStartTimeout
 		}
 	}
@@ -605,8 +605,8 @@ func GetCurrentConfigString(currConfig *controller.OperatorConfiguration) string
 		if workspace.IdleTimeout != defaultConfig.Workspace.IdleTimeout {
 			config = append(config, fmt.Sprintf("workspace.idleTimeout=%s", workspace.IdleTimeout))
 		}
-		if workspace.PostStartTimeout != nil && workspace.PostStartTimeout != defaultConfig.Workspace.PostStartTimeout {
-			config = append(config, fmt.Sprintf("workspace.postStartTimeout=%d", *workspace.PostStartTimeout))
+		if workspace.PostStartTimeout != defaultConfig.Workspace.PostStartTimeout {
+			config = append(config, fmt.Sprintf("workspace.postStartTimeout=%s", workspace.PostStartTimeout))
 		}
 		if workspace.ProgressTimeout != "" && workspace.ProgressTimeout != defaultConfig.Workspace.ProgressTimeout {
 			config = append(config, fmt.Sprintf("workspace.progressTimeout=%s", workspace.ProgressTimeout))

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -431,6 +431,10 @@ func mergeConfig(from, to *controller.OperatorConfiguration) {
 				to.Workspace.CleanupCronJob.Schedule = from.Workspace.CleanupCronJob.Schedule
 			}
 		}
+
+		if from.Workspace.PostStartTimeout != nil {
+			to.Workspace.PostStartTimeout = from.Workspace.PostStartTimeout
+		}
 	}
 }
 

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -605,6 +605,9 @@ func GetCurrentConfigString(currConfig *controller.OperatorConfiguration) string
 		if workspace.IdleTimeout != defaultConfig.Workspace.IdleTimeout {
 			config = append(config, fmt.Sprintf("workspace.idleTimeout=%s", workspace.IdleTimeout))
 		}
+		if workspace.PostStartTimeout != nil && workspace.PostStartTimeout != defaultConfig.Workspace.PostStartTimeout {
+			config = append(config, fmt.Sprintf("workspace.postStartTimeout=%d", *workspace.PostStartTimeout))
+		}
 		if workspace.ProgressTimeout != "" && workspace.ProgressTimeout != defaultConfig.Workspace.ProgressTimeout {
 			config = append(config, fmt.Sprintf("workspace.progressTimeout=%s", workspace.ProgressTimeout))
 		}

--- a/pkg/library/container/container.go
+++ b/pkg/library/container/container.go
@@ -45,7 +45,7 @@ import (
 // rewritten as Volumes are added to PodAdditions, in order to support e.g. using one PVC to hold all volumes
 //
 // Note: Requires DevWorkspace to be flattened (i.e. the DevWorkspace contains no Parent or Components of type Plugin)
-func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, securityContext *corev1.SecurityContext, pullPolicy string, defaultResources *corev1.ResourceRequirements, postStartTimeout *int32) (*v1alpha1.PodAdditions, error) {
+func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, securityContext *corev1.SecurityContext, pullPolicy string, defaultResources *corev1.ResourceRequirements, postStartTimeout string) (*v1alpha1.PodAdditions, error) {
 	if !flatten.DevWorkspaceIsFlattened(workspace, nil) {
 		return nil, fmt.Errorf("devfile is not flattened")
 	}

--- a/pkg/library/container/container.go
+++ b/pkg/library/container/container.go
@@ -45,7 +45,7 @@ import (
 // rewritten as Volumes are added to PodAdditions, in order to support e.g. using one PVC to hold all volumes
 //
 // Note: Requires DevWorkspace to be flattened (i.e. the DevWorkspace contains no Parent or Components of type Plugin)
-func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, securityContext *corev1.SecurityContext, pullPolicy string, defaultResources *corev1.ResourceRequirements) (*v1alpha1.PodAdditions, error) {
+func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, securityContext *corev1.SecurityContext, pullPolicy string, defaultResources *corev1.ResourceRequirements, postStartTimeout *int32) (*v1alpha1.PodAdditions, error) {
 	if !flatten.DevWorkspaceIsFlattened(workspace, nil) {
 		return nil, fmt.Errorf("devfile is not flattened")
 	}
@@ -77,7 +77,7 @@ func GetKubeContainersFromDevfile(workspace *dw.DevWorkspaceTemplateSpec, securi
 		podAdditions.Containers = append(podAdditions.Containers, *k8sContainer)
 	}
 
-	if err := lifecycle.AddPostStartLifecycleHooks(workspace, podAdditions.Containers); err != nil {
+	if err := lifecycle.AddPostStartLifecycleHooks(workspace, podAdditions.Containers, postStartTimeout); err != nil {
 		return nil, err
 	}
 

--- a/pkg/library/container/container_test.go
+++ b/pkg/library/container/container_test.go
@@ -87,7 +87,7 @@ func TestGetKubeContainersFromDevfile(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check that file is read correctly.
 			assert.True(t, len(tt.Input.Components) > 0, "Input defines no components")
-			gotPodAdditions, err := GetKubeContainersFromDevfile(tt.Input, nil, testImagePullPolicy, defaultResources, nil)
+			gotPodAdditions, err := GetKubeContainersFromDevfile(tt.Input, nil, testImagePullPolicy, defaultResources, "")
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {

--- a/pkg/library/container/container_test.go
+++ b/pkg/library/container/container_test.go
@@ -87,7 +87,7 @@ func TestGetKubeContainersFromDevfile(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			// sanity check that file is read correctly.
 			assert.True(t, len(tt.Input.Components) > 0, "Input defines no components")
-			gotPodAdditions, err := GetKubeContainersFromDevfile(tt.Input, nil, testImagePullPolicy, defaultResources)
+			gotPodAdditions, err := GetKubeContainersFromDevfile(tt.Input, nil, testImagePullPolicy, defaultResources, nil)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {

--- a/pkg/library/lifecycle/poststart.go
+++ b/pkg/library/lifecycle/poststart.go
@@ -81,6 +81,78 @@ func AddPostStartLifecycleHooks(wksp *dw.DevWorkspaceTemplateSpec, containers []
 	return nil
 }
 
+// processCommandsForPostStart processes a list of DevWorkspace commands
+// and generates a corev1.LifecycleHandler for the PostStart lifecycle hook.
+func processCommandsForPostStart(commands []dw.Command, postStartTimeout *int32) (*corev1.LifecycleHandler, error) {
+	if postStartTimeout == nil || *postStartTimeout == 0 {
+		// use the fallback if no timeout propagated
+		return processCommandsWithoutTimeoutFallback(commands)
+	}
+
+	originalUserScript, err := buildUserScript(commands)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build aggregated user script: %w", err)
+	}
+
+	// The user script needs 'set -e' to ensure it exits on error.
+	// This script is then passed to `sh -c '...'`, so single quotes within it must be escaped.
+	scriptToExecute := "set -e\n" + originalUserScript
+	escapedUserScriptForTimeoutWrapper := strings.ReplaceAll(scriptToExecute, "'", `'\''`)
+
+	fullScriptWithTimeout := generateScriptWithTimeout(escapedUserScriptForTimeoutWrapper, *postStartTimeout)
+
+	finalScriptForHook := fmt.Sprintf(redirectOutputFmt, fullScriptWithTimeout)
+
+	handler := &corev1.LifecycleHandler{
+		Exec: &corev1.ExecAction{
+			Command: []string{
+				"/bin/sh",
+				"-c",
+				finalScriptForHook,
+			},
+		},
+	}
+	return handler, nil
+}
+
+// processCommandsWithoutTimeoutFallback builds a lifecycle handler that runs the provided command(s)
+// The command has the format
+//
+// exec:
+//
+//	command:
+//	  - "/bin/sh"
+//	  - "-c"
+//	  - |
+//	    cd <workingDir>
+//	    <commandline>
+func processCommandsWithoutTimeoutFallback(commands []dw.Command) (*corev1.LifecycleHandler, error) {
+	var dwCommands []string
+	for _, command := range commands {
+		execCmd := command.Exec
+		if len(execCmd.Env) > 0 {
+			return nil, fmt.Errorf("env vars in postStart command %s are unsupported", command.Id)
+		}
+		if execCmd.WorkingDir != "" {
+			dwCommands = append(dwCommands, fmt.Sprintf("cd %s", execCmd.WorkingDir))
+		}
+		dwCommands = append(dwCommands, execCmd.CommandLine)
+	}
+
+	joinedCommands := strings.Join(dwCommands, "\n")
+
+	handler := &corev1.LifecycleHandler{
+		Exec: &corev1.ExecAction{
+			Command: []string{
+				"/bin/sh",
+				"-c",
+				fmt.Sprintf(noTimeoutRedirectOutputFmt, joinedCommands),
+			},
+		},
+	}
+	return handler, nil
+}
+
 // buildUserScript takes a list of DevWorkspace commands and constructs a single
 // shell script string that executes them sequentially.
 func buildUserScript(commands []dw.Command) (string, error) {
@@ -155,76 +227,4 @@ fi
 
 exit $exit_code
 `, timeoutSeconds, escapedUserScript)
-}
-
-// processCommandsForPostStart processes a list of DevWorkspace commands
-// and generates a corev1.LifecycleHandler for the PostStart lifecycle hook.
-func processCommandsForPostStart(commands []dw.Command, postStartTimeout *int32) (*corev1.LifecycleHandler, error) {
-	if postStartTimeout == nil || *postStartTimeout == 0 {
-		// use the fallback if no timeout propagated
-		return processCommandsWithoutTimeoutFallback(commands)
-	}
-
-	originalUserScript, err := buildUserScript(commands)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build aggregated user script: %w", err)
-	}
-
-	// The user script needs 'set -e' to ensure it exits on error.
-	// This script is then passed to `sh -c '...'`, so single quotes within it must be escaped.
-	scriptToExecute := "set -e\n" + originalUserScript
-	escapedUserScriptForTimeoutWrapper := strings.ReplaceAll(scriptToExecute, "'", `'\''`)
-
-	fullScriptWithTimeout := generateScriptWithTimeout(escapedUserScriptForTimeoutWrapper, *postStartTimeout)
-
-	finalScriptForHook := fmt.Sprintf(redirectOutputFmt, fullScriptWithTimeout)
-
-	handler := &corev1.LifecycleHandler{
-		Exec: &corev1.ExecAction{
-			Command: []string{
-				"/bin/sh",
-				"-c",
-				finalScriptForHook,
-			},
-		},
-	}
-	return handler, nil
-}
-
-// processCommandsForPostStart builds a lifecycle handler that runs the provided command(s)
-// The command has the format
-//
-// exec:
-//
-//	command:
-//	  - "/bin/sh"
-//	  - "-c"
-//	  - |
-//	    cd <workingDir>
-//	    <commandline>
-func processCommandsWithoutTimeoutFallback(commands []dw.Command) (*corev1.LifecycleHandler, error) {
-	var dwCommands []string
-	for _, command := range commands {
-		execCmd := command.Exec
-		if len(execCmd.Env) > 0 {
-			return nil, fmt.Errorf("env vars in postStart command %s are unsupported", command.Id)
-		}
-		if execCmd.WorkingDir != "" {
-			dwCommands = append(dwCommands, fmt.Sprintf("cd %s", execCmd.WorkingDir))
-		}
-		dwCommands = append(dwCommands, execCmd.CommandLine)
-	}
-
-	joinedCommands := strings.Join(dwCommands, "\n")
-
-	handler := &corev1.LifecycleHandler{
-		Exec: &corev1.ExecAction{
-			Command: []string{
-				"/bin/sh",
-				"-c",
-				fmt.Sprintf(noTimeoutRedirectOutputFmt, joinedCommands),
-			},
-		},
-	}
-	return handler, nil
 }

--- a/pkg/library/lifecycle/poststart.go
+++ b/pkg/library/lifecycle/poststart.go
@@ -119,7 +119,7 @@ _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
 if command -v timeout >/dev/null 2>&1; then
   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
   _WAS_TIMEOUT_USED="true"
 else
   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2

--- a/pkg/library/lifecycle/poststart.go
+++ b/pkg/library/lifecycle/poststart.go
@@ -222,7 +222,7 @@ func processCommandsWithoutTimeoutFallback(commands []dw.Command) (*corev1.Lifec
 			Command: []string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf(redirectOutputFmt, joinedCommands),
+				fmt.Sprintf(noTimeoutRedirectOutputFmt, joinedCommands),
 			},
 		},
 	}

--- a/pkg/library/lifecycle/poststart.go
+++ b/pkg/library/lifecycle/poststart.go
@@ -163,14 +163,13 @@ func buildUserScript(commands []dw.Command) (string, error) {
 			// Should be caught by earlier validation, but good to be safe
 			return "", fmt.Errorf("exec command is nil for command ID %s", command.Id)
 		}
-		if len(execCmd.Env) > 0 {
-			return "", fmt.Errorf("env vars in postStart command %s are unsupported", command.Id)
-		}
 		var singleCommandParts []string
+		for _, envVar := range execCmd.Env {
+			singleCommandParts = append(singleCommandParts, fmt.Sprintf("export %s=%q", envVar.Name, envVar.Value))
+		}
+
 		if execCmd.WorkingDir != "" {
-			// Safely quote the working directory path
-			safeWorkingDir := strings.ReplaceAll(execCmd.WorkingDir, "'", `'\''`)
-			singleCommandParts = append(singleCommandParts, fmt.Sprintf("cd '%s'", safeWorkingDir))
+			singleCommandParts = append(singleCommandParts, fmt.Sprintf("cd %q", execCmd.WorkingDir))
 		}
 		if execCmd.CommandLine != "" {
 			singleCommandParts = append(singleCommandParts, execCmd.CommandLine)

--- a/pkg/library/lifecycle/poststart_test.go
+++ b/pkg/library/lifecycle/poststart_test.go
@@ -132,7 +132,7 @@ func TestBuildUserScript(t *testing.T) {
 					},
 				},
 			},
-			expectedScript: "cd '/projects/app' && ls -la",
+			expectedScript: "cd \"/projects/app\" && ls -la",
 			expectedErr:    "",
 		},
 		{
@@ -148,7 +148,7 @@ func TestBuildUserScript(t *testing.T) {
 					},
 				},
 			},
-			expectedScript: "cd '/data'",
+			expectedScript: "cd \"/data\"",
 			expectedErr:    "",
 		},
 		{
@@ -165,7 +165,7 @@ func TestBuildUserScript(t *testing.T) {
 					},
 				},
 			},
-			expectedScript: "cd '/projects/app'\\''s' && cat file.txt",
+			expectedScript: "cd \"/projects/app's\" && cat file.txt",
 			expectedErr:    "",
 		},
 		{
@@ -201,11 +201,11 @@ func TestBuildUserScript(t *testing.T) {
 					},
 				},
 			},
-			expectedScript: "cd '/projects/frontend' && npm install\nnpm start\ncd '/projects/backend' && mvn spring-boot:run",
+			expectedScript: "cd \"/projects/frontend\" && npm install\nnpm start\ncd \"/projects/backend\" && mvn spring-boot:run",
 			expectedErr:    "",
 		},
 		{
-			name: "Command with unsupported Env vars",
+			name: "Command with Env vars",
 			commands: []dw.Command{
 				{
 					Id: "cmd-with-env",
@@ -220,8 +220,8 @@ func TestBuildUserScript(t *testing.T) {
 					},
 				},
 			},
-			expectedScript: "",
-			expectedErr:    "env vars in postStart command cmd-with-env are unsupported",
+			expectedScript: "export MY_VAR=\"test\" && echo $MY_VAR",
+			expectedErr:    "",
 		},
 		{
 			name: "Command with nil Exec field",

--- a/pkg/library/lifecycle/poststart_test.go
+++ b/pkg/library/lifecycle/poststart_test.go
@@ -313,7 +313,7 @@ _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
 if command -v timeout >/dev/null 2>&1; then
   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
   _WAS_TIMEOUT_USED="true"
 else
   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
@@ -359,7 +359,7 @@ _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
 if command -v timeout >/dev/null 2>&1; then
   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
   _WAS_TIMEOUT_USED="true"
 else
   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
@@ -404,7 +404,7 @@ _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
 if command -v timeout >/dev/null 2>&1; then
   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
   _WAS_TIMEOUT_USED="true"
 else
   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
@@ -449,7 +449,7 @@ _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
 if command -v timeout >/dev/null 2>&1; then
   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
   _WAS_TIMEOUT_USED="true"
 else
   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2

--- a/pkg/library/lifecycle/poststart_test.go
+++ b/pkg/library/lifecycle/poststart_test.go
@@ -75,7 +75,8 @@ func TestAddPostStartLifecycleHooks(t *testing.T) {
 	tests := loadAllPostStartTestCasesOrPanic(t, "./testdata/postStart")
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.testPath), func(t *testing.T) {
-			err := AddPostStartLifecycleHooks(tt.Input.Devfile, tt.Input.Containers, nil)
+			var timeout int32
+			err := AddPostStartLifecycleHooks(tt.Input.Devfile, tt.Input.Containers, &timeout)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {

--- a/pkg/library/lifecycle/poststart_test.go
+++ b/pkg/library/lifecycle/poststart_test.go
@@ -75,7 +75,7 @@ func TestAddPostStartLifecycleHooks(t *testing.T) {
 	tests := loadAllPostStartTestCasesOrPanic(t, "./testdata/postStart")
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s (%s)", tt.Name, tt.testPath), func(t *testing.T) {
-			err := AddPostStartLifecycleHooks(tt.Input.Devfile, tt.Input.Containers)
+			err := AddPostStartLifecycleHooks(tt.Input.Devfile, tt.Input.Containers, nil)
 			if tt.Output.ErrRegexp != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.Output.ErrRegexp, err.Error(), "Error message should match")
 			} else {
@@ -84,6 +84,341 @@ func TestAddPostStartLifecycleHooks(t *testing.T) {
 				}
 				assert.Equal(t, tt.Output.Containers, tt.Input.Containers, "Containers should be updated to match expected output")
 			}
+		})
+	}
+}
+
+func TestBuildUserScript(t *testing.T) {
+	tests := []struct {
+		name           string
+		commands       []dw.Command
+		expectedScript string
+		expectedErr    string
+	}{
+		{
+			name:           "No commands",
+			commands:       []dw.Command{},
+			expectedScript: "",
+			expectedErr:    "",
+		},
+		{
+			name: "Single command without workingDir",
+			commands: []dw.Command{
+				{
+					Id: "cmd1",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							CommandLine: "echo hello",
+							Component:   "tools",
+						},
+					},
+				},
+			},
+			expectedScript: "echo hello",
+			expectedErr:    "",
+		},
+		{
+			name: "Single command with workingDir",
+			commands: []dw.Command{
+				{
+					Id: "cmd1",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							CommandLine: "ls -la",
+							WorkingDir:  "/projects/app",
+							Component:   "tools",
+						},
+					},
+				},
+			},
+			expectedScript: "cd '/projects/app' && ls -la",
+			expectedErr:    "",
+		},
+		{
+			name: "Single command with only workingDir",
+			commands: []dw.Command{
+				{
+					Id: "cmd1",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							WorkingDir: "/data",
+							Component:  "tools",
+						},
+					},
+				},
+			},
+			expectedScript: "cd '/data'",
+			expectedErr:    "",
+		},
+		{
+			name: "Single command with workingDir containing single quote",
+			commands: []dw.Command{
+				{
+					Id: "cmd1",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							CommandLine: "cat file.txt",
+							WorkingDir:  "/projects/app's",
+							Component:   "tools",
+						},
+					},
+				},
+			},
+			expectedScript: "cd '/projects/app'\\''s' && cat file.txt",
+			expectedErr:    "",
+		},
+		{
+			name: "Multiple commands",
+			commands: []dw.Command{
+				{
+					Id: "cmd1",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							CommandLine: "npm install",
+							WorkingDir:  "/projects/frontend",
+							Component:   "tools",
+						},
+					},
+				},
+				{
+					Id: "cmd2",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							CommandLine: "npm start",
+							Component:   "tools",
+						},
+					},
+				},
+				{
+					Id: "cmd3",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							WorkingDir:  "/projects/backend",
+							CommandLine: "mvn spring-boot:run",
+							Component:   "tools",
+						},
+					},
+				},
+			},
+			expectedScript: "cd '/projects/frontend' && npm install\nnpm start\ncd '/projects/backend' && mvn spring-boot:run",
+			expectedErr:    "",
+		},
+		{
+			name: "Command with unsupported Env vars",
+			commands: []dw.Command{
+				{
+					Id: "cmd-with-env",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							CommandLine: "echo $MY_VAR",
+							Component:   "tools",
+							Env: []dw.EnvVar{
+								{Name: "MY_VAR", Value: "test"},
+							},
+						},
+					},
+				},
+			},
+			expectedScript: "",
+			expectedErr:    "env vars in postStart command cmd-with-env are unsupported",
+		},
+		{
+			name: "Command with nil Exec field",
+			commands: []dw.Command{
+				{
+					Id:           "cmd-nil-exec",
+					CommandUnion: dw.CommandUnion{Exec: nil},
+				},
+			},
+			expectedScript: "",
+			expectedErr:    "exec command is nil for command ID cmd-nil-exec",
+		},
+		{
+			name: "Command with empty CommandLine and no WorkingDir",
+			commands: []dw.Command{
+				{
+					Id: "cmd-empty",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							CommandLine: "",
+							WorkingDir:  "",
+							Component:   "tools",
+						},
+					},
+				},
+				{
+					Id: "cmd-after-empty",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							CommandLine: "echo 'still works'",
+							Component:   "tools",
+						},
+					},
+				},
+			},
+			expectedScript: "echo 'still works'", // The empty command should result in no line
+			expectedErr:    "",
+		},
+		{
+			name: "Command with only CommandLine (empty working dir)",
+			commands: []dw.Command{
+				{
+					Id: "cmd-empty-wdir",
+					CommandUnion: dw.CommandUnion{
+						Exec: &dw.ExecCommand{
+							CommandLine: "pwd",
+							WorkingDir:  "",
+							Component:   "tools",
+						},
+					},
+				},
+			},
+			expectedScript: "pwd",
+			expectedErr:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script, err := buildUserScript(tt.commands)
+
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedScript, script)
+			}
+		})
+	}
+}
+
+func TestGenerateScriptWithTimeout(t *testing.T) {
+	tests := []struct {
+		name              string
+		escapedUserScript string
+		timeoutSeconds    int32
+		expectedScript    string
+	}{
+		{
+			name:              "Basic script with timeout",
+			escapedUserScript: "echo 'hello world'\nsleep 1",
+			timeoutSeconds:    10,
+			expectedScript: `
+export POSTSTART_TIMEOUT_DURATION="10"
+export POSTSTART_KILL_AFTER_DURATION="5"
+
+echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+
+# Run the user's script under the 'timeout' utility.
+timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'echo 'hello world'
+sleep 1'
+exit_code=$?
+
+# Check the exit code from 'timeout'
+if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+else
+  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+fi
+
+exit $exit_code
+`,
+		},
+		{
+			name:              "Script with zero timeout (no timeout)",
+			escapedUserScript: "echo 'running indefinitely...'",
+			timeoutSeconds:    0,
+			expectedScript: `
+export POSTSTART_TIMEOUT_DURATION="0"
+export POSTSTART_KILL_AFTER_DURATION="5"
+
+echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+
+# Run the user's script under the 'timeout' utility.
+timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'echo 'running indefinitely...''
+exit_code=$?
+
+# Check the exit code from 'timeout'
+if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+else
+  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+fi
+
+exit $exit_code
+`,
+		},
+		{
+			name:              "Empty user script",
+			escapedUserScript: "",
+			timeoutSeconds:    5,
+			expectedScript: `
+export POSTSTART_TIMEOUT_DURATION="5"
+export POSTSTART_KILL_AFTER_DURATION="5"
+
+echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+
+# Run the user's script under the 'timeout' utility.
+timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c ''
+exit_code=$?
+
+# Check the exit code from 'timeout'
+if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+else
+  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+fi
+
+exit $exit_code
+`,
+		},
+		{
+			name:              "User script with already escaped single quotes",
+			escapedUserScript: "echo 'it'\\''s complex'",
+			timeoutSeconds:    30,
+			expectedScript: `
+export POSTSTART_TIMEOUT_DURATION="30"
+export POSTSTART_KILL_AFTER_DURATION="5"
+
+echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+
+# Run the user's script under the 'timeout' utility.
+timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'echo 'it'\''s complex''
+exit_code=$?
+
+# Check the exit code from 'timeout'
+if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+else
+  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+fi
+
+exit $exit_code
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := generateScriptWithTimeout(tt.escapedUserScript, tt.timeoutSeconds)
+			assert.Equal(t, tt.expectedScript, script)
 		})
 	}
 }

--- a/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
@@ -37,13 +37,8 @@ output:
               - -c
               - |
                 {
-                  # This script block ensures its exit code is preserved
-                  # while its stdout and stderr are tee'd.
-                  _script_to_run() {
-                    echo 'hello world 1' # This will be replaced by scriptWithTimeout
-                  }
-                  _script_to_run
-                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)
+                echo 'hello world 1'
+                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt
     - name: test-component-2
       image: test-img
       lifecycle:
@@ -54,13 +49,8 @@ output:
               - -c
               - |
                 {
-                  # This script block ensures its exit code is preserved
-                  # while its stdout and stderr are tee'd.
-                  _script_to_run() {
-                    cd /tmp/test-dir
-                echo 'hello world 2' # This will be replaced by scriptWithTimeout
-                  }
-                  _script_to_run
-                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)
+                cd /tmp/test-dir
+                echo 'hello world 2'
+                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt
     - name: test-component-3
       image: test-img

--- a/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
@@ -40,47 +40,7 @@ output:
                   # This script block ensures its exit code is preserved
                   # while its stdout and stderr are tee'd.
                   _script_to_run() {
-                    
-                export POSTSTART_TIMEOUT_DURATION="0"
-                export POSTSTART_KILL_AFTER_DURATION="5"
-
-                _TIMEOUT_COMMAND_PART=""
-                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
-
-                if command -v timeout >/dev/null 2>&1; then
-                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
-                  _WAS_TIMEOUT_USED="true"
-                else
-                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
-                fi
-
-                # Execute the user's script
-                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
-                echo '\''hello world 1'\'''
-                exit_code=$?
-
-                # Check the exit code based on whether timeout was attempted
-                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
-                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
-                  fi
-                else
-                  if [ $exit_code -ne 0 ]; then
-                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
-                  fi
-                fi
-
-                exit $exit_code
-                 # This will be replaced by scriptWithTimeout
+                    echo 'hello world 1' # This will be replaced by scriptWithTimeout
                   }
                   _script_to_run
                 } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)
@@ -97,50 +57,10 @@ output:
                   # This script block ensures its exit code is preserved
                   # while its stdout and stderr are tee'd.
                   _script_to_run() {
-                    
-                export POSTSTART_TIMEOUT_DURATION="0"
-                export POSTSTART_KILL_AFTER_DURATION="5"
-
-                _TIMEOUT_COMMAND_PART=""
-                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
-
-                if command -v timeout >/dev/null 2>&1; then
-                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
-                  _WAS_TIMEOUT_USED="true"
-                else
-                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
-                fi
-
-                # Execute the user's script
-                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
-                cd '\''/tmp/test-dir'\'' && echo '\''hello world 2'\'''
-                exit_code=$?
-
-                # Check the exit code based on whether timeout was attempted
-                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
-                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
-                  fi
-                else
-                  if [ $exit_code -ne 0 ]; then
-                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
-                  fi
-                fi
-
-                exit $exit_code
-                 # This will be replaced by scriptWithTimeout
+                    cd /tmp/test-dir
+                echo 'hello world 2' # This will be replaced by scriptWithTimeout
                   }
                   _script_to_run
                 } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)
-
     - name: test-component-3
       image: test-img

--- a/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
@@ -44,22 +44,39 @@ output:
                 export POSTSTART_TIMEOUT_DURATION="0"
                 export POSTSTART_KILL_AFTER_DURATION="5"
 
-                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                _TIMEOUT_COMMAND_PART=""
+                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
-                # Run the user's script under the 'timeout' utility.
-                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                if command -v timeout >/dev/null 2>&1; then
+                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _WAS_TIMEOUT_USED="true"
+                else
+                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
+                fi
+
+                # Execute the user's script
+                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
                 echo '\''hello world 1'\'''
                 exit_code=$?
 
-                # Check the exit code from 'timeout'
-                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                # Check the exit code based on whether timeout was attempted
+                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
+                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  fi
                 else
-                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  if [ $exit_code -ne 0 ]; then
+                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
+                  fi
                 fi
 
                 exit $exit_code
@@ -84,22 +101,39 @@ output:
                 export POSTSTART_TIMEOUT_DURATION="0"
                 export POSTSTART_KILL_AFTER_DURATION="5"
 
-                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                _TIMEOUT_COMMAND_PART=""
+                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
-                # Run the user's script under the 'timeout' utility.
-                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                if command -v timeout >/dev/null 2>&1; then
+                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _WAS_TIMEOUT_USED="true"
+                else
+                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
+                fi
+
+                # Execute the user's script
+                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
                 cd '\''/tmp/test-dir'\'' && echo '\''hello world 2'\'''
                 exit_code=$?
 
-                # Check the exit code from 'timeout'
-                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                # Check the exit code based on whether timeout was attempted
+                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
+                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  fi
                 else
-                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  if [ $exit_code -ne 0 ]; then
+                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
+                  fi
                 fi
 
                 exit $exit_code

--- a/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
@@ -33,25 +33,80 @@ output:
         postStart:
           exec:
             command:
-              - "/bin/sh"
-              - "-c"
+              - /bin/sh
+              - -c
               - |
                 {
-                echo 'hello world 1'
-                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt
+                  # This script block ensures its exit code is preserved
+                  # while its stdout and stderr are tee'd.
+                  _script_to_run() {
+                    
+                export POSTSTART_TIMEOUT_DURATION="0"
+                export POSTSTART_KILL_AFTER_DURATION="5"
+
+                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+
+                # Run the user's script under the 'timeout' utility.
+                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                echo '\''hello world 1'\'''
+                exit_code=$?
+
+                # Check the exit code from 'timeout'
+                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                else
+                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                fi
+
+                exit $exit_code
+                 # This will be replaced by scriptWithTimeout
+                  }
+                  _script_to_run
+                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)
     - name: test-component-2
       image: test-img
       lifecycle:
         postStart:
           exec:
             command:
-              - "/bin/sh"
-              - "-c"
+              - /bin/sh
+              - -c
               - |
                 {
-                cd /tmp/test-dir
-                echo 'hello world 2'
-                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt
+                  # This script block ensures its exit code is preserved
+                  # while its stdout and stderr are tee'd.
+                  _script_to_run() {
+                    
+                export POSTSTART_TIMEOUT_DURATION="0"
+                export POSTSTART_KILL_AFTER_DURATION="5"
+
+                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+
+                # Run the user's script under the 'timeout' utility.
+                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                cd '\''/tmp/test-dir'\'' && echo '\''hello world 2'\'''
+                exit_code=$?
+
+                # Check the exit code from 'timeout'
+                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                else
+                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                fi
+
+                exit $exit_code
+                 # This will be replaced by scriptWithTimeout
+                  }
+                  _script_to_run
+                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)
 
     - name: test-component-3
       image: test-img

--- a/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/adds_all_postStart_commands.yaml
@@ -49,7 +49,7 @@ output:
 
                 if command -v timeout >/dev/null 2>&1; then
                   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
                   _WAS_TIMEOUT_USED="true"
                 else
                   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
@@ -106,7 +106,7 @@ output:
 
                 if command -v timeout >/dev/null 2>&1; then
                   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
                   _WAS_TIMEOUT_USED="true"
                 else
                   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2

--- a/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
@@ -29,47 +29,7 @@ output:
                   # This script block ensures its exit code is preserved
                   # while its stdout and stderr are tee'd.
                   _script_to_run() {
-                    
-                export POSTSTART_TIMEOUT_DURATION="0"
-                export POSTSTART_KILL_AFTER_DURATION="5"
-
-                _TIMEOUT_COMMAND_PART=""
-                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
-
-                if command -v timeout >/dev/null 2>&1; then
-                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
-                  _WAS_TIMEOUT_USED="true"
-                else
-                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
-                fi
-
-                # Execute the user's script
-                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
-                echo '\''hello world'\'''
-                exit_code=$?
-
-                # Check the exit code based on whether timeout was attempted
-                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
-                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
-                  fi
-                else
-                  if [ $exit_code -ne 0 ]; then
-                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
-                  fi
-                fi
-
-                exit $exit_code
-                 # This will be replaced by scriptWithTimeout
+                    echo 'hello world' # This will be replaced by scriptWithTimeout
                   }
                   _script_to_run
                 } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)

--- a/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
@@ -26,10 +26,5 @@ output:
               - -c
               - |
                 {
-                  # This script block ensures its exit code is preserved
-                  # while its stdout and stderr are tee'd.
-                  _script_to_run() {
-                    echo 'hello world' # This will be replaced by scriptWithTimeout
-                  }
-                  _script_to_run
-                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)
+                echo 'hello world'
+                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt

--- a/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
@@ -22,9 +22,37 @@ output:
         postStart:
           exec:
             command:
-              - "/bin/sh"
-              - "-c"
+              - /bin/sh
+              - -c
               - |
                 {
-                echo 'hello world'
-                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt
+                  # This script block ensures its exit code is preserved
+                  # while its stdout and stderr are tee'd.
+                  _script_to_run() {
+                    
+                export POSTSTART_TIMEOUT_DURATION="0"
+                export POSTSTART_KILL_AFTER_DURATION="5"
+
+                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+
+                # Run the user's script under the 'timeout' utility.
+                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                echo '\''hello world'\'''
+                exit_code=$?
+
+                # Check the exit code from 'timeout'
+                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                else
+                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                fi
+
+                exit $exit_code
+                 # This will be replaced by scriptWithTimeout
+                  }
+                  _script_to_run
+                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)

--- a/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
@@ -38,7 +38,7 @@ output:
 
                 if command -v timeout >/dev/null 2>&1; then
                   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
                   _WAS_TIMEOUT_USED="true"
                 else
                   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2

--- a/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/basic_postStart.yaml
@@ -33,22 +33,39 @@ output:
                 export POSTSTART_TIMEOUT_DURATION="0"
                 export POSTSTART_KILL_AFTER_DURATION="5"
 
-                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                _TIMEOUT_COMMAND_PART=""
+                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
-                # Run the user's script under the 'timeout' utility.
-                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                if command -v timeout >/dev/null 2>&1; then
+                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _WAS_TIMEOUT_USED="true"
+                else
+                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
+                fi
+
+                # Execute the user's script
+                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
                 echo '\''hello world'\'''
                 exit_code=$?
 
-                # Check the exit code from 'timeout'
-                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                # Check the exit code based on whether timeout was attempted
+                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
+                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  fi
                 else
-                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  if [ $exit_code -ne 0 ]; then
+                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
+                  fi
                 fi
 
                 exit $exit_code

--- a/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
@@ -38,23 +38,40 @@ output:
                 export POSTSTART_TIMEOUT_DURATION="0"
                 export POSTSTART_KILL_AFTER_DURATION="5"
 
-                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                _TIMEOUT_COMMAND_PART=""
+                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
-                # Run the user's script under the 'timeout' utility.
-                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                if command -v timeout >/dev/null 2>&1; then
+                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _WAS_TIMEOUT_USED="true"
+                else
+                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
+                fi
+
+                # Execute the user's script
+                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
                 echo '\''hello world 1'\''
                 echo '\''hello world 2'\'''
                 exit_code=$?
 
-                # Check the exit code from 'timeout'
-                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                # Check the exit code based on whether timeout was attempted
+                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
+                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  fi
                 else
-                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  if [ $exit_code -ne 0 ]; then
+                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
+                  fi
                 fi
 
                 exit $exit_code

--- a/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
@@ -43,7 +43,7 @@ output:
 
                 if command -v timeout >/dev/null 2>&1; then
                   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
                   _WAS_TIMEOUT_USED="true"
                 else
                   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2

--- a/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
@@ -27,10 +27,38 @@ output:
         postStart:
           exec:
             command:
-              - "/bin/sh"
-              - "-c"
+              - /bin/sh
+              - -c
               - |
                 {
-                echo 'hello world 1'
-                echo 'hello world 2'
-                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt
+                  # This script block ensures its exit code is preserved
+                  # while its stdout and stderr are tee'd.
+                  _script_to_run() {
+                    
+                export POSTSTART_TIMEOUT_DURATION="0"
+                export POSTSTART_KILL_AFTER_DURATION="5"
+
+                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+
+                # Run the user's script under the 'timeout' utility.
+                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                echo '\''hello world 1'\''
+                echo '\''hello world 2'\'''
+                exit_code=$?
+
+                # Check the exit code from 'timeout'
+                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                else
+                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                fi
+
+                exit $exit_code
+                 # This will be replaced by scriptWithTimeout
+                  }
+                  _script_to_run
+                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)

--- a/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
@@ -31,11 +31,6 @@ output:
               - -c
               - |
                 {
-                  # This script block ensures its exit code is preserved
-                  # while its stdout and stderr are tee'd.
-                  _script_to_run() {
-                    echo 'hello world 1'
-                echo 'hello world 2' # This will be replaced by scriptWithTimeout
-                  }
-                  _script_to_run
-                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)
+                echo 'hello world 1'
+                echo 'hello world 2'
+                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt

--- a/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/multiple_poststart_commands.yaml
@@ -34,48 +34,8 @@ output:
                   # This script block ensures its exit code is preserved
                   # while its stdout and stderr are tee'd.
                   _script_to_run() {
-                    
-                export POSTSTART_TIMEOUT_DURATION="0"
-                export POSTSTART_KILL_AFTER_DURATION="5"
-
-                _TIMEOUT_COMMAND_PART=""
-                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
-
-                if command -v timeout >/dev/null 2>&1; then
-                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
-                  _WAS_TIMEOUT_USED="true"
-                else
-                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
-                fi
-
-                # Execute the user's script
-                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
-                echo '\''hello world 1'\''
-                echo '\''hello world 2'\'''
-                exit_code=$?
-
-                # Check the exit code based on whether timeout was attempted
-                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
-                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
-                  fi
-                else
-                  if [ $exit_code -ne 0 ]; then
-                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
-                  fi
-                fi
-
-                exit $exit_code
-                 # This will be replaced by scriptWithTimeout
+                    echo 'hello world 1'
+                echo 'hello world 2' # This will be replaced by scriptWithTimeout
                   }
                   _script_to_run
                 } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)

--- a/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
@@ -30,47 +30,8 @@ output:
                   # This script block ensures its exit code is preserved
                   # while its stdout and stderr are tee'd.
                   _script_to_run() {
-                    
-                export POSTSTART_TIMEOUT_DURATION="0"
-                export POSTSTART_KILL_AFTER_DURATION="5"
-
-                _TIMEOUT_COMMAND_PART=""
-                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
-
-                if command -v timeout >/dev/null 2>&1; then
-                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
-                  _WAS_TIMEOUT_USED="true"
-                else
-                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
-                fi
-
-                # Execute the user's script
-                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
-                cd '\''/tmp/test-dir'\'' && echo '\''hello world'\'''
-                exit_code=$?
-
-                # Check the exit code based on whether timeout was attempted
-                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
-                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
-                  fi
-                else
-                  if [ $exit_code -ne 0 ]; then
-                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
-                  else
-                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
-                  fi
-                fi
-
-                exit $exit_code
-                 # This will be replaced by scriptWithTimeout
+                    cd /tmp/test-dir
+                echo 'hello world' # This will be replaced by scriptWithTimeout
                   }
                   _script_to_run
                 } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)

--- a/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
@@ -34,22 +34,39 @@ output:
                 export POSTSTART_TIMEOUT_DURATION="0"
                 export POSTSTART_KILL_AFTER_DURATION="5"
 
-                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                _TIMEOUT_COMMAND_PART=""
+                _WAS_TIMEOUT_USED="false" # Use strings "true" or "false" for shell boolean
 
-                # Run the user's script under the 'timeout' utility.
-                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                if command -v timeout >/dev/null 2>&1; then
+                  echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _WAS_TIMEOUT_USED="true"
+                else
+                  echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2
+                fi
+
+                # Execute the user's script
+                ${_TIMEOUT_COMMAND_PART} /bin/sh -c 'set -e
                 cd '\''/tmp/test-dir'\'' && echo '\''hello world'\'''
                 exit_code=$?
 
-                # Check the exit code from 'timeout'
-                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
-                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
-                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
-                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
-                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
-                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                # Check the exit code based on whether timeout was attempted
+                if [ "$_WAS_TIMEOUT_USED" = "true" ]; then
+                  if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                    echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                  elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                    echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                  elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                    echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  fi
                 else
-                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                  if [ $exit_code -ne 0 ]; then
+                    echo "[postStart hook] Commands failed with exit code $exit_code (no timeout)." >&2
+                  else
+                    echo "[postStart hook] Commands completed successfully (no timeout)." >&2
+                  fi
                 fi
 
                 exit $exit_code

--- a/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
@@ -23,10 +23,37 @@ output:
         postStart:
           exec:
             command:
-              - "/bin/sh"
-              - "-c"
+              - /bin/sh
+              - -c
               - |
                 {
-                cd /tmp/test-dir
-                echo 'hello world'
-                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt
+                  # This script block ensures its exit code is preserved
+                  # while its stdout and stderr are tee'd.
+                  _script_to_run() {
+                    
+                export POSTSTART_TIMEOUT_DURATION="0"
+                export POSTSTART_KILL_AFTER_DURATION="5"
+
+                echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
+
+                # Run the user's script under the 'timeout' utility.
+                timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c 'set -e
+                cd '\''/tmp/test-dir'\'' && echo '\''hello world'\'''
+                exit_code=$?
+
+                # Check the exit code from 'timeout'
+                if [ $exit_code -eq 143 ]; then # 128 + 15 (SIGTERM)
+                  echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}s). Exit code 143." >&2
+                elif [ $exit_code -eq 137 ]; then # 128 + 9 (SIGKILL)
+                  echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION}s expired). Exit code 137." >&2
+                elif [ $exit_code -ne 0 ]; then # Catches any other non-zero exit code
+                  echo "[postStart hook] Commands failed with exit code $exit_code." >&2
+                else
+                  echo "[postStart hook] Commands completed successfully within the time limit." >&2
+                fi
+
+                exit $exit_code
+                 # This will be replaced by scriptWithTimeout
+                  }
+                  _script_to_run
+                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)

--- a/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
@@ -27,11 +27,6 @@ output:
               - -c
               - |
                 {
-                  # This script block ensures its exit code is preserved
-                  # while its stdout and stderr are tee'd.
-                  _script_to_run() {
-                    cd /tmp/test-dir
-                echo 'hello world' # This will be replaced by scriptWithTimeout
-                  }
-                  _script_to_run
-                } 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2)
+                cd /tmp/test-dir
+                echo 'hello world'
+                } 1>/tmp/poststart-stdout.txt 2>/tmp/poststart-stderr.txt

--- a/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
+++ b/pkg/library/lifecycle/testdata/postStart/workingDir_postStart.yaml
@@ -39,7 +39,7 @@ output:
 
                 if command -v timeout >/dev/null 2>&1; then
                   echo "[postStart hook] Executing commands with timeout: ${POSTSTART_TIMEOUT_DURATION} seconds, kill after: ${POSTSTART_KILL_AFTER_DURATION} seconds" >&2
-                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=\"${POSTSTART_KILL_AFTER_DURATION}\" \"${POSTSTART_TIMEOUT_DURATION}\""
+                  _TIMEOUT_COMMAND_PART="timeout --preserve-status --kill-after=${POSTSTART_KILL_AFTER_DURATION} ${POSTSTART_TIMEOUT_DURATION}"
                   _WAS_TIMEOUT_USED="true"
                 else
                   echo "[postStart hook] WARNING: 'timeout' utility not found. Executing commands without timeout." >&2

--- a/pkg/library/status/check.go
+++ b/pkg/library/status/check.go
@@ -33,19 +33,19 @@ import (
 
 var (
 	// reTerminatedSigterm matches: "[postStart hook] Commands terminated by SIGTERM (likely timed out after ...s). Exit code 143."
-	reTerminatedSigterm = regexp.MustCompile(`(\\[postStart hook\\] Commands terminated by SIGTERM \\(likely timed out after [^)]+?\\)\\. Exit code 143\\.)`)
+	reTerminatedSigterm = regexp.MustCompile(`\[postStart hook\] Commands terminated by SIGTERM \(likely timed out after \d+[^\)]+?\)\. Exit code 143\.`)
 
 	// reKilledSigkill matches: "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ...s expired). Exit code 137."
-	reKilledSigkill = regexp.MustCompile(`(\\[postStart hook\\] Commands forcefully killed by SIGKILL \\(likely after --kill-after [^)]+?\\)\\. Exit code 137\\.)`)
+	reKilledSigkill = regexp.MustCompile(`\[postStart hook\] Commands forcefully killed by SIGKILL \(likely after --kill-after \d+[^\)]+?\)\. Exit code 137\.`)
 
 	// reGenericFailedExitCode matches: "[postStart hook] Commands failed with exit code ..." (for any other script-reported non-zero exit code)
-	reGenericFailedExitCode = regexp.MustCompile(`(\\[postStart hook\\] Commands failed with exit code \\d+\\.)`)
+	reGenericFailedExitCode = regexp.MustCompile(`\[postStart hook\] Commands failed with exit code \d+\.`)
 
 	// reKubeletInternalMessage regex to capture Kubelet's explicit message field content if it exists
-	reKubeletInternalMessage = regexp.MustCompile(`message:\\s*"([^"]*)"`)
+	reKubeletInternalMessage = regexp.MustCompile(`message:\s*"([^"]*)"`)
 
 	// reKubeletExitCode regex to capture Kubelet's reported exit code for the hook command
-	reKubeletExitCode = regexp.MustCompile(`exited with (\\d+):`)
+	reKubeletExitCode = regexp.MustCompile(`exited with (\d+):`)
 )
 
 var containerFailureStateReasons = []string{

--- a/pkg/library/status/check.go
+++ b/pkg/library/status/check.go
@@ -18,6 +18,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
@@ -145,10 +146,15 @@ func CheckPodEvents(pod *corev1.Pod, workspaceID string, ignoredEvents []string,
 		if maxCount, isUnrecoverableEvent := unrecoverablePodEventReasons[ev.Reason]; isUnrecoverableEvent {
 			if !checkIfUnrecoverableEventIgnored(ev.Reason, ignoredEvents) && getEventCount(ev) >= maxCount {
 				var msg string
+				eventMessage := ev.Message // Original Kubelet message from the event
+				if ev.Reason == "FailedPostStartHook" {
+					eventMessage = getConcisePostStartFailureMessage(ev.Message)
+				}
+
 				if getEventCount(ev) > 1 {
-					msg = fmt.Sprintf("Detected unrecoverable event %s %d times: %s.", ev.Reason, getEventCount(ev), ev.Message)
+					msg = fmt.Sprintf("Detected unrecoverable event %s %d times: %s", ev.Reason, getEventCount(ev), eventMessage)
 				} else {
-					msg = fmt.Sprintf("Detected unrecoverable event %s: %s.", ev.Reason, ev.Message)
+					msg = fmt.Sprintf("Detected unrecoverable event %s: %s", ev.Reason, eventMessage)
 				}
 				return msg, nil
 			}
@@ -157,22 +163,110 @@ func CheckPodEvents(pod *corev1.Pod, workspaceID string, ignoredEvents []string,
 	return "", nil
 }
 
+// getConcisePostStartFailureMessage tries to parse the Kubelet's verbose message
+// for a PostStartHookError into a more user-friendly one.
+func getConcisePostStartFailureMessage(kubeletMsg string) string {
+
+	/* regexes for specific messages from our postStart script's output */
+
+	// matches: "[postStart hook] Commands terminated by SIGTERM (likely timed out after ...s). Exit code 143."
+	reTerminatedSigterm := regexp.MustCompile(`(\[postStart hook\] Commands terminated by SIGTERM \(likely timed out after [^)]+?\)\. Exit code 143\.)`)
+
+	// matches: "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ...s expired). Exit code 137."
+	reKilledSigkill := regexp.MustCompile(`(\[postStart hook\] Commands forcefully killed by SIGKILL \(likely after --kill-after [^)]+?\)\. Exit code 137\.)`)
+
+	// matches: "[postStart hook] Commands failed with exit code ..." (for any other script-reported non-zero exit code)
+	reGenericFailedExitCode := regexp.MustCompile(`(\[postStart hook\] Commands failed with exit code \d+\.)`)
+
+	// regex to capture Kubelet's explicit message field content if it exists
+	reKubeletInternalMessage := regexp.MustCompile(`message:\s*"([^"]*)"`)
+
+	// regex to capture Kubelet's reported exit code for the hook command
+	reKubeletExitCode := regexp.MustCompile(`exited with (\d+):`)
+
+	/* 1: check Kubelet's explicit `message: "..."` field for the specific output */
+
+	kubeletInternalMsgMatch := reKubeletInternalMessage.FindStringSubmatch(kubeletMsg)
+	if len(kubeletInternalMsgMatch) > 1 && kubeletInternalMsgMatch[1] != "" {
+		internalMsg := kubeletInternalMsgMatch[1]
+		if match := reTerminatedSigterm.FindString(internalMsg); match != "" {
+			return match
+		}
+		if match := reKilledSigkill.FindString(internalMsg); match != "" {
+			return match
+		}
+		if match := reGenericFailedExitCode.FindString(internalMsg); match != "" {
+			return match
+		}
+	}
+
+	/* 2: parse Kubelet's reported exit code for the entire hook command */
+
+	matchesKubeletExitCode := reKubeletExitCode.FindStringSubmatch(kubeletMsg)
+	if len(matchesKubeletExitCode) > 1 {
+		exitCodeStr := matchesKubeletExitCode[1]
+		var exitCode int
+		fmt.Sscanf(exitCodeStr, "%d", &exitCode)
+
+		// generate messages indicating the source is Kubelet's reported exit code
+		if exitCode == 143 { // SIGTERM
+			return "[postStart hook] Commands terminated by SIGTERM due to timeout"
+		} else if exitCode == 137 { // SIGKILL
+			return "[postStart hook] Commands forcefully killed by SIGKILL due to timeout"
+		} else if exitCode != 0 { // Other non-zero exit codes (e.g., 124, 127)
+			return fmt.Sprintf("[postStart hook] Commands failed (Kubelet reported exit code %s)", exitCodeStr)
+		}
+	}
+
+	/* 3: try to match specific script outputs against the *entire* Kubelet message */
+
+	if match := reTerminatedSigterm.FindString(kubeletMsg); match != "" {
+		return match
+	}
+	if match := reKilledSigkill.FindString(kubeletMsg); match != "" {
+		return match
+	}
+	if match := reGenericFailedExitCode.FindString(kubeletMsg); match != "" {
+		return match
+	}
+
+	/* 4: fallback */
+
+	return "[postStart hook] failed with an unknown error (see pod events or container logs for more details)"
+}
+
 func CheckContainerStatusForFailure(containerStatus *corev1.ContainerStatus, ignoredEvents []string) (ok bool, reason string) {
 	if containerStatus.State.Waiting != nil {
+		// Explicitly check for PostStartHookError
+		if containerStatus.State.Waiting.Reason == "PostStartHookError" { // Kubelet uses this reason
+			conciseMsg := getConcisePostStartFailureMessage(containerStatus.State.Waiting.Message)
+			return checkIfUnrecoverableEventIgnored("FailedPostStartHook", ignoredEvents), conciseMsg
+		}
+		// Check against other generic failure reasons
 		for _, failureReason := range containerFailureStateReasons {
 			if containerStatus.State.Waiting.Reason == failureReason {
-				return checkIfUnrecoverableEventIgnored(containerStatus.State.Waiting.Reason, ignoredEvents), containerStatus.State.Waiting.Reason
+				return checkIfUnrecoverableEventIgnored(containerStatus.State.Waiting.Reason, ignoredEvents),
+					containerStatus.State.Waiting.Reason
 			}
 		}
 	}
 
 	if containerStatus.State.Terminated != nil {
+		// Check if termination was due to a generic error, which might include postStart issues
+		// if the container failed to run.
+		if containerStatus.State.Terminated.Reason == "Error" || containerStatus.State.Terminated.Reason == "ContainerCannotRun" {
+			return checkIfUnrecoverableEventIgnored(containerStatus.State.Terminated.Reason, ignoredEvents),
+				fmt.Sprintf("%s: %s", containerStatus.State.Terminated.Reason, containerStatus.State.Terminated.Message)
+		}
+		// Check against other generic failure reasons for terminated state
 		for _, failureReason := range containerFailureStateReasons {
 			if containerStatus.State.Terminated.Reason == failureReason {
-				return checkIfUnrecoverableEventIgnored(containerStatus.State.Terminated.Reason, ignoredEvents), containerStatus.State.Terminated.Reason
+				return checkIfUnrecoverableEventIgnored(containerStatus.State.Terminated.Reason, ignoredEvents),
+					containerStatus.State.Terminated.Reason
 			}
 		}
 	}
+
 	return true, ""
 }
 

--- a/pkg/library/status/check_test.go
+++ b/pkg/library/status/check_test.go
@@ -1,3 +1,16 @@
+// Copyright (c) 2019-2025 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package status
 
 import (

--- a/pkg/library/status/check_test.go
+++ b/pkg/library/status/check_test.go
@@ -1,0 +1,107 @@
+package status
+
+import (
+	"testing"
+)
+
+func TestGetConcisePostStartFailureMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		kubeletMsg  string
+		expectedMsg string
+	}{
+		{
+			name:        "Kubelet internal message - SIGTERM",
+			kubeletMsg:  `PostStartHookError: rpc error: code = Unknown desc = command error: command terminated by SIGTERM, message: "[postStart hook] Commands terminated by SIGTERM (likely timed out after 30s). Exit code 143."`,
+			expectedMsg: "[postStart hook] Commands terminated by SIGTERM (likely timed out after 30s). Exit code 143.",
+		},
+		{
+			name:        "Kubelet internal message - SIGKILL",
+			kubeletMsg:  `PostStartHookError: rpc error: code = Unknown desc = command error: command terminated by SIGKILL, message: "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after 10s expired). Exit code 137."`,
+			expectedMsg: "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after 10s expired). Exit code 137.",
+		},
+		{
+			name:        "Kubelet internal message - Generic Fail",
+			kubeletMsg:  `PostStartHookError: rpc error: code = Unknown desc = command error: command failed, message: "[postStart hook] Commands failed with exit code 1."`,
+			expectedMsg: "[postStart hook] Commands failed with exit code 1.",
+		},
+		{
+			name:        "Kubelet internal message - No match, fall through to Kubelet exit code",
+			kubeletMsg:  `PostStartHookError: rpc error: code = Unknown desc = command error: command terminated by signal: SIGTERM, message: "Container command \\\'sleep 60\\\' was terminated by signal SIGTERM"\nexited with 143: ...`,
+			expectedMsg: "[postStart hook] Commands terminated by SIGTERM due to timeout",
+		},
+		{
+			name:        "Kubelet reported exit code - 143 (SIGTERM)",
+			kubeletMsg:  `PostStartHookError: command 'sh -c ...' exited with 143: ...`,
+			expectedMsg: "[postStart hook] Commands terminated by SIGTERM due to timeout",
+		},
+		{
+			name:        "Kubelet exit code - 137 (SIGKILL)",
+			kubeletMsg:  `PostStartHookError: command 'sh -c ...' exited with 137: ...`,
+			expectedMsg: "[postStart hook] Commands forcefully killed by SIGKILL due to timeout",
+		},
+		{
+			name:        "Kubelet exit code - 1 (Generic)",
+			kubeletMsg:  `PostStartHookError: command 'sh -c ...' exited with 1: ...`,
+			expectedMsg: "[postStart hook] Commands failed (Kubelet reported exit code 1)",
+		},
+		{
+			name:        "Kubelet exit code - 124 (e.g. timeout command itself)",
+			kubeletMsg:  `PostStartHookError: command 'sh -c ...' exited with 124: ...`,
+			expectedMsg: "[postStart hook] Commands failed (Kubelet reported exit code 124)",
+		},
+		{
+			name:        "Full Kubelet message match - SIGTERM (no internal message field, no Kubelet exit code first part)",
+			kubeletMsg:  `PostStartHookError: Error executing postStart hook: [postStart hook] Commands terminated by SIGTERM (likely timed out after 45s). Exit code 143.`,
+			expectedMsg: "[postStart hook] Commands terminated by SIGTERM (likely timed out after 45s). Exit code 143.",
+		},
+		{
+			name:        "Full Kubelet message match - SIGKILL (no internal message field, no Kubelet exit code first part)",
+			kubeletMsg:  `PostStartHookError: Error executing postStart hook: [postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after 5s expired). Exit code 137.`,
+			expectedMsg: "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after 5s expired). Exit code 137.",
+		},
+		{
+			name:        "Full Kubelet message match - Generic Fail (no internal message field, no Kubelet exit code first part)",
+			kubeletMsg:  `PostStartHookError: Error executing postStart hook: [postStart hook] Commands failed with exit code 2.`,
+			expectedMsg: "[postStart hook] Commands failed with exit code 2.",
+		},
+		{
+			name:        "Kubelet internal message with escaped quotes and script output",
+			kubeletMsg:  `PostStartHookError: rpc error: code = Unknown desc = failed to exec in container: command /bin/sh -c export POSTSTART_TIMEOUT_DURATION="30s"; export POSTSTART_KILL_AFTER_DURATION="10s"; echo "[postStart hook] Executing user commands with timeout ${POSTSTART_TIMEOUT_DURATION}, kill after ${POSTSTART_KILL_AFTER_DURATION}..."; _script_to_run() { set -e\\necho \\\'hello\\\' >&2\\nexit 1\\n }; timeout --preserve-status --kill-after="${POSTSTART_KILL_AFTER_DURATION}" "${POSTSTART_TIMEOUT_DURATION}" /bin/sh -c "_script_to_run" 1> >(tee -a "/tmp/poststart-stdout.txt") 2> >(tee -a "/tmp/poststart-stderr.txt" >&2); exit_code=$?; if [ $exit_code -eq 143 ]; then echo "[postStart hook] Commands terminated by SIGTERM (likely timed out after ${POSTSTART_TIMEOUT_DURATION}). Exit code 143." >&2; elif [ $exit_code -eq 137 ]; then echo "[postStart hook] Commands forcefully killed by SIGKILL (likely after --kill-after ${POSTSTART_KILL_AFTER_DURATION} expired). Exit code 137." >&2; elif [ $exit_code -ne 0 ]; then echo "[postStart hook] Commands failed with exit code ${exit_code}." >&2; fi; exit $exit_code: exit status 1, message: "[postStart hook] Commands failed with exit code 1."`,
+			expectedMsg: "[postStart hook] Commands failed with exit code 1.",
+		},
+		{
+			name:        "Fallback - Unrecognized Kubelet message",
+			kubeletMsg:  "PostStartHookError: An unexpected error occurred.",
+			expectedMsg: "[postStart hook] failed with an unknown error (see pod events or container logs for more details)",
+		},
+		{
+			name:        "Fallback - Empty Kubelet message",
+			kubeletMsg:  "",
+			expectedMsg: "[postStart hook] failed with an unknown error (see pod events or container logs for more details)",
+		},
+		{
+			name:        "Kubelet internal message - SIGTERM - with leading/trailing spaces in message",
+			kubeletMsg:  `PostStartHookError: rpc error: code = Unknown desc = command error: command terminated by SIGTERM, message: "  [postStart hook] Commands terminated by SIGTERM (likely timed out after 30s). Exit code 143.  "`,
+			expectedMsg: "[postStart hook] Commands terminated by SIGTERM (likely timed out after 30s). Exit code 143.",
+		},
+		{
+			name:        "Kubelet exit code - 143 - with surrounding text",
+			kubeletMsg:  `FailedPostStartHook: container "theia-ide" postStart hook failed: command 'sh -c mycommand' exited with 143:`,
+			expectedMsg: "[postStart hook] Commands terminated by SIGTERM due to timeout",
+		},
+		{
+			name:        "Fallback - Kubelet message with exit code 0 but error text",
+			kubeletMsg:  `PostStartHookError: command "sh -c echo hello && exit 0" exited with 0: "unexpected error"`,
+			expectedMsg: "[postStart hook] failed with an unknown error (see pod events or container logs for more details)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getConcisePostStartFailureMessage(tt.kubeletMsg); got != tt.expectedMsg {
+				t.Errorf("getConcisePostStartFailureMessage() = %v, want %v", got, tt.expectedMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR addresses the issue of `postStart` hook failures in DevWorkspaces when hook commands not exiting within the timeout period, so that the workspace pod gets stuck in `Terminating` state and never gets deleted.

This PR resolves the issue by:
- Introducing `timeout` for `postStart` hook. User-provided commands are now wrapped with the `timeout` utility. This ensures that `postStart` hook commands are terminated if they exceed a configurable duration. The timeout duration can be set in the `DevWorkspaceOperatorConfig` (a value of 0 means no timeout):
    ```yaml
    # DevWorkspaceOperatorConfig
    # ...
    config:
      workspace:
        postStartTimeout: 30 # Timeout in seconds
    ```
- Adding the parsing logic for interpreting various Kubelet messages to extract an exact reason or exit code for lifecycle hook failures.

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-8329

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

1. Install DWO from this PR:
```sh
oc apply -f - <<EOF
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: devworkspace-operator-catalog
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/okurinny/devworkspace-operator-index:postStartHookTimeout
  publisher: Red Hat
  displayName: DevWorkspace Operator Catalog
  updateStrategy:
    registryPoll:
      interval: 5m
EOF
```

```sh
oc apply -f - <<EOF
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: devworkspace-operator
  namespace: openshift-operators
spec:
  channel: next
  installPlanApproval: Automatic
  name: devworkspace-operator
  source: devworkspace-operator-catalog
  sourceNamespace: openshift-marketplace
EOF
```
2. Create `DevWorkspaceOperatorConfig` with the `postStart` hook timeout duration (in seconds):
```sh
oc apply -f - <<EOF
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
  namespace: openshift-operators
config:
  workspace:
    postStartTimeout: 30
EOF
```
3. Create a problematic `DevWorkspace` designed to have its `postStart` hook time out:
```sh
oc apply -f - <<EOF
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: problematic-workspace
spec:
  started: true
  template:
    components:
      - name: tools
        container:
          image: quay.io/devfile/universal-developer-image:ubi9-latest
          memoryLimit: "1Gi"
          memoryRequest: "512Mi"
          cpuRequest: "250m"
          cpuLimit: "1000m"
    commands:
      - id: sleep-infinity-cmd
        exec:
          component: tools
          commandLine: "echo 'PostStart: Starting infinite sleep...'; sleep infinity; echo 'PostStart: Sleep finished (should not be reached)'"
    events:
      postStart:
        - sleep-infinity-cmd
EOF
```
4. Watch the DevWorkspace:
```sh
oc get dw problematic-workspace -w
```
5. The DevWorkspace should eventually enter a `Failed` phase.
6. The `status.message` of the DevWorkspace should provide a reason for the failure, indicating a timeout. For example: `Error creating DevWorkspace deployment: Container tools has state [postStart hook] Commands terminated by SIGTERM (likely timed out after 30s). Exit code 143.`


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
