### PR TITLE
fix (storage) : use operator podSecurityContext for PVC cleanup job on OpenShift

### DIFF
--- a/pkg/provision/storage/cleanup.go
+++ b/pkg/provision/storage/cleanup.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/devfile/devworkspace-operator/pkg/dwerrors"
-	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/devfile/devworkspace-operator/pkg/library/status"
 	nsconfig "github.com/devfile/devworkspace-operator/pkg/provision/config"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
@@ -138,13 +137,6 @@ func getSpecCommonPVCCleanupJob(workspace *common.DevWorkspaceWithConfig, cluste
 		jobLabels[constants.DevWorkspaceRestrictedAccessAnnotation] = restrictedAccess
 	}
 
-	var securityContext *corev1.PodSecurityContext
-	if infrastructure.IsOpenShift() {
-		securityContext = &corev1.PodSecurityContext{}
-	} else {
-		securityContext = workspace.Config.Workspace.PodSecurityContext
-	}
-
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      common.PVCCleanupJobName(workspaceId),
@@ -160,7 +152,7 @@ func getSpecCommonPVCCleanupJob(workspace *common.DevWorkspaceWithConfig, cluste
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:   "Never",
-					SecurityContext: securityContext,
+					SecurityContext: workspace.Config.Workspace.PodSecurityContext,
 					Volumes: []corev1.Volume{
 						{
 							Name: pvcName,

--- a/pkg/provision/storage/cleanup_test.go
+++ b/pkg/provision/storage/cleanup_test.go
@@ -80,3 +80,45 @@ func TestGetSpecCommonPVCCleanupJobUsesConfigPodSecurityContext(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, customPodSecurityContext, job.Spec.Template.Spec.SecurityContext)
 }
+
+func TestGetSpecCommonPVCCleanupJobWithNilPodSecurityContext(t *testing.T) {
+	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
+
+	namespace := "test-ns"
+	pvcName := "claim-devworkspace"
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+	).Build()
+
+	workspace := &common.DevWorkspaceWithConfig{
+		DevWorkspace: &dw.DevWorkspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-workspace",
+				Namespace: namespace,
+				Labels: map[string]string{
+					constants.DevWorkspaceCreatorLabel: "test-creator",
+				},
+			},
+			Status: dw.DevWorkspaceStatus{
+				DevWorkspaceId: "test-workspace-id",
+			},
+		},
+		Config: &v1alpha1.OperatorConfiguration{
+			Workspace: &v1alpha1.WorkspaceConfig{
+				PVCName:            pvcName,
+				PodSecurityContext: nil, // No custom security context
+			},
+		},
+	}
+
+	clusterAPI := sync.ClusterAPI{
+		Client: fakeClient,
+		Scheme: scheme,
+		Logger: zap.New(zap.UseDevMode(true)),
+		Ctx:    context.Background(),
+	}
+
+	job, err := getSpecCommonPVCCleanupJob(workspace, clusterAPI)
+	assert.NoError(t, err)
+	assert.Nil(t, job.Spec.Template.Spec.SecurityContext)
+}

--- a/pkg/provision/storage/cleanup_test.go
+++ b/pkg/provision/storage/cleanup_test.go
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2019-2026 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	dw "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/common"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
+)
+
+func TestGetSpecCommonPVCCleanupJobUsesConfigPodSecurityContext(t *testing.T) {
+	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
+
+	fsGroupChangeOnRootMismatch := corev1.FSGroupChangeOnRootMismatch
+	customPodSecurityContext := &corev1.PodSecurityContext{
+		FSGroupChangePolicy: &fsGroupChangeOnRootMismatch,
+		SELinuxOptions:      &corev1.SELinuxOptions{Type: "spc_t"},
+	}
+
+	namespace := "test-ns"
+	pvcName := "claim-devworkspace"
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+	).Build()
+
+	workspace := &common.DevWorkspaceWithConfig{
+		DevWorkspace: &dw.DevWorkspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-workspace",
+				Namespace: namespace,
+				Labels: map[string]string{
+					constants.DevWorkspaceCreatorLabel: "test-creator",
+				},
+			},
+			Status: dw.DevWorkspaceStatus{
+				DevWorkspaceId: "test-workspace-id",
+			},
+		},
+		Config: &v1alpha1.OperatorConfiguration{
+			Workspace: &v1alpha1.WorkspaceConfig{
+				PVCName:            pvcName,
+				PodSecurityContext: customPodSecurityContext,
+			},
+		},
+	}
+
+	clusterAPI := sync.ClusterAPI{
+		Client: fakeClient,
+		Scheme: scheme,
+		Logger: zap.New(zap.UseDevMode(true)),
+		Ctx:    context.Background(),
+	}
+
+	job, err := getSpecCommonPVCCleanupJob(workspace, clusterAPI)
+	assert.NoError(t, err)
+	assert.Equal(t, customPodSecurityContext, job.Spec.Template.Spec.SecurityContext)
+}


### PR DESCRIPTION
### What does this PR do?
Apply `workspace.Config.Workspace.PodSecurityContext` to the cleanup Job pod spec, matching the workspace deployment behavior.

### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-10864

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Deploy DevWorkspaceOperator and follow these steps:

- Enable cleanup cronjob in DWOC and set podSecurityContext:
```bash
kubectl apply -f - <<EOF
apiVersion: controller.devfile.io/v1alpha1
kind: DevWorkspaceOperatorConfig
metadata:
  name: devworkspace-operator-config
  namespace: openshift-operators
config:
  workspace:
    cleanupCronJob:
      enable: true
      retainTime: 2592000
      schedule: "0 0 1 * *"
    podSecurityContext:
      fsGroupChangePolicy: OnRootMismatch
EOF
```
- Create test namespace
```bash
oc new-project test-cleanup-podsecuritycontext
``` 
- Create two DevWorkspaces
```bash
kubectl apply -f - <<EOF
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: test-cleanup-ws-a
  namespace: test-cleanup-podsecuritycontext
  labels:
    controller.devfile.io/creator: "test-user"
spec:
  started: true
  routingClass: basic
  template:
    attributes:
      controller.devfile.io/storage-type: common
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
          memoryLimit: 512Mi
          command: ["tail", "-f", "/dev/null"]
---
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: test-cleanup-ws-b
  namespace: test-cleanup-podsecuritycontext
  labels:
    controller.devfile.io/creator: "test-user"
spec:
  started: true
  routingClass: basic
  template:
    attributes:
      controller.devfile.io/storage-type: common
    projects:
      - name: web-nodejs-sample
        git:
          remotes:
            origin: "https://github.com/che-samples/web-nodejs-sample.git"
    components:
      - name: dev
        container:
          image: quay.io/devfile/universal-developer-image:latest
          memoryLimit: 512Mi
          command: ["tail", "-f", "/dev/null"]
EOF
```
-  Wait until both workspaces are running
- Delete workspace A only (triggers PVC cleanup Job while B still uses the PVC) . You need to keep monitoring for cleanup job in a separate tab, as it disappears quickly
```
kubectl delete devworkspace test-cleanup-ws-a -n test-cleanup-podsecuritycontext
```
- Check the Cleanup CronJob contains podSecurityContext:

Expected:
```
oc get jobs -o yaml
...
        securityContext:
          fsGroupChangePolicy: OnRootMismatch
```

Behavior on main:
```
oc get jobs -o yaml

        securityContext: {}
```

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test verifying the cleanup job pod uses the workspace-configured pod security context exactly as provided.

* **Refactor**
  * Simplified cleanup job security context logic to always use the workspace configuration, removing environment-specific branching for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->