### PR TITLE
Fix: check for empty storage in common storage provisioner

### DIFF
--- a/pkg/library/storage/storage.go
+++ b/pkg/library/storage/storage.go
@@ -49,16 +49,16 @@ func GetWorkspacePVCInfo(
 	if err != nil {
 		return "", "", err
 	}
-	if !storageProvisioner.NeedsStorage(&workspace.Spec.Template) {
-		// No storage provisioned for this workspace
-		return "", "", nil
-	}
 
 	if _, ok := storageProvisioner.(*storage.PerWorkspaceStorageProvisioner); ok {
 		pvcName := common.PerWorkspacePVCName(workspace.Status.DevWorkspaceId)
 		return pvcName, constants.DefaultProjectsSourcesRoot, nil
 
 	} else if _, ok := storageProvisioner.(*storage.CommonStorageProvisioner); ok {
+		if !storageProvisioner.NeedsStorage(&workspace.Spec.Template) {
+			// No storage provisioned for this workspace
+			return "", "", nil
+		}
 		pvcName := constants.DefaultWorkspacePVCName
 		if config.Workspace != nil && config.Workspace.PVCName != "" {
 			pvcName = config.Workspace.PVCName


### PR DESCRIPTION
The NeedsStorage always return false for per-wokrspace storage. This causes an issue and per-workspace workspaces are never backed up.

Moving the check to commonStorage only fixes the issue and still works with empty workspaces.

Fixes: https://github.com/devfile/devworkspace-operator/issues/1575
### What does this PR do?


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
