### PR TITLE
Update 0.36.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,25 @@ The `kube-rbac-proxy` container is now removed from the `devworkspace-controller
 
 This allows setting only the controller container's resource constraints using the Subscription resource as defined [here](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/subscription-config.md#example-4). The resource constraints defined in the Subscription apply the constraints to all containers in the `devworkspace-controller-manager` Deployment. As a result, previously both the controller and kube-rbac-proxy container's constraints were updated, when in most cases only the controller container was the desired container to be updated.
 
-### Execute preStart devfile events after the project-clone init-container has run. [#1454](https://github.com/devfile/devworkspace-operator/issues/1454)
+### Execute preStart devfile events after the project-clone init-container has run [#1454](https://github.com/devfile/devworkspace-operator/issues/1454)
 The `project-clone` init container is now the first init container for DevWorkspace Pods. This ensures that the project is already cloned when running pre-start events defined in the Devfile.
+
+### Provide timeout for postStart events [#1496](https://github.com/devfile/devworkspace-operator/issues/1496)
+A timeout can now be configured for postStart events to prevent workspace pods from being stuck in a terminating state:
+```
+apiVersion: controller.devfile.io/v1alpha1
+kind: DevWorkspaceOperatorConfig
+metadata:
+  name: devworkspace-operator-config
+config:
+  workspace:
+    postStartTimeout: 30 
+```
+By default, this timeout is disabled.
 
 ## Bug Fixes & Improvements
 - Update golang version to 1.24 in go.mod [#1413](https://github.com/devfile/devworkspace-operator/pull/1413)
+- Update cleanup job node affinity logic [#1455](https://github.com/devfile/devworkspace-operator/pull/1455)
 
 # v0.35.1
 ## Bug Fixes & Improvements


### PR DESCRIPTION
### What does this PR do?
Cherry-pick https://github.com/devfile/devworkspace-operator/pull/1497 to 0.36.x branch.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
