### PR TITLE
fix: fall back to canonical backup auth secret name on restore

### DIFF
--- a/pkg/secrets/backup.go
+++ b/pkg/secrets/backup.go
@@ -54,42 +54,23 @@ func HandleRegistryAuthSecret(ctx context.Context, c client.Client, workspace *d
 		return nil, nil
 	}
 
-	// First check the workspace namespace for the secret
+	// First check the workspace namespace for the secret.
+	// CopySecret always writes the copy under DevWorkspaceBackupAuthSecretName,
+	// so look it up by that canonical name.
 	registryAuthSecret := &corev1.Secret{}
 	err := c.Get(ctx, client.ObjectKey{
-		Name:      secretName,
+		Name:      constants.DevWorkspaceBackupAuthSecretName,
 		Namespace: workspace.Namespace}, registryAuthSecret)
 	if err == nil {
-		log.Info("Successfully retrieved registry auth secret for backup from workspace namespace", "secretName", secretName)
+		log.Info("Successfully retrieved registry auth secret for backup from workspace namespace",
+			"secretName", constants.DevWorkspaceBackupAuthSecretName)
 		return registryAuthSecret, nil
 	}
 	if client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
 	// If we don't provide an operator namespace, don't attempt to look there.
-	// However, CopySecret always writes the secret under DevWorkspaceBackupAuthSecretName,
-	// regardless of the configured name. If the configured name differs, attempt a fallback
-	// lookup under the canonical name so that the restore path can find it.
 	if operatorConfigNamespace == "" {
-		if secretName == constants.DevWorkspaceBackupAuthSecretName {
-			// The configured name IS the canonical name; it was already looked up and not
-			// found above, so there is nothing else to try.
-			return nil, nil
-		}
-		fallbackSecret := &corev1.Secret{}
-		fallbackErr := c.Get(ctx, client.ObjectKey{
-			Name:      constants.DevWorkspaceBackupAuthSecretName,
-			Namespace: workspace.Namespace,
-		}, fallbackSecret)
-		if fallbackErr == nil {
-			log.Info("Registry auth secret not found under configured name in workspace namespace; using canonical backup auth secret as fallback",
-				"configuredName", secretName,
-				"fallbackName", constants.DevWorkspaceBackupAuthSecretName)
-			return fallbackSecret, nil
-		}
-		if client.IgnoreNotFound(fallbackErr) != nil {
-			return nil, fallbackErr
-		}
 		return nil, nil
 	}
 	log.Info("Registry auth secret not found in workspace namespace, checking operator namespace", "secretName", secretName)

--- a/pkg/secrets/backup.go
+++ b/pkg/secrets/backup.go
@@ -54,7 +54,7 @@ func HandleRegistryAuthSecret(ctx context.Context, c client.Client, workspace *d
 		return nil, nil
 	}
 
-	// On the restore path (operatorConfigNamespace == ""), look for the canonical name
+	// On the restore path (operatorConfigNamespace == ""), look for the predefined name
 	// that CopySecret always uses. On the backup path, look for the configured name
 	// because the secret may exist directly in the workspace namespace under that name.
 	lookupName := secretName

--- a/pkg/secrets/backup.go
+++ b/pkg/secrets/backup.go
@@ -54,16 +54,21 @@ func HandleRegistryAuthSecret(ctx context.Context, c client.Client, workspace *d
 		return nil, nil
 	}
 
