### PR TITLE
Add jq in the e2e tests image

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -23,8 +23,8 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && sed
 RUN yum install --assumeyes -d1 python3-pip nodejs gettext && \
     pip3 install --upgrade pip && \
     pip3 install --ignore-installed --upgrade setuptools && \
-    # Install yq
-    pip3 install yq && \
+    # Install yq and jq
+    pip3 install yq jq && \
     # Install kubectl
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \


### PR DESCRIPTION
### What does this PR do?
Installs jq in the e2e dockerfile

### What issues does this PR fix or reference?
Used to hopefully fix e2e tests failures: https://github.com/devfile/devworkspace-operator/pull/1474

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
