### PR TITLE
feat: add Makefile targets for project-clone and project-backup images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,11 +332,170 @@ else
 	$(DOCKER) manifest push ${DWO_IMG}
 endif
 
+### docker-project-clone: Builds and pushes project-clone image
+docker-project-clone: _print_vars docker-build-project-clone docker-push-project-clone
+
+### docker-build-project-clone: Builds the multi-arch project-clone image (supports both amd64 and arm64)
+docker-build-project-clone:
+	@echo "Building multi-arch image ${PROJECT_CLONE_IMG} for linux/amd64,linux/arm64 using $(CONTAINER_TOOL)"
+ifeq ($(CONTAINER_TOOL),docker)
+  ifeq ($(BUILDX_AVAILABLE),false)
+	$(error Docker buildx is required for multi-arch builds. Please update Docker or enable buildx)
+  endif
+	@echo "Using Docker buildx to build multi-arch images"
+	$(MAKE) _docker-build-project-clone-amd64 _docker-build-project-clone-arm64
+	@echo "✅ Built multi-arch images locally:"
+	@echo "  ${PROJECT_CLONE_IMG}-amd64"
+	@echo "  ${PROJECT_CLONE_IMG}-arm64"
+	@echo "Note: Manifest list will be created during push to registry"
+else
+	@echo "Using Podman to build multi-arch image"
+	$(MAKE) _docker-build-project-clone-amd64 _docker-build-project-clone-arm64
+	@echo "Creating manifest list for ${PROJECT_CLONE_IMG} using Podman"
+	@echo "Cleaning up any existing images/manifests with the same name"
+	@$(DOCKER) manifest rm ${PROJECT_CLONE_IMG} 2>/dev/null || echo "    (manifest not found, continuing)"
+	@$(DOCKER) rmi ${PROJECT_CLONE_IMG} 2>/dev/null || echo "    (image not found, continuing)"
+	$(DOCKER) manifest create ${PROJECT_CLONE_IMG} ${PROJECT_CLONE_IMG}-amd64 ${PROJECT_CLONE_IMG}-arm64
+endif
+
+### _docker-build-project-clone-amd64: Builds the amd64 project-clone image
+_docker-build-project-clone-amd64:
+ifeq ($(CONTAINER_TOOL),docker)
+  ifeq ($(BUILDX_AVAILABLE),false)
+	$(error Docker buildx is required for platform-specific builds. Please update Docker or enable buildx)
+  endif
+	$(DOCKER) buildx build . --platform linux/amd64 --load -t ${PROJECT_CLONE_IMG}-amd64 -f project-clone/Dockerfile
+else
+	$(DOCKER) build . --platform linux/amd64 -t ${PROJECT_CLONE_IMG}-amd64 -f project-clone/Dockerfile
+endif
+
+### _docker-build-project-clone-arm64: Builds the arm64 project-clone image
+_docker-build-project-clone-arm64:
+ifeq ($(CONTAINER_TOOL),docker)
+  ifeq ($(BUILDX_AVAILABLE),false)
+	$(error Docker buildx is required for platform-specific builds. Please update Docker or enable buildx)
+  endif
+	$(DOCKER) buildx build . --platform linux/arm64 --load -t ${PROJECT_CLONE_IMG}-arm64 -f project-clone/Dockerfile
+else
+	$(DOCKER) build . --platform linux/arm64 -t ${PROJECT_CLONE_IMG}-arm64 -f project-clone/Dockerfile
+endif
+
+### docker-push-project-clone: Pushes the multi-arch project-clone image to the registry
+docker-push-project-clone: _docker-check-push-project-clone
+	@echo "Pushing multi-arch image ${PROJECT_CLONE_IMG} using $(CONTAINER_TOOL)"
+ifeq ($(CONTAINER_TOOL),docker)
+  ifeq ($(BUILDX_AVAILABLE),false)
+	$(error Docker buildx is required for multi-arch pushes. Please update Docker or enable buildx)
+  endif
+	@echo "Using Docker buildx to push multi-arch image"
+	$(DOCKER) push ${PROJECT_CLONE_IMG}-amd64
+	$(DOCKER) push ${PROJECT_CLONE_IMG}-arm64
+	@echo "Creating and pushing manifest list using Docker buildx"
+	$(DOCKER) buildx imagetools create -t ${PROJECT_CLONE_IMG} ${PROJECT_CLONE_IMG}-amd64 ${PROJECT_CLONE_IMG}-arm64
+else
+	@echo "Using Podman to push multi-arch image"
+	$(DOCKER) push ${PROJECT_CLONE_IMG}-amd64
+	$(DOCKER) push ${PROJECT_CLONE_IMG}-arm64
+	@echo "Cleaning up any existing manifests before recreating"
+	@$(DOCKER) manifest rm ${PROJECT_CLONE_IMG} 2>/dev/null || echo "    (manifest not found, continuing)"
+	$(DOCKER) manifest create ${PROJECT_CLONE_IMG} ${PROJECT_CLONE_IMG}-amd64 ${PROJECT_CLONE_IMG}-arm64
+	$(DOCKER) manifest push ${PROJECT_CLONE_IMG}
+endif
+
+### docker-project-backup: Builds and pushes project-backup image
+docker-project-backup: _print_vars docker-build-project-backup docker-push-project-backup
+
+### docker-build-project-backup: Builds the multi-arch project-backup image (supports both amd64 and arm64)
+docker-build-project-backup:
+	@echo "Building multi-arch image ${PROJECT_BACKUP_IMG} for linux/amd64,linux/arm64 using $(CONTAINER_TOOL)"
+ifeq ($(CONTAINER_TOOL),docker)
+  ifeq ($(BUILDX_AVAILABLE),false)
+	$(error Docker buildx is required for multi-arch builds. Please update Docker or enable buildx)
+  endif
+	@echo "Using Docker buildx to build multi-arch images"
+	$(MAKE) _docker-build-project-backup-amd64 _docker-build-project-backup-arm64
+	@echo "✅ Built multi-arch images locally:"
+	@echo "  ${PROJECT_BACKUP_IMG}-amd64"
+	@echo "  ${PROJECT_BACKUP_IMG}-arm64"
+	@echo "Note: Manifest list will be created during push to registry"
+else
+	@echo "Using Podman to build multi-arch image"
+	$(MAKE) _docker-build-project-backup-amd64 _docker-build-project-backup-arm64
+	@echo "Creating manifest list for ${PROJECT_BACKUP_IMG} using Podman"
+	@echo "Cleaning up any existing images/manifests with the same name"
+	@$(DOCKER) manifest rm ${PROJECT_BACKUP_IMG} 2>/dev/null || echo "    (manifest not found, continuing)"
+	@$(DOCKER) rmi ${PROJECT_BACKUP_IMG} 2>/dev/null || echo "    (image not found, continuing)"
+	$(DOCKER) manifest create ${PROJECT_BACKUP_IMG} ${PROJECT_BACKUP_IMG}-amd64 ${PROJECT_BACKUP_IMG}-arm64
+endif
+
+### _docker-build-project-backup-amd64: Builds the amd64 project-backup image
+_docker-build-project-backup-amd64:
+ifeq ($(CONTAINER_TOOL),docker)
+  ifeq ($(BUILDX_AVAILABLE),false)
+	$(error Docker buildx is required for platform-specific builds. Please update Docker or enable buildx)
+  endif
+	$(DOCKER) buildx build ./project-backup/ --platform linux/amd64 --load -t ${PROJECT_BACKUP_IMG}-amd64 -f project-backup/Containerfile
+else
+	$(DOCKER) build ./project-backup/ --platform linux/amd64 -t ${PROJECT_BACKUP_IMG}-amd64 -f project-backup/Containerfile
+endif
+
+### _docker-build-project-backup-arm64: Builds the arm64 project-backup image
+_docker-build-project-backup-arm64:
+ifeq ($(CONTAINER_TOOL),docker)
+  ifeq ($(BUILDX_AVAILABLE),false)
+	$(error Docker buildx is required for platform-specific builds. Please update Docker or enable buildx)
+  endif
+	$(DOCKER) buildx build ./project-backup/ --platform linux/arm64 --load -t ${PROJECT_BACKUP_IMG}-arm64 -f project-backup/Containerfile
+else
+	$(DOCKER) build ./project-backup/ --platform linux/arm64 -t ${PROJECT_BACKUP_IMG}-arm64 -f project-backup/Containerfile
+endif
+
+### docker-push-project-backup: Pushes the multi-arch project-backup image to the registry
+docker-push-project-backup: _docker-check-push-project-backup
+	@echo "Pushing multi-arch image ${PROJECT_BACKUP_IMG} using $(CONTAINER_TOOL)"
+ifeq ($(CONTAINER_TOOL),docker)
+  ifeq ($(BUILDX_AVAILABLE),false)
+	$(error Docker buildx is required for multi-arch pushes. Please update Docker or enable buildx)
+  endif
+	@echo "Using Docker buildx to push multi-arch image"
+	$(DOCKER) push ${PROJECT_BACKUP_IMG}-amd64
+	$(DOCKER) push ${PROJECT_BACKUP_IMG}-arm64
+	@echo "Creating and pushing manifest list using Docker buildx"
+	$(DOCKER) buildx imagetools create -t ${PROJECT_BACKUP_IMG} ${PROJECT_BACKUP_IMG}-amd64 ${PROJECT_BACKUP_IMG}-arm64
+else
+	@echo "Using Podman to push multi-arch image"
+	$(DOCKER) push ${PROJECT_BACKUP_IMG}-amd64
+	$(DOCKER) push ${PROJECT_BACKUP_IMG}-arm64
+	@echo "Cleaning up any existing manifests before recreating"
+	@$(DOCKER) manifest rm ${PROJECT_BACKUP_IMG} 2>/dev/null || echo "    (manifest not found, continuing)"
+	$(DOCKER) manifest create ${PROJECT_BACKUP_IMG} ${PROJECT_BACKUP_IMG}-amd64 ${PROJECT_BACKUP_IMG}-arm64
+	$(DOCKER) manifest push ${PROJECT_BACKUP_IMG}
+endif
+
+### docker-all: Builds and pushes all images (controller, project-clone, project-backup)
+docker-all: docker docker-project-clone docker-project-backup
+
 ### _docker-check-push: Asks for confirmation before pushing the image, unless running in CI
 _docker-check-push:
   ifneq ($(INITIATOR),CI)
     ifeq ($(DWO_IMG),quay.io/devfile/devworkspace-controller:next)
 	    @echo -n "Are you sure you want to push $(DWO_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
