### PR TITLE
docs: create DWO 0.43.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # DevWorkspace Operator Changelog
 
+# v0.43.0
+
+## Bug Fixes & Improvements
+
+- Apply configured `imagePullPolicy` from `DevWorkspaceOperatorConfig` to backup CronJob containers instead of hardcoding `Always` [#1654](https://github.com/devfile/devworkspace-operator/pull/1654)
+- Apply configured `podSecurityContext` from `DevWorkspaceOperatorConfig` to backup CronJob pod templates [#1655](https://github.com/devfile/devworkspace-operator/pull/1655)
+- Document `controller.devfile.io/allow-import-from` annotation for cross-namespace DevWorkspaceTemplate imports [#1673](https://github.com/devfile/devworkspace-operator/pull/1673)
+
 # v0.42.0
 
 ## Features


### PR DESCRIPTION
### What does this PR do?
Create DWO 0.43.0 release notes

### What issues does this PR fix or reference?

### Is it tested? How?
N/A - Documentation update

### PR Checklist
- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup CronJobs now honor the configured image pull policy.
  * Backup CronJobs now apply the configured pod security context.

* **Documentation**
  * Documented the annotation used to allow DevWorkspaceTemplate imports across namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->