### PR TITLE
Add project clone retries functionality

### DIFF
--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -64,7 +64,7 @@ func doInitialGitClone(project *dw.Project) error {
 		}
 	}
 	if cloneErr != nil {
-		return fmt.Errorf("failed to clone project: %s", cloneErr)
+		return fmt.Errorf("failed to clone project: %w", cloneErr)
 	}
 
 	if project.Attributes.Exists(internal.ProjectSparseCheckout) {

--- a/project-clone/internal/git/setup.go
+++ b/project-clone/internal/git/setup.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019-2025 Red Hat, Inc.
+// Copyright (c) 2019-2026 Red Hat, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"time"
 
 	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	projectslib "github.com/devfile/devworkspace-operator/pkg/library/projects"
@@ -46,9 +47,24 @@ func doInitialGitClone(project *dw.Project) error {
 	// Clone into a temp dir and then move set up project to PROJECTS_ROOT to try and make clone atomic in case
 	// project-clone container is terminated
 	tmpClonePath := path.Join(internal.CloneTmpDir, projectslib.GetClonePath(project))
-	err := CloneProject(project, tmpClonePath)
-	if err != nil {
-		return fmt.Errorf("failed to clone project: %s", err)
+	var cloneErr error
+	for attempt := 0; attempt <= internal.CloneRetries; attempt++ {
+		if attempt > 0 {
+			delayBeforeRetry(project.Name, attempt)
+			if err := os.RemoveAll(tmpClonePath); err != nil {
+				log.Printf("Warning: cleanup before retry failed: %s", err)
+			}
+		}
+		cloneErr = CloneProject(project, tmpClonePath)
+		if cloneErr == nil {
+			break
+		}
+		if attempt < internal.CloneRetries {
+			log.Printf("Failed git clone for project %s (attempt %d/%d): %s", project.Name, attempt+1, internal.CloneRetries+1, cloneErr)
+		}
+	}
+	if cloneErr != nil {
+		return fmt.Errorf("failed to clone project: %s", cloneErr)
 	}
 
 	if project.Attributes.Exists(internal.ProjectSparseCheckout) {
@@ -81,6 +97,12 @@ func doInitialGitClone(project *dw.Project) error {
 	}
 
 	return nil
+}
+
+func delayBeforeRetry(projectName string, attempt int) {
+	delay := internal.BaseRetryDelay * (1 << (attempt - 1))
+	log.Printf("Retrying git clone for project %s (attempt %d/%d) after %s", projectName, attempt+1, internal.CloneRetries+1, delay)
+	time.Sleep(delay)
 }
 
 func setupRemotesForExistingProject(project *dw.Project) error {

--- a/project-clone/internal/global.go
+++ b/project-clone/internal/global.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019-2025 Red Hat, Inc.
+// Copyright (c) 2019-2026 Red Hat, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,6 +21,8 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"strconv"
+	"time"
 
 	"github.com/devfile/devworkspace-operator/pkg/library/constants"
 	gittransport "github.com/go-git/go-git/v5/plumbing/transport"
@@ -30,14 +32,18 @@ import (
 )
 
 const (
-	credentialsMountPath = "/.git-credentials/credentials"
-	sshConfigMountPath   = "/etc/ssh/ssh_config"
-	publicCertsDir       = "/public-certs"
+	credentialsMountPath      = "/.git-credentials/credentials"
+	sshConfigMountPath        = "/etc/ssh/ssh_config"
+	publicCertsDir            = "/public-certs"
+	cloneRetriesEnvVar        = "PROJECT_CLONE_RETRIES"
+	defaultCloneRetries       = 3
+	BaseRetryDelay            = 1 * time.Second
 )
 
 var (
 	ProjectsRoot     string
 	CloneTmpDir      string
+	CloneRetries     int
 	tokenAuthMethod  map[string]*githttp.BasicAuth
 	credentialsRegex = regexp.MustCompile(`https://(.+):(.+)@(.+)`)
 )
@@ -58,6 +64,16 @@ func init() {
 	}
 	log.Printf("Using temporary directory %s", tmpDir)
 	CloneTmpDir = tmpDir
+
+	CloneRetries = defaultCloneRetries
+	if val := os.Getenv(cloneRetriesEnvVar); val != "" {
+		parsed, err := strconv.Atoi(val)
+		if err != nil || parsed < 0 {
+			log.Printf("Invalid value for %s: %q, using default (%d)", cloneRetriesEnvVar, val, defaultCloneRetries)
+		} else {
+			CloneRetries = parsed
+		}
+	}
 
 	setupAuth()
 }

--- a/project-clone/internal/global.go
+++ b/project-clone/internal/global.go
@@ -32,13 +32,13 @@ import (
 )
 
 const (
-	credentialsMountPath      = "/.git-credentials/credentials"
-	sshConfigMountPath        = "/etc/ssh/ssh_config"
-	publicCertsDir            = "/public-certs"
-	cloneRetriesEnvVar        = "PROJECT_CLONE_RETRIES"
-	defaultCloneRetries       = 3
-	maxCloneRetries           = 10
-	BaseRetryDelay            = 1 * time.Second
+	credentialsMountPath = "/.git-credentials/credentials"
+	sshConfigMountPath   = "/etc/ssh/ssh_config"
+	publicCertsDir       = "/public-certs"
+	cloneRetriesEnvVar   = "PROJECT_CLONE_RETRIES"
+	defaultCloneRetries  = 3
+	maxCloneRetries      = 10
+	BaseRetryDelay       = 1 * time.Second
 )
 
 var (

--- a/project-clone/internal/global.go
+++ b/project-clone/internal/global.go
@@ -37,6 +37,7 @@ const (
 	publicCertsDir            = "/public-certs"
 	cloneRetriesEnvVar        = "PROJECT_CLONE_RETRIES"
 	defaultCloneRetries       = 3
+	maxCloneRetries           = 10
 	BaseRetryDelay            = 1 * time.Second
 )
 
@@ -70,6 +71,9 @@ func init() {
 		parsed, err := strconv.Atoi(val)
 		if err != nil || parsed < 0 {
 			log.Printf("Invalid value for %s: %q, using default (%d)", cloneRetriesEnvVar, val, defaultCloneRetries)
+		} else if parsed > maxCloneRetries {
+			log.Printf("Value for %s (%d) exceeds maximum (%d), using maximum", cloneRetriesEnvVar, parsed, maxCloneRetries)
+			CloneRetries = maxCloneRetries
 		} else {
 			CloneRetries = parsed
 		}


### PR DESCRIPTION
Assisted-by: Claude Code Opus 4.6

### What does this PR do?
Adds project clone retries functionality.

For the time being, by default, there will be up to 3 retries (4 attempts in total) with an exponential backoff. In a later PR, it would be nice to add a field in the DWOC to configure the number of retry attempts.

### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-9779

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

After building the image, install DWO:
```
export PROJECT_CLONE_IMG=quay.io/dkwon17/project-clone:retries
podman build -t "$PROJECT_CLONE_IMG" -f ./project-clone/Dockerfile .
podman push $PROJECT_CLONE_IMG
export DOCKER=podman
make docker
make install 
```

I have tested two cases:

<details><summary>Verify that regular cloning is working as intended</summary>

Create the following DW and verify that project-clone was successful:
```
curl -sL https://raw.githubusercontent.com/devfile/devworkspace-operator/refs/heads/main/samples/git-clone-sample.yaml | oc apply -f -
```

Successful project-clone init container:
```
...
2026/04/09 23:09:41 Processing project devworkspace-operator
2026/04/09 23:09:41 Cloning project devworkspace-operator to /projects/project-clone-2875820073/devworkspace-operator
Cloning into '/projects/project-clone-2875820073/devworkspace-operator'...
2026/04/09 23:09:49 Cloned project devworkspace-operator to /projects/project-clone-2875820073/devworkspace-operator
...
```
</details>



<details><summary>Verify that retries are working as intended.</summary>

Create the following DW. Note that in this DW, the `devworkspace-operator` git project has typos in the remote urls, which will cause failures during git clone.

```
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha2
metadata:
  name: git-clone-sample-devworkspace
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
      - name: devworkspace-operator
        git:
          checkoutFrom:
            remote: origin
            revision: 0.21.x
          remotes:
            origin: "https://github.com/typo/devworkspace-operator.git"
            amisevsk: "https://github.com/typo/devworkspace-operator.git"
    commands:
      - id: say-hello
        exec:
          component: che-code-runtime-description
          commandLine: echo "Hello from $(pwd)"
          workingDir: ${PROJECT_SOURCE}/app
  contributions:
    - name: che-code
      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
      components:
        - name: che-code-runtime-description
          container:
            env:
              - name: CODE_HOST
                value: 0.0.0.0
```

Verify in the project-clone init container logs, that retries have been logged:
```
2026/04/09 23:59:47 Failed git clone for project devworkspace-operator (attempt 1/4): failed to git clone from https://github.com/ddevfile/devworkspace-operator.git: exit status 128
2026/04/09 23:59:47 Retrying git clone for project devworkspace-operator (attempt 2/4) after 1s
2026/04/09 23:59:48 Cloning project devworkspace-operator to /projects/project-clone-2688951296/devworkspace-operator
Cloning into '/projects/project-clone-2688951296/devworkspace-operator'...
Error: passphrase file is missing in the '/etc/ssh/' directory
error: unable to read askpass response from '/.ssh-askpass/ssh-askpass.sh'
fatal: could not read Username for 'https://github.com': No such device or address
2026/04/09 23:59:48 Failed git clone for project devworkspace-operator (attempt 2/4): failed to git clone from https://github.com/ddevfile/devworkspace-operator.git: exit status 128
2026/04/09 23:59:48 Retrying git clone for project devworkspace-operator (attempt 3/4) after 2s
2026/04/09 23:59:50 Cloning project devworkspace-operator to /projects/project-clone-2688951296/devworkspace-operator
Cloning into '/projects/project-clone-2688951296/devworkspace-operator'...
Error: passphrase file is missing in the '/etc/ssh/' directory
error: unable to read askpass response from '/.ssh-askpass/ssh-askpass.sh'
fatal: could not read Username for 'https://github.com': No such device or address
2026/04/09 23:59:50 Failed git clone for project devworkspace-operator (attempt 3/4): failed to git clone from https://github.com/ddevfile/devworkspace-operator.git: exit status 128
2026/04/09 23:59:50 Retrying git clone for project devworkspace-operator (attempt 4/4) after 4s
```

</details>


### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git clone now automatically retries failed attempts with exponential backoff between tries.
  * Number of retry attempts is configurable via PROJECT_CLONE_RETRIES (defaults applied, invalid values ignored, values clamped to a sensible maximum).
  * Previous failed clone data is cleaned up before each retry.

* **Bug Fixes**
  * Improved retry and failure logging for clearer diagnostics and preserved underlying error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->