### PR TITLE
Update e2e test dockerfile to use rhel-9-release-golang-1.24-openshif…

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.24
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
…t-4.20 image

### What does this PR do?
Changes the base image of the e2e test dockerfile, since the `registry.ci.openshift.org/openshift/release:golang-1.24` image doesn't seem to exist yet.

```
$ podman pull registry.ci.openshift.org/openshift/release:golang-1.24
Trying to pull registry.ci.openshift.org/openshift/release:golang-1.24...
Error: initializing source docker://registry.ci.openshift.org/openshift/release:golang-1.24: reading manifest golang-1.24 in registry.ci.openshift.org/openshift/release: manifest unknown
```
### What issues does this PR fix or reference?
This is needed for the e2e tests to pass for this PR: https://github.com/devfile/devworkspace-operator/pull/1463

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
