### PR TITLE
chore: Add user with id 1234 to /etc/passwd

### DIFF
--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -47,11 +47,11 @@ RUN microdnf -y update  \
     && echo "Installed Packages"  \
     && rpm -qa | sort -V  \
     && echo "End Of Installed Packages" \
-    && echo "user:x:1234:0::/:/bin/sh" > /etc/passwd
+    && echo "project-clone:x:1234:0::/home/user:/bin/sh" >> /etc/passwd
 WORKDIR /
 COPY --from=builder /project-clone/_output/bin/project-clone /usr/local/bin/project-clone
 
-ENV USER_UID=1001 \
+ENV USER_UID=1234 \
     USER_NAME=project-clone \
     HOME=/home/user
 


### PR DESCRIPTION
### What does this PR do?
This PR adds a user entry with UID 1234 to the `/etc/passwd` file in the project-clone container image,  ensuring that when the project-clone container runs on Kubernetes with the default security context, the user exists in the system's user database

https://github.com/devfile/devworkspace-operator/blob/a83998827afcbec18c50cf528f4f9d3cfd591f5d/pkg/config/defaults.go#L95

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23660

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Deploy Che on minikube
2. Add ssh keys and start a workspace from git ssh url, check that project failed to clone
3. Build image and update DWO deployment env var to set a new project clone image
4. Start a workpace, check that project cloned successfully. 

### PR Checklist

- [x] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [x] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [x] `v8-che-happy-path`: Happy path for verification integration with Che
