### PR TITLE
test (e2e) : create ServiceAccount token on newer versions of Kubernetes rather than waiting it to be automatically created (#1436)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.36.0
+	golang.org/x/mod v0.19.0
 	golang.org/x/net v0.38.0
 	k8s.io/api v0.30.1
 	k8s.io/apiextensions-apiserver v0.30.1
@@ -95,7 +96,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
-	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect


### PR DESCRIPTION

### What does this PR do?
On newer versions of Kubernetes, token is not automatically created for ServiceAccount 

https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#manual-secret-management-for-serviceaccounts

To ensure we don't fail waiting for a token on newer versions of Kubernetes, add a check to create a token if we're on newer versions of Kubernetes rather than waiting for the ServiceAccount token to become available.

### What issues does this PR fix or reference?
Fix #1436

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
I tested it on CRC cluster.

With these changes, I was able to run `make test_e2e` successfully:
```
> make test_e2e
2025/07/09 23:26:29 Running DevWorkspace Controller e2e tests...
Running Suite: Workspaces Controller Operator Tests - /Users/rokumar/go/src/github.com/devfile/devworkspace-operator
====================================================================================================================
Random Seed: 1752083789

Will run 4 of 4 specs
2025/07/09 23:26:29 Starting to setup objects before run ginkgo suite
2025/07/09 23:26:30 Pod 'devworkspace-webhook-server-7bf6479fd-sq5nl' created in namespace devworkspace-controller... Checking startup data.
2025/07/09 23:26:30 Pod started after 8839.468315 seconds
2025/07/09 23:26:30 Pod 'devworkspace-webhook-server-7bf6479fd-vnf4l' created in namespace devworkspace-controller... Checking startup data.
2025/07/09 23:26:30 Pod started after 8859.469902 seconds
•2025/07/09 23:26:32 Now current status of developer workspace is: Starting. Message: Waiting for workspace deployment
2025/07/09 23:26:34 Now current status of developer workspace is: Running. Message: Workspace is running
•••2025/07/09 23:26:34 Cleaning up test namespace test-terminal-namespace
2025/07/09 23:26:34 If you need resources for investigation, set the following env var CLEAN_UP_AFTER_SUITE=false
2025/07/09 23:26:35 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 59s
2025/07/09 23:26:36 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 58s
2025/07/09 23:26:37 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 57s
2025/07/09 23:26:38 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 56s
2025/07/09 23:26:39 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 55s
2025/07/09 23:26:40 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 54s
2025/07/09 23:26:41 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 53s
2025/07/09 23:26:42 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 52s
2025/07/09 23:26:43 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 51s
2025/07/09 23:26:44 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 50s
2025/07/09 23:26:45 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 49s
2025/07/09 23:26:46 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 48s
2025/07/09 23:26:47 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 47s
2025/07/09 23:26:48 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 46s
2025/07/09 23:26:49 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 45s
2025/07/09 23:26:50 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 44s
2025/07/09 23:26:51 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 43s


Ran 4 of 4 Specs in 23.612 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```

Without these changes, I was getting an error:
```
 1s until it's removed. Will time out in 1s
------------------------------
[SynchronizedBeforeSuite] [FAILED] [10.067 seconds]
[SynchronizedBeforeSuite]
/Users/rokumar/go/src/github.com/devfile/devworkspace-operator/test/e2e/cmd/workspaces_test.go:39

  [FAILED] Cannot get test SA token. Cause: ServiceAccount 'test-terminal-namespace/terminal-test' token is not found after 10
  In [SynchronizedBeforeSuite] at: /Users/rokumar/go/src/github.com/devfile/devworkspace-operator/test/e2e/cmd/workspaces_test.go:84 @ 07/09/25 23:29:48.764
------------------------------
2025/07/09 23:29:48 Cleaning up test namespace test-terminal-namespace
2025/07/09 23:29:48 If you need resources for investigation, set the following env var CLEAN_UP_AFTER_SUITE=false
2025/07/09 23:29:49 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 59s
2025/07/09 23:29:50 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 58s
2025/07/09 23:29:51 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 57s
2025/07/09 23:29:52 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 56s
2025/07/09 23:29:53 Namespace 'test-terminal-namespace' is in Terminating phase. Waiting 1s until it's removed. Will time out in 55s

Summarizing 1 Failure:
  [FAIL] [SynchronizedBeforeSuite]
  /Users/rokumar/go/src/github.com/devfile/devworkspace-operator/test/e2e/cmd/workspaces_test.go:84

Ran 0 of 4 Specs in 16.087 seconds
FAIL! -- A BeforeSuite node failed so all tests were skipped.
--- FAIL: TestWorkspaceController (16.09s)
FAIL
make: *** [test_e2e] Error 1
```
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
