### PR TITLE
Remove automatic Z stream version bumping in release branch

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -38,9 +38,7 @@ files within that branch to reflect the new version. This branch should then be
 tested, with additional commits cherry-picked as necessary to prepare for
 release. Once the HEAD commit of the '0.<VERSION>.x' branch is ready for
 release, use the '--release' from the release branch to create the release tag
-and build and push release container images to the Quay repo. Running with the
-release flag will also update versions in the release branch to reflect the next
-bugfix release (e.g. will update from v0.8.0 to v0.8.1).
+and build and push release container images to the Quay repo.
 
 To issue a bugfix release, cherry-pick commits into the existing release branch
 as necessary and run this script with the '--release' flag for the given bugfix
@@ -324,19 +322,6 @@ release() {
 
   # Commit changes from rendering digests bundle
   git_commit_and_push "[post-release] Add OLM digest bundle for $VERSION in $X_BRANCH" "ci-add-digest-bundle-$VERSION"
-
-  # Update ${X_BRANCH} to the new rc version
-  git checkout "${X_BRANCH}"
-
-  # bump the z digit
-  [[ ${VERSION#v} =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]] \
-    && BASE="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}";  \
-    NEXT="${BASH_REMATCH[3]}"; (( NEXT=NEXT+1 )) # for VERSION=0.1.2, get BASE=0.1, NEXT=3
-  NEXT_VERSION_Z="v${BASE}.${NEXT}"
-
-  update_version "$NEXT_VERSION_Z"
-  update_images "$NEXT_VERSION_Z"
-  git_commit_and_push "chore: release: bump to ${NEXT_VERSION_Z} in $X_BRANCH" "ci-bump-$X_BRANCH-$NEXT_VERSION_Z"
 
   echo "[INFO] Release is done"
 }


### PR DESCRIPTION
### What does this PR do?
Fixes issue where whenever we did the DWO upstream release, there would be an unnecessary "chore: release: bump ..." ([example](https://github.com/devfile/devworkspace-operator/commit/35ef73d667a9477839f034d41664fb7b7ad761e4)) commit that would bump the deployment manifest image tags to use a bumped Z-stream, which is a non-existing image.

In the example provided above, v0.39.0 tags are being bumped to v0.39.1, even though v0.39.1 does not exist (v0.39.0 exists).

It's why I've needed to create a new commit to revert the change for the manifests to be usable: https://github.com/devfile/devworkspace-operator/commit/43400deadfbc356daf3010235a0a6cdc941e33f4

### What issues does this PR fix or reference?
n/a

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
This change is not straight forward to test unfortunately. However, the change should be safe because we are simply preventing an image tag to be updated to a tag that does not exist.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