+    endif
+  endif
+
+### _docker-check-push-project-clone: Asks for confirmation before pushing project-clone, unless running in CI
+_docker-check-push-project-clone:
+  ifneq ($(INITIATOR),CI)
+    ifeq ($(PROJECT_CLONE_IMG),quay.io/devfile/project-clone:next)
+	    @echo -n "Are you sure you want to push $(PROJECT_CLONE_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
+    endif
+  endif
+
+### _docker-check-push-project-backup: Asks for confirmation before pushing project-backup, unless running in CI
+_docker-check-push-project-backup:
+  ifneq ($(INITIATOR),CI)
+    ifeq ($(PROJECT_BACKUP_IMG),quay.io/devfile/project-backup:next)
+	    @echo -n "Are you sure you want to push $(PROJECT_BACKUP_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
     endif
   endif
 

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -41,17 +41,18 @@ This means that to test commits in a release branch before running the release j
 export DWO_IMG=quay.io/yourrepo/devworkspace-controller:prerelease
 export PROJECT_CLONE_IMG=quay.io/yourrepo/project-clone:prerelease
 export PROJECT_BACKUP_IMG=quay.io/yourrepo/project-backup:prerelease
-# build and push project clone image
-podman build -t "$PROJECT_CLONE_IMG" -f ./project-clone/Dockerfile .
-podman push "$PROJECT_CLONE_IMG"
-# build and push project backup image
-podman build -t "$PROJECT_BACKUP_IMG" -f ./project-backup/Containerfile ./project-backup/
-podman push "$PROJECT_BACKUP_IMG"
-# build and push DevWorkspace Operator image
-export DOCKER=podman # optional
-make docker
+# build and push all images (controller, project-clone, project-backup)
+make docker-all
 # deploy DevWorkspace Operator using these images
 make install