-	// First check the workspace namespace for the secret.
-	// CopySecret always writes the copy under DevWorkspaceBackupAuthSecretName,
-	// so look it up by that canonical name.
+	// On the restore path (operatorConfigNamespace == ""), look for the canonical name
+	// that CopySecret always uses. On the backup path, look for the configured name
+	// because the secret may exist directly in the workspace namespace under that name.
+	lookupName := secretName
+	if operatorConfigNamespace == "" {
+		lookupName = constants.DevWorkspaceBackupAuthSecretName
+	}
+
 	registryAuthSecret := &corev1.Secret{}
 	err := c.Get(ctx, client.ObjectKey{
-		Name:      constants.DevWorkspaceBackupAuthSecretName,
+		Name:      lookupName,
 		Namespace: workspace.Namespace}, registryAuthSecret)
 	if err == nil {
 		log.Info("Successfully retrieved registry auth secret for backup from workspace namespace",
-			"secretName", constants.DevWorkspaceBackupAuthSecretName)
+			"secretName", lookupName)
 		return registryAuthSecret, nil
 	}
 	if client.IgnoreNotFound(err) != nil {

--- a/pkg/secrets/backup.go
+++ b/pkg/secrets/backup.go
@@ -66,8 +66,30 @@ func HandleRegistryAuthSecret(ctx context.Context, c client.Client, workspace *d
 	if client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
-	// If we don't provide an operator namespace, don't attempt to look there
+	// If we don't provide an operator namespace, don't attempt to look there.
+	// However, CopySecret always writes the secret under DevWorkspaceBackupAuthSecretName,
+	// regardless of the configured name. If the configured name differs, attempt a fallback
+	// lookup under the canonical name so that the restore path can find it.
 	if operatorConfigNamespace == "" {
+		if secretName == constants.DevWorkspaceBackupAuthSecretName {
+			// The configured name IS the canonical name; it was already looked up and not
+			// found above, so there is nothing else to try.
+			return nil, nil
+		}
+		fallbackSecret := &corev1.Secret{}
+		fallbackErr := c.Get(ctx, client.ObjectKey{
+			Name:      constants.DevWorkspaceBackupAuthSecretName,
+			Namespace: workspace.Namespace,
+		}, fallbackSecret)
+		if fallbackErr == nil {
+			log.Info("Registry auth secret not found under configured name in workspace namespace; using canonical backup auth secret as fallback",
+				"configuredName", secretName,
+				"fallbackName", constants.DevWorkspaceBackupAuthSecretName)
+			return fallbackSecret, nil
+		}
+		if client.IgnoreNotFound(fallbackErr) != nil {
+			return nil, fallbackErr
+		}
 		return nil, nil
 	}
 	log.Info("Registry auth secret not found in workspace namespace, checking operator namespace", "secretName", secretName)

--- a/pkg/secrets/backup_test.go
+++ b/pkg/secrets/backup_test.go
@@ -101,11 +101,11 @@ var _ = Describe("HandleRegistryAuthSecret (restore path: operatorConfigNamespac
 		scheme = buildScheme()
 	})
 
-	It("returns the canonical secret when it exists in the workspace namespace", func() {
-		By("creating the canonical DevWorkspaceBackupAuthSecretName secret in the workspace namespace")
-		canonicalSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, workspaceNS)
+	It("returns the predefined secret when it exists in the workspace namespace", func() {
+		By("creating the predefined DevWorkspaceBackupAuthSecretName secret in the workspace namespace")
+		predefinedSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, workspaceNS)
 
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(canonicalSecret).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(predefinedSecret).Build()
 		workspace := makeWorkspace(workspaceNS)
 		config := makeConfig("quay-backup-auth")
 
@@ -115,7 +115,7 @@ var _ = Describe("HandleRegistryAuthSecret (restore path: operatorConfigNamespac
 		Expect(result.Name).To(Equal(constants.DevWorkspaceBackupAuthSecretName))
 	})
 
-	It("returns nil when the canonical secret does not exist in the workspace namespace", func() {
+	It("returns nil when the predefined secret does not exist in the workspace namespace", func() {
 		By("using a fake client with no secrets")
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 		workspace := makeWorkspace(workspaceNS)
@@ -127,7 +127,7 @@ var _ = Describe("HandleRegistryAuthSecret (restore path: operatorConfigNamespac
 	})
 
 	It("propagates a non-NotFound error from the workspace namespace lookup", func() {
-		By("wrapping a fake client so that the canonical name lookup returns a server error")
+		By("wrapping a fake client so that the predefined name lookup returns a server error")
 		errClient := &errorOnNameClient{
 			Client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
 			failName: constants.DevWorkspaceBackupAuthSecretName,

--- a/pkg/secrets/backup_test.go
+++ b/pkg/secrets/backup_test.go
@@ -1,0 +1,201 @@
+//
+// Copyright (c) 2019-2026 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package secrets_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	dwv2 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"github.com/devfile/devworkspace-operator/pkg/secrets"
+)
+
+func TestSecrets(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Secrets Suite")
+}
+
+// buildScheme returns a minimal runtime.Scheme for tests: core v1 and the DWO API types.
+func buildScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	Expect(dwv2.AddToScheme(scheme)).To(Succeed())
+	Expect(controllerv1alpha1.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+// makeWorkspace returns a minimal DevWorkspace in the given namespace.
+func makeWorkspace(namespace string) *dwv2.DevWorkspace {
+	return &dwv2.DevWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workspace",
+			Namespace: namespace,
+		},
+	}
+}
+
+// makeConfig returns an OperatorConfiguration with BackupCronJob configured to use the given auth secret name.
+func makeConfig(authSecretName string) *controllerv1alpha1.OperatorConfiguration {
+	return &controllerv1alpha1.OperatorConfiguration{
+		Workspace: &controllerv1alpha1.WorkspaceConfig{
+			BackupCronJob: &controllerv1alpha1.BackupCronJobConfig{
+				Registry: &controllerv1alpha1.RegistryConfig{
+					Path:       "example.registry.io/org",
+					AuthSecret: authSecretName,
+				},
+			},
+		},
+	}
+}
+
+// makeSecret returns a corev1.Secret with the given name and namespace.
+func makeSecret(name, namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{"auth": []byte("dXNlcjpwYXNz")},
+		Type: corev1.SecretTypeDockerConfigJson,
+	}
+}
+
+var _ = Describe("HandleRegistryAuthSecret (restore path: operatorConfigNamespace='')", func() {
+	const workspaceNS = "user-namespace"
+
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+		log    = zap.New(zap.UseDevMode(true)).WithName("SecretsTest")
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = buildScheme()
+	})
+
+	It("returns the secret directly when the configured name is present in the workspace namespace", func() {
+		By("creating a workspace-namespace secret whose name matches the configured auth secret name")
+		configuredName := "quay-backup-auth"
+		secret := makeSecret(configuredName, workspaceNS)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+		workspace := makeWorkspace(workspaceNS)
+		config := makeConfig(configuredName)
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, "", scheme, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+		Expect(result.Name).To(Equal(configuredName))
+	})
+
+	It("returns the canonical backup auth secret as fallback when configured name is absent (the bug fix case)", func() {
+		By("creating only the canonical DevWorkspaceBackupAuthSecretName secret in the workspace namespace")
+		canonicalSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, workspaceNS)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(canonicalSecret).Build()
+		workspace := makeWorkspace(workspaceNS)
+		// Configured name is something like "quay-backup-auth" — different from the canonical name.
+		config := makeConfig("quay-backup-auth")
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, "", scheme, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil(), "should fall back to the canonical secret copied by CopySecret")
+		Expect(result.Name).To(Equal(constants.DevWorkspaceBackupAuthSecretName))
+	})
+
+	It("returns nil, nil when neither the configured name nor the canonical name exists in the workspace namespace", func() {
+		By("using a fake client with no secrets at all")
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		workspace := makeWorkspace(workspaceNS)
+		config := makeConfig("quay-backup-auth")
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, "", scheme, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("returns the secret on the first lookup when the configured name IS the canonical name (no duplicate query)", func() {
+		By("creating the canonical secret in the workspace namespace and configuring the same name")
+		canonicalSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, workspaceNS)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(canonicalSecret).Build()
+		workspace := makeWorkspace(workspaceNS)
+		// Configured name equals the canonical constant — must be found on the first Get.
+		config := makeConfig(constants.DevWorkspaceBackupAuthSecretName)
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, "", scheme, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+		Expect(result.Name).To(Equal(constants.DevWorkspaceBackupAuthSecretName))
+	})
+
+	It("propagates a real (non-NotFound) error from the fallback lookup", func() {
+		By("wrapping a fake client so that the fallback lookup returns a server error")
+		// The configured name differs from the canonical name, so the code will attempt the fallback
+		// lookup. We simulate that lookup returning a non-NotFound error.
+		errClient := &errorOnNameClient{
+			Client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
+			failName: constants.DevWorkspaceBackupAuthSecretName,
+			failErr:  k8sErrors.NewInternalError(errors.New("simulated etcd timeout")),
+		}
+		workspace := makeWorkspace(workspaceNS)
+		config := makeConfig("quay-backup-auth")
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, errClient, workspace, config, "", scheme, log)
+		Expect(err).To(HaveOccurred())
+		Expect(result).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("simulated etcd timeout"))
+	})
+})
+
+// errorOnNameClient is a thin client wrapper that injects an error for a specific secret name.
+type errorOnNameClient struct {
+	client.Client
+	failName string
+	failErr  error
+}
+
+func (e *errorOnNameClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if secret, ok := obj.(*corev1.Secret); ok {
+		_ = secret
+		if key.Name == e.failName {
+			return e.failErr
+		}
+	}
+	return e.Client.Get(ctx, key, obj, opts...)
+}
+
+// Ensure errorOnNameClient satisfies client.Client at compile time.
+var _ client.Client = &errorOnNameClient{}
+
+// secretGR is the GroupResource for secrets, used when constructing test errors.
+var secretGR = schema.GroupResource{Group: "", Resource: "secrets"} //nolint:unused

