### PR TITLE
chore(deps): bump go version to v1.25.9

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -15,17 +15,17 @@
 
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20
 
-ENV GO_VERSION=1.25.8
+ENV GO_VERSION=1.25.9
 ENV GOROOT=/usr/local/go
 ENV PATH=$GOROOT/bin:$PATH
 
-ENV GO_VERSION=1.25.8
+ENV GO_VERSION=1.25.9
 ENV GOROOT=/usr/local/go
 ENV PATH=$GOROOT/bin:$PATH
 
 SHELL ["/bin/bash", "-c"]
 
-# Install Go 1.25.8 to satisfy go.mod toolchain requirement (go 1.25.0)
+# Install Go 1.25.9 to satisfy go.mod toolchain requirement (go 1.25.0)
 RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
     curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o go.tar.gz && \
     rm -rf /usr/local/go && \

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,7 +14,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.25.8
+        go-version: 1.25.9
     -
       name: Set up Python 3.11
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.25.8
+        go-version: 1.25.9
     -
       name: Set up Python 3.11
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 #v2.2.0
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,7 +16,7 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
 # Use BUILDPLATFORM to ensure the builder always runs natively on the host machine
 # Image pinned by SHA256 to address GitHub security bot warnings about unpinned dependencies
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1775651161@sha256:34b22cd0b8b0d270b7b1d6c376f7130b58ae575822e375cd947859c21fdced5f AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.25-1777043046@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999 AS builder
 
 # Accept TARGETARCH and TARGETPLATFORM, which are automatically passed by the builder
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/devfile/devworkspace-operator
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/devfile/api/v2 v2.3.1-alpha.0.20250521155908-5c3d7b99d252

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -16,7 +16,7 @@
 # Build the manager binary
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
 # Image pinned by SHA256 to address GitHub security bot warnings about unpinned dependencies
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1775651161@sha256:34b22cd0b8b0d270b7b1d6c376f7130b58ae575822e375cd947859c21fdced5f as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25-1777043046@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999 as builder
 ARG TARGETARCH
 ARG TARGETOS
 ENV GOPATH=/go/


### PR DESCRIPTION


### What does this PR do?
Update Go toolchain to `1.25.9` 
- use Red Hat UBI9 `go-toolset:1.25-1777043046`

### What issues does this PR fix or reference?
This PR aims to resolve these CVE(s) :
- CVE-2026-32283
- CVE-2026-32280
- CVE-2026-33810

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain from version 1.25.8 to 1.25.9 across CI/CD pipelines and build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->