### PR TITLE
test (controllers) : Dynamically construct envtest binary assets while preparing envtest environment (#1387)

### DIFF
--- a/controllers/controller/devworkspacerouting/suite_test.go
+++ b/controllers/controller/devworkspacerouting/suite_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
@@ -86,7 +87,7 @@ var _ = BeforeSuite(func() {
 			filepath.Join(".", "testdata", "route.crd.yaml"),
 		},
 		ErrorIfCRDPathMissing: true,
-		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s", "1.24.2-linux-amd64"),
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s", fmt.Sprintf("1.24.2-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	cfg, err := testEnv.Start()

--- a/controllers/workspace/suite_test.go
+++ b/controllers/workspace/suite_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
@@ -87,7 +88,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "deploy", "templates", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", "1.24.2-linux-amd64"),
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", fmt.Sprintf("1.24.2-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	cfg, err := testEnv.Start()


### PR DESCRIPTION
### What does this PR do?
I was facing this error when trying to run envtest on my macbook:
```
 [FAILED] Unexpected error:
      <*fmt.wrapError | 0x140004696a0>: 
      unable to start control plane itself: failed to start the controlplane. retried 5 times: fork/exec ../../../bin/k8s/1.24.2-linux-amd64/etcd: no such file or directory
      {
          msg: "unable to start control plane itself: failed to start the controlplane. retried 5 times: fork/exec ../../../bin/k8s/1.24.2-linux-amd64/etcd: no such file or directory",
          err: <*fmt.wrapError | 0x14000469680>{
              msg: "failed to start the controlplane. retried 5 times: fork/exec ../../../bin/k8s/1.24.2-linux-amd64/etcd: no such file or directory",
              err: <*fs.PathError | 0x14000567980>{
                  Op: "fork/exec",
                  Path: "../../../bin/k8s/1.24.2-linux-amd64/etcd",
                  Err: <syscall.Errno>0x2,
              },
          },
      }
```
Test suite is hardcoded to look for binary assets for linux-amd64:
https://github.com/devfile/devworkspace-operator/blob/1a654502dde7fc2805dab0fb978610bd3da766f8/controllers/controller/devworkspacerouting/suite_test.go#L89

However, on my machine different binaries were downloaded by envtest:
```
ls bin/k8s 
1.24.2-darwin-arm64
```

Currently envtest environment is loaded with a hardcoded `BinaryAssetsDirectory` for linux/amd64 machine. This doesn't work on other machines that have other operating systems and processor architectures.

Updated `BinaryAssetsDirectory` to dynamically construct paths based on `runtime.GOOS` and `runtime.GOARCH`

This change adds flexibility when running EnvTest across multiple platforms.

### What issues does this PR fix or reference?
Fix #1387

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
I've verified that `make test` is working.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