--- a/pkg/secrets/backup_test.go
+++ b/pkg/secrets/backup_test.go
@@ -29,7 +29,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -102,38 +101,22 @@ var _ = Describe("HandleRegistryAuthSecret (restore path: operatorConfigNamespac
 		scheme = buildScheme()
 	})
 
-	It("returns the secret directly when the configured name is present in the workspace namespace", func() {
-		By("creating a workspace-namespace secret whose name matches the configured auth secret name")
-		configuredName := "quay-backup-auth"
-		secret := makeSecret(configuredName, workspaceNS)
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
-		workspace := makeWorkspace(workspaceNS)
-		config := makeConfig(configuredName)
-
-		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, "", scheme, log)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).NotTo(BeNil())
-		Expect(result.Name).To(Equal(configuredName))
-	})
-
-	It("returns the canonical backup auth secret as fallback when configured name is absent (the bug fix case)", func() {
-		By("creating only the canonical DevWorkspaceBackupAuthSecretName secret in the workspace namespace")
+	It("returns the canonical secret when it exists in the workspace namespace", func() {
+		By("creating the canonical DevWorkspaceBackupAuthSecretName secret in the workspace namespace")
 		canonicalSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, workspaceNS)
 
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(canonicalSecret).Build()
 		workspace := makeWorkspace(workspaceNS)
-		// Configured name is something like "quay-backup-auth" — different from the canonical name.
 		config := makeConfig("quay-backup-auth")
 
 		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, "", scheme, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).NotTo(BeNil(), "should fall back to the canonical secret copied by CopySecret")
+		Expect(result).NotTo(BeNil())
 		Expect(result.Name).To(Equal(constants.DevWorkspaceBackupAuthSecretName))
 	})
 
