### PR TITLE
Fix documentation indentation

### DIFF
--- a/docs/dwo-configuration.md
+++ b/docs/dwo-configuration.md
@@ -59,13 +59,13 @@ These configuration options exist in the **global** DWOC's `config.webhook`  fie
 apiVersion: controller.devfile.io/v1alpha1
 kind: DevWorkspaceOperatorConfig
 metadata:
-name: devworkspace-operator-config
-namespace: $OPERATOR_INSTALL_NAMESPACE
+  name: devworkspace-operator-config
+  namespace: $OPERATOR_INSTALL_NAMESPACE
 config:
-webhook:
-nodeSelector:  <string, string>
-tolerations: <[]tolerations>
-replicas: <int32>
+  webhook:
+    nodeSelector:  <string, string>
+    tolerations: <[]tolerations>
+    replicas: <int32>
 ```
 
 **Note:** In order for the `devworkspace-webhook-server` configuration options to take effect:


### PR DESCRIPTION
### What does this PR do?
Fixes documentation indentation.

Before:
![image](https://github.com/user-attachments/assets/01a109dc-b744-4022-9209-2adbb4aad334)

After:
![image](https://github.com/user-attachments/assets/5938638f-4bda-46f0-8da9-3df65ce650df)

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
