### PR TITLE
Create DWO 0.43.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # DevWorkspace Operator Changelog
 
+# v0.43.0
+
+## Bug Fixes & Improvements
+
+- Apply configured `imagePullPolicy` from `DevWorkspaceOperatorConfig` to backup CronJob containers instead of hardcoding `Always` [#1654](https://github.com/devfile/devworkspace-operator/pull/1654)
+
+- Apply configured `podSecurityContext` from `DevWorkspaceOperatorConfig` to backup CronJob pod templates for consistency with workspace deployments [#1655](https://github.com/devfile/devworkspace-operator/pull/1655)
+
+- Fix SSH askpass script to handle non-passphrase prompts, preventing error messages when cloning private repositories [#1658](https://github.com/devfile/devworkspace-operator/pull/1658)
+
+- Add documentation for cross-namespace DevWorkspaceTemplate imports using the `controller.devfile.io/allow-import-from` annotation [#1673](https://github.com/devfile/devworkspace-operator/pull/1673)
+
+- Update controller-runtime to v0.24.1 and Kubernetes dependencies to v0.36.0 [#1642](https://github.com/devfile/devworkspace-operator/pull/1642)
+
+- Update Go to v1.26.5 [#1671](https://github.com/devfile/devworkspace-operator/pull/1671)
+
 # v0.42.0
 
 ## Features

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ ifndef VERBOSE
 endif
 
 export NAMESPACE ?= devworkspace-controller
-export DWO_IMG ?= quay.io/devfile/devworkspace-controller:next
-export DWO_BUNDLE_IMG ?= quay.io/devfile/devworkspace-operator-bundle:next
-export DWO_INDEX_IMG ?= quay.io/devfile/devworkspace-operator-index:next
-export PROJECT_CLONE_IMG ?= quay.io/devfile/project-clone:next
-export PROJECT_BACKUP_IMG ?= quay.io/devfile/project-backup:next
+export DWO_IMG ?= quay.io/devfile/devworkspace-controller:v0.43.0
+export DWO_BUNDLE_IMG ?= quay.io/devfile/devworkspace-operator-bundle:v0.43.0
+export DWO_INDEX_IMG ?= quay.io/devfile/devworkspace-operator-index:release
+export PROJECT_CLONE_IMG ?= quay.io/devfile/project-clone:v0.43.0
+export PROJECT_BACKUP_IMG ?= quay.io/devfile/project-backup:v0.43.0
 export PULL_POLICY ?= Always
 export DEFAULT_ROUTING ?= basic
 export KUBECONFIG ?= ${HOME}/.kube/config
@@ -335,7 +335,7 @@ endif
 ### _docker-check-push: Asks for confirmation before pushing the image, unless running in CI
 _docker-check-push:
   ifneq ($(INITIATOR),CI)
-    ifeq ($(DWO_IMG),quay.io/devfile/devworkspace-controller:next)
+    ifeq ($(DWO_IMG),quay.io/devfile/devworkspace-controller:v0.43.0)
 	    @echo -n "Are you sure you want to push $(DWO_IMG)? [y/N] " && read ans && [ $${ans:-N} = y ]
     endif
   endif

--- a/build/scripts/generate_deployment.sh
+++ b/build/scripts/generate_deployment.sh
@@ -52,17 +52,17 @@ Arguments:
       Controller (and webhook) image to use for the default deployment.
       Used only when '--use-defaults' is passed; otherwise, the value of
       the DWO_IMG environment variable is used. If unspecified, the default
-      value of 'quay.io/devfile/devworkspace-controller:next' is used
+      value of 'quay.io/devfile/devworkspace-controller:v0.43.0' is used
   --project-clone-image
       Image to use for the project clone init container. Used only when
       '--use-defaults' is passed; otherwise, the value of the PROJECT_CLONE_IMG
       environment variable is used. If unspecifed, the default value of
-      'quay.io/devfile/project-clone:next' is used.
+      'quay.io/devfile/project-clone:v0.43.0' is used.
   --project-backup-image
       Image to use for the project backup workspace. Used only when
       '--use-defaults' is passed; otherwise, the value of the PROJECT_BACKUP_IMG
       environment variable is used. If unspecifed, the default value of
-      'quay.io/devfile/project-backup:next' is used.
+      'quay.io/devfile/project-backup:v0.43.0' is used.
   --split-yaml
       Parse output file combined.yaml into a yaml file for each record
       in combined yaml. Files are output to the 'objects' subdirectory
@@ -125,9 +125,9 @@ done
 if $USE_DEFAULT_ENV; then
   echo "Using defaults for environment variables"
   export NAMESPACE=devworkspace-controller
-  export DWO_IMG=${DEFAULT_DWO_IMG:-"quay.io/devfile/devworkspace-controller:next"}
-  export PROJECT_CLONE_IMG=${PROJECT_CLONE_IMG:-"quay.io/devfile/project-clone:next"}
-  export PROJECT_BACKUP_IMG=${PROJECT_BACKUP_IMG:-"quay.io/devfile/project-backup:next"}
+  export DWO_IMG=${DEFAULT_DWO_IMG:-"quay.io/devfile/devworkspace-controller:v0.43.0"}
+  export PROJECT_CLONE_IMG=${PROJECT_CLONE_IMG:-"quay.io/devfile/project-clone:v0.43.0"}
+  export PROJECT_BACKUP_IMG=${PROJECT_BACKUP_IMG:-"quay.io/devfile/project-backup:v0.43.0"}
   export PULL_POLICY=Always
   export DEFAULT_ROUTING=basic
   export DEVWORKSPACE_API_VERSION=a6ec0a38307b63a29fad2eea945cc69bee97a683

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: devworkspace-operator.v0.43.0-dev
+  name: devworkspace-operator.v0.43.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -388,11 +388,11 @@ spec:
                 - name: WEBHOOK_SECRET_NAME
                   value: devworkspace-webhookserver-tls
                 - name: RELATED_IMAGE_devworkspace_webhook_server
-                  value: quay.io/devfile/devworkspace-controller:next
+                  value: quay.io/devfile/devworkspace-controller:v0.43.0
                 - name: RELATED_IMAGE_project_clone
-                  value: quay.io/devfile/project-clone:next
+                  value: quay.io/devfile/project-clone:v0.43.0
                 - name: RELATED_IMAGE_project_backup
-                  value: quay.io/devfile/project-backup:next
+                  value: quay.io/devfile/project-backup:v0.43.0
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -423,7 +423,7 @@ spec:
                   value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
                 - name: RELATED_IMAGE_async_storage_sidecar
                   value: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
-                image: quay.io/devfile/devworkspace-controller:next
+                image: quay.io/devfile/devworkspace-controller:v0.43.0
                 imagePullPolicy: Always
                 livenessProbe:
                   failureThreshold: 5
@@ -522,11 +522,11 @@ spec:
     name: Devfile
     url: https://devfile.io
   relatedImages:
-  - image: quay.io/devfile/devworkspace-controller:next
+  - image: quay.io/devfile/devworkspace-controller:v0.43.0
     name: devworkspace_webhook_server
-  - image: quay.io/devfile/project-clone:next
+  - image: quay.io/devfile/project-clone:v0.43.0
     name: project_clone
-  - image: quay.io/devfile/project-backup:next
+  - image: quay.io/devfile/project-backup:v0.43.0
     name: project_backup
   - image: registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
     name: pvc_cleanup_job
@@ -534,7 +534,7 @@ spec:
     name: async_storage_server
   - image: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
     name: async_storage_sidecar
-  version: 0.43.0-dev
+  version: 0.43.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -28215,11 +28215,11 @@ spec:
         - name: WEBHOOK_SECRET_NAME
           value: devworkspace-operator-webhook-cert
         - name: RELATED_IMAGE_devworkspace_webhook_server
-          value: quay.io/devfile/devworkspace-controller:next
+          value: quay.io/devfile/devworkspace-controller:v0.43.0
         - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
+          value: quay.io/devfile/project-clone:v0.43.0
         - name: RELATED_IMAGE_project_backup
-          value: quay.io/devfile/project-backup:next
+          value: quay.io/devfile/project-backup:v0.43.0
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME
@@ -28248,7 +28248,7 @@ spec:
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar
           value: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
-        image: quay.io/devfile/devworkspace-controller:next
+        image: quay.io/devfile/devworkspace-controller:v0.43.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-manager.Deployment.yaml
@@ -27,11 +27,11 @@ spec:
         - name: WEBHOOK_SECRET_NAME
           value: devworkspace-operator-webhook-cert
         - name: RELATED_IMAGE_devworkspace_webhook_server
-          value: quay.io/devfile/devworkspace-controller:next
+          value: quay.io/devfile/devworkspace-controller:v0.43.0
         - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
+          value: quay.io/devfile/project-clone:v0.43.0
         - name: RELATED_IMAGE_project_backup
-          value: quay.io/devfile/project-backup:next
+          value: quay.io/devfile/project-backup:v0.43.0
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME
@@ -60,7 +60,7 @@ spec:
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar
           value: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
-        image: quay.io/devfile/devworkspace-controller:next
+        image: quay.io/devfile/devworkspace-controller:v0.43.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -28217,11 +28217,11 @@ spec:
         - name: WEBHOOK_SECRET_NAME
           value: devworkspace-webhookserver-tls
         - name: RELATED_IMAGE_devworkspace_webhook_server
-          value: quay.io/devfile/devworkspace-controller:next
+          value: quay.io/devfile/devworkspace-controller:v0.43.0
         - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
+          value: quay.io/devfile/project-clone:v0.43.0
         - name: RELATED_IMAGE_project_backup
-          value: quay.io/devfile/project-backup:next
+          value: quay.io/devfile/project-backup:v0.43.0
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME
@@ -28250,7 +28250,7 @@ spec:
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar
           value: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
-        image: quay.io/devfile/devworkspace-controller:next
+        image: quay.io/devfile/devworkspace-controller:v0.43.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5

--- a/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-manager.Deployment.yaml
@@ -27,11 +27,11 @@ spec:
         - name: WEBHOOK_SECRET_NAME
           value: devworkspace-webhookserver-tls
         - name: RELATED_IMAGE_devworkspace_webhook_server
-          value: quay.io/devfile/devworkspace-controller:next
+          value: quay.io/devfile/devworkspace-controller:v0.43.0
         - name: RELATED_IMAGE_project_clone
-          value: quay.io/devfile/project-clone:next
+          value: quay.io/devfile/project-clone:v0.43.0
         - name: RELATED_IMAGE_project_backup
-          value: quay.io/devfile/project-backup:next
+          value: quay.io/devfile/project-backup:v0.43.0
         - name: WATCH_NAMESPACE
           value: ""
         - name: POD_NAME
@@ -60,7 +60,7 @@ spec:
           value: quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
         - name: RELATED_IMAGE_async_storage_sidecar
           value: quay.io/eclipse/che-sidecar-workspace-data-sync:0.0.1
-        image: quay.io/devfile/devworkspace-controller:next
+        image: quay.io/devfile/devworkspace-controller:v0.43.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5

--- a/deploy/templates/components/csv/clusterserviceversion.yaml
+++ b/deploy/templates/components/csv/clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     operators.operatorframework.io/internal-objects: '["devworkspaceroutings.controller.devfile.io"]'
-  name: devworkspace-operator.v0.43.0-dev
+  name: devworkspace-operator.v0.43.0
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
@@ -98,13 +98,13 @@ spec:
   provider:
     name: Devfile
     url: https://devfile.io
-  version: 0.43.0-dev
+  version: 0.43.0
   relatedImages:
-    - image: quay.io/devfile/devworkspace-controller:next
+    - image: quay.io/devfile/devworkspace-controller:v0.43.0
       name: devworkspace_webhook_server
-    - image: quay.io/devfile/project-clone:next
+    - image: quay.io/devfile/project-clone:v0.43.0
       name: project_clone
-    - image: quay.io/devfile/project-backup:next
+    - image: quay.io/devfile/project-backup:v0.43.0
       name: project_backup
     - image: registry.access.redhat.com/ubi9/ubi-micro:9.5-1733126338
       name: pvc_cleanup_job

--- a/version/version.go
+++ b/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the operator version
-	Version = "v0.43.0-dev"
+	Version = "v0.43.0"
 	// Commit is the commit hash corresponding to the code that was built. Can be suffixed with `-dirty`
 	Commit string = "unknown"
 	// BuildTime is the time of build of the binary


### PR DESCRIPTION
### What does this PR do?
Create DWO 0.43.0 release notes

### What issues does this PR fix or reference?

### Is it tested? How?
N/A - Documentation update

### PR Checklist
- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
  - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
  - [ ] `v8-che-happy-path`: Happy path for verification integration with Che

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 0.43.0 with stable image tags and deployment manifests.
* **Bug Fixes & Improvements**
  * Improved backup job image handling and security settings.
  * Improved SSH authentication for prompts without passphrases.
  * Added guidance for cross-namespace development workspace template imports.
  * Updated Kubernetes-related tooling and Go version.
* **Documentation**
  * Added the v0.43.0 changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->