### PR TITLE
docs: clarify that `registry.authSecret` must be labeled for operator detection

### DIFF
--- a/docs/dwo-configuration.md
+++ b/docs/dwo-configuration.md
@@ -125,7 +125,10 @@ Backup CronJob configuration fields:
 The value provided for registry.path is only the first segment of the final location. The full registry path is assembled dynamically, incorporating the name of the workspace and the :latest tag, following this pattern:
 `<registry.path>/<devworkspace-name>:latest`
 
-- **`registry.authSecret`**: (Optional) The name of the Kubernetes Secret containing credentials to access the OCI registry. If not provided, it is assumed that the registry is public or uses integrated OpenShift registry.
+- **`registry.authSecret`**: (Optional) The name of the Kubernetes Secret containing credentials to access the OCI registry. If not provided, it is assumed that the registry is public or uses integrated OpenShift registry. 
+
+**Note**: This Secret **must** be labeled with `controller.devfile.io/watch-secret=true` in order for the DevWorkspace Operator to recognize and use it.
+ 
 - **`oras.extraArgs`**: (Optional) Additional arguments to pass to the `oras` CLI tool during push and pull operations.
 
 


### PR DESCRIPTION


### What does this PR do?
Clarifies the documentation for `registry.authSecret` by explicitly stating that the referenced Kubernetes Secret **must** be labeled with `controller.devfile.io/watch-secret=true` to be detected and used by the DevWorkspace Operator.

This prevents confusion when valid registry credentials are ignored due to missing labels. I was confused as I was following this documentation and not labeling the secret.


### What issues does this PR fix or reference?
Related to #1556 

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
N/A (documentation-only change.)
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
