### PR TITLE
chore(deps): bump go version to v1.26.5

### DIFF
--- a/.ci/oci.Dockerfile
+++ b/.ci/oci.Dockerfile
@@ -15,17 +15,17 @@
 
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20
 
-ENV GO_VERSION=1.26.4
+ENV GO_VERSION=1.26.5
 ENV GOROOT=/usr/local/go
 ENV PATH=$GOROOT/bin:$PATH
 
-ENV GO_VERSION=1.26.4
+ENV GO_VERSION=1.26.5
 ENV GOROOT=/usr/local/go
 ENV PATH=$GOROOT/bin:$PATH
 
 SHELL ["/bin/bash", "-c"]
 
-# Install Go 1.26.4 to satisfy go.mod toolchain requirement (go 1.26.0)
+# Install Go 1.26.5 to satisfy go.mod toolchain requirement (go 1.26.0)
 RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
     curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o go.tar.gz && \
     rm -rf /usr/local/go && \

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,7 +14,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     -
       name: Set up Python 3.11
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.26.4
+        go-version: 1.26.5
     -
       name: Set up Python 3.11
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.26.4
+          go-version: 1.26.5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 #v2.2.0
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,7 +16,7 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
 # Use BUILDPLATFORM to ensure the builder always runs natively on the host machine
 # Image pinned by SHA256 to address GitHub security bot warnings about unpinned dependencies
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1783628461@sha256:78c30e4fb77d1fa049d3bff5d9da1b5d77cc0ed96a2c30e6c4905380d3580462 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515@sha256:d8698410eb806fedd5c0ddbd08e981436051e0ed2113b8e402736e7ee578f6f4 AS builder
 
 # Accept TARGETARCH and TARGETPLATFORM, which are automatically passed by the builder
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/devfile/devworkspace-operator
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/devfile/api/v2 v2.3.1-alpha.0.20250521155908-5c3d7b99d252

--- a/project-clone/Dockerfile
+++ b/project-clone/Dockerfile
@@ -16,7 +16,7 @@
 # Build the manager binary
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
 # Image pinned by SHA256 to address GitHub security bot warnings about unpinned dependencies
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.4-1783628461@sha256:78c30e4fb77d1fa049d3bff5d9da1b5d77cc0ed96a2c30e6c4905380d3580462 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1783931515@sha256:d8698410eb806fedd5c0ddbd08e981436051e0ed2113b8e402736e7ee578f6f4 as builder
 ARG TARGETARCH
 ARG TARGETOS
 ENV GOPATH=/go/


### PR DESCRIPTION
## Summary
- Bump Go toolchain from 1.26.4 to 1.26.5 in `go.mod`, CI workflows, and OCI Dockerfile
- Update UBI9 go-toolset builder images to `1.26.5-1783931515` with digest `sha256:d8698410eb806fedd5c0ddbd08e981436051e0ed2113b8e402736e7ee578f6f4` in `build/Dockerfile` and `project-clone/Dockerfile`

## Test plan
- [ ] CI passes (unit tests, lint, code coverage)
- [ ] Container images build successfully with updated go-toolset image


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to version 1.26.5 across development, testing, release, and container build environments.
  * Refreshed the pinned builder image to match the updated Go version.
  * No application behavior or public interfaces changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->