### PR TITLE
[post-release] Add OLM digest bundle for v0.42.0

### DIFF
--- a/olm-catalog/release-digest/channel.yaml
+++ b/olm-catalog/release-digest/channel.yaml
@@ -62,3 +62,5 @@ entries:
   - name: devworkspace-operator.v0.41.0
     replaces: devworkspace-operator.v0.40.1
     skipRange: '>=0.40.0 <0.40.1'
+  - name: devworkspace-operator.v0.42.0
+    replaces: devworkspace-operator.v0.41.0


### PR DESCRIPTION
## Summary

- Adds OLM digest bundle for v0.42.0 to the release-digest catalog
- Adds v0.42.0 channel entry (replaces v0.41.0) to `olm-catalog/release-digest/channel.yaml`

This commit was generated by the release workflow but could not be pushed directly to the protected `0.42.x` branch. PRs #1660 and #1661 were closed as they had conflicts due to the `[release]` commit already being on `0.42.x`.

Cherry-picked from `ci-add-digest-bundle-v0.42.0` branch (commit a28918537b).