### PR TITLE
For prerelease job temporarily don't create a new branch

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -233,7 +233,7 @@ prerelease() {
 
   echo "[INFO] Creating ${X_BRANCH} from ${MAIN_BRANCH}"
   git checkout ${MAIN_BRANCH}
-  git checkout -b "${X_BRANCH}"
+  git checkout "${X_BRANCH}"
 
   echo "[INFO] Updating version to $VERSION"
   update_version "$VERSION"


### PR DESCRIPTION
### What does this PR do?
This commit is done to not have the release action create the 0.36.x branch, since it already exists.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
