### PR TITLE
docs: add documentation for cross-namespace DevWorkspaceTemplate imports

### DIFF
--- a/docs/additional-configuration.adoc
+++ b/docs/additional-configuration.adoc
@@ -361,6 +361,56 @@ merged with the default DevWorkspaceOperatorConfig, overriding
 fields in the default configuration. Fields unset in the overridden
 configuration will use the global values.
 
+## Configuring cross-namespace DevWorkspaceTemplate imports
+
+By default, a DevWorkspace can only import a DevWorkspaceTemplate from its own namespace.
+To allow a DevWorkspaceTemplate to be imported by DevWorkspaces in other namespaces,
+the annotation `controller.devfile.io/allow-import-from` must be added to the DevWorkspaceTemplate.
+
+The annotation supports the following values:
+
+* `*`: allow importing by all DevWorkspaces on the cluster
+* `namespaceA,namespaceB`: allow importing by DevWorkspaces in a specific list of namespaces
+
+If the annotation is not set or is empty, only DevWorkspaces in the same namespace as the template can reference it.
+
+[source,yaml]
+----
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspaceTemplate
+metadata:
+  name: my-template
+  namespace: platform-namespace
+  annotations:
+    controller.devfile.io/allow-import-from: "*"  # allow all namespaces
+----
+
+Or to restrict to specific namespaces:
+
+[source,yaml]
+----
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspaceTemplate
+metadata:
+  name: my-template
+  namespace: platform-namespace
+  annotations:
+    controller.devfile.io/allow-import-from: "namespace-a,namespace-b"
+----
+
+A DevWorkspace can then reference the template using the `parent.kubernetes` field in the devfile:
+
+[source,yaml]
+----
+schemaVersion: 2.2.0
+metadata:
+  name: my-workspace
+parent:
+  kubernetes:
+    name: my-template
+    namespace: platform-namespace
+----
+
 ## Fine-grained configuration of workspace pods and containers
 The attributes `pod-overrides` and `container-overrides` can be applied to DevWorkspaces in order to configure fields on the Kubernetes objects that are not normally exposed through the Kubernetes API.
 


### PR DESCRIPTION
### What does this PR do?

Adds documentation for the `controller.devfile.io/allow-import-from` annotation, 
which allows DevWorkspaceTemplates to be imported by DevWorkspaces in other namespaces.

Previously, this annotation was only documented in the source code 
(pkg/library/flatten/flatten.go) but was not mentioned in the official documentation, 
making it very difficult to discover. Without this documentation, users encounter the 
misleading error `Error processing devfile: plugin for component parent not found` with 
no indication of the solution.

### What issues does this PR fix or reference?

Closes #1672

### Is it tested? How?

This is a documentation-only change. The feature itself is already implemented and tested 
in the codebase. The annotation has been verified to work as documented.

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
  - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
  - [ ] `v8-che-happy-path`: Happy path for verification integration with Che

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring cross-namespace `DevWorkspaceTemplate` imports.
  * Documented supported annotation values, default behavior, and example YAML configurations for defining and referencing templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->