### PR TITLE
fix (project-clone) : update user_setup script to modify `/etc/passwd` permissions/ownership 

### DIFF
--- a/build/bin/user_setup
+++ b/build/bin/user_setup
@@ -6,8 +6,7 @@ mkdir -p ${HOME}
 chown ${USER_UID}:0 ${HOME}
 chmod ug+rwx ${HOME}
 
-# runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
+chmod g-w /etc/passwd
 
 # no need for this script to remain in the image after running
 rm $0


### PR DESCRIPTION
### What does this PR do?
We have a script that's used in Dockerfiles to setup users, it sets these permissions for `/etc/passwd`:
https://github.com/devfile/devworkspace-operator/blob/6f01ac30e04ce718d3c6e45c50f27c61add26b22/build/bin/user_setup#L10

This gets used in both main image and project-clone image:
- https://github.com/devfile/devworkspace-operator/blob/6f01ac30e04ce718d3c6e45c50f27c61add26b22/build/Dockerfile#L52
- https://github.com/devfile/devworkspace-operator/blob/6f01ac30e04ce718d3c6e45c50f27c61add26b22/project-clone/Dockerfile#L52

Update user_setup script to not make `/etc/passwd` group writable

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-9380

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- Checkout PR branch
- Create container image for `project-clone` : `docker build . -f project-clone/Dockerfile -t <registry>/<user>/project-clone:next`
- Run container based on the created image and check permissions of `/etc/passwd` (it should NOT be group writable):
```shell
devworkspace-operator : $ docker run --rm docker.io/rohankanojia/project-clone:next ls -lt /etc/passwd
-rw-r--r-- 1 root root 533 Feb  7  2024 /etc/passwd
```
main branch behavior:
```shell
docker run --rm -it quay.io/devfile/project-clone:next bash
bash-5.1$ ls -lt /etc/passwd 
-rw-rw-r-- 1 root root 600 Sep  4 11:22 /etc/passwd
```

#### Verifying on CRC and minikube

I verified these steps:
- minikube with docker driver (not CRI-O)
- CRC (CRI-o) driver
---
- Deploy operator to cluster and verify DevWorkspace Operator gets cloned correctly:
   - Push Project clone image to some registry
   - `export PROJECT_CLONE_IMG=<registry>/<user>/project-clone:next`
   - `export DWO_IMG=<registry>/<user>/devworkspace-controller:next`
   - `make docker`
   - `make install`
   - Wait for DevWorkspace Operator pods to become ready
   - Create a sample workspace `oc create -f samples/code-latest.yaml`
   -  DevWorkspace should come in `Running` state
   - Both init-containers should succeed
   - Verify `project-clone` init-container logs to see if project cloned successfuly: `oc logs -l controller.devfile.io/devworkspace_name=code-latest -cproject-clone`
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
