### PR TITLE
fix: add NetworkPolicy RBAC permissions

### DIFF
--- a/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
+++ b/controllers/controller/devworkspacerouting/devworkspacerouting_controller.go
@@ -66,6 +66,7 @@ type DevWorkspaceRoutingReconciler struct {
 // +kubebuilder:rbac:groups=controller.devfile.io,resources=devworkspaceroutings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=services,verbs=*
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=*
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update;patch;get;list;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=*
 // +kubebuidler:rbac:groups=route.openshift.io,resources=routes/status,verbs=get,list,watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=create

--- a/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/devworkspace-operator.clusterserviceversion.yaml
@@ -289,6 +289,18 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - oauth.openshift.io
           resources:
           - oauthclients

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -27998,6 +27998,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - oauth.openshift.io
   resources:
   - oauthclients

--- a/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -209,6 +209,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - oauth.openshift.io
   resources:
   - oauthclients

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -27998,6 +27998,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - oauth.openshift.io
   resources:
   - oauthclients

--- a/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/devworkspace-controller-role.ClusterRole.yaml
@@ -209,6 +209,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - oauth.openshift.io
   resources:
   - oauthclients

--- a/deploy/templates/components/rbac/role.yaml
+++ b/deploy/templates/components/rbac/role.yaml
@@ -207,6 +207,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - oauth.openshift.io
   resources:
   - oauthclients


### PR DESCRIPTION
### What does this PR do?

Add kubebuilder RBAC for `networking.k8s.io/networkpolicies` (`create`, `delete`, `update`, `patch`, `get`, `list`, `watch`) on the DevWorkspaceRouting controller.
### What issues does this PR fix or reference?

Operators are expected to be able to manage NetworkPolicy resources for their operands. The CSV currently only requests `networking.k8s.io/ingresses`.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- Marker-only change in this PR; generated RBAC/CSV updates come from `make generate_all` (include those manifests in this PR or a follow-up commit before merge).
- Target branch: `0.43.x` (also needed on `main` if not cherry-picked later).

### PR Checklist

- [ ] E2E tests pass (when PR is ready, comment `/test v8-devworkspace-operator-e2e, v8-che-happy-path` to trigger)
    - [ ] `v8-devworkspace-operator-e2e`: DevWorkspace e2e test
    - [ ] `v8-che-happy-path`: Happy path for verification integration with Che


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the permissions required to manage Kubernetes NetworkPolicy resources.
  * Enables creating, viewing, updating, deleting, listing, and monitoring network policies for supported workspace deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->