### PR TITLE
Add jq in the e2e tests image

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -20,11 +20,11 @@ SHELL ["/bin/bash", "-c"]
 # Temporary workaround since mirror.centos.org is down and can be replaced with vault.centos.org
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
-RUN yum install --assumeyes -d1 python3-pip nodejs gettext && \
+RUN yum install --assumeyes -d1 python3-pip nodejs gettext jq && \
     pip3 install --upgrade pip && \
     pip3 install --ignore-installed --upgrade setuptools && \
-    # Install yq and jq
-    pip3 install yq jq && \
+    # Install yq
+    pip3 install yq && \
     # Install kubectl
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \


### PR DESCRIPTION
### What does this PR do?
Realized that `jq` was being installed incorrectly.

This commit fixes the issue.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
```
 $ podman build -f ./.ci/oci.Dockerfile -t test
 $ podman run --rm  test jq --version
 jq-1.6
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
