### PR TITLE
Free disk space in github runner for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,14 @@ jobs:
       OPM_VERSION: v1.19.5
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
+        with:
+          tool-cache: false
       - name: Set up Go 1.x
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: 1.23.6
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 #v2.2.0
 


### PR DESCRIPTION
### What does this PR do?
Adds `jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be` to the release workflow.

### What issues does this PR fix or reference?
There is a `No space left on device` error when running the release action: https://github.com/devfile/devworkspace-operator/actions/runs/20752449945

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
