### PR TITLE
fix (backupcronjob): use non-cached client for registry auth Secret lookup

### DIFF
--- a/controllers/backupcronjob/backupcronjob_controller.go
+++ b/controllers/backupcronjob/backupcronjob_controller.go
@@ -474,7 +474,7 @@ func (r *BackupCronJobReconciler) handleRegistryAuthSecret(ctx context.Context, 
 
 	// First check the workspace namespace for the secret
 	registryAuthSecret := &corev1.Secret{}
-	err := r.Get(ctx, client.ObjectKey{
+	err := r.NonCachingClient.Get(ctx, client.ObjectKey{
 		Name:      secretName,
 		Namespace: workspace.Namespace}, registryAuthSecret)
 	if err == nil {
@@ -488,7 +488,7 @@ func (r *BackupCronJobReconciler) handleRegistryAuthSecret(ctx context.Context, 
 	log.Info("Registry auth secret not found in workspace namespace, checking operator namespace", "secretName", secretName)
 
 	// If the secret is not found in the workspace namespace, check the operator namespace as fallback
-	err = r.Get(ctx, client.ObjectKey{
+	err = r.NonCachingClient.Get(ctx, client.ObjectKey{
 		Name:      secretName,
 		Namespace: dwOperatorConfig.Namespace}, registryAuthSecret)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Fix #1556

This PR fixes an issue where the `BackupCronJob` controller fails to detect a configured registry auth Secret when the Secret exists in the operator namespace.

The controller was using the cached controller-runtime client (`r.Get`) to retrieve the registry auth Secret. Because the DevWorkspace Operator configures a label-restricted cache, user-provided registry auth Secrets are not present in the cache and are therefore invisible to cached reads.

This change updates the controller to use the non-caching client when retrieving the registry auth Secret from both the workspace namespace and the operator namespace, ensuring the Secret can always be found when it exists.

---

### What issues does this PR fix or reference?

Fix #1556

---

### Is it tested? How?

**Manual testing steps:**

1. Create a registry auth Secret in the DevWorkspace Operator namespace (e.g., `openshift-operators`).
2. Update DevWorkspace Operator config to enable workspace backup and push to registry along with it's push secret

```yaml
kind: DevWorkspaceOperatorConfig
apiVersion: controller.devfile.io/v1alpha1
config:
  workspace:
    backupCronJob:
      enable: true
      registry:
        authSecret: quay-push-secret
        path: quay.io/rokumar
      schedule: '* * * * *'
```
3. Create a DevWorkspace.
4. Stop DevWorkspace
5. Wait for the backup cron schedule to run.
6. Verify that:
   - The registry auth Secret is successfully retrieved and copied into the workspace namespace.
   - The backup Job is created successfully.
   - A new backup image is created on the remote registry
   - No `Secret "<name>" not found` errors appear in the operator logs.



### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