-	It("returns nil, nil when neither the configured name nor the canonical name exists in the workspace namespace", func() {
-		By("using a fake client with no secrets at all")
+	It("returns nil when the canonical secret does not exist in the workspace namespace", func() {
+		By("using a fake client with no secrets")
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 		workspace := makeWorkspace(workspaceNS)
 		config := makeConfig("quay-backup-auth")
@@ -143,25 +126,8 @@ var _ = Describe("HandleRegistryAuthSecret (restore path: operatorConfigNamespac
 		Expect(result).To(BeNil())
 	})
 
-	It("returns the secret on the first lookup when the configured name IS the canonical name (no duplicate query)", func() {
-		By("creating the canonical secret in the workspace namespace and configuring the same name")
-		canonicalSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, workspaceNS)
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(canonicalSecret).Build()
-		workspace := makeWorkspace(workspaceNS)
-		// Configured name equals the canonical constant — must be found on the first Get.
-		config := makeConfig(constants.DevWorkspaceBackupAuthSecretName)
-
-		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, "", scheme, log)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).NotTo(BeNil())
-		Expect(result.Name).To(Equal(constants.DevWorkspaceBackupAuthSecretName))
-	})
-
-	It("propagates a real (non-NotFound) error from the fallback lookup", func() {
-		By("wrapping a fake client so that the fallback lookup returns a server error")
-		// The configured name differs from the canonical name, so the code will attempt the fallback
-		// lookup. We simulate that lookup returning a non-NotFound error.
+	It("propagates a non-NotFound error from the workspace namespace lookup", func() {
+		By("wrapping a fake client so that the canonical name lookup returns a server error")
 		errClient := &errorOnNameClient{
 			Client:   fake.NewClientBuilder().WithScheme(scheme).Build(),
 			failName: constants.DevWorkspaceBackupAuthSecretName,
@@ -196,6 +162,3 @@ func (e *errorOnNameClient) Get(ctx context.Context, key client.ObjectKey, obj c
 
 // Ensure errorOnNameClient satisfies client.Client at compile time.
 var _ client.Client = &errorOnNameClient{}
-
-// secretGR is the GroupResource for secrets, used when constructing test errors.
-var secretGR = schema.GroupResource{Group: "", Resource: "secrets"} //nolint:unused


### PR DESCRIPTION
### What does this PR do?

When a workspace is backed up to a private registry, `CopySecret` copies the registry auth secret into the workspace namespace using a hardcoded name (`devworkspace-backup-registry-auth`), regardless of the name configured in the `DWOC`. During restore, `GetNamespaceRegistryAuthSecret` looks for the configured name, doesn't find it, and returns `nil` - so the `workspace-restore` init container has no credentials and crashes with `CrashLoopBackOff`.

This PR adds a fallback lookup in `HandleRegistryAuthSecret`: when called from the restore path (`operatorConfigNamespace == ""`), if the configured secret name is not found in the workspace namespace, it also
  checks for the canonical `devworkspace-backup-registry-auth` name that `CopySecret` always uses.

**Note**: This is a surgical workaround. See https://github.com/devfile/devworkspace-operator/pull/1615 for a root-cause fix that changes the secret naming in `CopySecret` instead.

### What issues does this PR fix or reference?

[CRW-10591](https://redhat.atlassian.net/browse/CRW-10591)

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

New unit tests added.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * During restore, the system now prefers the canonical workspace backup auth secret name when looking up registry credentials, with clearer logging and preserved fallback behavior.

* **Tests**
  * Added focused tests covering restore-path secret retrieval, the case of a missing workspace secret, and propagation of retrieval errors to ensure robust secret-handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->