### PR TITLE
chore: revert "For prerelease job temporarily don't create a new branch"

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -233,7 +233,7 @@ prerelease() {
 
   echo "[INFO] Creating ${X_BRANCH} from ${MAIN_BRANCH}"
   git checkout ${MAIN_BRANCH}
-  git checkout "${X_BRANCH}"
+  git checkout -b "${X_BRANCH}"
 
   echo "[INFO] Updating version to $VERSION"
   update_version "$VERSION"


### PR DESCRIPTION
This reverts commit 4375b0415b91e424eb2f99026b77d6a57ecd12a7.

### What does this PR do?
Reverts the change introduced in this PR: https://github.com/devfile/devworkspace-operator/pull/1486

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
