### PR TITLE
fix(rbac): implement registry rolebinding finalization for OpenShift

### DIFF
--- a/pkg/provision/workspace/rbac/finalize.go
+++ b/pkg/provision/workspace/rbac/finalize.go
@@ -16,6 +16,7 @@ package rbac
 import (
 	"github.com/devfile/devworkspace-operator/pkg/common"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/devfile/devworkspace-operator/pkg/provision/sync"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -42,11 +43,16 @@ func FinalizeRBAC(workspace *common.DevWorkspaceWithConfig, api sync.ClusterAPI)
 		if err := deleteRolebinding(rolebindingName, workspace.Namespace, api); err != nil {
 			return err
 		}
-		return nil
-	}
-	if err := removeServiceAccountFromRolebinding(saName, workspace.Namespace, rolebindingName, api); err != nil {
+	} else if err := removeServiceAccountFromRolebinding(saName, workspace.Namespace, rolebindingName, api); err != nil {
 		return err
 	}
+
+	if infrastructure.IsOpenShift() {
+		if err := finalizeRegistryRBAC(workspace, api); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -72,6 +78,19 @@ func finalizeSCCRBAC(workspace *common.DevWorkspaceWithConfig, api sync.ClusterA
 		return err
 	}
 	return nil
+}
+
+func finalizeRegistryRBAC(workspace *common.DevWorkspaceWithConfig, api sync.ClusterAPI) error {
+	saName := common.ServiceAccountName(workspace)
+	rolebindingName := common.RegistryImagePullerRolebindingName(workspace.Namespace)
+	numWorkspaces, err := countNonDeletedWorkspaces(workspace.Namespace, api)
+	if err != nil {
+		return err
+	}
+	if numWorkspaces == 0 {
+		return deleteRolebinding(rolebindingName, workspace.Namespace, api)
+	}
+	return removeServiceAccountFromRolebinding(saName, workspace.Namespace, rolebindingName, api)
 }
 
 func countNonDeletedWorkspaces(namespace string, api sync.ClusterAPI) (int, error) {

--- a/pkg/provision/workspace/rbac/finalize_test.go
+++ b/pkg/provision/workspace/rbac/finalize_test.go
@@ -133,6 +133,85 @@ func TestFinalizeDoesNothingWhenRolebindingDoesNotExist(t *testing.T) {
 	}
 }
 
