### PR TITLE
Add user home mount for ephemeral storage when init-persistent-home i…

### DIFF
--- a/pkg/library/home/persistentHome.go
+++ b/pkg/library/home/persistentHome.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfilevalidation "github.com/devfile/api/v2/pkg/validation"
-	"github.com/devfile/devworkspace-operator/pkg/provision/storage"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
@@ -87,20 +86,22 @@ func AddPersistentHomeVolume(workspace *common.DevWorkspaceWithConfig) (*v1alpha
 	return dwTemplateSpecCopy, nil
 }
 
-// Returns true if the following criteria is met:
-// - `persistUserHome` is enabled in the DevWorkspaceOperatorConfig
-// - The storage strategy used by the DevWorkspace supports home persistence
-// - None of the container components in the DevWorkspace mount a volume to `/home/user/`.
-// - Persistent storage is required for the DevWorkspace
-// Returns false otherwise.
+// Returns true if persistUserHome is enabled, the workspace has at least one container component,
+// and no container already mounts a volume to /home/user/.
+// For ephemeral storage workspaces, only returns true if init-persistent-home init container
+// is configured in the DevWorkspaceOperatorConfig. This is to allow consistent behaviour
+// between ephemeral and non-ephemeral workspaces for setups with a custom init-persistent-home.
 func NeedsPersistentHomeDirectory(workspace *common.DevWorkspaceWithConfig) bool {
-	if !PersistUserHomeEnabled(workspace) || !storageStrategySupportsPersistentHome(workspace) {
+	if !PersistUserHomeEnabled(workspace) {
 		return false
 	}
+
+	hasContainerComponents := false
 	for _, component := range workspace.Spec.Template.Components {
 		if component.Container == nil {
 			continue
 		}
+		hasContainerComponents = true
 		for _, volumeMount := range component.Container.VolumeMounts {
 			if volumeMount.Path == constants.HomeUserDirectory {
 				// If a volume is already being mounted to /home/user/, it takes precedence
@@ -109,19 +110,36 @@ func NeedsPersistentHomeDirectory(workspace *common.DevWorkspaceWithConfig) bool
 			}
 		}
 	}
-	return storage.WorkspaceNeedsStorage(&workspace.Spec.Template)
+
+	if !hasContainerComponents {
+		return false
+	}
+
+	// For ephemeral storage, only add persistent home if init-persistent-home is configured in DWOC
+	storageType := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
+	if storageType == constants.EphemeralStorageClassType {
+		return hasInitPersistentHomeInConfig(workspace)
+	}
+
+	return true
 }
 
 func PersistUserHomeEnabled(workspace *common.DevWorkspaceWithConfig) bool {
 	return pointer.BoolDeref(workspace.Config.Workspace.PersistUserHome.Enabled, false)
 }
 
-// Returns true if the workspace's storage strategy supports persisting the user home directory.
-// The storage strategies which support home persistence are: per-user/common, per-workspace & async.
-// The ephemeral storage strategy does not support home persistence.
-func storageStrategySupportsPersistentHome(workspace *common.DevWorkspaceWithConfig) bool {
-	storageClass := workspace.Spec.Template.Attributes.GetString(constants.DevWorkspaceStorageTypeAttribute, nil)
-	return storageClass != constants.EphemeralStorageClassType
+func hasInitPersistentHomeInConfig(workspace *common.DevWorkspaceWithConfig) bool {
+	if workspace.Config == nil || workspace.Config.Workspace == nil {
+		return false
+	}
+
+	for _, container := range workspace.Config.Workspace.InitContainers {
+		if container.Name == constants.HomeInitComponentName {
+			return true
+		}
+	}
+
+	return false
 }
 
 func addInitContainer(dwTemplateSpec *v1alpha2.DevWorkspaceTemplateSpec) error {

--- a/pkg/library/home/testdata/persistent-home/creates-home-vm-with-ephemeral-storage.yaml
+++ b/pkg/library/home/testdata/persistent-home/creates-home-vm-with-ephemeral-storage.yaml
@@ -1,0 +1,42 @@
+name: "Creates persistent home volume when persistUserHome is enabled with ephemeral storage and init-persistent-home is explicitly configured"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  config:
+    workspace:
+      persistUserHome:
+        enabled: true
+        disableInitContainer: true
+      initContainers:
+        - name: init-persistent-home
+          image: testing-image-1
+  workspace:
+    attributes:
+      controller.devfile.io/storage-type: ephemeral
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          volumeMounts:
+            - name: my-defined-volume
+              path: /my-defined-volume-path
+      - name: my-defined-volume
+        volume: {}
+
+output:
+  workspace:
+    attributes:
+      controller.devfile.io/storage-type: ephemeral
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          volumeMounts:
+            - name: my-defined-volume
+              path: /my-defined-volume-path
+            - name: persistent-home
+              path: /home/user/
+      - name: my-defined-volume
+        volume: {}
+      - name: persistent-home
+        volume: {}

--- a/pkg/library/home/testdata/persistent-home/noop-ephemeral-storage-without-init-container.yaml
+++ b/pkg/library/home/testdata/persistent-home/noop-ephemeral-storage-without-init-container.yaml
@@ -1,0 +1,34 @@
+name: "Does not create persistent home volume for ephemeral storage when init-persistent-home is not explicitly configured"
+
+input:
+  devworkspaceId: "test-workspaceid"
+  config:
+    workspace:
+      persistUserHome:
+        enabled: true
+  workspace:
+    attributes:
+      controller.devfile.io/storage-type: ephemeral
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          volumeMounts:
+            - name: my-defined-volume
+              path: /my-defined-volume-path
+      - name: my-defined-volume
+        volume: {}
+
+output:
+  workspace:
+    attributes:
+      controller.devfile.io/storage-type: ephemeral
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
+          volumeMounts:
+            - name: my-defined-volume
+              path: /my-defined-volume-path
+      - name: my-defined-volume
+        volume: {}

--- a/pkg/library/home/testdata/persistent-home/noop-if-init-prestartevent-already-defined.yaml
+++ b/pkg/library/home/testdata/persistent-home/noop-if-init-prestartevent-already-defined.yaml
@@ -12,7 +12,7 @@ input:
         - init-persistent-home
 
 output:
-  error: "failed to add init container for home persistence setup: command with id init-persistent-home already exists in the devworkspace"
+  error: "failed to add init container for home persistence setup: event with id init-persistent-home already exists in the devworkspace"
   workspace:
     events:
       prestart:

--- a/pkg/library/home/testdata/persistent-home/noop-if-init-prestartevent-already-defined.yaml
+++ b/pkg/library/home/testdata/persistent-home/noop-if-init-prestartevent-already-defined.yaml
@@ -7,6 +7,10 @@ input:
       persistUserHome:
         enabled: true
   workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
     events:
       prestart:
         - init-persistent-home
@@ -14,6 +18,10 @@ input:
 output:
   error: "failed to add init container for home persistence setup: event with id init-persistent-home already exists in the devworkspace"
   workspace:
+    components:
+      - name: testing-container-1
+        container:
+          image: testing-image-1
     events:
       prestart:
         - init-persistent-home


### PR DESCRIPTION
…s explicitly configured

### What does this PR do?
If an init-persistent-home init container is explicitly defined in the DWOC's `config.workspaces.initContainers` field and if persistUserHome is enabled, a /user/home empty dir volume mount will be added to the workspace pod.

This is to allow consistent behaviour between ephemeral and non-ephemeral workspaces when `persistUserHome` is enabled and a custom `init-persistent-home` init container is defined.

### What issues does this PR fix or reference?
https://redhat.atlassian.net/browse/CRW-11010

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

Install DWO with the following catalog source:
```
apiVersion: operators.coreos.com/v1alpha1
  kind: CatalogSource
  metadata:
    name: dwo-custom
    namespace: openshift-marketplace
  spec:
    sourceType: grpc
    image: quay.io/dkwon17/devworkspace-operator-index:ephemeral-mount
    displayName: DWO Custom
    updateStrategy:   
      registryPoll:
        interval: 5m
```

For both cases, ensure that the global DWOC has `persistUserHome` enabled:
```
apiVersion: controller.devfile.io/v1alpha1
  kind: DevWorkspaceOperatorConfig
  metadata:
    name: devworkspace-operator-config
    namespace: openshift-operators
  config:   
    workspace:
      persistUserHome:
        enabled: true
```

<details><summary>Test case 1</summary>

1. Create an Empty Workspace with ephemeral storage:
```
apiVersion: workspace.devfile.io/v1alpha2
  kind: DevWorkspace
  metadata:
    name: my-workspace
  spec:
    started: true
    template:
      attributes:
        controller.devfile.io/storage-type: ephemeral
      components:
        - name: tooling-container
          container:
            image: quay.io/devspaces/udi-rhel9:latest
```
2. Verify pod has no `init-persistent-home` init container and no PVC created

</details>

<details><summary>Test case 2</summary>

1. Update global DWOC such that `init-persistent-home` explicitly configured:
```
apiVersion: controller.devfile.io/v1alpha1
  kind: DevWorkspaceOperatorConfig
  metadata:
    name: devworkspace-operator-config
    namespace: openshift-operators
  config:
    workspace:
      initContainers:
        - name: init-persistent-home
          image: registry.access.redhat.com/ubi9/ubi-minimal:latest
          command: ["/bin/sh", "-c", "echo custom-init-ran"]
```

2. Create an Empty Workspace with ephemeral storage:
```
apiVersion: workspace.devfile.io/v1alpha2
  kind: DevWorkspace
  metadata:
    name: my-workspace
  spec:
    started: true
    template:
      attributes:
        controller.devfile.io/storage-type: ephemeral
      components:
        - name: tooling-container
          container:
            image: quay.io/devspaces/udi-rhel9:latest
```

3. Wait until workspace starts. Verify `init-persistent-home` ran, `persistent-home` volume is `emptyDir` (not PVC), no PVC created.

For example:

<img width="918" height="153" alt="image" src="https://github.com/user-attachments/assets/778ce0ec-a075-4470-a866-7ad00e4dd82d" />


<img width="914" height="260" alt="image" src="https://github.com/user-attachments/assets/58c6609f-fbe1-43b8-a7c3-cef647e09c11" />


</details>



### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Refined persistent home eligibility rules, including improved handling for ephemeral workspaces and stricter checks for existing `/home/user/` mounts and initialization configuration.

* **Tests**
  * Added/updated test scenarios covering ephemeral storage with and without `init-persistent-home`, and improved assertions for expected failure messaging and resulting workspace components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->