### PR TITLE
fix: Add HOST_USERS environment variable support for user namespace config…

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -100,6 +100,12 @@ const (
 
 	// ProjectCloneDisable specifies that project cloning should be disabled.
 	ProjectCloneDisable = "disable"
+
+	// DefaultHostUsers is the default value for spec.hostUsers in pod security context.
+	// When true (default), containers run in the host's user namespace. When false,
+	// Kubernetes creates a dedicated user namespace for the pod (requires user namespace support).
+	// See: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/
+	DefaultHostUsers = true
 )
 
 const (

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -34,6 +34,12 @@ const (
 	// DevWorkspaceIdleTimeout contains env var name which value is the suggested idle timeout
 	DevWorkspaceIdleTimeout = "DEVWORKSPACE_IDLE_TIMEOUT"
 
+	// DevWorkspaceHostUsers contains the env var name whose value indicates whether the container
+	// runs in the host's user namespace. When set to "false", container images should adjust their
+	// logic to work in a dedicated user namespace (e.g., file permissions, UID/GID handling).
+	// See: https://github.com/devfile/developer-images/pull/232
+	DevWorkspaceHostUsers = "HOST_USERS"
+
 	// DevWorkspaceComponentName contains env var name which indicates from which devfile container component
 	// the container is created from. Note the flattened devfile is used to evaluate it.
 	DevWorkspaceComponentName = "DEVWORKSPACE_COMPONENT_NAME"

--- a/pkg/library/env/workspaceenv.go
+++ b/pkg/library/env/workspaceenv.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/devfile/devworkspace-operator/pkg/provision/workspace"
-
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	devfileConstants "github.com/devfile/devworkspace-operator/pkg/library/constants"
+	"github.com/devfile/devworkspace-operator/pkg/provision/workspace"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
@@ -82,6 +82,14 @@ func commonEnvironmentVariables(workspaceWithConfig *common.DevWorkspaceWithConf
 			Name:  constants.DevWorkspaceIdleTimeout,
 			Value: workspaceWithConfig.Config.Workspace.IdleTimeout,
 		},
+	}
+
+	hostUsers := pointer.BoolDeref(workspaceWithConfig.Config.Workspace.HostUsers, constants.DefaultHostUsers)
+	if !hostUsers {
+		envvars = append(envvars, corev1.EnvVar{
+			Name:  constants.DevWorkspaceHostUsers,
+			Value: "false",
+		})
 	}
 
 	envvars = append(envvars, getProxyEnvVars(workspaceWithConfig.Config.Routing.ProxyConfig)...)


### PR DESCRIPTION
…uration

### What does this PR do?
Adds support for injecting the HOST_USERS environment variable into workspace containers based on the workspace configuration. When hostUsers is set to false, containers receive HOST_USERS=false to indicate they're running in a dedicated user namespace, allowing container images to adjust their behavior accordingly.


### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23728

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Start a workspace from a [devfile](https://gist.githubusercontent.com/tolusha/3464998635986c240d6d92fa52819c54/raw/cbb4407a6fdb37745a7af049cd5c223347e490c7/devfile.yaml
)
2. Run `podman run -ti --rm hello-world` in the terminal

### PR Checklist

- [x] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [x] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [x] `v8-che-happy-path`: Happy path for verification integration with Che
