### PR TITLE
Revert "Temporarily don't build new bundle image on next release"

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -276,15 +276,15 @@ release() {
   git checkout "${X_BRANCH}"
 
   # Build bundle and index images
-  # $DRY_RUN build/scripts/build_index_image.sh \
-  #   --release \
-  #   --bundle-tag "$VERSION" \
-  #   --bundle-repo "$DWO_BUNDLE_QUAY_REPO" \
-  #   --index-image "$DWO_INDEX_IMAGE" \
-  #   --force
+  $DRY_RUN build/scripts/build_index_image.sh \
+    --release \
+    --bundle-tag "$VERSION" \
+    --bundle-repo "$DWO_BUNDLE_QUAY_REPO" \
+    --index-image "$DWO_INDEX_IMAGE" \
+    --force
 
-  # # Commit changes from releasing bundle
-  # git_commit_and_push "[release] Add OLM bundle for $VERSION in $X_BRANCH" "ci-add-bundle-$VERSION"
+  # Commit changes from releasing bundle
+  git_commit_and_push "[release] Add OLM bundle for $VERSION in $X_BRANCH" "ci-add-bundle-$VERSION"
 
   # Tag current commit as release version
   git tag "${VERSION}"


### PR DESCRIPTION
This reverts commit b01e2733fe3a91c677a66d911322d5bf29cd1b23.

### What does this PR do?


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
