### PR TITLE
fix(backup): use configured imagePullPolicy for backup CronJob

### DIFF
--- a/controllers/backupcronjob/backupcronjob_controller.go
+++ b/controllers/backupcronjob/backupcronjob_controller.go
@@ -415,7 +415,7 @@ func (r *BackupCronJobReconciler) createBackupJob(
 								{Name: "ORAS_EXTRA_ARGS", Value: orasExtraArgs},
 							},
 							Image:           images.GetProjectBackupImage(),
-							ImagePullPolicy: "Always",
+							ImagePullPolicy: getImagePullPolicy(dwOperatorConfig),
 							Args: []string{
 								"/workspace-recovery.sh",
 								"--backup",
@@ -485,4 +485,11 @@ func (r *BackupCronJobReconciler) createBackupJob(
 	}
 	log.Info("Created backup Job for DevWorkspace", "jobName", job.Name, "devworkspace", workspace.Name)
 	return nil
+}
+
+func getImagePullPolicy(dwOperatorConfig *controllerv1alpha1.DevWorkspaceOperatorConfig) corev1.PullPolicy {
+	if dwOperatorConfig.Config.Workspace.ImagePullPolicy != "" {
+		return corev1.PullPolicy(dwOperatorConfig.Config.Workspace.ImagePullPolicy)
+	}
+	return corev1.PullAlways
 }

--- a/controllers/backupcronjob/backupcronjob_controller_test.go
+++ b/controllers/backupcronjob/backupcronjob_controller_test.go
@@ -426,6 +426,75 @@ var _ = Describe("BackupCronJobReconciler", func() {
 			Expect(*jobList.Items[0].Spec.BackoffLimit).To(Equal(int32(2)))
 		})
 
+		It("creates a Job with configured imagePullPolicy", func() {
+			enabled := true
+			schedule := "* * * * *"
+			dwoc := &controllerv1alpha1.DevWorkspaceOperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: nameNamespace.Name, Namespace: nameNamespace.Namespace},
+				Config: &controllerv1alpha1.OperatorConfiguration{
+					Workspace: &controllerv1alpha1.WorkspaceConfig{
+						ImagePullPolicy: "IfNotPresent",
+						BackupCronJob: &controllerv1alpha1.BackupCronJobConfig{
+							Enable:   &enabled,
+							Schedule: schedule,
+							Registry: &controllerv1alpha1.RegistryConfig{
+								Path: "fake-registry",
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, dwoc)).To(Succeed())
+			dw := createDevWorkspace("dw-pullpolicy", "ns-a", false, metav1.NewTime(time.Now().Add(-10*time.Minute)))
+			dw.Status.Phase = dwv2.DevWorkspaceStatusStopped
+			dw.Status.DevWorkspaceId = "id-pullpolicy"
+			Expect(fakeClient.Create(ctx, dw)).To(Succeed())
+
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim-devworkspace", Namespace: dw.Namespace}}
+			Expect(fakeClient.Create(ctx, pvc)).To(Succeed())
+
+			Expect(reconciler.executeBackupSync(ctx, dwoc, log)).To(Succeed())
+
+			jobList := &batchv1.JobList{}
+			Expect(fakeClient.List(ctx, jobList, &client.ListOptions{Namespace: dw.Namespace})).To(Succeed())
+			Expect(jobList.Items).To(HaveLen(1))
+			Expect(jobList.Items[0].Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+		})
+
+		It("defaults imagePullPolicy to Always when not configured", func() {
+			enabled := true
+			schedule := "* * * * *"
+			dwoc := &controllerv1alpha1.DevWorkspaceOperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: nameNamespace.Name, Namespace: nameNamespace.Namespace},
+				Config: &controllerv1alpha1.OperatorConfiguration{
+					Workspace: &controllerv1alpha1.WorkspaceConfig{
+						BackupCronJob: &controllerv1alpha1.BackupCronJobConfig{
+							Enable:   &enabled,
+							Schedule: schedule,
+							Registry: &controllerv1alpha1.RegistryConfig{
+								Path: "fake-registry",
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, dwoc)).To(Succeed())
+			dw := createDevWorkspace("dw-default-policy", "ns-a", false, metav1.NewTime(time.Now().Add(-10*time.Minute)))
+			dw.Status.Phase = dwv2.DevWorkspaceStatusStopped
+			dw.Status.DevWorkspaceId = "id-default-policy"
+			Expect(fakeClient.Create(ctx, dw)).To(Succeed())
+
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "claim-devworkspace", Namespace: dw.Namespace}}
+			Expect(fakeClient.Create(ctx, pvc)).To(Succeed())
+
+			Expect(reconciler.executeBackupSync(ctx, dwoc, log)).To(Succeed())
+
+			jobList := &batchv1.JobList{}
+			Expect(fakeClient.List(ctx, jobList, &client.ListOptions{Namespace: dw.Namespace})).To(Succeed())
+			Expect(jobList.Items).To(HaveLen(1))
+			Expect(jobList.Items[0].Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullAlways))
+		})
+
 		It("does not create a Job when the DevWorkspace was stopped beyond time range", func() {
 			enabled := true
 			schedule := "* * * * *"


### PR DESCRIPTION
## Summary
- Read `imagePullPolicy` from `DevWorkspaceOperatorConfig` for backup Job containers instead of hardcoding `"Always"`
- Falls back to `"Always"` when the field is not explicitly configured, preserving existing default behavior
- Adds unit tests for both configured and default `imagePullPolicy` scenarios

Fixes https://github.com/devfile/devworkspace-operator/issues/1637

## Verification

Configure `imagePullPolicy` in the DevWorkspaceOperatorConfig:

```bash
kubectl patch devworkspaceoperatorconfig devworkspace-operator-config \
  -n devworkspace-controller --type merge \
  -p '{"config":{"workspace":{"imagePullPolicy":"IfNotPresent"}}}'
```

After a backup Job is created, confirm the policy is applied:

```bash
kubectl get job -l controller.devfile.io/devworkspace-backup=true \
  -o jsonpath='{.items[0].spec.template.spec.containers[0].imagePullPolicy}'
```

Expected output: `IfNotPresent`

## Test plan
- [x] Unit test verifies backup Job uses configured `imagePullPolicy` (e.g. `IfNotPresent`)
- [x] Unit test verifies default `Always` behavior when `imagePullPolicy` is not set
- [x] All existing backup controller tests pass (`go test ./controllers/backupcronjob/...`)
- [x] `go vet` clean

Assisted-by: Claude Code