### PR TITLE
fix: backup job handles workspace with no storage

### DIFF
--- a/controllers/backupcronjob/backupcronjob_controller.go
+++ b/controllers/backupcronjob/backupcronjob_controller.go
@@ -357,8 +357,9 @@ func (r *BackupCronJobReconciler) createBackupJob(
 		return err
 	}
 	if pvcName == "" {
-		log.Error(err, "No PVC found for DevWorkspace", "id", dwID)
-		return err
+		// No PVC to back up
+		log.Info("No workspace PVC found, skipping backup", "devworkspace", workspace.Name)
+		return nil
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{}

--- a/pkg/library/storage/storage.go
+++ b/pkg/library/storage/storage.go
@@ -49,6 +49,10 @@ func GetWorkspacePVCInfo(
 	if err != nil {
 		return "", "", err
 	}
+	if !storageProvisioner.NeedsStorage(&workspace.Spec.Template) {
+		// No storage provisioned for this workspace
+		return "", "", nil
+	}
 
 	if _, ok := storageProvisioner.(*storage.PerWorkspaceStorageProvisioner); ok {
 		pvcName := common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId)


### PR DESCRIPTION
### What does this PR do?
Skip backup if the workspace is missing volumes
    
Workspace with no storage failed in the backup process. This commit
fixes it by checking if the volumes are present and skips the job if no
pvc is available.

fixes: 1555


### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1555

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
