### PR TITLE
Try updating happy path test install namespace to openshift-operators

### DIFF
--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -46,7 +46,7 @@ ATTEMPT_LOG="${ARTIFACT_DIR}/attempt-log.txt"
 
 deployDWO() {
   echo "======== Deploying DevWorkspace Operator ========"
-  export NAMESPACE="devworkspace-controller"
+  export NAMESPACE="openshift-operators"
   export DWO_IMG="${DEVWORKSPACE_OPERATOR}"
 
   if ! make install; then


### PR DESCRIPTION
### What does this PR do?
Updates happy path test to install DWO in openshift-operators namespace.

### What issues does this PR fix or reference?
Test to check if it fixes happy path test failures such as:  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/devfile_devworkspace-operator/1685/pull-ci-devfile-devworkspace-operator-main-v14-che-happy-path/2085024195422457856

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che
