### PR TITLE
Remove unused chectl flag

### DIFF
--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -42,8 +42,7 @@ deployChe() {
     -p openshift \
     --batch \
     --telemetry=off \
-    --installer=operator \
-    --workspace-engine=dev-workspace
+    --installer=operator
 }
 
 deployDWO


### PR DESCRIPTION
### What does this PR do?
Removes the `--workspace-engine=dev-workspace` flag in the ci job


### What issues does this PR fix or reference?
Should fix this error in the ci check:
```
+ chectl server:deploy -p openshift --batch --telemetry=off --installer=operator --workspace-engine=dev-workspace
Error: Nonexistent flag: --workspace-engine=dev-workspace
See more help with --help
    at validateArgs (/usr/local/lib/chectl/node_modules/@oclif/core/lib/parser/validate.js:10:19)
    at validate (/usr/local/lib/chectl/node_modules/@oclif/core/lib/parser/validate.js:173:5)
    at Object.parse (/usr/local/lib/chectl/node_modules/@oclif/core/lib/parser/index.js:19:35)
    at async Deploy.parse (/usr/local/lib/chectl/node_modules/@oclif/core/lib/command.js:246:25)>
```
Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/devfile_devworkspace-operator/1461/pull-ci-devfile-devworkspace-operator-main-v14-che-happy-path/1949933534399434752

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
