### PR TITLE
Add missing backslash in make-release.sh

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -142,7 +142,7 @@ update_images() {
   # Update defaults in generate_deployment.sh
   sed -i build/scripts/generate_deployment.sh -r \
     -e "s|quay.io/devfile/devworkspace-controller:[0-9a-zA-Z._-]+|${DWO_QUAY_IMG}|g" \
-    -e "s|quay.io/devfile/project-clone:[0-9a-zA-Z._-]+|${PROJECT_CLONE_QUAY_IMG}|g"
+    -e "s|quay.io/devfile/project-clone:[0-9a-zA-Z._-]+|${PROJECT_CLONE_QUAY_IMG}|g" \
     -e "s|quay.io/devfile/project-backup:[0-9a-zA-Z._-]+|${PROJECT_BACKUP_QUAY_IMG}|g"
 
   local DEFAULT_DWO_IMG="$DWO_QUAY_IMG"


### PR DESCRIPTION
### What does this PR do?
Adds missing backslash in the make-release script.

### What issues does this PR fix or reference?
The missing backslash causes the error in the following github action: https://github.com/devfile/devworkspace-operator/actions/runs/20727988253/job/59508350980

```
./make-release.sh: line 146: -e: command not found
```

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
