### PR TITLE
fix(home): skip persistent home init container for ephemeral workspaces

### DIFF
--- a/controllers/workspace/devworkspace_controller.go
+++ b/controllers/workspace/devworkspace_controller.go
@@ -417,6 +417,11 @@ func (r *DevWorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					reqLogger.Info("Skipping init-persistent-home container: persistent home is disabled")
 					continue
 				}
+				// Skip if workspace does not need persistent home (e.g. ephemeral storage)
+				if !home.NeedsPersistentHomeDirectory(workspace) {
+					reqLogger.Info("Skipping init-persistent-home container: workspace does not need persistent home directory")
+					continue
+				}
 				// Skip if init container is explicitly disabled
 				if disableHomeInit {
 					reqLogger.Info("Skipping init-persistent-home container: DisableInitContainer is true")


### PR DESCRIPTION
When a DevWorkspaceOperatorConfig defines an init-persistent-home entry in workspace.initContainers, the config merge logic only checked whether persistent home was globally enabled (PersistUserHomeEnabled) but not whether the specific workspace actually needs it. Ephemeral workspaces passed this check, causing an init container to be injected that references a non-existent persistent-home volume and potentially has no image — resulting in an invalid Deployment.

Add a NeedsPersistentHomeDirectory check to also skip the config-level init container when the workspace storage strategy does not support home persistence (e.g. ephemeral storage).

Assisted-by: Claude Code


### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23884

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
TODO

### PR Checklist

- [x] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [x] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [x] `v8-che-happy-path`: Happy path for verification integration with Che
