### PR TITLE
doc : add ginkgo prerequisite and running tests section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ To build, test and debug the DevWorkspace Operator the following development too
 - yq (python-yq from <https://github.com/kislyuk/yq#installation>, other distributions may not work)
 - skopeo (if building the OLM catalogsource)
 - podman or docker
+- ginkgo (required for running tests locally)
 
 Note: kustomize `v4.0.5` is required for most tasks. It is downloaded automatically to the `.kustomize` folder in this
 repo when required. This downloaded version is used regardless of whether or not kustomize is already installed on the
@@ -257,6 +258,24 @@ when you are done debugging you have to manually uninstall the telepresence agen
 ```bash
 make disconnect-debug-webhook-server
 ```
+
+### Running Tests
+
+To run tests locally, you need to have `ginkgo` installed. Install it using:
+
+```bash
+go install github.com/onsi/ginkgo/v2/ginkgo@latest
+```
+
+Ensure that `$GOPATH/bin` or `$GOBIN` is added to your `$PATH` so that `ginkgo` can be found.
+
+Then run the tests:
+
+```bash
+make test
+```
+
+This will run all unit tests and controller tests. The Makefile will automatically use `ginkgo` if it's available in your `$PATH`, otherwise it will fall back to `go test` (though `ginkgo` is recommended for the full test suite).
 
 ### Updating devfile API
 


### PR DESCRIPTION


### What does this PR do?
Add ginkgo to the prerequisites list as it's required for running tests locally. Also add a new \"Running Tests\" section that documents:
- How to install ginkgo
- How to ensure ginkgo is in PATH
- How to run tests with make test
- Note about ginkgo vs go test fallback behavior

This addresses the missing documentation about test requirements for local development.

### What issues does this PR fix or reference?
This PR addresses a gap in the documentation that was discovered during an internal slack discussion. The Prerequisites section mentioned various tools needed for development, but omitted `ginkgo`, which is required for the full test suite to run properly.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
N/A


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
