### PR TITLE
fix: handle non-passphrase SSH prompts in askpass script

### DIFF
--- a/pkg/provision/workspace/ssh-askpass.sh
+++ b/pkg/provision/workspace/ssh-askpass.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+# Only handle passphrase prompts - exit silently for other prompts (e.g., HTTPS git repo username/password request)
+case "$1" in
+  "Enter passphrase for key '"*) ;;
+  *) exit 0 ;;
+esac
 PASSPHRASE_FILE_PATH="/etc/ssh/passphrase"
 if [ ! -f $PASSPHRASE_FILE_PATH ]; then
     echo "Error: passphrase file is missing in the '/etc/ssh/' directory" 1>&2


### PR DESCRIPTION
### What does this PR do?
Add early exit for SSH prompts that aren't requesting passphrase input. This prevents the askpass script from attempting to provide a passphrase for other SSH prompts like host key verification.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse-che/che/issues/23874

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Apply a DevWorkspace with a private git repository e.g.
```
apiVersion: workspace.devfile.io/v1alpha2
kind: DevWorkspace
metadata:
  name: private
spec:
  started: true
  template:
    components:
      - container:
          env:
            - name: HOST_USERS
              value: 'true'
          image: 'quay.io/devfile/universal-developer-image:ubi9-latest'
          sourceMapping: /projects
        name: universal-developer-image
    projects:
      - git:
          remotes:
            origin: 'https://github.com/vinokurig/private.git'
        name: private
```
2. Check the `project-clone` container logs and see no error messages.
### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH askpass handling to respond only to key passphrase prompts (e.g., “Enter passphrase for key …”).
  * Non-passphrase prompts (such as username/password requests) are now ignored to prevent incorrect responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->