### PR TITLE
fix: project backup image build

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -170,7 +170,7 @@ build_and_push_images() {
     --platform "$ARCHITECTURES"
     docker buildx build . -t "${PROJECT_CLONE_QUAY_IMG}" -f ./project-clone/Dockerfile \
     --platform "$ARCHITECTURES"
-    docker buildx build . -t "${PROJECT_BACKUP_QUAY_IMG}" -f ./project-backup/Containerfile \
+    docker buildx build ./project-backup/ -t "${PROJECT_BACKUP_QUAY_IMG}" -f ./project-backup/Containerfile \
     --platform "$ARCHITECTURES"
   else
     docker buildx build . -t "${DWO_QUAY_IMG}" -f ./build/Dockerfile \
@@ -179,7 +179,7 @@ build_and_push_images() {
     docker buildx build . -t "${PROJECT_CLONE_QUAY_IMG}" -f ./project-clone/Dockerfile \
     --platform "$ARCHITECTURES" \
     --push
-    docker buildx build . -t "${PROJECT_BACKUP_QUAY_IMG}" -f ./project-backup/Containerfile \
+    docker buildx build ./project-backup/ -t "${PROJECT_BACKUP_QUAY_IMG}" -f ./project-backup/Containerfile \
     --platform "$ARCHITECTURES" \
     --push
   fi

--- a/project-backup/Containerfile
+++ b/project-backup/Containerfile
@@ -14,7 +14,7 @@
 #
 
 FROM quay.io/konflux-ci/oras:3d83c68 AS oras
-FROM quay.io/devfile/base-developer-image:ubi10-latest
+FROM registry.access.redhat.com/ubi10:latest
 LABEL project="devworkspace-operator"
 
 USER 0


### PR DESCRIPTION
### What does this PR do?
* Use `registry.access.redhat.com/ubi10:latest` since `quay.io/devfile/base-developer-image:ubi10-latest` is not available for all platforms
* Fix release script

### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/actions/runs/20454674717/job/58774157779

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Triggering backup https://github.com/devfile/devworkspace-operator/pull/1530

### PR Checklist

- [x] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [x] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [x] `v8-che-happy-path`: Happy path for verification integration with Che
