### PR TITLE
Update e2e test dockerfile to use go 1.24

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.23
+FROM registry.ci.openshift.org/openshift/release:golang-1.24
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
### What does this PR do?
Updates the e2e test dockerfile to use go 1.24.

### What issues does this PR fix or reference?
This is needed for the e2e tests to pass for this PR: https://github.com/devfile/devworkspace-operator/pull/1463

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