+```
+
+The `docker-all` target builds multi-arch (amd64 and arm64) images for all three components. It auto-detects Docker or Podman. You can also build images individually:
+
+```bash
+make docker                 # controller only
+make docker-project-clone   # project-clone only
+make docker-project-backup  # project-backup only
 ```
 
 ### Releasing a new version


### PR DESCRIPTION
## Summary

- Adds multi-arch build and push Makefile targets for project-clone and project-backup images, matching the existing controller image pattern
- Previously these images required manual `podman build`/`docker build` commands that produced single-arch images only
- All new targets support Docker (with buildx) and Podman, producing multi-arch (amd64 + arm64) images with proper manifest lists

**New targets:**
- `docker-project-clone` — build and push project-clone
- `docker-project-backup` — build and push project-backup
- `docker-all` — build and push all three images (controller + project-clone + project-backup)

**Updated docs:** `docs/release/README.md` prerelease testing section now uses `make docker-all`

## Test plan

- [ ] `make -n docker-all` dry-run produces correct build/push commands for all 3 images
- [ ] `make help` lists all new targets
- [ ] Build and push with Docker: `make docker-all DWO_IMG=... PROJECT_CLONE_IMG=... PROJECT_BACKUP_IMG=...`
- [ ] Build and push with Podman: `DOCKER=podman make docker-all ...`
- [ ] Push confirmation prompt appears when targeting default `quay.io/devfile/*:next` images
- [ ] Push confirmation is skipped with `INITIATOR=CI`

🤖 Generated with [Claude Code](https://claude.com/claude-code)