### PR TITLE
refactor (backup) : conditionally copy registry auth secret from operator namespace to workspace namespace for backup/restore

### DIFF
--- a/controllers/backupcronjob/backupcronjob_controller_test.go
+++ b/controllers/backupcronjob/backupcronjob_controller_test.go
@@ -335,7 +335,8 @@ var _ = Describe("BackupCronJobReconciler", func() {
 							Enable:   &enabled,
 							Schedule: schedule,
 							Registry: &controllerv1alpha1.RegistryConfig{
-								Path: "fake-registry",
+								Path:       "fake-registry",
+								AuthSecret: "backup-auth",
 							},
 							OrasConfig: &controllerv1alpha1.OrasConfig{
 								ExtraArgs: "--extra-arg1",
@@ -352,6 +353,10 @@ var _ = Describe("BackupCronJobReconciler", func() {
 
 			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim-devworkspace", Namespace: dw.Namespace}}
 			Expect(fakeClient.Create(ctx, pvc)).To(Succeed())
+
+			// Create auth secret in operator namespace so it can be copied
+			authSecret := createAuthSecret("backup-auth", nameNamespace.Namespace, map[string][]byte{})
+			Expect(fakeClient.Create(ctx, authSecret)).To(Succeed())
 
 			Expect(reconciler.executeBackupSync(ctx, dwoc, log)).To(Succeed())
 
@@ -392,7 +397,8 @@ var _ = Describe("BackupCronJobReconciler", func() {
 							Schedule:     schedule,
 							BackoffLimit: &backoffLimit,
 							Registry: &controllerv1alpha1.RegistryConfig{
-								Path: "fake-registry",
+								Path:       "fake-registry",
+								AuthSecret: "backup-auth",
 							},
 						},
 					},
@@ -406,6 +412,10 @@ var _ = Describe("BackupCronJobReconciler", func() {
 
 			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim-devworkspace", Namespace: dw.Namespace}}
 			Expect(fakeClient.Create(ctx, pvc)).To(Succeed())
+
+			// Create auth secret in operator namespace so it can be copied
+			authSecret := createAuthSecret("backup-auth", nameNamespace.Namespace, map[string][]byte{})
+			Expect(fakeClient.Create(ctx, authSecret)).To(Succeed())
 
 			Expect(reconciler.executeBackupSync(ctx, dwoc, log)).To(Succeed())
 
@@ -552,7 +562,8 @@ var _ = Describe("BackupCronJobReconciler", func() {
 			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim-devworkspace", Namespace: dw.Namespace}}
 			Expect(fakeClient.Create(ctx, pvc)).To(Succeed())
 
-			authSecret := createAuthSecret("my-secret", "ns-a", map[string][]byte{})
+			// User-provided secret in workspace namespace with canonical name
+			authSecret := createAuthSecret("devworkspace-backup-registry-auth", "ns-a", map[string][]byte{})
 			Expect(fakeClient.Create(ctx, authSecret)).To(Succeed())
 
 			Expect(reconciler.executeBackupSync(ctx, dwoc, log)).To(Succeed())

--- a/docs/dwo-configuration.md
+++ b/docs/dwo-configuration.md
@@ -125,7 +125,7 @@ Backup CronJob configuration fields:
 The value provided for registry.path is only the first segment of the final location. The full registry path is assembled dynamically, incorporating the name of the workspace and the :latest tag, following this pattern:
 `<registry.path>/<devworkspace-name>:latest`
 
-- **`registry.authSecret`**: (Optional) The name of the Kubernetes Secret containing credentials to access the OCI registry. If not provided, it is assumed that the registry is public or uses integrated OpenShift registry.
+- **`registry.authSecret`**: (Optional) The name of the secret in the **operator namespace** to copy to workspace namespaces. The secret is always copied as `devworkspace-backup-registry-auth` in the workspace namespace. If not provided, backup/restore jobs proceed without authentication.
 - **`oras.extraArgs`**: (Optional) Additional arguments to pass to the `oras` CLI tool during push and pull operations.
 
 

--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func main() {
 	if err = (&backupCronJobController.BackupCronJobReconciler{
 		Client:           mgr.GetClient(),
 		NonCachingClient: nonCachingClient,
-		Log:              ctrl.Log.WithName("controllers").WithName("BackupCronJob").V(1),
+		Log:              ctrl.Log.WithName("controllers").WithName("BackupCronJob"),
 		Scheme:           mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BackupCronJob")

--- a/pkg/secrets/backup.go
+++ b/pkg/secrets/backup.go
@@ -24,12 +24,11 @@ import (
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 )
 
 // GetRegistryAuthSecret retrieves the registry authentication secret for accessing backup images
@@ -48,27 +47,14 @@ func HandleRegistryAuthSecret(ctx context.Context, c client.Client, workspace *d
 		dwOperatorConfig.Workspace.BackupCronJob.Registry == nil {
 		return nil, fmt.Errorf("backup/restore configuration not properly set in DevWorkspaceOperatorConfig")
 	}
-	secretName := dwOperatorConfig.Workspace.BackupCronJob.Registry.AuthSecret
-	if secretName == "" {
-		// No auth secret configured - anonymous access to registry
-		return nil, nil
-	}
-
-	// On the restore path (operatorConfigNamespace == ""), look for the predefined name
-	// that CopySecret always uses. On the backup path, look for the configured name
-	// because the secret may exist directly in the workspace namespace under that name.
-	lookupName := secretName
-	if operatorConfigNamespace == "" {
-		lookupName = constants.DevWorkspaceBackupAuthSecretName
-	}
 
 	registryAuthSecret := &corev1.Secret{}
 	err := c.Get(ctx, client.ObjectKey{
-		Name:      lookupName,
+		Name:      constants.DevWorkspaceBackupAuthSecretName,
 		Namespace: workspace.Namespace}, registryAuthSecret)
 	if err == nil {
 		log.Info("Successfully retrieved registry auth secret for backup from workspace namespace",
-			"secretName", lookupName)
+			"secretName", constants.DevWorkspaceBackupAuthSecretName)
 		return registryAuthSecret, nil
 	}
 	if client.IgnoreNotFound(err) != nil {
@@ -78,23 +64,58 @@ func HandleRegistryAuthSecret(ctx context.Context, c client.Client, workspace *d
 	if operatorConfigNamespace == "" {
 		return nil, nil
 	}
-	log.Info("Registry auth secret not found in workspace namespace, checking operator namespace", "secretName", secretName)
 
-	// If the secret is not found in the workspace namespace, check the operator namespace as fallback
+	// Check if AuthSecret is configured in operator config
+	authSecretName := dwOperatorConfig.Workspace.BackupCronJob.Registry.AuthSecret
+	if len(authSecretName) == 0 {
+		return nil, fmt.Errorf(
+			"registry auth secret %q not found in workspace namespace %q and AuthSecret is not configured in DevWorkspaceOperatorConfig. "+
+				"Either create the secret in the workspace namespace or configure Registry.AuthSecret in the operator config to enable copying from the operator namespace",
+			constants.DevWorkspaceBackupAuthSecretName,
+			workspace.Namespace,
+		)
+	}
+
+	log.Info("Registry auth secret not found in workspace namespace, checking operator namespace",
+		"secretName", authSecretName,
+		"operatorNamespace", operatorConfigNamespace)
+
+	// Look for the configured secret name in operator namespace
 	err = c.Get(ctx, client.ObjectKey{
-		Name:      secretName,
+		Name:      authSecretName,
 		Namespace: operatorConfigNamespace}, registryAuthSecret)
 	if err != nil {
-		log.Error(err, "Failed to get registry auth secret for backup job", "secretName", secretName)
+		log.Error(err, "Failed to get registry auth secret for backup job",
+			"secretName", authSecretName,
+			"namespace", operatorConfigNamespace)
 		return nil, err
 	}
-	log.Info("Successfully retrieved registry auth secret for backup job", "secretName", secretName)
+	log.Info("Successfully retrieved registry auth secret from operator namespace",
+		"secretName", authSecretName)
 	return CopySecret(ctx, c, workspace, registryAuthSecret, scheme, log)
 }
 
 // CopySecret copies the given secret from the operator namespace to the workspace namespace.
+// It NEVER overwrites an existing secret: if a secret already exists in the workspace namespace,
+// it returns the existing secret without modification.
 func CopySecret(ctx context.Context, c client.Client, workspace *dw.DevWorkspace, sourceSecret *corev1.Secret, scheme *runtime.Scheme, log logr.Logger) (namespaceSecret *corev1.Secret, err error) {
-	// Construct the desired secret state
+	// First check if secret already exists in workspace namespace
+	existingSecret := &corev1.Secret{}
+	err = c.Get(ctx, client.ObjectKey{
+		Name:      constants.DevWorkspaceBackupAuthSecretName,
+		Namespace: workspace.Namespace,
+	}, existingSecret)
+
+	if err == nil {
+		log.Info("Registry auth secret already exists in workspace namespace, using existing secret",
+			"secretName", constants.DevWorkspaceBackupAuthSecretName)
+		return existingSecret, nil
+	}
+
+	if client.IgnoreNotFound(err) != nil {
+		return nil, err
+	}
+
 	desiredSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.DevWorkspaceBackupAuthSecretName,
@@ -111,27 +132,25 @@ func CopySecret(ctx context.Context, c client.Client, workspace *dw.DevWorkspace
 		return nil, err
 	}
 
-	// Use the sync mechanism
-	clusterAPI := sync.ClusterAPI{
-		Client: c,
-		Scheme: scheme,
-		Logger: log,
-		Ctx:    ctx,
-	}
-
-	syncedObj, err := sync.SyncObjectWithCluster(desiredSecret, clusterAPI)
+	err = c.Create(ctx, desiredSecret)
 	if err != nil {
-		if _, ok := err.(*sync.NotInSyncError); !ok {
-			return nil, err
+		if k8sErrors.IsAlreadyExists(err) {
+			// Race condition - secret was created between Get and Create
+			// Fetch and return it (respect what's there)
+			if err := c.Get(ctx, client.ObjectKey{
+				Name:      constants.DevWorkspaceBackupAuthSecretName,
+				Namespace: workspace.Namespace,
+			}, existingSecret); err != nil {
+				return nil, err
+			}
+			log.Info("Registry auth secret was created concurrently, using existing secret",
+				"secretName", constants.DevWorkspaceBackupAuthSecretName)
+			return existingSecret, nil
 		}
-		// NotInSyncError means the sync operation was successful but triggered a change
-		log.Info("Successfully synced secret", "name", desiredSecret.Name, "namespace", workspace.Namespace)
+		return nil, err
 	}
 
-	// If syncedObj is nil (due to NotInSyncError), return the desired object
-	if syncedObj == nil {
-		return desiredSecret, nil
-	}
-
-	return syncedObj.(*corev1.Secret), nil
+	log.Info("Successfully copied registry auth secret to workspace namespace",
+		"name", desiredSecret.Name, "namespace", workspace.Namespace)
+	return desiredSecret, nil
 }

--- a/pkg/secrets/backup.go
+++ b/pkg/secrets/backup.go
@@ -68,12 +68,12 @@ func HandleRegistryAuthSecret(ctx context.Context, c client.Client, workspace *d
 	// Check if AuthSecret is configured in operator config
 	authSecretName := dwOperatorConfig.Workspace.BackupCronJob.Registry.AuthSecret
 	if len(authSecretName) == 0 {
-		return nil, fmt.Errorf(
-			"registry auth secret %q not found in workspace namespace %q and AuthSecret is not configured in DevWorkspaceOperatorConfig. "+
-				"Either create the secret in the workspace namespace or configure Registry.AuthSecret in the operator config to enable copying from the operator namespace",
-			constants.DevWorkspaceBackupAuthSecretName,
-			workspace.Namespace,
-		)
+		log.Info("Registry auth secret not found in workspace namespace and not configured in operator config. "+
+			"Proceeding without authentication. Ensure your registry allows anonymous access or configure authentication if needed.",
+			"secretName", constants.DevWorkspaceBackupAuthSecretName,
+			"namespace", workspace.Namespace,
+			"registry", dwOperatorConfig.Workspace.BackupCronJob.Registry.Path)
+		return nil, nil
 	}
 
 	log.Info("Registry auth secret not found in workspace namespace, checking operator namespace",

--- a/pkg/secrets/backup.go
+++ b/pkg/secrets/backup.go
@@ -99,23 +99,6 @@ func HandleRegistryAuthSecret(ctx context.Context, c client.Client, workspace *d
 // It NEVER overwrites an existing secret: if a secret already exists in the workspace namespace,
 // it returns the existing secret without modification.
 func CopySecret(ctx context.Context, c client.Client, workspace *dw.DevWorkspace, sourceSecret *corev1.Secret, scheme *runtime.Scheme, log logr.Logger) (namespaceSecret *corev1.Secret, err error) {
-	// First check if secret already exists in workspace namespace
-	existingSecret := &corev1.Secret{}
-	err = c.Get(ctx, client.ObjectKey{
-		Name:      constants.DevWorkspaceBackupAuthSecretName,
-		Namespace: workspace.Namespace,
-	}, existingSecret)
-
-	if err == nil {
-		log.Info("Registry auth secret already exists in workspace namespace, using existing secret",
-			"secretName", constants.DevWorkspaceBackupAuthSecretName)
-		return existingSecret, nil
-	}
-
-	if client.IgnoreNotFound(err) != nil {
-		return nil, err
-	}
-
 	desiredSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.DevWorkspaceBackupAuthSecretName,
@@ -140,12 +123,12 @@ func CopySecret(ctx context.Context, c client.Client, workspace *dw.DevWorkspace
 			if err := c.Get(ctx, client.ObjectKey{
 				Name:      constants.DevWorkspaceBackupAuthSecretName,
 				Namespace: workspace.Namespace,
-			}, existingSecret); err != nil {
+			}, sourceSecret); err != nil {
 				return nil, err
 			}
 			log.Info("Registry auth secret was created concurrently, using existing secret",
 				"secretName", constants.DevWorkspaceBackupAuthSecretName)
-			return existingSecret, nil
+			return sourceSecret, nil
 		}
 		return nil, err
 	}

--- a/pkg/secrets/backup_test.go
+++ b/pkg/secrets/backup_test.go
@@ -143,6 +143,131 @@ var _ = Describe("HandleRegistryAuthSecret (restore path: operatorConfigNamespac
 	})
 })
 
+var _ = Describe("HandleRegistryAuthSecret (backup path: operatorConfigNamespace set)", func() {
+	const (
+		workspaceNS = "user-namespace"
+		operatorNS  = "devworkspace-controller"
+	)
+
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+		log    = zap.New(zap.UseDevMode(true)).WithName("SecretsTest")
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = buildScheme()
+	})
+
+	It("returns the secret from workspace namespace if it exists", func() {
+		By("creating a secret in the workspace namespace")
+		workspaceSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, workspaceNS)
+		workspaceSecret.Data = map[string][]byte{"auth": []byte("user-credentials")}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(workspaceSecret).Build()
+		workspace := makeWorkspace(workspaceNS)
+		config := makeConfig(constants.DevWorkspaceBackupAuthSecretName)
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, operatorNS, scheme, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+		Expect(result.Name).To(Equal(constants.DevWorkspaceBackupAuthSecretName))
+		Expect(result.Namespace).To(Equal(workspaceNS))
+		Expect(result.Data["auth"]).To(Equal([]byte("user-credentials")))
+	})
+
+	It("returns error when AuthSecret is not configured and secret not found in workspace namespace", func() {
+		By("using a config with empty AuthSecret")
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		workspace := makeWorkspace(workspaceNS)
+		config := makeConfig("") // Empty AuthSecret
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, operatorNS, scheme, log)
+		Expect(err).To(HaveOccurred())
+		Expect(result).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("AuthSecret is not configured"))
+		Expect(err.Error()).To(ContainSubstring(workspaceNS))
+	})
+
+	It("copies secret from operator namespace when AuthSecret is configured and secret not found in workspace namespace", func() {
+		By("creating a secret in the operator namespace")
+		operatorSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, operatorNS)
+		operatorSecret.Data = map[string][]byte{"auth": []byte("operator-credentials")}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(operatorSecret).Build()
+		workspace := makeWorkspace(workspaceNS)
+		config := makeConfig(constants.DevWorkspaceBackupAuthSecretName)
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, operatorNS, scheme, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+		Expect(result.Name).To(Equal(constants.DevWorkspaceBackupAuthSecretName))
+		Expect(result.Namespace).To(Equal(workspaceNS))
+		Expect(result.Data["auth"]).To(Equal([]byte("operator-credentials")))
+
+		By("verifying the secret was created in the workspace namespace")
+		copiedSecret := &corev1.Secret{}
+		err = fakeClient.Get(ctx, client.ObjectKey{
+			Name:      constants.DevWorkspaceBackupAuthSecretName,
+			Namespace: workspaceNS,
+		}, copiedSecret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(copiedSecret.Data["auth"]).To(Equal([]byte("operator-credentials")))
+
+		By("verifying the copied secret has the watch-secret label")
+		Expect(copiedSecret.Labels).To(HaveKeyWithValue(constants.DevWorkspaceWatchSecretLabel, "true"))
+
+		By("verifying the copied secret has an owner reference to the workspace")
+		Expect(copiedSecret.OwnerReferences).To(HaveLen(1))
+		Expect(copiedSecret.OwnerReferences[0].Name).To(Equal(workspace.Name))
+		Expect(copiedSecret.OwnerReferences[0].Kind).To(Equal("DevWorkspace"))
+		Expect(copiedSecret.OwnerReferences[0].Controller).NotTo(BeNil())
+		Expect(*copiedSecret.OwnerReferences[0].Controller).To(BeTrue())
+	})
+
+	It("NEVER overwrites user-provided secret even if operator has different credentials", func() {
+		By("creating different secrets in both namespaces")
+		userSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, workspaceNS)
+		userSecret.Data = map[string][]byte{"auth": []byte("user-scoped-credentials")}
+
+		operatorSecret := makeSecret(constants.DevWorkspaceBackupAuthSecretName, operatorNS)
+		operatorSecret.Data = map[string][]byte{"auth": []byte("operator-wide-credentials")}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(userSecret, operatorSecret).Build()
+		workspace := makeWorkspace(workspaceNS)
+		config := makeConfig(constants.DevWorkspaceBackupAuthSecretName)
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, operatorNS, scheme, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+
+		By("verifying the user's secret was NOT overwritten")
+		Expect(result.Data["auth"]).To(Equal([]byte("user-scoped-credentials")), "User's secret should be preserved")
+
+		By("verifying the secret in workspace namespace still has user's credentials")
+		workspaceSecret := &corev1.Secret{}
+		err = fakeClient.Get(ctx, client.ObjectKey{
+			Name:      constants.DevWorkspaceBackupAuthSecretName,
+			Namespace: workspaceNS,
+		}, workspaceSecret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(workspaceSecret.Data["auth"]).To(Equal([]byte("user-scoped-credentials")), "User's secret must never be overwritten")
+	})
+
+	It("returns error when AuthSecret is configured but secret not found in operator namespace", func() {
+		By("using a config with AuthSecret but no secret in operator namespace")
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		workspace := makeWorkspace(workspaceNS)
+		config := makeConfig(constants.DevWorkspaceBackupAuthSecretName)
+
+		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, operatorNS, scheme, log)
+		Expect(err).To(HaveOccurred())
+		Expect(result).To(BeNil())
+		Expect(k8sErrors.IsNotFound(err)).To(BeTrue(), "Should return a NotFound error when secret doesn't exist in operator namespace")
+	})
+})
+
 // errorOnNameClient is a thin client wrapper that injects an error for a specific secret name.
 type errorOnNameClient struct {
 	client.Client

--- a/pkg/secrets/backup_test.go
+++ b/pkg/secrets/backup_test.go
@@ -177,17 +177,15 @@ var _ = Describe("HandleRegistryAuthSecret (backup path: operatorConfigNamespace
 		Expect(result.Data["auth"]).To(Equal([]byte("user-credentials")))
 	})
 
-	It("returns error when AuthSecret is not configured and secret not found in workspace namespace", func() {
+	It("returns nil when AuthSecret is not configured and secret not found in workspace namespace (anonymous registry access)", func() {
 		By("using a config with empty AuthSecret")
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 		workspace := makeWorkspace(workspaceNS)
 		config := makeConfig("") // Empty AuthSecret
 
 		result, err := secrets.HandleRegistryAuthSecret(ctx, fakeClient, workspace, config, operatorNS, scheme, log)
-		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(BeNil())
-		Expect(err.Error()).To(ContainSubstring("AuthSecret is not configured"))
-		Expect(err.Error()).To(ContainSubstring(workspaceNS))
 	})
 
 	It("copies secret from operator namespace when AuthSecret is configured and secret not found in workspace namespace", func() {


### PR DESCRIPTION
### What does this PR do?
Only copy the registry auth secret from the operator namespace to the workspace namespace when it is configured inside DevWorkspaceOperatorConfig. Always give precedence to the user-defined secret named devworkspace-backup-registry-auth in the workspace namespace; do not modify it when it's present while copying.

### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10758

### Is it tested? How?
<details>
  <summary>Scenario 1: AuthSecret Not Configured (Secure by Default)</summary>

**Expected:** Operator will NOT copy secrets. User must provide their own.

1. Configure DWOC without AuthSecret:
```bash
kubectl apply -f - <<EOF
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
  namespace: openshift-operators
config:
  workspace:
    backupCronJob:
      enable: true
      schedule: "* * * * *"
      registry:
        path: "quay.io/rokumar"
        # authSecret is NOT set - secure by default
EOF
```

2. Create test namespace
```bash
oc new-project test-workspace-no-auth
```

3. Create a DevWorkspace
```bash
kubectl apply -f - <<EOF
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: test-workspace-no-copy
  namespace: test-workspace-no-auth
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
          memoryLimit: 512Mi
EOF
```

4. Wait for workspace to become running, then stop it:
```bash
kubectl patch devworkspace test-workspace-no-copy -n test-workspace-no-auth \
  --type merge -p '{"spec":{"started":false}}'
```

5. **Expected Result:** Check operator logs - should show error about missing AuthSecret:
```bash
oc logs -l app.kubernetes.io/name=devworkspace-controller -n openshift-operators -f
```

**Expected log:**
```
{"level":"info","ts":"2026-05-11T07:22:00Z","logger":"controllers.BackupCronJob","msg":"Registry auth secret not found in workspace namespace and not configured in operator config. Proceeding without authentication. Ensure your registry allows anonymous access or configure authentication if needed.","secretName":"devworkspace-backup-registry-auth","namespace":"test-workspace-no-auth","registry":"quay.io/rokumar"}
```

6. Verify no secret was created:
```bash
kubectl get secret devworkspace-backup-registry-auth -n test-workspace-no-auth
# Expected: Error from server (NotFound)
```

</details>

<details>
  <summary>Scenario 2: AuthSecret Configured - Operator Copies Secret</summary>

**Expected:** Operator copies secret from operator namespace to workspace namespace.

1. Create operator secret first:
```bash
kubectl create secret docker-registry quay-push-secret \
  --docker-server=quay.io \
  --docker-username=<your-username> \
  --docker-password=<your-token> \
  -n openshift-operators

kubectl label secret quay-push-secret controller.devfile.io/watch-secret=true -n openshift-operators
```

2. Configure DWOC with AuthSecret:
```bash
kubectl apply -f - <<EOF
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
  namespace: openshift-operators
config:
  workspace:
    backupCronJob:
      enable: true
      schedule: "* * * * *"
      registry:
        path: "quay.io/rokumar"
        authSecret: "quay-push-secret"  # Configured - will enable copying
EOF
```

3. Create test namespace
```bash
oc new-project test-workspace-copy
```

4. Create a DevWorkspace
```bash
kubectl apply -f - <<EOF
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: test-workspace-with-copy
  namespace: test-workspace-copy
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
EOF
```

5. Wait for workspace to become running, then stop it:
```bash
kubectl patch devworkspace test-workspace-with-copy -n test-workspace-copy \
  --type merge -p '{"spec":{"started":false}}'
```

6. **Expected Result:** Verify secret was copied automatically:
```bash
kubectl get secret devworkspace-backup-registry-auth -n test-workspace-copy
# Expected: ✅ Secret exists

# Verify it has the controller.devfile.io/watch-secret label
kubectl get secret devworkspace-backup-registry-auth -n test-workspace-copy -o jsonpath='{.metadata.labels}'
```

</details>

<details>
  <summary>Scenario 3: User-Provided Secret NEVER gets Overwritten</summary>

**Expected:** User's secret is respected and NEVER overwritten, even if operator has different credentials.

1. Create operator secret:
```bash
kubectl create secret docker-registry quay-push-secret \
  --docker-server=quay.io \
  --docker-username=operator-user \
  --docker-password=operator-token \
  -n openshift-operators

kubectl label secret quay-push-secret controller.devfile.io/watch-secret=true -n openshift-operators
```

2. Configure DWOC:
```bash
kubectl apply -f - <<EOF
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
  namespace: openshift-operators
config:
  workspace:
    backupCronJob:
      enable: true
      schedule: "* * * * *"
      registry:
        path: "quay.io/rokumar"
        authSecret: "quay-push-secret"
EOF
```

3. Create test namespace
```bash
oc new-project test-workspace-user-secret
```

4. **IMPORTANT:** User manually creates secret BEFORE workspace (with different credentials):
```bash
kubectl create secret docker-registry devworkspace-backup-registry-auth \
  --docker-server=quay.io \
  --docker-username=user-scoped \
  --docker-password=user-token \
  -n test-workspace-user-secret

kubectl label secret devworkspace-backup-registry-auth \
  controller.devfile.io/watch-secret=true \
  -n test-workspace-user-secret

# Note the resourceVersion
echo "Original resourceVersion:"
kubectl get secret devworkspace-backup-registry-auth -n test-workspace-user-secret -o jsonpath='{.metadata.resourceVersion}'
echo
```

5. Create a DevWorkspace
```bash
kubectl apply -f - <<EOF
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: test-workspace-user-secret
  namespace: test-workspace-user-secret
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
EOF
```

6. Wait for workspace to become running, then stop it:
```bash
kubectl patch devworkspace test-workspace-user-secret -n test-workspace-user-secret \
  --type merge -p '{"spec":{"started":false}}'
```

7. **Critical Test:** Verify secret was NOT overwritten:
```bash
echo "Current resourceVersion:"
kubectl get secret devworkspace-backup-registry-auth -n test-workspace-user-secret -o jsonpath='{.metadata.resourceVersion}'
echo

# ResourceVersion should be EXACTLY THE SAME as step 4
```

</details>

<details>
  <summary>Scenario 4: AuthSecret Configured but Operator Secret Missing</summary>

**Expected:** Operator logs error that it cannot find the configured secret in operator namespace.

1. Configure DWOC with non-existent secret:
```bash
kubectl apply -f - <<EOF
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
  namespace: openshift-operators
config:
  workspace:
    backupCronJob:
      enable: true
      schedule: "* * * * *"
      registry:
        path: "quay.io/rokumar"
        authSecret: "missing-secret"  # This secret doesn't exist
EOF
```

2. Create test namespace
```bash
oc new-project test-workspace-missing-secret
```

3. Ensure no operator secret exists:
```bash
kubectl delete secret missing-secret -n openshift-operators --ignore-not-found
```

4. Create a DevWorkspace
```bash
kubectl apply -f - <<EOF
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: test-workspace-missing
  namespace: test-workspace-missing-secret
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
EOF
```

5. Wait for workspace to become running, then stop it:
```bash
kubectl patch devworkspace test-workspace-missing -n test-workspace-missing-secret \
  --type merge -p '{"spec":{"started":false}}'
```

6. **Expected Result:** Check operator logs for error:
```bash
oc logs -l app.kubernetes.io/name=devworkspace-controller -n openshift-operators -f
```

**Expected log:**
```
{"level":"error","ts":"2026-05-08T14:28:00Z","logger":"controllers.BackupCronJob","msg":"Failed to get registry auth secret for backup job","secretName":"missing-secret","namespace":"openshift-operators","error":"Secret \"missing-secret\" not found","stacktrace":"github.com/devfile/devworkspace-operator/pkg/secrets.HandleRegistryAuthSecret\n\t/devworkspace-operator/pkg/secrets/backup.go:88\ngithub.com/devfile/devworkspace-operator/controllers/backupcronjob.(*BackupCronJobReconciler).createBackupJob\n\t/devworkspace-operator/controllers/backupcronjob/backupcronjob_controller.go:348\ngithub.com/devfile/devworkspace-operator/controllers/backupcronjob.(*BackupCronJobReconciler).executeBackupSync\n\t/devworkspace-operator/controllers/backupcronjob/backupcronjob_controller.go:253\ngithub.com/devfile/devworkspace-operator/controllers/backupcronjob.(*BackupCronJobReconciler).startCron.func1\n\t/devworkspace-operator/controllers/backupcronjob/backupcronjob_controller.go:194\ngithub.com/robfig/cron/v3.FuncJob.Run\n\t/devworkspace-operator/vendor/github.com/robfig/cron/v3/cron.go:131\ngithub.com/robfig/cron/v3.(*Cron).startJob.func1\n\t/devworkspace-operator/vendor/github.com/robfig/cron/v3/cron.go:307"}
```

7. Verify no secret was created in workspace namespace:
```bash
kubectl get secret devworkspace-backup-registry-auth -n test-workspace-missing-secret
# Expected: Error from server (NotFound)
```

</details>

<details>
  <summary>Scenario 5: OpenShift Internal Registry - No Auth Required</summary>

**Expected:** Backup works without authentication when using OpenShift internal registry service URL.

1. Configure DWOC for OpenShift internal registry (no AuthSecret):
```bash
kubectl apply -f - <<EOF
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
  namespace: openshift-operators
config:
  workspace:
    backupCronJob:
      enable: true
      schedule: "* * * * *"
      oras:
          extraArgs: --insecure
      registry:
        path: "image-registry.openshift-image-registry.svc:5000"
        # authSecret is NOT set - internal registry doesn't require it
EOF
```

2. Create test namespace
```bash
oc new-project test-workspace-internal-registry
```

3. Create a DevWorkspace
```bash
kubectl apply -f - <<EOF
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: test-workspace-internal
  namespace: test-workspace-internal-registry
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
          memoryLimit: 512Mi
EOF
```

4. Wait for workspace to become running, then stop it:
```bash
kubectl patch devworkspace test-workspace-internal -n test-workspace-internal-registry \
  --type merge -p '{"spec":{"started":false}}'
```

5. **Expected Result:** Check operator logs - should show info message about proceeding without auth:
```bash
oc logs -l app.kubernetes.io/name=devworkspace-controller -n openshift-operators -f
```

**Expected log:**
```
{"level":"info","msg":"Registry auth secret not found in workspace namespace and not configured in operator config. Proceeding without authentication. Ensure your registry allows anonymous access or configure authentication if needed.","secretName":"devworkspace-backup-registry-auth","namespace":"test-workspace-internal-registry","registry":"image-registry.openshift-image-registry.svc:5000/backups"}
```

6. Verify backup job was created and succeeded:
```bash
kubectl get jobs -n test-workspace-internal-registry -l controller.devfile.io/devworkspace_name=test-workspace-internal

# Check job status
kubectl get jobs -n test-workspace-internal-registry -l controller.devfile.io/devworkspace_name=test-workspace-internal -o jsonpath='{.items[0].status.succeeded}'
# Expected: 1 (job succeeded)
```

7. Verify backup was pushed to internal registry:
```bash
# The backup image should exist in the OpenShift internal registry
oc get imagestream -n backups test-workspace-internal
```

</details>

<details>
  <summary>Scenario 6: Public/Anonymous Registry - No Auth Required</summary>

**Expected:** Backup works without authentication for registries that allow anonymous push (rare but valid use case).

1. Configure DWOC for a hypothetical public registry:
```bash
kubectl apply -f - <<EOF
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
  namespace: openshift-operators
config:
  workspace:
    backupCronJob:
      enable: true
      schedule: "* * * * *"
      registry:
        path: "ttl.sh/backups"
        # authSecret is NOT set - registry allows anonymous access
EOF
```

2. Create test namespace
```bash
oc new-project test-workspace-public-registry
```

3. Create a DevWorkspace
```bash
kubectl apply -f - <<EOF
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: test-workspace-public
  namespace: test-workspace-public-registry
spec:
  started: true
  template:
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
          memoryLimit: 512Mi
EOF
```

4. Wait for workspace to become running, then stop it:
```bash
kubectl patch devworkspace test-workspace-public -n test-workspace-public-registry \
  --type merge -p '{"spec":{"started":false}}'
```

5. **Expected Result:** Backup job created without auth:
```bash
kubectl get jobs -n test-workspace-public-registry -l controller.devfile.io/devworkspace_name=test-workspace-public
```

</details>

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registry auth secret handling now prefers existing workspace secrets, falls back to configured operator secret if needed, and enforces "never overwrite" semantics to avoid unintended replacements.
  * Improved error behavior when configured operator secrets are missing.

* **Tests**
  * Added tests covering backup-path scenarios: workspace-first retrieval, operator fallback, non-overwrite preservation, and not-found error cases.

* **Style**
  * Adjusted backup controller logging naming for clearer logs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devfile/devworkspace-operator/pull/1618)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->