### PR TITLE
fix : execute `preStart` devfile events after `project-clone` initContainer

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -355,7 +355,7 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if projectClone, err := projects.GetProjectCloneInitContainer(&workspace.Spec.Template, projectCloneOptions, workspace.Config.Routing.ProxyConfig); err != nil {
 		return r.failWorkspace(workspace, fmt.Sprintf("Failed to set up project-clone init container: %s", err), metrics.ReasonInfrastructureFailure, reqLogger, &reconcileStatus), nil
 	} else if projectClone != nil {
-		devfilePodAdditions.InitContainers = append(devfilePodAdditions.InitContainers, *projectClone)
+		devfilePodAdditions.InitContainers = append([]corev1.Container{*projectClone}, devfilePodAdditions.InitContainers...)
 	}
 
 	// Add ServiceAccount tokens into devfile containers

--- a/controllers/workspace/testdata/test-devworkspace-prestart.yaml
+++ b/controllers/workspace/testdata/test-devworkspace-prestart.yaml
@@ -1,0 +1,50 @@
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspace
+metadata:
+  labels:
+    controller.devfile.io/creator: ""
+spec:
+  started: true
+  template:
+    projects:
+      - name: my-app
+        clonePath: my-app
+        git:
+          remotes:
+            origin: https://github.com/che-samples/web-nodejs-sample.git
+          checkoutFrom:
+            revision: main
+    components:
+      - name: tools
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-latest
+          memoryLimit: 256Mi
+          mountSources: true
+          sourceMapping: /projects
+      - name: go-mod-builder
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-latest
+          command:
+            - "go"
+            - "mod"
+            - "download"
+      - name: go-builder
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-latest
+          command:
+            - "go"
+            - "build"
+            - "-buildvcs=false"
+            - "-o"
+            - "./main"
+    commands:
+      - id: go-mod
+        apply:
+          component: go-mod-builder
+      - id: go-build
+        apply:
+          component: go-builder
+    events:
+      preStart:
+        - go-mod
+        - go-build


### PR DESCRIPTION
### What does this PR do?
Change the ordering of initContainers to ensure that `project-clone` initContainer is executed before preStart initContainers

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1454

### Is it tested? How?

- Make sure Kubernetes cluster is running
- Install DWO on cluster based on changes added in this PR. You'd need to create new container image and install operator
```
export DWO_IMG=docker.io/rohankanojia/devworkspace-controller:next
make docker
make install
```
- Apply the following DevWorkspace object, which adds preStart events along with an existing git clone attribute
```yaml
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: simple-devfile-prestart
spec:
  started: true
  template:
    projects:
      - name: eclipse-jkube-demo-project
        clonePath: eclipse-jkube-demo-project
        git:
          remotes:
            origin: https://github.com/rohanKanojia/eclipse-jkube-demo-project.git
          checkoutFrom:
            revision: main
    components:
      - name: tools
        container:
          image: quay.io/devfile/universal-developer-image:ubi9-latest
          memoryLimit: 256Mi
          mountSources: true
          sourceMapping: /projects
      - name: readme
        container:
          image: quay.io/devfile/universal-developer-image:ubi9-latest
          mountSources: true
          sourceMapping: /projects
          command:
          - "cat"
          - "eclipse-jkube-demo-project/readme.md"
      - name: license
        container:
          image: quay.io/devfile/universal-developer-image:ubi9-latest
          mountSources: true
          sourceMapping: /projects
          command:
          - "cat"
          - "eclipse-jkube-demo-project/license.txt"
    commands:
      - id: project-license
        apply:
          component: license
      - id: project-readme
        apply:
          component: readme
    events:
      preStart:
        - project-license
        - project-readme
```
- Check the pod created for workspace, espectially the order of initContainer execution:

Without these changes, it should be like this:
```shell
kubectl get deployments -l controller.devfile.io/creator -o json | jq -r '
  .items[] |
  "Deployment: \(.metadata.name)\n" +
  (
    .spec.template.spec.initContainers // [] |
    map("- \(.name)") | join("\n")
  ) + "\n"
'

Deployment: workspace91da279bda6b47fb
- readme
- license
- project-clone
```
With this PR `project-clone` initContainer is before preStart containers:
```
Deployment: workspace91da279bda6b47fb
- project-clone
- readme
- license
```

You'd notice that with changes in this PR DevWorkspace would come up in `Running` state. However, on main branch it would be in `CrashLoopBackOff` state due to failing `initContainers`

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
