### PR TITLE
test: fix tests to run on Macos

### DIFF
--- a/controllers/controller/devworkspacerouting/suite_test.go
+++ b/controllers/controller/devworkspacerouting/suite_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
@@ -86,7 +87,7 @@ var _ = BeforeSuite(func() {
 			filepath.Join(".", "testdata", "route.crd.yaml"),
 		},
 		ErrorIfCRDPathMissing: true,
-		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s", "1.24.2-linux-amd64"),
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s", "1.24.2-"+runtime.GOOS+"-"+runtime.GOARCH),
 	}
 
 	cfg, err := testEnv.Start()

--- a/controllers/workspace/suite_test.go
+++ b/controllers/workspace/suite_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	dwv1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha1"
@@ -87,7 +88,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "deploy", "templates", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", "1.24.2-linux-amd64"),
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s", "1.24.2-"+runtime.GOOS+"-"+runtime.GOARCH),
 	}
 
 	cfg, err := testEnv.Start()


### PR DESCRIPTION
### What does this PR do?

Make unit tests OS-agnostic for K8s binary assets

### What issues does this PR fix or reference?

N/a

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

Run `make test` on Macos.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
