### PR TITLE
Make container status check less restrictive

### DIFF
--- a/pkg/library/status/check.go
+++ b/pkg/library/status/check.go
@@ -251,13 +251,6 @@ func CheckContainerStatusForFailure(containerStatus *corev1.ContainerStatus, ign
 	}
 
 	if containerStatus.State.Terminated != nil {
-		// Check if termination was due to a generic error, which might include postStart issues
-		// if the container failed to run.
-		if containerStatus.State.Terminated.Reason == "Error" || containerStatus.State.Terminated.Reason == "ContainerCannotRun" {
-			return checkIfUnrecoverableEventIgnored(containerStatus.State.Terminated.Reason, ignoredEvents),
-				fmt.Sprintf("%s: %s", containerStatus.State.Terminated.Reason, containerStatus.State.Terminated.Message)
-		}
-		// Check against other generic failure reasons for terminated state
 		for _, failureReason := range containerFailureStateReasons {
 			if containerStatus.State.Terminated.Reason == failureReason {
 				return checkIfUnrecoverableEventIgnored(containerStatus.State.Terminated.Reason, ignoredEvents),


### PR DESCRIPTION
### What does this PR do?
Cherry picks this change https://github.com/devfile/devworkspace-operator/pull/1523 to the 0.37.x branch.

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23551

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
