### PR TITLE
Fix changelog typo for postStartTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ metadata:
   name: devworkspace-operator-config
 config:
   workspace:
-    postStartTimeout: 30 
+    postStartTimeout: '30s'
 ```
 By default, this timeout is disabled.
 


### PR DESCRIPTION
### What does this PR do?
Fixes typo for postStartTimeout config. The `config.workspace.postStartTimeout` field takes a string that represents a `time.Duration` which is parsed by `time.ParseDuration`: https://pkg.go.dev/time#Duration

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
