### PR TITLE
chore: release: bump to 0.44.0-dev in main

### DIFF
--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: devworkspace-operator.v0.43.0-dev
+  name: devworkspace-operator.v0.44.0-dev
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -534,7 +534,7 @@ spec:
     name: async_storage_server
   - image: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
     name: async_storage_sidecar
-  version: 0.43.0-dev
+  version: 0.44.0-dev
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     operators.operatorframework.io/internal-objects: '["devworkspaceroutings.controller.devfile.io"]'
-  name: devworkspace-operator.v0.43.0-dev
+  name: devworkspace-operator.v0.44.0-dev
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
@@ -98,7 +98,7 @@ spec:
   provider:
     name: Devfile
     url: https://devfile.io
-  version: 0.43.0-dev
+  version: 0.44.0-dev
   relatedImages:
     - image: quay.io/devfile/devworkspace-controller:next
       name: devworkspace_webhook_server

--- a/version/version.go
+++ b/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the operator version
-	Version = "v0.43.0-dev"
+	Version = "v0.44.0-dev"
 	// Commit is the commit hash corresponding to the code that was built. Can be suffixed with `-dirty`
 	Commit string = "unknown"
 	// BuildTime is the time of build of the binary


### PR DESCRIPTION
### What does this PR do?
Bumps the version in the `main` branch to `0.44.0-dev` following the creation of the `0.43.x` release branch for `v0.43.0`.

### What issues does this PR fix or reference?
N/A (Standard release cycle version bump)

### Is it tested? How?
N/A - Routine version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the DevWorkspace Operator development release version to **0.44.0-dev**.
  - Version information is now consistent across deployment metadata and displayed release details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->