+func TestShouldRemoveWorkspaceSAFromRegistryRolebindingWhenDeletedOnOpenShift(t *testing.T) {
+	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
+	testdw := getTestDevWorkspace("test-devworkspace")
+	testdw2 := getTestDevWorkspace("test-devworkspace2")
+	testdw.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	testdw.DevWorkspace.ObjectMeta.Finalizers = []string{"test-finalizer"}
+	testdwSAName := common.ServiceAccountName(testdw)
+	testdw2SAName := common.ServiceAccountName(testdw2)
+	registryRolebinding := newRegistryImagePullerRolebinding(
+		rbacv1.Subject{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      testdwSAName,
+			Namespace: testNamespace,
+		},
+		rbacv1.Subject{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      testdw2SAName,
+			Namespace: testNamespace,
+		})
+	api := getTestClusterAPI(t, testdw.DevWorkspace, testdw2.DevWorkspace, registryRolebinding)
+	retryErr := &dwerrors.RetryError{}
+	err := FinalizeRBAC(testdw, api)
+	if assert.Error(t, err, "Should return error to indicate registry rolebinding updated") {
+		assert.ErrorAs(t, err, &retryErr, "Error should be RetryError")
+	}
+	err = FinalizeRBAC(testdw, api)
+	assert.NoError(t, err, "Should not return error once registry rolebinding is in sync")
+
+	actualRolebinding := &rbacv1.RoleBinding{}
+	err = api.Client.Get(api.Ctx, types.NamespacedName{
+		Name:      common.RegistryImagePullerRolebindingName(testNamespace),
+		Namespace: testNamespace,
+	}, actualRolebinding)
+	assert.NoError(t, err, "Unexpected test error getting registry rolebinding")
+	assert.False(t, testHasSubject(testdwSAName, testNamespace, actualRolebinding), "Should remove deleted workspace SA from registry rolebinding subjects")
+	assert.True(t, testHasSubject(testdw2SAName, testNamespace, actualRolebinding), "Should leave other workspace SA in registry rolebinding subjects")
+}
+
+func TestDeletesRegistryRolebindingWhenLastWorkspaceIsDeletedOnOpenShift(t *testing.T) {
+	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
+	testdw := getTestDevWorkspace("test-devworkspace")
+	testdw.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	testdw.DevWorkspace.ObjectMeta.Finalizers = []string{"test-finalizer"}
+	registryRolebinding := newRegistryImagePullerRolebinding(rbacv1.Subject{
+		Kind:      rbacv1.ServiceAccountKind,
+		Name:      common.ServiceAccountName(testdw),
+		Namespace: testNamespace,
+	})
+	api := getTestClusterAPI(t, testdw.DevWorkspace, registryRolebinding)
+	retryErr := &dwerrors.RetryError{}
+	err := FinalizeRBAC(testdw, api)
+	if assert.Error(t, err, "Should return error to indicate registry rolebinding deleted") {
+		assert.ErrorAs(t, err, &retryErr, "Error should be RetryError")
+		assert.Regexp(t, fmt.Sprintf("deleted rolebinding .* in namespace %s", testNamespace), err.Error())
+	}
+	err = FinalizeRBAC(testdw, api)
+	assert.NoError(t, err, "Should not return error once registry rolebinding is deleted")
+
+	actualRolebinding := &rbacv1.RoleBinding{}
+	err = api.Client.Get(api.Ctx, types.NamespacedName{
+		Name:      common.RegistryImagePullerRolebindingName(testNamespace),
+		Namespace: testNamespace,
+	}, actualRolebinding)
+	if assert.Error(t, err, "Expect error when getting deleted registry rolebinding") {
+		assert.True(t, k8sErrors.IsNotFound(err), "Error should have IsNotFound type")
+	}
+}
+
+func TestFinalizeDoesNothingWhenRegistryRolebindingDoesNotExistOnOpenShift(t *testing.T) {
+	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
+	testdw := getTestDevWorkspace("test-devworkspace")
+	testdw2 := getTestDevWorkspace("test-devworkspace2")
+	testdw.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	testdw.DevWorkspace.ObjectMeta.Finalizers = []string{"test-finalizer"}
+	api := getTestClusterAPI(t, testdw.DevWorkspace, testdw2.DevWorkspace)
+	err := FinalizeRBAC(testdw, api)
+	assert.NoError(t, err, "Should not return error when registry rolebinding does not exist")
+}
+
 func TestDeletesSCCRoleAndRolebindingWhenLastWorkspaceIsDeleted(t *testing.T) {
 	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
 	testdw := getTestDevWorkspaceWithAttributes(t, "test-devworkspace", constants.WorkspaceSCCAttribute, testSCCName)
@@ -236,4 +315,14 @@ func TestFinalizeDoesNothingWhenSCCRolebindingDoesNotExist(t *testing.T) {
 	if assert.Error(t, err, "Expect error when getting non-existent rolebinding") {
 		assert.True(t, k8sErrors.IsNotFound(err), "Error should have IsNotFound type")
 	}
+}
+
+func newRegistryImagePullerRolebinding(subjects ...rbacv1.Subject) *rbacv1.RoleBinding {
+	rolebinding := generateDefaultRolebinding(
+		common.RegistryImagePullerRolebindingName(testNamespace),
+		testNamespace,
+		common.RegistryImagePullerRoleName(),
+		constants.RbacClusterRoleKind)
+	rolebinding.Subjects = append(rolebinding.Subjects, subjects...)
+	return rolebinding
 }


### PR DESCRIPTION
Closes #1640

### What does this PR do?

This PR fixes an OpenShift-specific RBAC leak in the shared registry image-puller RoleBinding.

When a DevWorkspace is deleted, the operator now cleans up its ServiceAccount from:

`devworkspace-registry-image-puller-<namespace>-binding`

If there are no remaining non-deleted DevWorkspaces in the namespace, the shared RoleBinding is deleted entirely. The fix only affects the OpenShift `system:image-puller` RoleBinding cleanup path and does not change the existing default workspace RBAC or SCC RBAC behavior.

### What issues does this PR fix or reference?

Fixes the shared OpenShift registry image-puller RoleBinding subject leak described in:

- #1640
- https://redhat.atlassian.net/browse/OCPBUGS-87804

Related issues:

- #1512


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

Yes.

Local validation:

- `go test ./pkg/provision/workspace/rbac`
- `make test`

Live validation on OpenShift (Already done by me):

1. Built a custom image locally with this fix.
2. Pushed the image to our registry.
3. Updated `devworkspace-controller-manager` to use the custom image.
4. Ran live verification by creating and deleting DevWorkspaces on OpenShift.
5. Confirmed the deleted workspace ServiceAccount is removed from `devworkspace-registry-image-puller-<namespace>-binding`.
6. Confirmed the shared RoleBinding is deleted when the last remaining DevWorkspace in the namespace is finalized.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of the registry image-puller RoleBinding on OpenShift: removes workspace service accounts correctly when other workspaces remain and deletes the RoleBinding when the last workspace is removed.

* **Tests**
  * Added tests covering OpenShift registry image-puller RoleBinding scenarios: removal of a single workspace SA, deletion when last workspace is removed, and no-op when RoleBinding is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->