### PR TITLE
Set readOnlyRootFilesystem for deployments to true

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -400,6 +400,8 @@ spec:
                   requests:
                     cpu: 250m
                     memory: 100Mi
+                securityContext:
+                  readOnlyRootFilesystem: true
               serviceAccountName: devworkspace-controller-serviceaccount
               terminationGracePeriodSeconds: 10
       permissions:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -26224,6 +26224,8 @@ spec:
           requests:
             cpu: 250m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -96,6 +96,8 @@ spec:
           requests:
             cpu: 250m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -26226,6 +26226,8 @@ spec:
           requests:
             cpu: 250m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -96,6 +96,8 @@ spec:
           requests:
             cpu: 250m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/templates/components/manager/manager.yaml
+++ b/deploy/templates/components/manager/manager.yaml
@@ -51,6 +51,8 @@ spec:
             requests:
               cpu: 250m
               memory: 100Mi
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
             - name: WATCH_NAMESPACE
               value: ""

--- a/pkg/webhook/deployment.go
+++ b/pkg/webhook/deployment.go
@@ -187,6 +187,9 @@ func getSpecDeployment(webhooksSecretName, namespace string) (*appsv1.Deployment
 									Name: "WATCH_NAMESPACE",
 								},
 							},
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: pointer.Bool(true),
+							},
 						},
 					},
 					RestartPolicy:                 "Always",


### PR DESCRIPTION
### What does this PR do?
Sets the `securityContext.readOnlyRootFilesystem` field to true for the controller and webhook deployments.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Checkout the PR branch, and run the changes in a cluster:
```
make install WAIT=true
```

Verify that the `devworkspace-controller-manager` and `devworkspace-webhook-server` deployments have:
```
securityContext.readOnlyRootFilesystem: true
```

in their container definitions.

Verify that workspaces can start, stop without issue.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
