### PR TITLE
Make container status check less restrictive

### DIFF
--- a/pkg/library/status/check.go
+++ b/pkg/library/status/check.go
@@ -251,13 +251,6 @@ func CheckContainerStatusForFailure(containerStatus *corev1.ContainerStatus, ign
 	}
 
 	if containerStatus.State.Terminated != nil {
-		// Check if termination was due to a generic error, which might include postStart issues
-		// if the container failed to run.
-		if containerStatus.State.Terminated.Reason == "Error" || containerStatus.State.Terminated.Reason == "ContainerCannotRun" {
-			return checkIfUnrecoverableEventIgnored(containerStatus.State.Terminated.Reason, ignoredEvents),
-				fmt.Sprintf("%s: %s", containerStatus.State.Terminated.Reason, containerStatus.State.Terminated.Message)
-		}
-		// Check against other generic failure reasons for terminated state
 		for _, failureReason := range containerFailureStateReasons {
 			if containerStatus.State.Terminated.Reason == failureReason {
 				return checkIfUnrecoverableEventIgnored(containerStatus.State.Terminated.Reason, ignoredEvents),


### PR DESCRIPTION
### What does this PR do?
Fixes issue with workspace restarts.

The issue with workspace restarts happens when the new CDE pod is starting when the previous CDE pod has not yet terminated. For example:
<img width="3678" height="898" alt="image" src="https://github.com/user-attachments/assets/5d641c89-cbc7-4681-b2c4-8a6f8b4d0a7b" />

In this case, there is a temporary error with the new pod. The error has no error message, but looks like the following:
```
Container 'universal-developer-image' terminated with Error: 
```

This error seems to be occurring for only a few seconds, and dissappears in seconds. Although, I'm not too sure what is the root cause of this error. 

Nevertheless, this PR reverts an error check that was done as part of https://github.com/devfile/devworkspace-operator/pull/1440 to allow the DevWorkspace startup to not fail when restarting the DevWorkspace.

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23551

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Build and deploy the DWO with Eclipse Che.

The catalog source I used for testing is:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: devworkspace-operator-testing-catalog
  namespace: openshift-marketplace
spec:
  displayName: DevWorkspace Operator Catalog
  image: 'quay.io/dkwon17/devworkspace-operator-index:workspace-restart'
  publisher: DWO Testing
  sourceType: grpc
```

2. Create an empty workspace.
3. Wait until the workspace is running.
4. From the Che Dashboard, restart the running workspace.
5. Verify that the issue mentioned in https://github.com/eclipse-che/che/issues/23551 is not reproduced.
6. Verify that the post start timeout feature still works by following steps 2 and onwards from https://github.com/devfile/devworkspace-operator/pull/1440.


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
