### PR TITLE
Update devfile with ephemeral graphroot directory

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -43,6 +43,6 @@ commands:
         make generate_olm_bundle_yaml build_bundle_and_index
         read -p "Run register_catalogsource? (y/n) " -n 1 -r
         echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then if [[ ! "$(oc whoami)" =~ ^kube:admin$ ]]; then echo "You need to login as kubeadmin" && exit 1; fi && make register_catalogsource; fi
+        if [[ $REPLY =~ ^[Yy]$ ]]; then if [[ ! "$(oc whoami)" =~ ^kube:admin$ ]]; then echo "You need to login as kubeadmin" && exit 1; fi && make register_catalogsource; else make view_catalogsource; fi
       group:
         kind: build

--- a/build/make/olm.mk
+++ b/build/make/olm.mk
@@ -54,6 +54,14 @@ register_catalogsource: _check_skopeo_installed
 	sed -e "s|quay.io/devfile/devworkspace-operator-index:next|$(DWO_INDEX_IMG)|g" ./catalog-source.yaml \
 	  | oc apply -f -
 
+### view_catalogsource: prints the catalog source to standard output
+view_catalogsource:
+	@echo "To apply the CatalogSource, run:"
+	@echo ""
+	@echo "oc apply -f - <<EOF"
+	@sed -e "s|quay.io/devfile/devworkspace-operator-index:next|$(DWO_INDEX_IMG)|g" ./catalog-source.yaml
+	@echo "EOF"
+
 ### unregister_catalogsource: unregister the catalogsource and delete the imageContentSourcePolicy
 unregister_catalogsource:
 	oc delete catalogsource devworkspace-operator-catalog -n openshift-marketplace --ignore-not-found


### PR DESCRIPTION
### What does this PR do?
Mounts an ephemeral volume to the graphroot directory. Without this change, `out of space` errors would occur for image builds.

This PR also updates the devfile tasks for building and pushing DWO images.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
To test, run the `build-and-push-controller` and `make-olm-bundle-index-catalogsource` devfile tasks. They should both run successfully.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
