### PR TITLE
feat(Makefile): add optional WAIT=true env to until all operands are running (#1456)

### DIFF
--- a/build/make/deploy.mk
+++ b/build/make/deploy.mk
@@ -85,6 +85,12 @@ install: _print_vars _check_cert_manager _init_devworkspace_crds _create_namespa
 	cat deploy/default-config.yaml | envsubst > deploy/default-config.temp.yaml
 	$(K8S_CLI) apply -f deploy/default-config.temp.yaml
 	rm -rf deploy/default-config.temp.yaml
+	@if [ "$(WAIT)" = "true" ]; then \
+		echo "⌛ Waiting for DevWorkspace Operator deployments to get ready"; \
+		$(K8S_CLI) rollout status deployment devworkspace-controller-manager -n $(NAMESPACE) --timeout 90s; \
+		$(K8S_CLI) rollout status deployment devworkspace-webhook-server -n $(NAMESPACE) --timeout 90s; \
+	fi
+	@echo "✅ Installation Successful"
 
 ### install_plugin_templates: Deploys the sample plugin templates to namespace devworkspace-plugins:
 install_plugin_templates: _print_vars


### PR DESCRIPTION

### What does this PR do?

- Introduced WAIT variable to wait until DevWorkspace Deployment becomes ready
- Added conditional shell logic to wait before proceeding


### What issues does this PR fix or reference?
Fix #1456

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Run `make install WAIT=true` You'll see that it would wait for Deployments to get ready:
```
⌛ Waiting for DevWorkspace Operator deployments to get ready
Waiting for deployment "devworkspace-controller-manager" rollout to finish: 0 of 1 updated replicas are available...
deployment "devworkspace-controller-manager" successfully rolled out
Waiting for deployment "devworkspace-webhook-server" rollout to finish: 0 of 2 updated replicas are available...
Waiting for deployment "devworkspace-webhook-server" rollout to finish: 1 of 2 updated replicas are available...
deployment "devworkspace-webhook-server" successfully rolled out
✅ Installation Successful
```

Run it without any option, `make install`. You'll see that no waiting is performed:
```
service/devworkspace-controller-metrics created
deployment.apps/devworkspace-controller-manager created
devworkspaceoperatorconfig.controller.devfile.io/devworkspace-operator-config created
✅ Installation Successful
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
